### PR TITLE
refactor(ui): rename selectedAction to headerContent

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -71,13 +71,13 @@ describe("ActionForm", () => {
     expect(wrapper.find("ActionButton").prop("disabled")).toBe(true);
   });
 
-  it("runs clearSelectedAction function when processing complete", () => {
+  it("runs clearHeaderContent function when processing complete", () => {
     const store = mockStore(state);
-    const clearSelectedAction = jest.fn();
+    const clearHeaderContent = jest.fn();
     const Proxy = ({ processingCount }: { processingCount: number }) => (
       <Provider store={store}>
         <ActionForm
-          clearSelectedAction={clearSelectedAction}
+          clearHeaderContent={clearHeaderContent}
           initialValues={{}}
           modelName="machine"
           onSubmit={jest.fn()}
@@ -92,7 +92,7 @@ describe("ActionForm", () => {
     wrapper.setProps({ processingCount: 0 });
     wrapper.update();
 
-    expect(clearSelectedAction).toHaveBeenCalled();
+    expect(clearHeaderContent).toHaveBeenCalled();
   });
 
   it("runs onSuccess function if processing is successful", () => {
@@ -119,9 +119,9 @@ describe("ActionForm", () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
-  it("does not run clearSelectedAction function if errors occur while processing", () => {
+  it("does not run clearHeaderContent function if errors occur while processing", () => {
     const store = mockStore(state);
-    const clearSelectedAction = jest.fn();
+    const clearHeaderContent = jest.fn();
     const Proxy = ({
       errors,
       processingCount,
@@ -131,7 +131,7 @@ describe("ActionForm", () => {
     }) => (
       <Provider store={store}>
         <ActionForm
-          clearSelectedAction={clearSelectedAction}
+          clearHeaderContent={clearHeaderContent}
           errors={errors}
           initialValues={{}}
           modelName="machine"
@@ -150,16 +150,16 @@ describe("ActionForm", () => {
     });
     wrapper.update();
 
-    expect(clearSelectedAction).not.toHaveBeenCalled();
+    expect(clearHeaderContent).not.toHaveBeenCalled();
   });
 
   it("shows correct saving label if selectedCount changes after submit", async () => {
     const store = mockStore(state);
-    const clearSelectedAction = jest.fn();
+    const clearHeaderContent = jest.fn();
     const Proxy = ({ selectedCount }: { selectedCount: number }) => (
       <Provider store={store}>
         <ActionForm
-          clearSelectedAction={clearSelectedAction}
+          clearHeaderContent={clearHeaderContent}
           initialValues={{}}
           modelName="machine"
           onSubmit={jest.fn()}

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -94,7 +94,7 @@ const getLabel = (
 export type Props<V, E = null> = FormikFormProps<V, E> & {
   actionDisabled?: boolean;
   actionName?: string;
-  clearSelectedAction?: (...args: unknown[]) => void;
+  clearHeaderContent?: (...args: unknown[]) => void;
   loaded?: boolean;
   modelName: string;
   onSuccess?: () => void;
@@ -107,7 +107,7 @@ const ActionForm = <V, E = null>({
   actionName,
   buttonsBordered = false,
   children,
-  clearSelectedAction,
+  clearHeaderContent,
   errors,
   loaded = true,
   modelName,
@@ -136,14 +136,14 @@ const ActionForm = <V, E = null>({
   // Clearing the selected action is moved into its own effect so that `saved`
   // can be set before the component unmounts. This triggers analytics being sent.
   useEffect(() => {
-    if (saved && clearSelectedAction) {
-      clearSelectedAction();
+    if (saved && clearHeaderContent) {
+      clearHeaderContent();
     }
-  }, [clearSelectedAction, saved]);
+  }, [clearHeaderContent, saved]);
 
   // Don't display the form when the action is disabled, an update selection
   // notification is show instead. However, we do still need to render this
-  // component so that the clearSelectedAction useEffect can still run when the
+  // component so that the clearHeaderContent useEffect can still run when the
   // action completes.
   if (actionDisabled) {
     return null;
@@ -155,7 +155,7 @@ const ActionForm = <V, E = null>({
         buttonsAlign="right"
         buttonsBordered={buttonsBordered}
         errors={formattedErrors}
-        onCancel={clearSelectedAction}
+        onCancel={clearHeaderContent}
         onSubmit={(values?, formikHelpers?) => {
           onSubmit(values, formikHelpers);
           // Set selected count in component state once form is submitted, so

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -54,7 +54,7 @@ describe("SectionHeader", () => {
 
   it("can render a form wrapper", () => {
     const wrapper = shallow(
-      <SectionHeader title="Title" formWrapper={<div>Form wrapper</div>} />
+      <SectionHeader title="Title" headerContent={<div>Form wrapper</div>} />
     );
     expect(
       wrapper.find("[data-test='section-header-form-wrapper']").exists()

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -9,7 +9,7 @@ import type { DataTestElement } from "app/base/types";
 
 type Props<P = LinkProps> = {
   buttons?: JSX.Element[] | null;
-  formWrapper?: JSX.Element | null;
+  headerContent?: JSX.Element | null;
   loading?: boolean;
   subtitle?: ReactNode | ReactNode[];
   tabLinks?: DataTestElement<TabsProps<P>["links"]>;
@@ -35,7 +35,7 @@ const generateSubtitle = (subtitle: Props["subtitle"]) => {
 
 const SectionHeader = ({
   buttons,
-  formWrapper,
+  headerContent,
   loading,
   subtitle,
   tabLinks,
@@ -78,11 +78,11 @@ const SectionHeader = ({
           </ul>
         )}
       </div>
-      {formWrapper && (
+      {headerContent && (
         <Row data-test="section-header-form-wrapper">
           <Col size={12}>
             <hr />
-            {formWrapper}
+            {headerContent}
           </Col>
         </Row>
       )}

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -23,14 +23,14 @@ export type AnalyticsEvent = {
   label: string;
 };
 
-export type SelectedAction<A, E> = {
-  name: A;
+export type HeaderContent<N, E> = {
+  name: N;
   extras?: E;
 };
 
-export type SetSelectedAction<SA> = (action: SA | null) => void;
+export type SetHeaderContent<H> = (headerContent: H | null) => void;
 
-export type ClearSelectedAction = () => void;
+export type ClearHeaderContent = () => void;
 
 export type AnyObject = Record<string, unknown>;
 

--- a/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
@@ -33,10 +33,10 @@ const DashboardHeader = (): JSX.Element => {
       Clear all discoveries
     </Button>,
   ];
-  let formWrapper: JSX.Element | null = null;
+  let headerContent: JSX.Element | null = null;
   if (isFormOpen) {
     buttons = null;
-    formWrapper = (
+    headerContent = (
       <ClearAllForm
         closeForm={() => {
           setFormOpen(false);
@@ -48,7 +48,7 @@ const DashboardHeader = (): JSX.Element => {
   return (
     <SectionHeader
       buttons={buttons}
-      formWrapper={formWrapper}
+      headerContent={headerContent}
       title="Network discovery"
       tabLinks={[
         {

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -84,7 +84,7 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
         "No resource records"
       )}`}
       title={domain?.name}
-      formWrapper={
+      headerContent={
         formOpen === null ? null : (
           <>
             {formOpen === "delete" && (

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -32,11 +32,11 @@ const DomainListHeader = (): JSX.Element => {
     </Button>,
   ];
 
-  let formWrapper: JSX.Element | null = null;
+  let headerContent: JSX.Element | null = null;
 
   if (isFormOpen) {
     buttons = null;
-    formWrapper = (
+    headerContent = (
       <DomainListHeaderForm
         closeForm={() => {
           setFormOpen(false);
@@ -50,7 +50,7 @@ const DomainListHeader = (): JSX.Element => {
       loading={!domainsLoaded}
       subtitle={`${pluralize("domain", domainCount, true)} available`}
       title="DNS"
-      formWrapper={formWrapper}
+      headerContent={headerContent}
     />
   );
 };

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.test.tsx
@@ -76,7 +76,7 @@ describe("ComposeForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearSelectedAction={jest.fn()} />
+          <ComposeForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -103,7 +103,7 @@ describe("ComposeForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearSelectedAction={jest.fn()} />
+          <ComposeForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -130,7 +130,7 @@ describe("ComposeForm", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -221,7 +221,7 @@ describe("ComposeForm", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
@@ -15,7 +15,7 @@ import InterfacesTable from "./InterfacesTable";
 import StorageTable from "./StorageTable";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction, RouteParams } from "app/base/types";
+import type { ClearHeaderContent, RouteParams } from "app/base/types";
 import { RANGE_REGEX } from "app/base/validation";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
@@ -173,10 +173,10 @@ export const getDefaultPoolLocation = (pod: Pod): string => {
 };
 
 type Props = {
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
-const ComposeForm = ({ clearSelectedAction }: Props): JSX.Element => {
+const ComposeForm = ({ clearHeaderContent }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
   const pod = useSelector((state: RootState) =>
@@ -419,7 +419,7 @@ const ComposeForm = ({ clearSelectedAction }: Props): JSX.Element => {
         actionName="compose"
         allowUnchanged
         cleanup={cleanup}
-        clearSelectedAction={clearSelectedAction}
+        clearHeaderContent={clearHeaderContent}
         errors={errors}
         initialTouched={{ cores: true, memory: true, pinnedCores: true }}
         initialValues={{

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -94,7 +94,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -133,7 +133,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -189,7 +189,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -404,7 +404,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -444,7 +444,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -476,7 +476,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -528,7 +528,7 @@ describe("ComposeFormFields", () => {
           <Route
             exact
             path="/kvm/:id"
-            component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+            component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -41,7 +41,7 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
         <Route
           exact
           path="/kvm/:id"
-          component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+          component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
         />
       </MemoryRouter>
     </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -44,7 +44,7 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
         <Route
           exact
           path="/kvm/:id"
-          component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+          component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
         />
       </MemoryRouter>
     </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -39,7 +39,7 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
         <Route
           exact
           path="/kvm/:id"
-          component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+          component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
         />
       </MemoryRouter>
     </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -40,7 +40,7 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
         <Route
           exact
           path="/kvm/:id"
-          component={() => <ComposeForm clearSelectedAction={jest.fn()} />}
+          component={() => <ComposeForm clearHeaderContent={jest.fn()} />}
         />
       </MemoryRouter>
     </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.test.tsx
@@ -33,7 +33,7 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearSelectedAction={jest.fn()} />
+          <DeleteForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -60,7 +60,7 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearSelectedAction={jest.fn()} />
+          <DeleteForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +83,7 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearSelectedAction={jest.fn()} />
+          <DeleteForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +106,7 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearSelectedAction={jest.fn()} />
+          <DeleteForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -6,7 +6,7 @@ import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { PodType } from "app/store/pod/types";
@@ -16,14 +16,14 @@ type DeleteFormValues = {
 };
 
 type Props = {
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 const DeleteFormSchema = Yup.object().shape({
   decompose: Yup.boolean(),
 });
 
-const DeleteForm = ({ clearSelectedAction }: Props): JSX.Element | null => {
+const DeleteForm = ({ clearHeaderContent }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const activePod = useSelector(podSelectors.active);
   const errors = useSelector(podSelectors.errors);
@@ -37,7 +37,7 @@ const DeleteForm = ({ clearSelectedAction }: Props): JSX.Element | null => {
         allowAllEmpty
         allowUnchanged
         cleanup={cleanup}
-        clearSelectedAction={clearSelectedAction}
+        clearHeaderContent={clearHeaderContent}
         errors={errors}
         initialValues={{
           decompose: false,

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
@@ -34,15 +34,15 @@ describe("KVMActionFormWrapper", () => {
     });
   });
 
-  it("does not render if selectedAction is not defined", () => {
+  it("does not render if headerContent is not defined", () => {
     const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
           <KVMActionFormWrapper
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -59,8 +59,8 @@ describe("KVMActionFormWrapper", () => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
           <KVMActionFormWrapper
-            selectedAction={PodAction.COMPOSE}
-            setSelectedAction={jest.fn()}
+            headerContent={PodAction.COMPOSE}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -75,8 +75,8 @@ describe("KVMActionFormWrapper", () => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
           <KVMActionFormWrapper
-            selectedAction={PodAction.DELETE}
-            setSelectedAction={jest.fn()}
+            headerContent={PodAction.DELETE}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -91,8 +91,8 @@ describe("KVMActionFormWrapper", () => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
           <KVMActionFormWrapper
-            selectedAction={PodAction.REFRESH}
-            setSelectedAction={jest.fn()}
+            headerContent={PodAction.REFRESH}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -107,8 +107,8 @@ describe("KVMActionFormWrapper", () => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
           <KVMActionFormWrapper
-            selectedAction={{ name: NodeActions.COMMISSION }}
-            setSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.COMMISSION }}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.tsx
@@ -5,68 +5,65 @@ import DeleteForm from "./DeleteForm";
 import RefreshForm from "./RefreshForm";
 
 import { useScrollOnRender } from "app/base/hooks";
-import type { ClearSelectedAction } from "app/base/types";
-import type {
-  KVMSelectedAction,
-  KVMSetSelectedAction,
-} from "app/kvm/views/KVMDetails/KVMDetails";
+import type { ClearHeaderContent } from "app/base/types";
+import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import MachineActionForms from "app/machines/components/ActionFormWrapper";
 import { PodAction } from "app/store/pod/types";
 
 type Props = {
-  selectedAction: KVMSelectedAction | null;
-  setSelectedAction: KVMSetSelectedAction;
+  headerContent: KVMHeaderContent | null;
+  setHeaderContent: KVMSetHeaderContent;
 };
 
 const getFormComponent = (
-  selectedAction: KVMSelectedAction,
-  setSelectedAction: KVMSetSelectedAction,
-  clearSelectedAction: ClearSelectedAction
+  headerContent: KVMHeaderContent,
+  setHeaderContent: KVMSetHeaderContent,
+  clearHeaderContent: ClearHeaderContent
 ) => {
   // This is a reliable of differentiating a machine action from a pod action,
   // but we should eventually try to have a consistent shape between them.
   // https://github.com/canonical-web-and-design/maas-ui/issues/3017
   if (
-    selectedAction &&
-    typeof selectedAction === "object" &&
-    "name" in selectedAction
+    headerContent &&
+    typeof headerContent === "object" &&
+    "name" in headerContent
   ) {
     return (
       <MachineActionForms
-        selectedAction={selectedAction}
-        setSelectedAction={setSelectedAction}
+        headerContent={headerContent}
+        setHeaderContent={setHeaderContent}
       />
     );
   }
 
-  switch (selectedAction) {
+  switch (headerContent) {
     case PodAction.COMPOSE:
-      return <ComposeForm clearSelectedAction={clearSelectedAction} />;
+      return <ComposeForm clearHeaderContent={clearHeaderContent} />;
     case PodAction.DELETE:
-      return <DeleteForm clearSelectedAction={clearSelectedAction} />;
+      return <DeleteForm clearHeaderContent={clearHeaderContent} />;
     case PodAction.REFRESH:
-      return <RefreshForm clearSelectedAction={clearSelectedAction} />;
+      return <RefreshForm clearHeaderContent={clearHeaderContent} />;
     default:
       return null;
   }
 };
 
 const KVMActionFormWrapper = ({
-  selectedAction,
-  setSelectedAction,
+  headerContent,
+  setHeaderContent,
 }: Props): JSX.Element | null => {
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
-  const clearSelectedAction = useCallback(
-    () => setSelectedAction(null),
-    [setSelectedAction]
+  const clearHeaderContent = useCallback(
+    () => setHeaderContent(null),
+    [setHeaderContent]
   );
 
-  if (!selectedAction) {
+  if (!headerContent) {
     return null;
   }
   return (
     <div ref={onRenderRef}>
-      {getFormComponent(selectedAction, setSelectedAction, clearSelectedAction)}
+      {getFormComponent(headerContent, setHeaderContent, clearHeaderContent)}
     </div>
   );
 };

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.test.tsx
@@ -32,7 +32,7 @@ describe("RefreshForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <RefreshForm clearSelectedAction={jest.fn()} />
+          <RefreshForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -59,7 +59,7 @@ describe("RefreshForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <RefreshForm clearSelectedAction={jest.fn()} />
+          <RefreshForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -3,15 +3,15 @@ import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction, EmptyObject } from "app/base/types";
+import type { ClearHeaderContent, EmptyObject } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 
 type Props = {
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
-const RefreshForm = ({ clearSelectedAction }: Props): JSX.Element | null => {
+const RefreshForm = ({ clearHeaderContent }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const activePod = useSelector(podSelectors.active);
   const errors = useSelector(podSelectors.errors);
@@ -23,7 +23,7 @@ const RefreshForm = ({ clearSelectedAction }: Props): JSX.Element | null => {
       <ActionForm<EmptyObject>
         actionName="refresh"
         cleanup={cleanup}
-        clearSelectedAction={clearSelectedAction}
+        clearHeaderContent={clearHeaderContent}
         errors={errors}
         initialValues={{}}
         modelName="KVM"

--- a/ui/src/app/kvm/components/PodDetailsActionMenu/PodDetailsActionMenu.tsx
+++ b/ui/src/app/kvm/components/PodDetailsActionMenu/PodDetailsActionMenu.tsx
@@ -1,11 +1,11 @@
 import { ContextualMenu } from "@canonical/react-components";
 
-import type { KVMSetSelectedAction } from "app/kvm/views/KVMDetails/KVMDetails";
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import { PodAction } from "app/store/pod/types";
 
-type Props = { setSelectedAction: KVMSetSelectedAction };
+type Props = { setHeaderContent: KVMSetHeaderContent };
 
-const PodDetailsActionMenu = ({ setSelectedAction }: Props): JSX.Element => {
+const PodDetailsActionMenu = ({ setHeaderContent }: Props): JSX.Element => {
   return (
     <ContextualMenu
       data-test="action-dropdown"
@@ -13,15 +13,15 @@ const PodDetailsActionMenu = ({ setSelectedAction }: Props): JSX.Element => {
       links={[
         {
           children: "Compose",
-          onClick: () => setSelectedAction(PodAction.COMPOSE),
+          onClick: () => setHeaderContent(PodAction.COMPOSE),
         },
         {
           children: "Refresh",
-          onClick: () => setSelectedAction(PodAction.REFRESH),
+          onClick: () => setHeaderContent(PodAction.REFRESH),
         },
         {
           children: "Delete",
-          onClick: () => setSelectedAction(PodAction.DELETE),
+          onClick: () => setHeaderContent(PodAction.DELETE),
         },
       ]}
       position="right"

--- a/ui/src/app/kvm/types.ts
+++ b/ui/src/app/kvm/types.ts
@@ -1,0 +1,9 @@
+import type { SetHeaderContent } from "app/base/types";
+import type { MachineHeaderContent } from "app/machines/types";
+import type { PodAction } from "app/store/pod/types";
+
+export type KVMHeaderContent = PodAction | MachineHeaderContent;
+
+export type KVMSetHeaderContent = SetHeaderContent<KVMHeaderContent>;
+
+export type SetSearchFilter = (searchFilter: string) => void;

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
@@ -49,7 +49,7 @@ describe("KVMConfiguration", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <KVMConfiguration id={1} setSelectedAction={jest.fn()} />
+          <KVMConfiguration id={1} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -74,7 +74,7 @@ describe("KVMConfiguration", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <KVMConfiguration id={1} setSelectedAction={jest.fn()} />
+          <KVMConfiguration id={1} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -84,20 +84,20 @@ describe("KVMConfiguration", () => {
   it("can open the delete form if the KVM is a LXD KVM", () => {
     const state = { ...initialState };
     state.pod.items[0].type = PodType.LXD;
-    const setSelectedAction = jest.fn();
+    const setHeaderContent = jest.fn();
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <KVMConfiguration id={1} setSelectedAction={setSelectedAction} />
+          <KVMConfiguration id={1} setHeaderContent={setHeaderContent} />
         </MemoryRouter>
       </Provider>
     );
 
     wrapper.find("button[data-test='remove-kvm']").simulate("click");
-    expect(setSelectedAction).toHaveBeenCalledWith(PodAction.DELETE);
+    expect(setHeaderContent).toHaveBeenCalledWith(PodAction.DELETE);
   });
 
   it("can handle updating a lxd KVM", () => {
@@ -112,7 +112,7 @@ describe("KVMConfiguration", () => {
             exact
             path="/kvm/:id/edit"
             component={() => (
-              <KVMConfiguration id={1} setSelectedAction={jest.fn()} />
+              <KVMConfiguration id={1} setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>
@@ -167,7 +167,7 @@ describe("KVMConfiguration", () => {
             exact
             path="/kvm/:id/edit"
             component={() => (
-              <KVMConfiguration id={1} setSelectedAction={jest.fn()} />
+              <KVMConfiguration id={1} setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -4,13 +4,12 @@ import { Button, Col, Row, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
-import type { KVMSetSelectedAction } from "../KVMDetails";
-
 import KVMConfigurationFields from "./KVMConfigurationFields";
 
 import FormCard from "app/base/components/FormCard";
 import FormikForm from "app/base/components/FormikForm";
 import { useWindowTitle } from "app/base/hooks";
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
@@ -50,10 +49,10 @@ export type KVMConfigurationValues = {
 
 type Props = {
   id: Pod["id"];
-  setSelectedAction: KVMSetSelectedAction;
+  setHeaderContent: KVMSetHeaderContent;
 };
 
-const KVMConfiguration = ({ id, setSelectedAction }: Props): JSX.Element => {
+const KVMConfiguration = ({ id, setHeaderContent }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, id)
@@ -144,7 +143,7 @@ const KVMConfiguration = ({ id, setSelectedAction }: Props): JSX.Element => {
                 <Button
                   appearance="neutral"
                   data-test="remove-kvm"
-                  onClick={() => setSelectedAction(PodAction.DELETE)}
+                  onClick={() => setHeaderContent(PodAction.DELETE)}
                 >
                   Remove KVM
                 </Button>

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
@@ -54,7 +54,7 @@ describe("KVMConfigurationFields", () => {
             exact
             path="/kvm/:id/edit"
             component={() => (
-              <KVMConfiguration id={1} setSelectedAction={jest.fn()} />
+              <KVMConfiguration id={1} setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>
@@ -98,7 +98,7 @@ describe("KVMConfigurationFields", () => {
             exact
             path="/kvm/:id/edit"
             component={() => (
-              <KVMConfiguration id={1} setSelectedAction={jest.fn()} />
+              <KVMConfiguration id={1} setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -16,20 +16,14 @@ import KVMResources from "./KVMResources";
 import LxdProject from "./LxdProject";
 
 import Section from "app/base/components/Section";
-import type { RouteParams, SetSelectedAction } from "app/base/types";
+import type { RouteParams } from "app/base/types";
+import type { KVMHeaderContent, SetSearchFilter } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
-import type { MachineSelectedAction } from "app/machines/views/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import type { PodAction } from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
-
-export type KVMSelectedAction = PodAction | MachineSelectedAction;
-
-export type KVMSetSelectedAction = SetSelectedAction<KVMSelectedAction>;
-export type SetSearchFilter = (searchFilter: string) => void;
 
 const KVMDetails = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -46,8 +40,9 @@ const KVMDetails = (): JSX.Element => {
   const [searchFilter, setFilter] = useState<string>(
     FilterMachines.filtersToString(currentFilters)
   );
-  const [selectedAction, setSelectedAction] =
-    useState<KVMSelectedAction | null>(null);
+  const [headerContent, setHeaderContent] = useState<KVMHeaderContent | null>(
+    null
+  );
 
   useEffect(() => {
     dispatch(podActions.get(id));
@@ -76,8 +71,8 @@ const KVMDetails = (): JSX.Element => {
       header={
         <KVMDetailsHeader
           id={id}
-          selectedAction={selectedAction}
-          setSelectedAction={setSelectedAction}
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
         />
       }
       headerClassName="u-no-padding--bottom"
@@ -90,7 +85,7 @@ const KVMDetails = (): JSX.Element => {
                 id={id}
                 searchFilter={searchFilter}
                 setSearchFilter={setSearchFilter}
-                setSelectedAction={setSelectedAction}
+                setHeaderContent={setHeaderContent}
               />
             </Route>
           )}
@@ -98,7 +93,7 @@ const KVMDetails = (): JSX.Element => {
             <KVMResources id={id} />
           </Route>
           <Route exact path={kvmURLs.edit(null, true)}>
-            <KVMConfiguration id={id} setSelectedAction={setSelectedAction} />
+            <KVMConfiguration id={id} setHeaderContent={setHeaderContent} />
           </Route>
           <Redirect
             from={kvmURLs.details(null, true)}

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -52,8 +52,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -71,8 +71,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -95,8 +95,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={PodAction.COMPOSE}
-            setSelectedAction={jest.fn()}
+            headerContent={PodAction.COMPOSE}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -124,8 +124,8 @@ describe("KVMDetailsHeader", () => {
         >
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -147,8 +147,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -169,8 +169,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -191,8 +191,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -213,8 +213,8 @@ describe("KVMDetailsHeader", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMDetailsHeader
             id={1}
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -5,11 +5,10 @@ import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
-import type { KVMSelectedAction, KVMSetSelectedAction } from "../KVMDetails";
-
 import SectionHeader from "app/base/components/SectionHeader";
 import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
+import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import { getActionTitle as getPodActionTitle } from "app/kvm/utils";
 import { getActionTitle as getMachineActionTitle } from "app/machines/utils";
 import { actions as podActions } from "app/store/pod";
@@ -20,28 +19,28 @@ import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Pod["id"];
-  selectedAction: KVMSelectedAction | null;
-  setSelectedAction: KVMSetSelectedAction;
+  headerContent: KVMHeaderContent | null;
+  setHeaderContent: KVMSetHeaderContent;
 };
 
-const getActionTitle = (selectedAction: KVMSelectedAction) => {
+const getActionTitle = (headerContent: KVMHeaderContent) => {
   // This is a reliable of differentiating a machine action from a pod action,
   // but we should eventually try to have a consistent shape between them.
   // https://github.com/canonical-web-and-design/maas-ui/issues/3017
   if (
-    selectedAction &&
-    typeof selectedAction === "object" &&
-    "name" in selectedAction
+    headerContent &&
+    typeof headerContent === "object" &&
+    "name" in headerContent
   ) {
-    return getMachineActionTitle(selectedAction.name);
+    return getMachineActionTitle(headerContent.name);
   }
-  return getPodActionTitle(selectedAction);
+  return getPodActionTitle(headerContent);
 };
 
 const KVMDetailsHeader = ({
   id,
-  selectedAction,
-  setSelectedAction,
+  headerContent,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -59,30 +58,27 @@ const KVMDetailsHeader = ({
   // Close the action form if the pathname changes.
   useEffect(() => {
     if (previousPathname && pathname !== previousPathname) {
-      setSelectedAction(null);
+      setHeaderContent(null);
     }
-  }, [pathname, previousPathname, setSelectedAction]);
+  }, [pathname, previousPathname, setHeaderContent]);
 
   return (
     <SectionHeader
       buttons={
-        !selectedAction && pod?.type !== PodType.LXD
+        !headerContent && pod?.type !== PodType.LXD
           ? [
               <PodDetailsActionMenu
                 key="action-dropdown"
-                setSelectedAction={setSelectedAction}
+                setHeaderContent={setHeaderContent}
               />,
             ]
           : undefined
       }
-      formWrapper={
-        (selectedAction && (
-          <KVMActionFormWrapper
-            selectedAction={selectedAction}
-            setSelectedAction={setSelectedAction}
-          />
-        )) ||
-        undefined
+      headerContent={
+        <KVMActionFormWrapper
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
+        />
       }
       subtitle={`${vmCount} VM${vmCount === 1 ? "" : "s"} available`}
       tabLinks={[
@@ -117,9 +113,9 @@ const KVMDetailsHeader = ({
               className="p-heading--four u-no-margin--bottom"
               data-test="kvm-details-title"
             >
-              {selectedAction ? getActionTitle(selectedAction) : pod.name}
+              {headerContent ? getActionTitle(headerContent) : pod.name}
             </h1>
-            {!selectedAction && (
+            {!headerContent && (
               <p
                 className="u-text--muted u-no-margin--bottom u-no-padding--top"
                 data-test="pod-address"

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.test.tsx
@@ -32,7 +32,7 @@ describe("LxdProject", () => {
             id={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -58,7 +58,7 @@ describe("LxdProject", () => {
             id={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -84,7 +84,7 @@ describe("LxdProject", () => {
             id={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -113,7 +113,7 @@ describe("LxdProject", () => {
             id={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
@@ -6,11 +6,8 @@ import ProjectSummaryCard from "./ProjectSummaryCard";
 import ProjectVMs from "./ProjectVMs";
 
 import { useWindowTitle } from "app/base/hooks";
+import type { KVMSetHeaderContent, SetSearchFilter } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
-import type {
-  KVMSetSelectedAction,
-  SetSearchFilter,
-} from "app/kvm/views/KVMDetails";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
@@ -20,14 +17,14 @@ type Props = {
   id: Pod["id"];
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
-  setSelectedAction: KVMSetSelectedAction;
+  setHeaderContent: KVMSetHeaderContent;
 };
 
 const LxdProject = ({
   id,
   searchFilter,
   setSearchFilter,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
@@ -62,7 +59,7 @@ const LxdProject = ({
         id={id}
         searchFilter={searchFilter}
         setSearchFilter={setSearchFilter}
-        setSelectedAction={setSelectedAction}
+        setHeaderContent={setHeaderContent}
       />
     </>
   );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.test.tsx
@@ -32,7 +32,7 @@ describe("ProjectVMs", () => {
             id={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -60,7 +60,7 @@ describe("ProjectVMs", () => {
             id={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
@@ -6,10 +6,7 @@ import { useDispatch } from "react-redux";
 import VMsActionBar from "./VMsActionBar";
 import VMsTable from "./VMsTable";
 
-import type {
-  KVMSetSelectedAction,
-  SetSearchFilter,
-} from "app/kvm/views/KVMDetails";
+import type { KVMSetHeaderContent, SetSearchFilter } from "app/kvm/types";
 import { actions as machineActions } from "app/store/machine";
 import type { Pod } from "app/store/pod/types";
 
@@ -17,7 +14,7 @@ type Props = {
   id: Pod["id"];
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
-  setSelectedAction: KVMSetSelectedAction;
+  setHeaderContent: KVMSetHeaderContent;
 };
 
 export const VMS_PER_PAGE = 10;
@@ -26,7 +23,7 @@ const ProjectVMs = ({
   id,
   searchFilter,
   setSearchFilter,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(1);
@@ -48,7 +45,7 @@ const ProjectVMs = ({
         searchFilter={searchFilter}
         setCurrentPage={setCurrentPage}
         setSearchFilter={setSearchFilter}
-        setSelectedAction={setSelectedAction}
+        setHeaderContent={setHeaderContent}
       />
       <Strip shallow>
         <VMsTable

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
@@ -17,7 +17,7 @@ const mockStore = configureStore();
 
 describe("VMsActionBar", () => {
   it("can open the 'Compose VM' form", () => {
-    const setSelectedAction = jest.fn();
+    const setHeaderContent = jest.fn();
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [podFactory({ id: 1 })],
@@ -32,18 +32,18 @@ describe("VMsActionBar", () => {
           searchFilter=""
           setCurrentPage={jest.fn()}
           setSearchFilter={jest.fn()}
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />
       </Provider>
     );
 
     wrapper.find("button[data-test='compose-vm']").simulate("click");
 
-    expect(setSelectedAction).toHaveBeenCalledWith(PodAction.COMPOSE);
+    expect(setHeaderContent).toHaveBeenCalledWith(PodAction.COMPOSE);
   });
 
   it("can open the 'Refresh KVM' form", () => {
-    const setSelectedAction = jest.fn();
+    const setHeaderContent = jest.fn();
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [podFactory({ id: 1 })],
@@ -58,14 +58,14 @@ describe("VMsActionBar", () => {
           searchFilter=""
           setCurrentPage={jest.fn()}
           setSearchFilter={jest.fn()}
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />
       </Provider>
     );
 
     wrapper.find("button[data-test='refresh-kvm']").simulate("click");
 
-    expect(setSelectedAction).toHaveBeenCalledWith(PodAction.REFRESH);
+    expect(setHeaderContent).toHaveBeenCalledWith(PodAction.REFRESH);
   });
 
   it("disables VM actions if none are selected", () => {
@@ -86,7 +86,7 @@ describe("VMsActionBar", () => {
           searchFilter=""
           setCurrentPage={jest.fn()}
           setSearchFilter={jest.fn()}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );
@@ -120,7 +120,7 @@ describe("VMsActionBar", () => {
           searchFilter=""
           setCurrentPage={jest.fn()}
           setSearchFilter={jest.fn()}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -4,10 +4,7 @@ import { useSelector } from "react-redux";
 import { VMS_PER_PAGE } from "../ProjectVMs";
 
 import ArrowPagination from "app/base/components/ArrowPagination";
-import type {
-  KVMSetSelectedAction,
-  SetSearchFilter,
-} from "app/kvm/views/KVMDetails";
+import type { KVMSetHeaderContent, SetSearchFilter } from "app/kvm/types";
 import VmActionMenu from "app/machines/components/TakeActionMenu";
 import machineSelectors from "app/store/machine/selectors";
 import podSelectors from "app/store/pod/selectors";
@@ -22,7 +19,7 @@ type Props = {
   searchFilter: string;
   setCurrentPage: (page: number) => void;
   setSearchFilter: SetSearchFilter;
-  setSelectedAction: KVMSetSelectedAction;
+  setHeaderContent: KVMSetHeaderContent;
 };
 
 const VMsActionBar = ({
@@ -31,7 +28,7 @@ const VMsActionBar = ({
   searchFilter,
   setCurrentPage,
   setSearchFilter,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element | null => {
   const loading = useSelector(machineSelectors.loading);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
@@ -47,7 +44,7 @@ const VMsActionBar = ({
           className="u-no-margin--bottom"
           data-test="compose-vm"
           hasIcon
-          onClick={() => setSelectedAction(PodAction.COMPOSE)}
+          onClick={() => setHeaderContent(PodAction.COMPOSE)}
         >
           <Icon name="plus" />
           <span>Compose VM</span>
@@ -56,7 +53,7 @@ const VMsActionBar = ({
           appearance="vmTable"
           data-test="vm-actions"
           excludeActions={[NodeActions.DELETE]}
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />
         <span className="u-nudge-right">
           <Button
@@ -64,7 +61,7 @@ const VMsActionBar = ({
             appearance="base"
             data-test="refresh-kvm"
             hasIcon
-            onClick={() => setSelectedAction(PodAction.REFRESH)}
+            onClick={() => setHeaderContent(PodAction.REFRESH)}
             small
           >
             <Icon name="restart" />
@@ -81,7 +78,7 @@ const VMsActionBar = ({
             data-test="delete-vm"
             disabled={vmActionsDisabled}
             hasIcon
-            onClick={() => setSelectedAction({ name: NodeActions.DELETE })}
+            onClick={() => setHeaderContent({ name: NodeActions.DELETE })}
             small
           >
             <Icon name="delete" />

--- a/ui/src/app/kvm/views/KVMDetails/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/index.ts
@@ -1,6 +1,1 @@
 export { default } from "./KVMDetails";
-export type {
-  KVMSelectedAction,
-  KVMSetSelectedAction,
-  SetSearchFilter,
-} from "./KVMDetails";

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -92,10 +92,10 @@ describe("ActionFormWrapper", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <ActionFormWrapper
-            selectedAction={{
+            headerContent={{
               name: NodeActions.COMMISSION,
             }}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -130,10 +130,10 @@ describe("ActionFormWrapper", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <ActionFormWrapper
-            selectedAction={{
+            headerContent={{
               name: NodeActions.COMMISSION,
             }}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>,
@@ -161,10 +161,10 @@ describe("ActionFormWrapper", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <ActionFormWrapper
-            selectedAction={{
+            headerContent={{
               name: NodeActions.COMMISSION,
             }}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -18,17 +18,17 @@ import TestForm from "./TestForm";
 
 import { useScrollOnRender } from "app/base/hooks";
 import { useMachineActionForm } from "app/machines/hooks";
-import { canOpenActionForm } from "app/machines/utils";
 import type {
-  MachineSelectedAction,
-  MachineSetSelectedAction,
-} from "app/machines/views/types";
+  MachineHeaderContent,
+  MachineSetHeaderContent,
+} from "app/machines/types";
+import { canOpenActionForm } from "app/machines/utils";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
 
-const getErrorSentence = (action: MachineSelectedAction, count: number) => {
+const getErrorSentence = (action: MachineHeaderContent, count: number) => {
   const machineString = pluralize("machine", count, true);
 
   switch (action.name) {
@@ -78,24 +78,24 @@ const getErrorSentence = (action: MachineSelectedAction, count: number) => {
 };
 
 type Props = {
-  selectedAction: MachineSelectedAction;
-  setSelectedAction: MachineSetSelectedAction;
+  headerContent: MachineHeaderContent;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 export const ActionFormWrapper = ({
-  selectedAction,
-  setSelectedAction,
+  headerContent,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const activeMachineId = useSelector(machineSelectors.activeID);
   const { machinesToAction, processingCount } = useMachineActionForm(
-    selectedAction.name
+    headerContent.name
   );
-  const actionableMachineIDs = selectedAction
+  const actionableMachineIDs = headerContent
     ? machinesToAction.reduce<Machine[MachineMeta.PK][]>(
         (machineIDs, machine) => {
-          if (canOpenActionForm(machine, selectedAction?.name)) {
+          if (canOpenActionForm(machine, headerContent?.name)) {
             machineIDs.push(machine.system_id);
           }
           return machineIDs;
@@ -110,98 +110,98 @@ export const ActionFormWrapper = ({
     !activeMachineId &&
     processingCount === 0 &&
     actionableMachineIDs.length !== machinesToAction.length;
-  const clearSelectedAction = useCallback(
-    () => setSelectedAction(null),
-    [setSelectedAction]
+  const clearHeaderContent = useCallback(
+    () => setHeaderContent(null),
+    [setHeaderContent]
   );
 
   useEffect(() => {
     if (machinesToAction.length === 0) {
       // All the machines were deselected so close the form.
-      clearSelectedAction();
+      clearHeaderContent();
     }
-  }, [machinesToAction, clearSelectedAction]);
+  }, [machinesToAction, clearHeaderContent]);
 
   const getFormComponent = () => {
-    if (selectedAction && selectedAction.name) {
-      switch (selectedAction.name) {
+    if (headerContent && headerContent.name) {
+      switch (headerContent.name) {
         case NodeActions.CLONE:
           return (
             <CloneForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.COMMISSION:
           return (
             <CommissionForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.DEPLOY:
           return (
             <DeployForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.MARK_BROKEN:
           return (
             <MarkBrokenForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.OVERRIDE_FAILED_TESTING:
           return (
             <OverrideTestForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.RELEASE:
           return (
             <ReleaseForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.SET_POOL:
           return (
             <SetPoolForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.SET_ZONE:
           return (
             <SetZoneForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.TAG:
           return (
             <TagForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
+              clearHeaderContent={clearHeaderContent}
             />
           );
         case NodeActions.TEST:
           return (
             <TestForm
               actionDisabled={actionDisabled}
-              clearSelectedAction={clearSelectedAction}
-              {...selectedAction.extras}
+              clearHeaderContent={clearHeaderContent}
+              {...headerContent.extras}
             />
           );
         default:
           return (
             <FieldlessForm
               actionDisabled={actionDisabled}
-              selectedAction={selectedAction}
-              clearSelectedAction={clearSelectedAction}
+              headerContent={headerContent}
+              clearHeaderContent={clearHeaderContent}
             />
           );
       }
@@ -216,7 +216,7 @@ export const ActionFormWrapper = ({
           <i className="p-icon--warning" />
           <span className="u-nudge-right--small">
             {getErrorSentence(
-              selectedAction,
+              headerContent,
               machinesToAction.length - actionableMachineIDs.length
             )}
             . To proceed,{" "}

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -53,7 +53,7 @@ describe("CloneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneForm clearSelectedAction={jest.fn()} />
+          <CloneForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +94,7 @@ describe("CloneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneForm clearSelectedAction={jest.fn()} />
+          <CloneForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -133,7 +133,7 @@ describe("CloneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneForm clearSelectedAction={jest.fn()} />
+          <CloneForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -182,7 +182,7 @@ describe("CloneForm", () => {
           <Route
             exact
             path="/machine/:id"
-            component={() => <CloneForm clearSelectedAction={jest.fn()} />}
+            component={() => <CloneForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -8,7 +8,7 @@ import CloneFormFields from "./CloneFormFields";
 import CloneResults from "./CloneResults";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineDetails } from "app/store/machine/types";
@@ -16,7 +16,7 @@ import { NodeActions } from "app/store/types/node";
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export type CloneFormValues = {
@@ -48,7 +48,7 @@ const CloneFormSchema = Yup.object()
 
 export const CloneForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [selectedMachine, setSelectedMachine] = useState<MachineDetails | null>(
@@ -70,7 +70,7 @@ export const CloneForm = ({
 
   return showResults ? (
     <CloneResults
-      closeForm={clearSelectedAction}
+      closeForm={clearHeaderContent}
       destinations={destinations}
       sourceMachine={selectedMachine}
     />
@@ -94,7 +94,7 @@ export const CloneForm = ({
           </Link>
         </p>
       }
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       initialValues={{
         interfaces: false,
         source: "",

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -83,7 +83,7 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CommissionForm clearSelectedAction={jest.fn()} />
+          <CommissionForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -102,7 +102,7 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CommissionForm clearSelectedAction={jest.fn()} />
+          <CommissionForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -193,7 +193,7 @@ describe("CommissionForm", () => {
           <Route
             exact
             path="/machine/:id"
-            component={() => <CommissionForm clearSelectedAction={jest.fn()} />}
+            component={() => <CommissionForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -8,7 +8,7 @@ import CommissionFormFields from "./CommissionFormFields";
 import type { CommissionFormValues, FormattedScript } from "./types";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -50,12 +50,12 @@ type ScriptInput = {
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export const CommissionForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -104,7 +104,7 @@ export const CommissionForm = ({
       actionName={NodeActions.COMMISSION}
       allowUnchanged
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         enableSSH: false,
@@ -168,7 +168,7 @@ export const CommissionForm = ({
 };
 
 CommissionForm.propTypes = {
-  clearSelectedAction: PropTypes.func.isRequired,
+  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default CommissionForm;

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
@@ -74,7 +74,7 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <CommissionForm clearSelectedAction={jest.fn()} />
+          <CommissionForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -119,7 +119,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -144,7 +144,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -212,7 +212,7 @@ describe("DeployForm", () => {
           <Route
             exact
             path="/machine/:id"
-            component={() => <DeployForm clearSelectedAction={jest.fn()} />}
+            component={() => <DeployForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -260,7 +260,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -308,7 +308,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -359,7 +359,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -393,7 +393,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -421,7 +421,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -8,7 +8,7 @@ import DeployFormFields from "./DeployFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
 import { useSendAnalytics } from "app/base/hooks";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as generalActions } from "app/store/general";
 import {
@@ -40,12 +40,12 @@ export type DeployFormValues = {
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export const DeployForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -90,7 +90,7 @@ export const DeployForm = ({
       actionName={NodeActions.DEPLOY}
       allowUnchanged={osystems?.length !== 0 && releases?.length !== 0}
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         oSystem: initialOS,
@@ -141,7 +141,7 @@ export const DeployForm = ({
 };
 
 DeployForm.propTypes = {
-  clearSelectedAction: PropTypes.func.isRequired,
+  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default DeployForm;

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -138,7 +138,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -156,7 +156,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -172,7 +172,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -192,7 +192,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -230,7 +230,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -270,7 +270,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -294,7 +294,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -314,7 +314,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -341,7 +341,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -366,7 +366,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -150,7 +150,7 @@ describe("DeployFormFields", () => {
     wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DeployForm clearSelectedAction={jest.fn()} />
+          <DeployForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.test.tsx
@@ -91,8 +91,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.ON }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.ON }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -108,22 +108,22 @@ describe("FieldlessForm", () => {
     state.machine.selected = ["a"];
     state.machine.statuses = { a: machineStatusFactory() };
     const store = mockStore(state);
-    const clearSelectedAction = jest.fn();
+    const clearHeaderContent = jest.fn();
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.ON }}
-            clearSelectedAction={clearSelectedAction}
+            headerContent={{ name: NodeActions.ON }}
+            clearHeaderContent={clearHeaderContent}
           />
         </MemoryRouter>
       </Provider>
     );
     wrapper.find('[data-test="cancel-action"] button').simulate("click");
 
-    expect(clearSelectedAction).toHaveBeenCalled();
+    expect(clearHeaderContent).toHaveBeenCalled();
   });
 
   it("can dispatch abort action on selected machines", () => {
@@ -139,8 +139,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.ABORT }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.ABORT }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -182,8 +182,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.ABORT }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.ABORT }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -225,8 +225,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.ACQUIRE }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.ACQUIRE }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -268,8 +268,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.ACQUIRE }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.ACQUIRE }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -315,8 +315,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.EXIT_RESCUE_MODE }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.EXIT_RESCUE_MODE }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -358,8 +358,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.EXIT_RESCUE_MODE }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.EXIT_RESCUE_MODE }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -402,8 +402,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.LOCK }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.LOCK }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -445,8 +445,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.LOCK }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.LOCK }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -492,8 +492,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.MARK_FIXED }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.MARK_FIXED }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -535,8 +535,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.MARK_FIXED }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.MARK_FIXED }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -579,8 +579,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.OFF }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.OFF }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -622,8 +622,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.OFF }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.OFF }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -666,8 +666,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.ON }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.ON }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -709,8 +709,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.ON }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.ON }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -753,8 +753,8 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: NodeActions.UNLOCK }}
-            clearSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.UNLOCK }}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -796,8 +796,8 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: NodeActions.UNLOCK }}
-                clearSelectedAction={jest.fn()}
+                headerContent={{ name: NodeActions.UNLOCK }}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -835,15 +835,15 @@ describe("FieldlessForm", () => {
       ];
       state.machine.selected = ["abc123"];
       const store = mockStore(state);
-      const clearSelectedAction = jest.fn();
+      const clearHeaderContent = jest.fn();
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
             <FieldlessForm
-              selectedAction={{ name: NodeActions.DELETE }}
-              clearSelectedAction={clearSelectedAction}
+              headerContent={{ name: NodeActions.DELETE }}
+              clearHeaderContent={clearHeaderContent}
             />
           </MemoryRouter>
         </Provider>
@@ -864,8 +864,8 @@ describe("FieldlessForm", () => {
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
             <FieldlessForm
-              selectedAction={{ name: NodeActions.DELETE }}
-              clearSelectedAction={jest.fn()}
+              headerContent={{ name: NodeActions.DELETE }}
+              clearHeaderContent={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -907,8 +907,8 @@ describe("FieldlessForm", () => {
               path="/machine/:id"
               component={() => (
                 <FieldlessForm
-                  selectedAction={{ name: NodeActions.DELETE }}
-                  clearSelectedAction={jest.fn()}
+                  headerContent={{ name: NodeActions.DELETE }}
+                  clearHeaderContent={jest.fn()}
                 />
               )}
             />
@@ -953,8 +953,8 @@ describe("FieldlessForm", () => {
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
             <FieldlessForm
-              selectedAction={{ name: NodeActions.DELETE }}
-              clearSelectedAction={jest.fn()}
+              headerContent={{ name: NodeActions.DELETE }}
+              clearHeaderContent={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -984,8 +984,8 @@ describe("FieldlessForm", () => {
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
             <FieldlessForm
-              selectedAction={{ name: NodeActions.DELETE }}
-              clearSelectedAction={jest.fn()}
+              headerContent={{ name: NodeActions.DELETE }}
+              clearHeaderContent={jest.fn()}
             />
           </MemoryRouter>
         </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction, EmptyObject } from "app/base/types";
+import type { ClearHeaderContent, EmptyObject } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
+import type { MachineHeaderContent } from "app/machines/types";
 import machineURLs from "app/machines/urls";
-import type { MachineSelectedAction } from "app/machines/views/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineEventErrors } from "app/store/machine/types/base";
@@ -32,23 +32,23 @@ const fieldlessActions = [
 
 type Props = {
   actionDisabled?: boolean;
-  selectedAction: MachineSelectedAction;
-  clearSelectedAction: ClearSelectedAction;
+  headerContent: MachineHeaderContent;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export const FieldlessForm = ({
   actionDisabled,
-  selectedAction,
-  clearSelectedAction,
+  headerContent,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const { errors, machinesToAction, processingCount } = useMachineActionForm(
-    selectedAction.name
+    headerContent.name
   );
   const isDeletingMachine =
     activeMachine &&
-    selectedAction.name === NodeActions.DELETE &&
+    headerContent.name === NodeActions.DELETE &&
     processingCount === 1;
   const previousIsDeletingMachine = usePrevious(isDeletingMachine, false);
   // Check if the machine cycled from deleting to not deleting and didn't
@@ -61,21 +61,21 @@ export const FieldlessForm = ({
   return (
     <ActionForm<EmptyObject, MachineEventErrors>
       actionDisabled={actionDisabled}
-      actionName={selectedAction.name}
+      actionName={headerContent.name}
       allowUnchanged
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{}}
       modelName="machine"
       onSaveAnalytics={{
         action: "Submit",
         category: `Machine ${activeMachine ? "details" : "list"} action form`,
-        label: selectedAction.name,
+        label: headerContent.name,
       }}
       onSubmit={() => {
-        if (fieldlessActions.includes(selectedAction.name)) {
-          const actionMethod = kebabToCamelCase(selectedAction.name);
+        if (fieldlessActions.includes(headerContent.name)) {
+          const actionMethod = kebabToCamelCase(headerContent.name);
           // Find the method for the function.
           const [, actionFunction] =
             Object.entries(machineActions).find(
@@ -91,7 +91,7 @@ export const FieldlessForm = ({
       processingCount={processingCount}
       selectedCount={machinesToAction.length}
       submitAppearance={
-        selectedAction.name === NodeActions.DELETE ? "negative" : "positive"
+        headerContent.name === NodeActions.DELETE ? "negative" : "positive"
       }
     />
   );

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`FieldlessForm renders 1`] = `
 <FieldlessForm
-  clearSelectedAction={[MockFunction]}
-  selectedAction={
+  clearHeaderContent={[MockFunction]}
+  headerContent={
     Object {
       "name": "on",
     }
@@ -13,7 +13,7 @@ exports[`FieldlessForm renders 1`] = `
     actionName="on"
     allowUnchanged={true}
     cleanup={[Function]}
-    clearSelectedAction={[MockFunction]}
+    clearHeaderContent={[MockFunction]}
     initialValues={Object {}}
     modelName="machine"
     onSaveAnalytics={

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -58,7 +58,7 @@ describe("MarkBrokenForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MarkBrokenForm clearSelectedAction={jest.fn()} />
+          <MarkBrokenForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -113,7 +113,7 @@ describe("MarkBrokenForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MarkBrokenForm clearSelectedAction={jest.fn()} />
+          <MarkBrokenForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -157,7 +157,7 @@ describe("MarkBrokenForm", () => {
           <Route
             exact
             path="/machine/:id"
-            component={() => <MarkBrokenForm clearSelectedAction={jest.fn()} />}
+            component={() => <MarkBrokenForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -7,7 +7,7 @@ import * as Yup from "yup";
 import MarkBrokenFormFields from "./MarkBrokenFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -24,12 +24,12 @@ type MarkBrokenFormValues = {
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export const MarkBrokenForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -50,7 +50,7 @@ export const MarkBrokenForm = ({
       actionName={NodeActions.MARK_BROKEN}
       allowAllEmpty
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         comment: "",
@@ -81,7 +81,7 @@ export const MarkBrokenForm = ({
 };
 
 MarkBrokenForm.propTypes = {
-  clearSelectedAction: PropTypes.func.isRequired,
+  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default MarkBrokenForm;

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -100,7 +100,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -127,7 +127,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -152,7 +152,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -177,7 +177,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -199,7 +199,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -259,7 +259,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -284,7 +284,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -317,7 +317,7 @@ describe("OverrideTestForm", () => {
         >
           <OverrideTestForm
             actionDisabled={false}
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -379,7 +379,7 @@ describe("OverrideTestForm", () => {
             component={() => (
               <OverrideTestForm
                 actionDisabled={false}
-                clearSelectedAction={jest.fn()}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -432,7 +432,7 @@ describe("OverrideTestForm", () => {
             component={() => (
               <OverrideTestForm
                 actionDisabled={false}
-                clearSelectedAction={jest.fn()}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -9,7 +9,7 @@ import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import machineURLs from "app/machines/urls";
 import { actions as machineActions } from "app/store/machine";
@@ -23,7 +23,7 @@ import { NodeActions } from "app/store/types/node";
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export type OverrideTestFormValues = {
@@ -79,7 +79,7 @@ const OverrideTestFormSchema = Yup.object().shape({
 
 export const OverrideTestForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [requestedScriptResults, setRequestedScriptResults] = useState<
@@ -129,7 +129,7 @@ export const OverrideTestForm = ({
       actionName={NodeActions.OVERRIDE_FAILED_TESTING}
       allowUnchanged
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         suppressResults: false,
@@ -220,7 +220,7 @@ export const OverrideTestForm = ({
 };
 
 OverrideTestForm.propTypes = {
-  clearSelectedAction: PropTypes.func.isRequired,
+  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default OverrideTestForm;

--- a/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
@@ -76,7 +76,7 @@ describe("ReleaseForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReleaseForm clearSelectedAction={jest.fn()} />
+          <ReleaseForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +94,7 @@ describe("ReleaseForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReleaseForm clearSelectedAction={jest.fn()} />
+          <ReleaseForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -161,7 +161,7 @@ describe("ReleaseForm", () => {
           <Route
             exact
             path="/machine/:id"
-            component={() => <ReleaseForm clearSelectedAction={jest.fn()} />}
+            component={() => <ReleaseForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -8,7 +8,7 @@ import * as Yup from "yup";
 import ReleaseFormFields from "./ReleaseFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
@@ -31,12 +31,12 @@ const ReleaseSchema = Yup.object().shape({
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export const ReleaseForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -61,7 +61,7 @@ export const ReleaseForm = ({
       actionName={NodeActions.RELEASE}
       allowAllEmpty
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         enableErase: enableErase || false,
@@ -101,7 +101,7 @@ export const ReleaseForm = ({
 };
 
 ReleaseForm.propTypes = {
-  clearSelectedAction: PropTypes.func.isRequired,
+  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default ReleaseForm;

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
@@ -74,7 +74,7 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+          <SetPoolForm actionDisabled={false} clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -92,7 +92,7 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+          <SetPoolForm actionDisabled={false} clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -157,7 +157,7 @@ describe("SetPoolForm", () => {
             component={() => (
               <SetPoolForm
                 actionDisabled={false}
-                clearSelectedAction={jest.fn()}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />
@@ -203,7 +203,7 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+          <SetPoolForm actionDisabled={false} clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -7,7 +7,7 @@ import SetPoolFormFields from "./SetPoolFormFields";
 import type { SetPoolFormValues } from "./types";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -18,7 +18,7 @@ import { NodeActions } from "app/store/types/node";
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 const SetPoolSchema = Yup.object().shape({
@@ -29,7 +29,7 @@ const SetPoolSchema = Yup.object().shape({
 
 export const SetPoolForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [initialValues, setInitialValues] = useState<SetPoolFormValues>({
@@ -66,7 +66,7 @@ export const SetPoolForm = ({
       actionDisabled={actionDisabled}
       actionName={NodeActions.SET_POOL}
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={initialValues}
       loaded={resourcePoolsLoaded}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
@@ -51,7 +51,7 @@ describe("SetPoolFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm clearSelectedAction={jest.fn()} />
+          <SetPoolForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -71,7 +71,7 @@ describe("SetPoolFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm clearSelectedAction={jest.fn()} />
+          <SetPoolForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.test.tsx
@@ -73,7 +73,7 @@ describe("SetZoneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetZoneForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+          <SetZoneForm actionDisabled={false} clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -136,7 +136,7 @@ describe("SetZoneForm", () => {
             component={() => (
               <SetZoneForm
                 actionDisabled={false}
-                clearSelectedAction={jest.fn()}
+                clearHeaderContent={jest.fn()}
               />
             )}
           />

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
@@ -6,7 +6,7 @@ import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
 import ZoneSelect from "app/base/components/ZoneSelect";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -18,7 +18,7 @@ import type { Zone } from "app/store/zone/types";
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export type SetZoneFormValues = {
@@ -31,7 +31,7 @@ const SetZoneSchema = Yup.object().shape({
 
 export const SetZoneForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -50,7 +50,7 @@ export const SetZoneForm = ({
       actionDisabled={actionDisabled}
       actionName={NodeActions.SET_ZONE}
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{ zone: "" }}
       loaded={zonesLoaded}

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -57,7 +57,7 @@ describe("TagForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TagForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+          <TagForm actionDisabled={false} clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -76,7 +76,7 @@ describe("TagForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TagForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+          <TagForm actionDisabled={false} clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -138,7 +138,7 @@ describe("TagForm", () => {
             exact
             path="/machine/:id"
             component={() => (
-              <TagForm actionDisabled={false} clearSelectedAction={jest.fn()} />
+              <TagForm actionDisabled={false} clearHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.tsx
@@ -6,7 +6,7 @@ import * as Yup from "yup";
 import TagFormFields from "./TagFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -16,7 +16,7 @@ import { NodeActions } from "app/store/types/node";
 
 type Props = {
   actionDisabled?: boolean;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export type TagFormValues = {
@@ -32,7 +32,7 @@ const TagFormSchema = Yup.object().shape({
 
 export const TagForm = ({
   actionDisabled,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -62,7 +62,7 @@ export const TagForm = ({
       actionDisabled={actionDisabled}
       actionName={NodeActions.TAG}
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={formErrors}
       initialValues={initialValues}
       loaded={tagsLoaded}

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -45,7 +45,7 @@ describe("TagFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TagForm clearSelectedAction={jest.fn()} />
+          <TagForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -90,7 +90,7 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TestForm clearSelectedAction={jest.fn()} />
+          <TestForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -181,7 +181,7 @@ describe("TestForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <TestForm
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
             hardwareType={HardwareType.Network}
           />
         </MemoryRouter>
@@ -224,7 +224,7 @@ describe("TestForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <TestForm
-            clearSelectedAction={jest.fn()}
+            clearHeaderContent={jest.fn()}
             applyConfiguredNetworking={true}
           />
         </MemoryRouter>
@@ -254,7 +254,7 @@ describe("TestForm", () => {
           <Route
             exact
             path="/machine/:id"
-            component={() => <TestForm clearSelectedAction={jest.fn()} />}
+            component={() => <TestForm clearHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -7,7 +7,7 @@ import TestFormFields from "./TestFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
 import type { HardwareType } from "app/base/enum";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearHeaderContent } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -45,14 +45,14 @@ type Props = {
   actionDisabled?: boolean;
   applyConfiguredNetworking?: Script["apply_configured_networking"];
   hardwareType?: HardwareType;
-  clearSelectedAction: ClearSelectedAction;
+  clearHeaderContent: ClearHeaderContent;
 };
 
 export const TestForm = ({
   actionDisabled,
   applyConfiguredNetworking,
   hardwareType,
-  clearSelectedAction,
+  clearHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -120,7 +120,7 @@ export const TestForm = ({
       actionName={NodeActions.TEST}
       allowUnchanged
       cleanup={machineActions.cleanup}
-      clearSelectedAction={clearSelectedAction}
+      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         enableSSH: false,

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -75,7 +75,7 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <TestForm clearSelectedAction={jest.fn()} />
+          <TestForm clearHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -31,7 +31,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -54,7 +54,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -77,7 +77,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +105,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -139,7 +139,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -182,7 +182,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -212,7 +212,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={jest.fn()} />
+          <TakeActionMenu setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -222,7 +222,7 @@ describe("TakeActionMenu", () => {
     );
   });
 
-  it("fires setSelectedAction function on action button click", () => {
+  it("fires setHeaderContent function on action button click", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
@@ -234,14 +234,14 @@ describe("TakeActionMenu", () => {
         selected: ["abc123"],
       }),
     });
-    const setSelectedAction = jest.fn();
+    const setHeaderContent = jest.fn();
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu setSelectedAction={setSelectedAction} />
+          <TakeActionMenu setHeaderContent={setHeaderContent} />
         </MemoryRouter>
       </Provider>
     );
@@ -249,7 +249,7 @@ describe("TakeActionMenu", () => {
     wrapper
       .find("button[data-test='action-link-commission']")
       .simulate("click");
-    expect(setSelectedAction).toHaveBeenCalledWith({
+    expect(setHeaderContent).toHaveBeenCalledWith({
       name: NodeActions.COMMISSION,
     });
   });
@@ -262,7 +262,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu appearance="default" setSelectedAction={jest.fn()} />
+          <TakeActionMenu appearance="default" setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -290,7 +290,7 @@ describe("TakeActionMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TakeActionMenu appearance="vmTable" setSelectedAction={jest.fn()} />
+          <TakeActionMenu appearance="vmTable" setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -332,7 +332,7 @@ describe("TakeActionMenu", () => {
         >
           <TakeActionMenu
             excludeActions={[NodeActions.DELETE]}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -4,8 +4,8 @@ import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 
 import type { DataTestElement } from "app/base/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import { canOpenActionForm, getActionTitle } from "app/machines/utils";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
@@ -21,7 +21,7 @@ type ActionLink = DataTestElement<ButtonProps>;
 type Props = {
   appearance?: "default" | "vmTable";
   excludeActions?: NodeActions[];
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 const actionGroups: ActionGroup[] = [
@@ -68,7 +68,7 @@ const actionGroups: ActionGroup[] = [
 
 const getTakeActionLinks = (
   machines: Machine[],
-  setSelectedAction: Props["setSelectedAction"],
+  setHeaderContent: Props["setHeaderContent"],
   excludeActions: NodeActions[]
 ) => {
   return actionGroups.reduce<ActionLink[][]>((links, group) => {
@@ -102,7 +102,7 @@ const getTakeActionLinks = (
             "data-test": `action-link-${action}`,
             disabled: count === 0,
             onClick: () => {
-              setSelectedAction({ name: action });
+              setHeaderContent({ name: action });
             },
           });
         }
@@ -121,7 +121,7 @@ const getTakeActionLinks = (
 export const TakeActionMenu = ({
   appearance = "default",
   excludeActions = [],
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const activeMachine = useSelector(machineSelectors.active);
   const selectedMachines = useSelector(machineSelectors.selected);
@@ -156,7 +156,7 @@ export const TakeActionMenu = ({
         hasToggleIcon
         links={getTakeActionLinks(
           machinesToAction,
-          setSelectedAction,
+          setHeaderContent,
           excludeActions
         )}
         position={variations.position}
@@ -170,7 +170,7 @@ export const TakeActionMenu = ({
 };
 
 TakeActionMenu.propTypes = {
-  setSelectedAction: PropTypes.func.isRequired,
+  setHeaderContent: PropTypes.func.isRequired,
 };
 
 export default TakeActionMenu;

--- a/ui/src/app/machines/types.ts
+++ b/ui/src/app/machines/types.ts
@@ -1,9 +1,9 @@
 import type { HardwareType } from "app/base/enum";
-import type { SelectedAction, SetSelectedAction } from "app/base/types";
+import type { HeaderContent, SetHeaderContent } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
 import type { Script } from "app/store/script/types";
 
-export type MachineSelectedAction = SelectedAction<
+export type MachineHeaderContent = HeaderContent<
   MachineAction["name"],
   {
     applyConfiguredNetworking?: Script["apply_configured_networking"];
@@ -11,4 +11,4 @@ export type MachineSelectedAction = SelectedAction<
   }
 >;
 
-export type MachineSetSelectedAction = SetSelectedAction<MachineSelectedAction>;
+export type MachineSetHeaderContent = SetHeaderContent<MachineHeaderContent>;

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -22,8 +22,8 @@ import MachineUSBDevices from "./MachineUSBDevices";
 
 import Section from "app/base/components/Section";
 import type { RouteParams } from "app/base/types";
+import type { MachineHeaderContent } from "app/machines/types";
 import machineURLs from "app/machines/urls";
-import type { MachineSelectedAction } from "app/machines/views/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
@@ -37,8 +37,8 @@ const MachineDetails = (): JSX.Element => {
     machineSelectors.getById(state, id)
   );
   const machinesLoading = useSelector(machineSelectors.loading);
-  const [selectedAction, setSelectedAction] =
-    useState<MachineSelectedAction | null>(null);
+  const [headerContent, setHeaderContent] =
+    useState<MachineHeaderContent | null>(null);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -73,8 +73,8 @@ const MachineDetails = (): JSX.Element => {
     <Section
       header={
         <MachineHeader
-          selectedAction={selectedAction}
-          setSelectedAction={setSelectedAction}
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
           systemId={id}
         />
       }
@@ -84,24 +84,24 @@ const MachineDetails = (): JSX.Element => {
         <Switch>
           <Route exact path={machineURLs.machine.summary(null, true)}>
             <SummaryNotifications id={id} />
-            <MachineSummary setSelectedAction={setSelectedAction} />
+            <MachineSummary setHeaderContent={setHeaderContent} />
           </Route>
           <Route exact path={machineURLs.machine.instances(null, true)}>
             <MachineInstances />
           </Route>
           <Route exact path={machineURLs.machine.network(null, true)}>
             <NetworkNotifications id={id} />
-            <MachineNetwork setSelectedAction={setSelectedAction} />
+            <MachineNetwork setHeaderContent={setHeaderContent} />
           </Route>
           <Route exact path={machineURLs.machine.storage(null, true)}>
             <StorageNotifications id={id} />
             <MachineStorage />
           </Route>
           <Route exact path={machineURLs.machine.pciDevices(null, true)}>
-            <MachinePCIDevices setSelectedAction={setSelectedAction} />
+            <MachinePCIDevices setHeaderContent={setHeaderContent} />
           </Route>
           <Route exact path={machineURLs.machine.usbDevices(null, true)}>
-            <MachineUSBDevices setSelectedAction={setSelectedAction} />
+            <MachineUSBDevices setHeaderContent={setHeaderContent} />
           </Route>
           <Route
             exact

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -45,8 +45,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>
@@ -63,8 +63,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={{ name: NodeActions.DEPLOY }}
-            setSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.DEPLOY }}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>
@@ -84,8 +84,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>
@@ -107,8 +107,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>
@@ -131,8 +131,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>
@@ -154,8 +154,8 @@ describe("MachineHeader", () => {
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
             <MachineHeader
-              selectedAction={null}
-              setSelectedAction={jest.fn()}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -184,8 +184,8 @@ describe("MachineHeader", () => {
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
             <MachineHeader
-              selectedAction={null}
-              setSelectedAction={jest.fn()}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -214,8 +214,8 @@ describe("MachineHeader", () => {
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
             <MachineHeader
-              selectedAction={null}
-              setSelectedAction={jest.fn()}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -250,8 +250,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>
@@ -285,8 +285,8 @@ describe("MachineHeader", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <MachineHeader
-            selectedAction={null}
-            setSelectedAction={jest.fn()}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
             systemId="abc123"
           />
         </MemoryRouter>

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -13,11 +13,11 @@ import TableMenu from "app/base/components/TableMenu";
 import { useMachineActions } from "app/base/hooks";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
-import { getActionTitle } from "app/machines/utils";
 import type {
-  MachineSelectedAction,
-  MachineSetSelectedAction,
-} from "app/machines/views/types";
+  MachineHeaderContent,
+  MachineSetHeaderContent,
+} from "app/machines/types";
+import { getActionTitle } from "app/machines/utils";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
@@ -26,14 +26,14 @@ import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 
 type Props = {
-  selectedAction: MachineSelectedAction | null;
-  setSelectedAction: MachineSetSelectedAction;
+  headerContent: MachineHeaderContent | null;
+  setHeaderContent: MachineSetHeaderContent;
   systemId: Machine["system_id"];
 };
 
 const MachineHeader = ({
-  selectedAction,
-  setSelectedAction,
+  headerContent,
+  setHeaderContent,
   systemId,
 }: Props): JSX.Element => {
   const [editingName, setEditingName] = useState(false);
@@ -66,20 +66,20 @@ const MachineHeader = ({
   return (
     <SectionHeader
       buttons={
-        !selectedAction
+        !headerContent
           ? [
               <TakeActionMenu
                 key="action-dropdown"
-                setSelectedAction={setSelectedAction}
+                setHeaderContent={setHeaderContent}
               />,
             ]
           : null
       }
-      formWrapper={
-        selectedAction ? (
+      headerContent={
+        headerContent ? (
           <ActionFormWrapper
-            selectedAction={selectedAction}
-            setSelectedAction={setSelectedAction}
+            headerContent={headerContent}
+            setHeaderContent={setHeaderContent}
           />
         ) : null
       }
@@ -210,8 +210,8 @@ const MachineHeader = ({
         },
       ]}
       title={
-        selectedAction ? (
-          getActionTitle(selectedAction.name)
+        headerContent ? (
+          getActionTitle(headerContent.name)
         ) : (
           <MachineName
             editingName={editingName}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -31,7 +31,7 @@ describe("MachineNetwork", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineNetwork setSelectedAction={jest.fn()} />
+          <MachineNetwork setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -58,7 +58,7 @@ describe("MachineNetwork", () => {
           <Route
             exact
             path="/machine/:id/network"
-            component={() => <MachineNetwork setSelectedAction={jest.fn()} />}
+            component={() => <MachineNetwork setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -97,7 +97,7 @@ describe("MachineNetwork", () => {
           <Route
             exact
             path="/machine/:id/network"
-            component={() => <MachineNetwork setSelectedAction={jest.fn()} />}
+            component={() => <MachineNetwork setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -16,13 +16,13 @@ import { ExpandedState } from "./NetworkTable/types";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 
-type Props = { setSelectedAction: MachineSetSelectedAction };
+type Props = { setHeaderContent: MachineSetHeaderContent };
 
-const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
+const MachineNetwork = ({ setHeaderContent }: Props): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
   const [selected, setSelected] = useState<Selected[]>([]);
@@ -81,7 +81,7 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
         expanded={interfaceExpanded}
         selected={selected}
         setExpanded={setInterfaceExpanded}
-        setSelectedAction={setSelectedAction}
+        setHeaderContent={setHeaderContent}
         systemId={id}
       />
       <Strip shallow>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
@@ -47,7 +47,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -58,7 +58,7 @@ describe("NetworkActions", () => {
 
     it("shows the test form when clicking the button", () => {
       const store = mockStore(state);
-      const setSelectedAction = jest.fn();
+      const setHeaderContent = jest.fn();
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter
@@ -68,14 +68,14 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={setSelectedAction}
+              setHeaderContent={setHeaderContent}
               systemId="abc123"
             />
           </MemoryRouter>
         </Provider>
       );
       wrapper.find("Button").last().simulate("click");
-      expect(setSelectedAction).toHaveBeenCalledWith({
+      expect(setHeaderContent).toHaveBeenCalledWith({
         name: NodeActions.TEST,
         extras: { applyConfiguredNetworking: true },
       });
@@ -95,7 +95,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={setExpanded}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -119,7 +119,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -145,7 +145,7 @@ describe("NetworkActions", () => {
               expanded={{ content: ExpandedState.ADD_PHYSICAL }}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -187,7 +187,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1 }, { nicId: 2 }]}
               setExpanded={setExpanded}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -211,7 +211,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -236,7 +236,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -276,7 +276,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1 }]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -322,7 +322,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -364,7 +364,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -403,7 +403,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1 }]}
               setExpanded={setExpanded}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -427,7 +427,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -452,7 +452,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -492,7 +492,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1 }, { nicId: 2 }]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -538,7 +538,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1, linkId: 2 }]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>
@@ -578,7 +578,7 @@ describe("NetworkActions", () => {
               expanded={null}
               selected={[{ nicId: 1 }, { nicId: 2 }]}
               setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
+              setHeaderContent={jest.fn()}
               systemId="abc123"
             />
           </MemoryRouter>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
@@ -5,7 +5,7 @@ import { ExpandedState } from "../NetworkTable/types";
 import type { Expanded, Selected, SetExpanded } from "../NetworkTable/types";
 
 import { useSendAnalytics } from "app/base/hooks";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import {
@@ -28,7 +28,7 @@ type Props = {
   expanded: Expanded | null;
   selected: Selected[];
   setExpanded: SetExpanded;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
   systemId: Machine["system_id"];
 };
 
@@ -77,7 +77,7 @@ const NetworkActions = ({
   expanded,
   setExpanded,
   selected,
-  setSelectedAction,
+  setHeaderContent,
   systemId,
 }: Props): JSX.Element | null => {
   const machine = useSelector((state: RootState) =>
@@ -176,7 +176,7 @@ const NetworkActions = ({
           className="u-no-margin--bottom"
           disabled={isAllNetworkingDisabled}
           onClick={() => {
-            setSelectedAction({
+            setHeaderContent({
               name: NodeActions.TEST,
               extras: { applyConfiguredNetworking: true },
             });

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
@@ -35,9 +35,7 @@ describe("MachinePCIDevices", () => {
           <Route
             exact
             path="/machine/:id/pci-devices"
-            component={() => (
-              <MachinePCIDevices setSelectedAction={jest.fn()} />
-            )}
+            component={() => <MachinePCIDevices setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -5,17 +5,15 @@ import NodeDevices from "../NodeDevices";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import { isMachineDetails } from "app/store/machine/utils";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
 import type { RootState } from "app/store/root/types";
 
-type Props = { setSelectedAction: MachineSetSelectedAction };
+type Props = { setHeaderContent: MachineSetHeaderContent };
 
-const MachinePCIDevices = ({
-  setSelectedAction,
-}: Props): JSX.Element | null => {
+const MachinePCIDevices = ({ setHeaderContent }: Props): JSX.Element | null => {
   const { id } = useParams<RouteParams>();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
@@ -27,7 +25,7 @@ const MachinePCIDevices = ({
       <NodeDevices
         bus={NodeDeviceBus.PCIE}
         machine={machine}
-        setSelectedAction={setSelectedAction}
+        setHeaderContent={setHeaderContent}
       />
     );
   }

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -33,7 +33,7 @@ describe("MachineSummary", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineSummary setSelectedAction={jest.fn()} />
+          <MachineSummary setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -47,7 +47,7 @@ describe("MachineSummary", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineSummary setSelectedAction={jest.fn()} />
+          <MachineSummary setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +72,7 @@ describe("MachineSummary", () => {
           <Route
             exact
             path="/machine/:id/summary"
-            component={() => <MachineSummary setSelectedAction={jest.fn()} />}
+            component={() => <MachineSummary setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -98,7 +98,7 @@ describe("MachineSummary", () => {
           <Route
             exact
             path="/machine/:id/summary"
-            component={() => <MachineSummary setSelectedAction={jest.fn()} />}
+            component={() => <MachineSummary setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -121,7 +121,7 @@ describe("MachineSummary", () => {
           <Route
             exact
             path="/machine/:id/summary"
-            component={() => <MachineSummary setSelectedAction={jest.fn()} />}
+            component={() => <MachineSummary setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -12,17 +12,17 @@ import WorkloadCard from "./WorkloadCard";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 import { NodeStatusCode } from "app/store/types/node";
 
 type Props = {
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
-const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
+const MachineSummary = ({ setHeaderContent }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
   const machine = useSelector((state: RootState) =>
@@ -47,10 +47,10 @@ const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <div className="machine-summary__cards">
-      <OverviewCard id={id} setSelectedAction={setSelectedAction} />
+      <OverviewCard id={id} setHeaderContent={setHeaderContent} />
       <SystemCard id={id} />
       <NumaCard id={id} />
-      <NetworkCard id={id} setSelectedAction={setSelectedAction} />
+      <NetworkCard id={id} setHeaderContent={setHeaderContent} />
       {showWorkloadCard ? <WorkloadCard id={id} /> : null}
     </div>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -41,7 +41,7 @@ describe("NetworkCard", () => {
             exact
             path="/machine/abc123/summary"
             component={() => (
-              <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+              <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>
@@ -83,7 +83,7 @@ describe("NetworkCard", () => {
             exact
             path="/machine/abc123/summary"
             component={() => (
-              <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+              <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>
@@ -150,7 +150,7 @@ describe("NetworkCard", () => {
             exact
             path="/machine/abc123/summary"
             component={() => (
-              <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+              <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
             )}
           />
         </MemoryRouter>
@@ -180,7 +180,7 @@ describe("NetworkCard", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
           </MemoryRouter>
         </Provider>
       );
@@ -207,7 +207,7 @@ describe("NetworkCard", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
           </MemoryRouter>
         </Provider>
       );
@@ -232,7 +232,7 @@ describe("NetworkCard", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
           </MemoryRouter>
         </Provider>
       );
@@ -257,7 +257,7 @@ describe("NetworkCard", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
           </MemoryRouter>
         </Provider>
       );
@@ -280,7 +280,7 @@ describe("NetworkCard", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            <NetworkCard id="abc123" setHeaderContent={jest.fn()} />
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -9,7 +9,7 @@ import TestResults from "../TestResults";
 import NetworkCardTable from "./NetworkCardTable";
 
 import { HardwareType } from "app/base/enum";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import machineSelectors from "app/store/machine/selectors";
@@ -29,7 +29,7 @@ type InterfaceGroup = {
 
 type Props = {
   id: Machine["system_id"];
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 /**
@@ -101,7 +101,7 @@ const groupInterfaces = (interfaces: NetworkInterface[]): InterfaceGroup[] => {
   return sortedGroups;
 };
 
-const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
+const NetworkCard = ({ id, setHeaderContent }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
@@ -157,7 +157,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
         <TestResults
           machine={machine}
           hardwareType={HardwareType.Network}
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />
       </>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -35,7 +35,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -55,7 +55,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -78,7 +78,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -102,7 +102,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -125,7 +125,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -148,7 +148,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -169,7 +169,7 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -3,12 +3,12 @@ import pluralize from "pluralize";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 // Get the subtext for the CPU card. Only nodes commissioned after
@@ -29,7 +29,7 @@ const getCPUSubtext = (machine: MachineDetails) => {
   return text;
 };
 
-const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
+const CpuCard = ({ machine, setHeaderContent }: Props): JSX.Element => (
   <>
     <div className="overview-card__cpu">
       <div className="u-flex--between">
@@ -47,7 +47,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
     <TestResults
       machine={machine}
       hardwareType={HardwareType.CPU}
-      setSelectedAction={setSelectedAction}
+      setHeaderContent={setHeaderContent}
     />
   </>
 );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -38,7 +38,7 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -62,7 +62,7 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -85,7 +85,7 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -108,7 +108,7 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -129,7 +129,7 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -1,15 +1,15 @@
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
-const MemoryCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
+const MemoryCard = ({ machine, setHeaderContent }: Props): JSX.Element => (
   <>
     <div className="overview-card__memory">
       <strong className="p-muted-heading">Memory</strong>
@@ -19,7 +19,7 @@ const MemoryCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
     <TestResults
       machine={machine}
       hardwareType={HardwareType.Memory}
-      setSelectedAction={setSelectedAction}
+      setHeaderContent={setHeaderContent}
     />
   </>
 );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -7,7 +7,7 @@ import MemoryCard from "./MemoryCard";
 import StatusCard from "./StatusCard";
 import StorageCard from "./StorageCard";
 
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
@@ -15,10 +15,10 @@ import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Machine["system_id"];
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
-const OverviewCard = ({ id, setSelectedAction }: Props): JSX.Element => {
+const OverviewCard = ({ id, setHeaderContent }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
@@ -38,9 +38,9 @@ const OverviewCard = ({ id, setSelectedAction }: Props): JSX.Element => {
     content = (
       <div className="overview-card">
         <StatusCard machine={machine} />
-        <CpuCard machine={machine} setSelectedAction={setSelectedAction} />
-        <MemoryCard machine={machine} setSelectedAction={setSelectedAction} />
-        <StorageCard machine={machine} setSelectedAction={setSelectedAction} />
+        <CpuCard machine={machine} setHeaderContent={setHeaderContent} />
+        <MemoryCard machine={machine} setHeaderContent={setHeaderContent} />
+        <StorageCard machine={machine} setHeaderContent={setHeaderContent} />
         <DetailsCard machine={machine} />
       </div>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -36,7 +36,7 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setSelectedAction={jest.fn()} />
+          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -60,7 +60,7 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setSelectedAction={jest.fn()} />
+          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +83,7 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setSelectedAction={jest.fn()} />
+          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +106,7 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setSelectedAction={jest.fn()} />
+          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -127,7 +127,7 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setSelectedAction={jest.fn()} />
+          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
@@ -3,15 +3,15 @@ import pluralize from "pluralize";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
-const StorageCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
+const StorageCard = ({ machine, setHeaderContent }: Props): JSX.Element => (
   <>
     <div className="overview-card__storage">
       <strong className="p-muted-heading">Storage</strong>
@@ -28,7 +28,7 @@ const StorageCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
     <TestResults
       machine={machine}
       hardwareType={HardwareType.Storage}
-      setSelectedAction={setSelectedAction}
+      setHeaderContent={setHeaderContent}
     />
   </>
 );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -40,7 +40,7 @@ describe("TestResults", () => {
           <TestResults
             machine={machine}
             hardwareType={HardwareType.CPU}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -68,7 +68,7 @@ describe("TestResults", () => {
           <TestResults
             machine={machine}
             hardwareType={HardwareType.Memory}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -95,7 +95,7 @@ describe("TestResults", () => {
           <TestResults
             machine={machine}
             hardwareType={HardwareType.Storage}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -122,7 +122,7 @@ describe("TestResults", () => {
           <TestResults
             machine={machine}
             hardwareType={HardwareType.CPU}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -147,7 +147,7 @@ describe("TestResults", () => {
           <TestResults
             machine={machine}
             hardwareType={HardwareType.Network}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 import type { TestStatus } from "app/store/types/node";
 import { NodeActions } from "app/store/types/node";
@@ -12,7 +12,7 @@ import { capitaliseFirst } from "app/utils";
 type Props = {
   machine: MachineDetails;
   hardwareType: HardwareType;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 const hasTestsRun = (testStatus: TestStatus) =>
@@ -25,7 +25,7 @@ const hasTestsRun = (testStatus: TestStatus) =>
 const TestResults = ({
   machine,
   hardwareType,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element | null => {
   const sendAnalytics = useSendAnalytics();
 
@@ -143,7 +143,7 @@ const TestResults = ({
                 className="p-button--link"
                 disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
-                  setSelectedAction({
+                  setHeaderContent({
                     name: NodeActions.TEST,
                     extras: { hardwareType: hardwareType },
                   });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/__snapshots__/MachineSummary.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/__snapshots__/MachineSummary.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MachineSummary renders 1`] = `
 <MachineSummary
-  setSelectedAction={[MockFunction]}
+  setHeaderContent={[MockFunction]}
 >
   <Spinner
     text="Loading"

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
@@ -35,9 +35,7 @@ describe("MachineUSBDevices", () => {
           <Route
             exact
             path="/machine/:id/usb-devices"
-            component={() => (
-              <MachineUSBDevices setSelectedAction={jest.fn()} />
-            )}
+            component={() => <MachineUSBDevices setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -5,17 +5,15 @@ import NodeDevices from "../NodeDevices";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import { isMachineDetails } from "app/store/machine/utils";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
 import type { RootState } from "app/store/root/types";
 
-type Props = { setSelectedAction: MachineSetSelectedAction };
+type Props = { setHeaderContent: MachineSetHeaderContent };
 
-const MachineUSBDevices = ({
-  setSelectedAction,
-}: Props): JSX.Element | null => {
+const MachineUSBDevices = ({ setHeaderContent }: Props): JSX.Element | null => {
   const { id } = useParams<RouteParams>();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
@@ -27,7 +25,7 @@ const MachineUSBDevices = ({
       <NodeDevices
         bus={NodeDeviceBus.USB}
         machine={machine}
-        setSelectedAction={setSelectedAction}
+        setHeaderContent={setHeaderContent}
       />
     );
   }

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -31,7 +31,7 @@ describe("NodeDevices", () => {
         <NodeDevices
           bus={NodeDeviceBus.PCIE}
           machine={machine}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );
@@ -68,7 +68,7 @@ describe("NodeDevices", () => {
         <NodeDevices
           bus={NodeDeviceBus.PCIE}
           machine={machine}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );
@@ -93,7 +93,7 @@ describe("NodeDevices", () => {
         <NodeDevices
           bus={NodeDeviceBus.PCIE}
           machine={machine}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );
@@ -110,7 +110,7 @@ describe("NodeDevices", () => {
         <NodeDevices
           bus={NodeDeviceBus.PCIE}
           machine={machine}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );
@@ -127,7 +127,7 @@ describe("NodeDevices", () => {
         <NodeDevices
           bus={NodeDeviceBus.USB}
           machine={machine}
-          setSelectedAction={jest.fn()}
+          setHeaderContent={jest.fn()}
         />
       </Provider>
     );
@@ -170,7 +170,7 @@ describe("NodeDevices", () => {
           <NodeDevices
             bus={NodeDeviceBus.PCIE}
             machine={machine}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -234,7 +234,7 @@ describe("NodeDevices", () => {
           <NodeDevices
             bus={NodeDeviceBus.PCIE}
             machine={machine}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -276,7 +276,7 @@ describe("NodeDevices", () => {
           <NodeDevices
             bus={NodeDeviceBus.PCIE}
             machine={machine}
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -11,8 +11,8 @@ import NodeDevicesWarning from "./NodeDevicesWarning";
 import DoubleRow from "app/base/components/DoubleRow";
 import Placeholder from "app/base/components/Placeholder";
 import { HardwareType } from "app/base/enum";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import machineURLs from "app/machines/urls";
-import type { MachineSetSelectedAction } from "app/machines/views/types";
 import type { MachineDetails } from "app/store/machine/types";
 import { actions as nodeDeviceActions } from "app/store/nodedevice";
 import nodeDeviceSelectors from "app/store/nodedevice/selectors";
@@ -23,7 +23,7 @@ import type { RootState } from "app/store/root/types";
 type Props = {
   bus: NodeDeviceBus;
   machine: MachineDetails;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 type NodeDeviceGroup = {
   hardwareTypes: HardwareType[];
@@ -128,7 +128,7 @@ const generateGroup = (
 const NodeDevices = ({
   bus,
   machine,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const nodeDevices = useSelector((state: RootState) =>
@@ -290,7 +290,7 @@ const NodeDevices = ({
           bus={bus}
           machine={machine}
           nodeDevices={nodeDevices}
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />
       )}
     </>

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
@@ -12,7 +12,7 @@ import {
 describe("NodeDevicesWarning", () => {
   it(`prompts user to commission machine if no devices found and machine can be
     commissioned`, () => {
-    const setSelectedAction = jest.fn();
+    const setHeaderContent = jest.fn();
     const machine = machineDetailsFactory({
       actions: [NodeActions.COMMISSION],
     });
@@ -21,7 +21,7 @@ describe("NodeDevicesWarning", () => {
         bus={NodeDeviceBus.PCIE}
         machine={machine}
         nodeDevices={[]}
-        setSelectedAction={setSelectedAction}
+        setHeaderContent={setHeaderContent}
       />
     );
 
@@ -31,7 +31,7 @@ describe("NodeDevicesWarning", () => {
 
     wrapper.find("[data-test='commission-machine'] button").simulate("click");
 
-    expect(setSelectedAction).toHaveBeenCalledWith({
+    expect(setHeaderContent).toHaveBeenCalledWith({
       name: NodeActions.COMMISSION,
     });
   });
@@ -43,7 +43,7 @@ describe("NodeDevicesWarning", () => {
         bus={NodeDeviceBus.PCIE}
         machine={machine}
         nodeDevices={[]}
-        setSelectedAction={jest.fn()}
+        setHeaderContent={jest.fn()}
       />
     );
 
@@ -61,7 +61,7 @@ describe("NodeDevicesWarning", () => {
         bus={NodeDeviceBus.PCIE}
         machine={machine}
         nodeDevices={[]}
-        setSelectedAction={jest.fn()}
+        setHeaderContent={jest.fn()}
       />
     );
 
@@ -79,7 +79,7 @@ describe("NodeDevicesWarning", () => {
         bus={NodeDeviceBus.PCIE}
         machine={machine}
         nodeDevices={[]}
-        setSelectedAction={jest.fn()}
+        setHeaderContent={jest.fn()}
       />
     );
 
@@ -98,7 +98,7 @@ describe("NodeDevicesWarning", () => {
         bus={NodeDeviceBus.PCIE}
         machine={machine}
         nodeDevices={[]}
-        setSelectedAction={jest.fn()}
+        setHeaderContent={jest.fn()}
       />
     );
 
@@ -118,7 +118,7 @@ describe("NodeDevicesWarning", () => {
         bus={NodeDeviceBus.PCIE}
         machine={machine}
         nodeDevices={[]}
-        setSelectedAction={jest.fn()}
+        setHeaderContent={jest.fn()}
       />
     );
 
@@ -136,7 +136,7 @@ describe("NodeDevicesWarning", () => {
         nodeDevices={[
           nodeDeviceFactory({ bus: NodeDeviceBus.PCIE, node_id: machine.id }),
         ]}
-        setSelectedAction={jest.fn()}
+        setHeaderContent={jest.fn()}
       />
     );
 

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
@@ -1,6 +1,6 @@
 import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 
-import type { MachineSetSelectedAction } from "app/machines/views/types";
+import type { MachineSetHeaderContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
 import type { NodeDevice } from "app/store/nodedevice/types";
@@ -10,14 +10,14 @@ type Props = {
   bus: NodeDeviceBus;
   machine: MachineDetails;
   nodeDevices: NodeDevice[];
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 const NodeDevicesWarning = ({
   bus,
   machine,
   nodeDevices,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element | null => {
   const busDisplay = bus === NodeDeviceBus.PCIE ? "PCI" : "USB";
   const canBeCommissioned = machine?.actions.includes(NodeActions.COMMISSION);
@@ -56,7 +56,7 @@ const NodeDevicesWarning = ({
           <Button
             appearance="positive"
             data-test="commission-machine"
-            onClick={() => setSelectedAction({ name: NodeActions.COMMISSION })}
+            onClick={() => setHeaderContent({ name: NodeActions.COMMISSION })}
           >
             Commission
           </Button>

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -80,7 +80,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -98,7 +98,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -119,7 +119,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -141,7 +141,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={setSearchFilter}
           />
         </MemoryRouter>
@@ -166,7 +166,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -185,7 +185,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -206,7 +206,7 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -227,7 +227,7 @@ describe("MachineListHeader", () => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
           <MachineListHeader
-            setSelectedAction={jest.fn()}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
@@ -247,8 +247,8 @@ describe("MachineListHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <MachineListHeader
-            selectedAction={{ name: NodeActions.DEPLOY }}
-            setSelectedAction={jest.fn()}
+            headerContent={{ name: NodeActions.DEPLOY }}
+            setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -10,12 +10,12 @@ import AddHardware from "./AddHardwareMenu";
 import SectionHeader from "app/base/components/SectionHeader";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
+import type {
+  MachineHeaderContent,
+  MachineSetHeaderContent,
+} from "app/machines/types";
 import machineURLs from "app/machines/urls";
 import { getActionTitle } from "app/machines/utils";
-import type {
-  MachineSelectedAction,
-  MachineSetSelectedAction,
-} from "app/machines/views/types";
 import poolsURLs from "app/pools/urls";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -49,15 +49,15 @@ const getMachineCount = (
 };
 
 type Props = {
-  selectedAction?: MachineSelectedAction | null;
+  headerContent?: MachineHeaderContent | null;
   setSearchFilter: (filter: string) => void;
-  setSelectedAction: MachineSetSelectedAction;
+  setHeaderContent: MachineSetHeaderContent;
 };
 
 export const MachineListHeader = ({
-  selectedAction,
+  headerContent,
   setSearchFilter,
-  setSelectedAction,
+  setHeaderContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -73,9 +73,9 @@ export const MachineListHeader = ({
 
   useEffect(() => {
     if (location.pathname !== machineURLs.machines.index) {
-      setSelectedAction(null);
+      setHeaderContent(null);
     }
-  }, [location.pathname, setSelectedAction]);
+  }, [location.pathname, setHeaderContent]);
 
   const getHeaderButtons = () => {
     if (location.pathname === machineURLs.machines.index) {
@@ -86,7 +86,7 @@ export const MachineListHeader = ({
         />,
         <TakeActionMenu
           key="machine-list-action-menu"
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />,
       ];
     }
@@ -103,11 +103,11 @@ export const MachineListHeader = ({
   return (
     <SectionHeader
       buttons={getHeaderButtons()}
-      formWrapper={
-        selectedAction && (
+      headerContent={
+        headerContent && (
           <ActionFormWrapper
-            selectedAction={selectedAction}
-            setSelectedAction={setSelectedAction}
+            headerContent={headerContent}
+            setHeaderContent={setHeaderContent}
           />
         )
       }
@@ -127,7 +127,7 @@ export const MachineListHeader = ({
           to: poolsURLs.pools,
         },
       ]}
-      title={selectedAction ? getActionTitle(selectedAction.name) : "Machines"}
+      title={headerContent ? getActionTitle(headerContent.name) : "Machines"}
     />
   );
 };

--- a/ui/src/app/machines/views/Machines.test.tsx
+++ b/ui/src/app/machines/views/Machines.test.tsx
@@ -258,7 +258,7 @@ describe("Machines", () => {
       wrapper
         .find(TakeActionMenu)
         .props()
-        .setSelectedAction({ name: NodeActions.SET_POOL })
+        .setHeaderContent({ name: NodeActions.SET_POOL })
     );
     wrapper.update();
     expect(wrapper.find("ActionFormWrapper").exists()).toBe(true);
@@ -289,7 +289,7 @@ describe("Machines", () => {
       wrapper
         .find(MachineListHeader)
         .props()
-        .setSelectedAction({ name: NodeActions.SET_POOL })
+        .setHeaderContent({ name: NodeActions.SET_POOL })
     );
     wrapper.update();
     expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
@@ -313,13 +313,13 @@ describe("Machines", () => {
       wrapper
         .find(MachineListHeader)
         .props()
-        .setSelectedAction({ name: NodeActions.SET_POOL })
+        .setHeaderContent({ name: NodeActions.SET_POOL })
     );
     wrapper.update();
     expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
       "in:(selected)"
     );
-    act(() => wrapper.find(MachineListHeader).props().setSelectedAction(null));
+    act(() => wrapper.find(MachineListHeader).props().setHeaderContent(null));
     wrapper.update();
     expect(wrapper.find("MachineList").prop("searchFilter")).toBe("");
   });

--- a/ui/src/app/machines/views/Machines.tsx
+++ b/ui/src/app/machines/views/Machines.tsx
@@ -4,10 +4,10 @@ import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { Route, Switch, useHistory, useLocation } from "react-router-dom";
 
 import MachineListHeader from "./MachineList/MachineListHeader";
-import type { MachineSelectedAction } from "./types";
 
 import Section from "app/base/components/Section";
 import NotFound from "app/base/views/NotFound";
+import type { MachineHeaderContent } from "app/machines/types";
 import machineURLs from "app/machines/urls";
 import AddChassisForm from "app/machines/views/AddChassis/AddChassisForm";
 import AddMachineForm from "app/machines/views/AddMachine/AddMachineForm";
@@ -26,10 +26,10 @@ const Machines = (): JSX.Element => {
   const [searchFilter, setFilter] = useState(
     FilterMachines.filtersToString(currentFilters)
   );
-  const [selectedAction, setSelectedAction] =
-    useState<MachineSelectedAction | null>(null);
+  const [headerContent, setHeaderContent] =
+    useState<MachineHeaderContent | null>(null);
   const previousPath = usePrevious(location.pathname);
-  const previousHasSelectedAction = usePrevious(!!selectedAction);
+  const previousHasHeaderContent = usePrevious(!!headerContent);
 
   const setSearchFilter = useCallback(
     (searchText) => {
@@ -48,40 +48,35 @@ const Machines = (): JSX.Element => {
   }, [location.pathname, currentFilters, previousPath]);
 
   useEffect(() => {
-    const hasSelectedAction = !!selectedAction;
-    if (hasSelectedAction !== previousHasSelectedAction) {
+    const hasHeaderContent = !!headerContent;
+    if (hasHeaderContent !== previousHasHeaderContent) {
       const filters = FilterMachines.getCurrentFilters(searchFilter);
       const newFilters = FilterMachines.toggleFilter(
         filters,
         "in",
         "selected",
         false,
-        !!hasSelectedAction
+        !!hasHeaderContent
       );
       setSearchFilter(FilterMachines.filtersToString(newFilters));
     }
-  }, [
-    searchFilter,
-    selectedAction,
-    setSearchFilter,
-    previousHasSelectedAction,
-  ]);
+  }, [searchFilter, headerContent, setSearchFilter, previousHasHeaderContent]);
 
   return (
     <Section
       headerClassName="u-no-padding--bottom"
       header={
         <MachineListHeader
-          selectedAction={selectedAction}
+          headerContent={headerContent}
           setSearchFilter={setSearchFilter}
-          setSelectedAction={setSelectedAction}
+          setHeaderContent={setHeaderContent}
         />
       }
     >
       <Switch>
         <Route exact path={machineURLs.machines.index}>
           <MachineList
-            headerFormOpen={!!selectedAction}
+            headerFormOpen={!!headerContent}
             searchFilter={searchFilter}
             setSearchFilter={setSearchFilter}
           />

--- a/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.tsx
@@ -34,11 +34,11 @@ const ZonesListHeader = (): JSX.Element => {
     </Button>,
   ];
 
-  let formWrapper: JSX.Element | null = null;
+  let headerContent: JSX.Element | null = null;
 
   if (showForm) {
     buttons = null;
-    formWrapper = (
+    headerContent = (
       <ZonesListForm
         key="add-zone-form"
         closeForm={() => {
@@ -54,7 +54,7 @@ const ZonesListHeader = (): JSX.Element => {
       loading={!zonesLoaded}
       title={<ZonesListTitle />}
       subtitle={`${zonesCount} AZs available`}
-      formWrapper={formWrapper}
+      headerContent={headerContent}
     ></SectionHeader>
   );
 };


### PR DESCRIPTION
## Done

- Renamed `selectedAction` and related variables/types to `headerContent`, to better reflect that the header content is not always a model action
- Moved `machines` and `kvm` types to `/app/<view>/types.ts`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A