### PR TITLE
feat(ui): add ability to filter machines by clone error

### DIFF
--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -32,6 +32,8 @@ export type SetHeaderContent<H> = (headerContent: H | null) => void;
 
 export type ClearHeaderContent = () => void;
 
+export type SetSearchFilter = (searchFilter: string) => void;
+
 export type AnyObject = Record<string, unknown>;
 
 export type EmptyObject = Record<string, never>;

--- a/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -6,7 +6,7 @@ import DeleteForm from "./DeleteForm";
 import RefreshForm from "./RefreshForm";
 
 import { useScrollOnRender } from "app/base/hooks";
-import type { ClearHeaderContent } from "app/base/types";
+import type { ClearHeaderContent, SetSearchFilter } from "app/base/types";
 import { KVMHeaderNames } from "app/kvm/constants";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import MachineActionForms from "app/machines/components/ActionFormWrapper";
@@ -14,12 +14,14 @@ import MachineActionForms from "app/machines/components/ActionFormWrapper";
 type Props = {
   headerContent: KVMHeaderContent | null;
   setHeaderContent: KVMSetHeaderContent;
+  setSearchFilter?: SetSearchFilter;
 };
 
 const getFormComponent = (
   headerContent: KVMHeaderContent,
   setHeaderContent: KVMSetHeaderContent,
-  clearHeaderContent: ClearHeaderContent
+  clearHeaderContent: ClearHeaderContent,
+  setSearchFilter?: SetSearchFilter
 ) => {
   switch (headerContent.name) {
     case KVMHeaderNames.ADD_KVM:
@@ -35,6 +37,7 @@ const getFormComponent = (
         <MachineActionForms
           headerContent={headerContent}
           setHeaderContent={setHeaderContent}
+          setSearchFilter={setSearchFilter}
         />
       );
   }
@@ -43,6 +46,7 @@ const getFormComponent = (
 const KVMHeaderForms = ({
   headerContent,
   setHeaderContent,
+  setSearchFilter,
 }: Props): JSX.Element | null => {
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const clearHeaderContent = useCallback(
@@ -55,7 +59,12 @@ const KVMHeaderForms = ({
   }
   return (
     <div ref={onRenderRef}>
-      {getFormComponent(headerContent, setHeaderContent, clearHeaderContent)}
+      {getFormComponent(
+        headerContent,
+        setHeaderContent,
+        clearHeaderContent,
+        setSearchFilter
+      )}
     </div>
   );
 };

--- a/ui/src/app/kvm/types.ts
+++ b/ui/src/app/kvm/types.ts
@@ -10,5 +10,3 @@ export type KVMHeaderContent =
   | MachineHeaderContent;
 
 export type KVMSetHeaderContent = SetHeaderContent<KVMHeaderContent>;
-
-export type SetSearchFilter = (searchFilter: string) => void;

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -16,8 +16,8 @@ import KVMResources from "./KVMResources";
 import LxdProject from "./LxdProject";
 
 import Section from "app/base/components/Section";
-import type { RouteParams } from "app/base/types";
-import type { KVMHeaderContent, SetSearchFilter } from "app/kvm/types";
+import type { RouteParams, SetSearchFilter } from "app/base/types";
+import type { KVMHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as podActions } from "app/store/pod";
@@ -73,6 +73,7 @@ const KVMDetails = (): JSX.Element => {
           id={id}
           headerContent={headerContent}
           setHeaderContent={setHeaderContent}
+          setSearchFilter={setSearchFilter}
         />
       }
       headerClassName="u-no-padding--bottom"

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -55,6 +55,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -74,6 +75,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -98,6 +100,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={{ name: KVMHeaderNames.COMPOSE_VM }}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -127,6 +130,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -150,6 +154,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -172,6 +177,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -194,6 +200,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -216,6 +223,7 @@ describe("KVMDetailsHeader", () => {
             id={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
 import SectionHeader from "app/base/components/SectionHeader";
+import type { SetSearchFilter } from "app/base/types";
 import KVMHeaderForms from "app/kvm/components/KVMHeaderForms";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
@@ -20,12 +21,14 @@ type Props = {
   id: Pod["id"];
   headerContent: KVMHeaderContent | null;
   setHeaderContent: KVMSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
 };
 
 const KVMDetailsHeader = ({
   id,
   headerContent,
   setHeaderContent,
+  setSearchFilter,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -64,6 +67,7 @@ const KVMDetailsHeader = ({
           <KVMHeaderForms
             headerContent={headerContent}
             setHeaderContent={setHeaderContent}
+            setSearchFilter={setSearchFilter}
           />
         ) : null
       }

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
@@ -6,7 +6,8 @@ import ProjectSummaryCard from "./ProjectSummaryCard";
 import ProjectVMs from "./ProjectVMs";
 
 import { useWindowTitle } from "app/base/hooks";
-import type { KVMSetHeaderContent, SetSearchFilter } from "app/kvm/types";
+import type { SetSearchFilter } from "app/base/types";
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
@@ -6,7 +6,8 @@ import { useDispatch } from "react-redux";
 import VMsActionBar from "./VMsActionBar";
 import VMsTable from "./VMsTable";
 
-import type { KVMSetHeaderContent, SetSearchFilter } from "app/kvm/types";
+import type { SetSearchFilter } from "app/base/types";
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import { actions as machineActions } from "app/store/machine";
 import type { Pod } from "app/store/pod/types";
 

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -4,8 +4,9 @@ import { useSelector } from "react-redux";
 import { VMS_PER_PAGE } from "../ProjectVMs";
 
 import ArrowPagination from "app/base/components/ArrowPagination";
+import type { SetSearchFilter } from "app/base/types";
 import { KVMHeaderNames } from "app/kvm/constants";
-import type { KVMSetHeaderContent, SetSearchFilter } from "app/kvm/types";
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import VmActionMenu from "app/machines/components/TakeActionMenu";
 import machineSelectors from "app/store/machine/selectors";
 import podSelectors from "app/store/pod/selectors";

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -17,6 +17,7 @@ import TagForm from "./TagForm";
 import TestForm from "./TestForm";
 
 import { useScrollOnRender } from "app/base/hooks";
+import type { SetSearchFilter } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import type {
   MachineHeaderContent,
@@ -80,11 +81,15 @@ const getErrorSentence = (action: MachineHeaderContent, count: number) => {
 type Props = {
   headerContent: MachineHeaderContent;
   setHeaderContent: MachineSetHeaderContent;
+  setSearchFilter?: SetSearchFilter;
+  viewingDetails?: boolean;
 };
 
 export const ActionFormWrapper = ({
   headerContent,
   setHeaderContent,
+  setSearchFilter,
+  viewingDetails = false,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
@@ -130,6 +135,8 @@ export const ActionFormWrapper = ({
             <CloneForm
               actionDisabled={actionDisabled}
               clearHeaderContent={clearHeaderContent}
+              setSearchFilter={setSearchFilter}
+              viewingDetails={viewingDetails}
             />
           );
         case NodeActions.COMMISSION:

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -8,7 +8,7 @@ import CloneFormFields from "./CloneFormFields";
 import CloneResults from "./CloneResults";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearHeaderContent } from "app/base/types";
+import type { ClearHeaderContent, SetSearchFilter } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineDetails } from "app/store/machine/types";
@@ -17,6 +17,8 @@ import { NodeActions } from "app/store/types/node";
 type Props = {
   actionDisabled?: boolean;
   clearHeaderContent: ClearHeaderContent;
+  setSearchFilter?: SetSearchFilter;
+  viewingDetails?: boolean;
 };
 
 export type CloneFormValues = {
@@ -49,6 +51,8 @@ const CloneFormSchema = Yup.object()
 export const CloneForm = ({
   actionDisabled,
   clearHeaderContent,
+  setSearchFilter,
+  viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [selectedMachine, setSelectedMachine] = useState<MachineDetails | null>(
@@ -72,7 +76,9 @@ export const CloneForm = ({
     <CloneResults
       closeForm={clearHeaderContent}
       destinations={destinations}
+      setSearchFilter={setSearchFilter}
       sourceMachine={selectedMachine}
+      viewingDetails={viewingDetails}
     />
   ) : (
     <ActionForm<CloneFormValues>

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
@@ -203,4 +203,88 @@ describe("CloneResults", () => {
     expect(wrapper.find("Table[data-test='errors-table']").exists()).toBe(true);
     expect(wrapper.find("TableRow[data-test='error-row']").length).toBe(2);
   });
+
+  it("can filter machines by error type", () => {
+    const setSearchFilter = jest.fn();
+    state.machine.eventErrors = [
+      eventErrorFactory({
+        error: {
+          destinations: [
+            {
+              code: CloneErrorCodes.NETWORKING,
+              message: "Invalid networking",
+              system_id: "def456",
+            },
+            {
+              code: CloneErrorCodes.NETWORKING,
+              message: "Invalid networking",
+              system_id: "ghi789",
+            },
+          ],
+        },
+        event: NodeActions.CLONE,
+        id: machine.system_id,
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CloneResults
+            closeForm={jest.fn()}
+            destinations={["def456", "ghi789"]}
+            setSearchFilter={setSearchFilter}
+            sourceMachine={machine}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Link[data-test='error-filter-link']").simulate("click");
+    expect(setSearchFilter).toHaveBeenCalledWith("system_id:(def456,ghi789)");
+  });
+
+  it("does not show filter links if viewing from machine details", () => {
+    const setSearchFilter = jest.fn();
+    state.machine.eventErrors = [
+      eventErrorFactory({
+        error: {
+          destinations: [
+            {
+              code: CloneErrorCodes.NETWORKING,
+              message: "Invalid networking",
+              system_id: "def456",
+            },
+            {
+              code: CloneErrorCodes.NETWORKING,
+              message: "Invalid networking",
+              system_id: "ghi789",
+            },
+          ],
+        },
+        event: NodeActions.CLONE,
+        id: machine.system_id,
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CloneResults
+            closeForm={jest.fn()}
+            destinations={["def456", "ghi789"]}
+            setSearchFilter={setSearchFilter}
+            sourceMachine={machine}
+            viewingDetails
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Link[data-test='error-filter-link']").exists()).toBe(
+      false
+    );
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -76,6 +76,7 @@ const MachineHeader = ({
           <ActionFormWrapper
             headerContent={headerContent}
             setHeaderContent={setHeaderContent}
+            viewingDetails
           />
         ) : null
       }

--- a/ui/src/app/machines/views/MachineList/MachineList.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.tsx
@@ -8,6 +8,7 @@ import MachineListControls from "./MachineListControls";
 import MachineListTable from "./MachineListTable";
 
 import { useWindowTitle } from "app/base/hooks";
+import type { SetSearchFilter } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
@@ -16,7 +17,7 @@ import { formatErrors } from "app/utils";
 type Props = {
   headerFormOpen?: boolean;
   searchFilter?: string;
-  setSearchFilter: (filter: string) => void;
+  setSearchFilter: SetSearchFilter;
 };
 
 const MachineList = ({

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -8,6 +8,7 @@ import { Link, useLocation } from "react-router-dom";
 import AddHardware from "./AddHardwareMenu";
 
 import SectionHeader from "app/base/components/SectionHeader";
+import type { SetSearchFilter } from "app/base/types";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
 import type {
@@ -26,7 +27,7 @@ import resourcePoolSelectors from "app/store/resourcepool/selectors";
 const getMachineCount = (
   machines: Machine[],
   selectedMachines: Machine[],
-  setSearchFilter: (filter: string) => void
+  setSearchFilter: SetSearchFilter
 ) => {
   const machineCountString = `${machines.length} ${pluralize(
     "machine",
@@ -50,7 +51,7 @@ const getMachineCount = (
 
 type Props = {
   headerContent?: MachineHeaderContent | null;
-  setSearchFilter: (filter: string) => void;
+  setSearchFilter: SetSearchFilter;
   setHeaderContent: MachineSetHeaderContent;
 };
 
@@ -108,6 +109,7 @@ export const MachineListHeader = ({
           <ActionFormWrapper
             headerContent={headerContent}
             setHeaderContent={setHeaderContent}
+            setSearchFilter={setSearchFilter}
           />
         )
       }


### PR DESCRIPTION
## Done

- Added filtering to clone results table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, select some machines and select "Clone from" from the action menu
- Choose a source with incompatible networking/storage and submit the form
- Check that you can filter the machine list by clicking the "Show" link, and that opening the link in a new tab will also filter the machine list
- Check the same things from the KVM details page, using VMs
- Go to the details page of a machine and try to clone from an incompatible source machine
- Check that there is no column for "Affected machines" in the error table

## Fixes

Fixes canonical-web-and-design/app-squad#230