### PR TITLE
feat(ui): hide header subtitle and buttons if form is open

### DIFF
--- a/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -52,15 +52,6 @@ describe("SectionHeader", () => {
     );
   });
 
-  it("can render a form wrapper", () => {
-    const wrapper = shallow(
-      <SectionHeader title="Title" headerContent={<div>Form wrapper</div>} />
-    );
-    expect(
-      wrapper.find("[data-test='section-header-form-wrapper']").exists()
-    ).toBe(true);
-  });
-
   it("can render tabs", () => {
     const tabLinks = [
       {
@@ -79,6 +70,39 @@ describe("SectionHeader", () => {
     );
     expect(wrapper.find("[data-test='section-header-tabs']").exists()).toBe(
       true
+    );
+  });
+
+  it("can render extra header content", () => {
+    const wrapper = shallow(
+      <SectionHeader title="Title" headerContent={<div>Header content</div>} />
+    );
+    expect(wrapper.find("[data-test='section-header-content']").exists()).toBe(
+      true
+    );
+  });
+
+  it("does not render subtitle or buttons if header content is present", () => {
+    const wrapper = shallow(
+      <SectionHeader
+        buttons={[<button key="button">Click me</button>]}
+        subtitle="subtitle"
+        title="Title"
+      />
+    );
+    expect(wrapper.find("[data-test='section-header-buttons']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("[data-test='section-header-subtitle']").exists()).toBe(
+      true
+    );
+
+    wrapper.setProps({ headerContent: <div>Header content</div> });
+    expect(wrapper.find("[data-test='section-header-buttons']").exists()).toBe(
+      false
+    );
+    expect(wrapper.find("[data-test='section-header-subtitle']").exists()).toBe(
+      false
     );
   });
 });

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -16,21 +16,34 @@ type Props<P = LinkProps> = {
   title: ReactNode;
 };
 
-const generateSubtitle = (subtitle: Props["subtitle"]) => {
+const generateSubtitle = (
+  subtitle: Props["subtitle"],
+  loading: Props["loading"],
+  headerContent: Props["headerContent"]
+) => {
+  if (headerContent) {
+    return null;
+  }
   const items = (Array.isArray(subtitle) ? subtitle : [subtitle]).filter(
     Boolean
   );
-  return items.map((item, i) => (
-    <li
-      className={classNames("p-inline-list__item u-text--light", {
-        "last-item": i === items.length - 1,
-      })}
-      data-test="section-header-subtitle"
-      key={i}
-    >
-      {item}
+  return loading ? (
+    <li className="p-inline-list__item last-item u-text--light">
+      <Spinner text="Loading..." />
     </li>
-  ));
+  ) : (
+    items.map((item, i) => (
+      <li
+        className={classNames("p-inline-list__item u-text--light", {
+          "last-item": i === items.length - 1,
+        })}
+        data-test="section-header-subtitle"
+        key={i}
+      >
+        {item}
+      </li>
+    ))
+  );
 };
 
 const SectionHeader = ({
@@ -52,15 +65,9 @@ const SectionHeader = ({
               title
             )}
           </li>
-          {loading ? (
-            <li className="p-inline-list__item last-item u-text--light">
-              <Spinner text="Loading..." />
-            </li>
-          ) : (
-            generateSubtitle(subtitle)
-          )}
+          {generateSubtitle(subtitle, loading, headerContent)}
         </ul>
-        {buttons?.length && (
+        {buttons?.length && !headerContent && (
           <ul
             className="p-inline-list u-no-margin--bottom"
             data-test="section-header-buttons"
@@ -79,7 +86,7 @@ const SectionHeader = ({
         )}
       </div>
       {headerContent && (
-        <Row data-test="section-header-form-wrapper">
+        <Row data-test="section-header-content">
           <Col size={12}>
             <hr />
             {headerContent}

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -74,7 +74,7 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
 
   return (
     <SectionHeader
-      buttons={formOpen === null ? buttons : null}
+      buttons={buttons}
       loading={!domain}
       subtitle={`${pluralizeString("host", hostsCount, "")}${
         hostsCount > 1 ? "; " : ""

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -50,7 +50,7 @@ const KVMDetailsHeader = ({
   return (
     <SectionHeader
       buttons={
-        !headerContent && pod?.type !== PodType.LXD
+        pod?.type !== PodType.LXD
           ? [
               <PodDetailsActionMenu
                 key="action-dropdown"
@@ -95,7 +95,7 @@ const KVMDetailsHeader = ({
       ]}
       title={
         pod ? (
-          <div className="kvm-details-header">
+          <div className={headerContent ? undefined : "kvm-details-header"}>
             <h1
               className="p-heading--four u-no-margin--bottom"
               data-test="kvm-details-title"

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -31,22 +31,16 @@ const KVMListHeader = ({
 
   return (
     <SectionHeader
-      buttons={
-        !headerContent
-          ? [
-              <Button
-                appearance="positive"
-                data-test="add-kvm"
-                key="add-kvm"
-                onClick={() =>
-                  setHeaderContent({ name: KVMHeaderNames.ADD_KVM })
-                }
-              >
-                Add KVM
-              </Button>,
-            ]
-          : null
-      }
+      buttons={[
+        <Button
+          appearance="positive"
+          data-test="add-kvm"
+          key="add-kvm"
+          onClick={() => setHeaderContent({ name: KVMHeaderNames.ADD_KVM })}
+        >
+          Add KVM
+        </Button>,
+      ]}
       headerContent={
         headerContent ? (
           <KVMHeaderForms

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -65,16 +65,12 @@ const MachineHeader = ({
 
   return (
     <SectionHeader
-      buttons={
-        !headerContent
-          ? [
-              <TakeActionMenu
-                key="action-dropdown"
-                setHeaderContent={setHeaderContent}
-              />,
-            ]
-          : null
-      }
+      buttons={[
+        <TakeActionMenu
+          key="action-dropdown"
+          setHeaderContent={setHeaderContent}
+        />,
+      ]}
       headerContent={
         headerContent ? (
           <ActionFormWrapper


### PR DESCRIPTION
## Done

- Removed subtitle and buttons from `SectionHeader` if there is any `headerContent` present (i.e. a form is open)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, select some machines and open a form
- Check that there is no subtitle and no buttons present in the header
- Check the same thing in a few other places (machine details, KVM, AZs, domains, etc)

## Fixes

Fixes #3031 