### PR TITLE
feat(ui): add Authentication card to VM host config

### DIFF
--- a/ui/src/app/base/components/FormCard/FormCard.tsx
+++ b/ui/src/app/base/components/FormCard/FormCard.tsx
@@ -1,13 +1,14 @@
 import type { ReactNode } from "react";
 
 import { Card, Col, Row } from "@canonical/react-components";
-import type { ColSize } from "@canonical/react-components";
-import PropTypes from "prop-types";
+import type { ClassName, ColSize } from "@canonical/react-components";
+import classNames from "classnames";
 
 import { COL_SIZES } from "app/base/constants";
 
 type Props = {
   children: ReactNode;
+  className?: ClassName;
   sidebar?: boolean;
   stacked?: boolean;
   title?: ReactNode;
@@ -27,6 +28,7 @@ const getContentSize = (sidebar: boolean, title: ReactNode) => {
 
 export const FormCard = ({
   children,
+  className,
   sidebar = true,
   stacked,
   title,
@@ -53,17 +55,10 @@ export const FormCard = ({
     </Row>
   );
   return (
-    <Card highlighted={true} className="form-card">
+    <Card highlighted={true} className={classNames("form-card", className)}>
       {content}
     </Card>
   );
-};
-
-FormCard.propTypes = {
-  children: PropTypes.node.isRequired,
-  sidebar: PropTypes.bool,
-  stacked: PropTypes.bool,
-  title: PropTypes.node,
 };
 
 export default FormCard;

--- a/ui/src/app/base/components/LabelledList/_index.scss
+++ b/ui/src/app/base/components/LabelledList/_index.scss
@@ -20,6 +20,7 @@
 
     .p-list__item-value {
       flex: 2 1 0;
+      word-break: break-word;
     }
   }
 }

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/AuthenticationCard.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/AuthenticationCard.test.tsx
@@ -1,0 +1,111 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AuthenticationCard from "./AuthenticationCard";
+
+import {
+  podCertificate as certificateFactory,
+  podDetails as podFactory,
+  podPowerParameters as powerParametersFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+const mockStore = configureStore();
+
+describe("AuthenticationCard", () => {
+  it("does not render if the pod has no certificate metadata", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            certificate: undefined,
+            power_parameters: powerParametersFactory({
+              certificate: "abc123",
+              key: "abc123",
+            }),
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <AuthenticationCard id={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='authentication-card']").exists()).toBe(
+      false
+    );
+  });
+
+  it("renders if the pod has certificate metadata", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            certificate: certificateFactory(),
+            power_parameters: powerParametersFactory({
+              certificate: "abc123",
+              key: "abc123",
+            }),
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <AuthenticationCard id={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='authentication-card']").exists()).toBe(
+      true
+    );
+  });
+
+  it("can toggle displaying the private key", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            certificate: certificateFactory(),
+            power_parameters: powerParametersFactory({
+              certificate: "abc123",
+              key: "abc123",
+            }),
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <AuthenticationCard id={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='private-key']").exists()).toBe(false);
+
+    wrapper.find("Button[data-test='toggle-key']").simulate("click");
+    expect(wrapper.find("[data-test='private-key']").exists()).toBe(true);
+
+    wrapper.find("Button[data-test='toggle-key']").simulate("click");
+    expect(wrapper.find("[data-test='private-key']").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/AuthenticationCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/AuthenticationCard.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+
+import {
+  Button,
+  Card,
+  Col,
+  Icon,
+  Link,
+  Row,
+  Textarea,
+} from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import FormCard from "app/base/components/FormCard";
+import LabelledList from "app/base/components/LabelledList";
+import { useSendAnalytics } from "app/base/hooks";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import { isPodDetails } from "app/store/pod/utils";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  id: Pod["id"];
+};
+
+const AuthenticationCard = ({ id }: Props): JSX.Element | null => {
+  const [showKey, setShowKey] = useState(false);
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, id)
+  );
+  const sendAnalytics = useSendAnalytics();
+
+  if (!isPodDetails(pod)) {
+    return null;
+  }
+
+  const { certificate, power_parameters } = pod;
+  if (certificate && power_parameters.certificate && power_parameters.key) {
+    return (
+      <FormCard
+        className="authentication-card"
+        data-test="authentication-card"
+        sidebar={false}
+        title="Authentication"
+      >
+        <Row>
+          <Col size={6}>
+            <p>Certificate</p>
+            <p>
+              <Link
+                href="https://discourse.maas.io/t/lxd-authentication/4856"
+                onClick={() =>
+                  sendAnalytics(
+                    "KVM configuration",
+                    "Click link to LXD authentication discourse",
+                    "Read more about authentication"
+                  )
+                }
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Read more about authentication
+              </Link>
+            </p>
+            <Card>
+              <LabelledList
+                className="authentication-card__metadata"
+                items={[
+                  { label: "CN", value: certificate.CN },
+                  { label: "Expiration date", value: certificate.expiration },
+                  { label: "Fingerprint", value: certificate.fingerprint },
+                ]}
+              />
+            </Card>
+            <Textarea
+              className="authentication-card__textarea"
+              id="lxd-cert"
+              readOnly
+              value={power_parameters.certificate}
+            />
+            <p>Private key</p>
+            {showKey && (
+              <Textarea
+                className="authentication-card__textarea"
+                data-test="private-key"
+                id="lxd-key"
+                readOnly
+                value={power_parameters.key}
+              />
+            )}
+            <Button data-test="toggle-key" onClick={() => setShowKey(!showKey)}>
+              {showKey ? (
+                "Close"
+              ) : (
+                <>
+                  <span className="u-nudge-left--small">
+                    <Icon name="begin-downloading" />
+                  </span>
+                  Fetch private key
+                </>
+              )}
+            </Button>
+          </Col>
+        </Row>
+        <hr />
+        <div className="u-align--right">
+          <Button className="u-no-margin--bottom">
+            <span className="u-nudge-left--small">
+              <Icon name="change-version" />
+            </span>
+            Update certificate
+          </Button>
+        </div>
+      </FormCard>
+    );
+  } else {
+    // TODO: Handle pods that have not yet generated a certificate.
+    // https://github.com/canonical-web-and-design/app-squad/issues/256
+    return null;
+  }
+};
+
+export default AuthenticationCard;

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/_index.scss
@@ -1,0 +1,17 @@
+@mixin AuthenticationCard {
+  .authentication-card {
+    .authentication-card__textarea {
+      @extend %small-text;
+      color: $color-dark;
+      min-height: 10rem;
+    }
+
+    .authentication-card__metadata {
+      margin-bottom: 0;
+
+      .p-list__item-label {
+        flex-grow: 0.75;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AuthenticationCard";

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -4,6 +4,7 @@ import { Button, Col, Row, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import AuthenticationCard from "./AuthenticationCard";
 import KVMConfigurationFields from "./KVMConfigurationFields";
 
 import FormCard from "app/base/components/FormCard";
@@ -124,6 +125,7 @@ const KVMConfiguration = ({ id, setHeaderContent }: Props): JSX.Element => {
             <KVMConfigurationFields />
           </FormikForm>
         </FormCard>
+        <AuthenticationCard id={id} />
         {pod.type === PodType.LXD && (
           <FormCard sidebar={false} title="Danger zone">
             <Row>

--- a/ui/src/app/store/pod/types/base.ts
+++ b/ui/src/app/store/pod/types/base.ts
@@ -117,16 +117,18 @@ export type BasePod = Model & {
   zone: number;
 };
 
+export type PodCertificate = {
+  CN: string;
+  expiration: string;
+  fingerprint: string;
+};
+
 // PodDetails is returned from the server when using "pod.get", and is used in the
 // pod details pages. This type contains all possible properties of a pod model.
 export type PodDetails = BasePod & {
   attached_vlans: number[];
   boot_vlans: number[];
-  certificate?: {
-    CN: string;
-    expiration: string;
-    fingerprint: string;
-  };
+  certificate?: PodCertificate;
 };
 
 // Depending on where the user has navigated in the app, pods in state can

--- a/ui/src/app/store/pod/types/index.ts
+++ b/ui/src/app/store/pod/types/index.ts
@@ -10,6 +10,7 @@ export type {
   BasePod,
   LxdServerGroup,
   Pod,
+  PodCertificate,
   PodDetails,
   PodMemoryResource,
   PodNetworkInterface,

--- a/ui/src/app/store/pod/utils.ts
+++ b/ui/src/app/store/pod/utils.ts
@@ -1,4 +1,9 @@
-import type { Pod, PodNuma, PodResource } from "app/store/pod/types";
+import type {
+  Pod,
+  PodDetails,
+  PodNuma,
+  PodResource,
+} from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
 
 export const formatHostType = (type: PodType): string => {
@@ -52,3 +57,12 @@ export const resourceWithOverCommit = (
     free: overCommitted - totalAllocated,
   };
 };
+
+/**
+ * Whether a pod is of type PodDetails.
+ * @param pod - The pod to check
+ * @returns Whether the pod is PodDetails.
+ */
+export const isPodDetails = (pod: Pod | null): pod is PodDetails =>
+  // We use "attached_vlans" as the canary, which only exists on PodDetails.
+  Boolean(pod && "attached_vlans" in pod);

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -13,6 +13,7 @@
 @include vf-b-grid-definitions;
 @include vf-p-icons-common;
 @include vf-p-icon-begin-downloading;
+@include vf-p-icon-change-version;
 @include vf-p-icon-inspector-debug;
 @include vf-p-icon-restart;
 @include vf-p-icon-success-grey;
@@ -114,6 +115,7 @@
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect";
 @import "~app/kvm/components/PodMeter";
 @import "~app/kvm/views/KVMDetails/CoreResources";
+@import "~app/kvm/views/KVMDetails/KVMConfiguration/AuthenticationCard";
 @import "~app/kvm/views/KVMDetails/KVMDetailsHeader";
 @import "~app/kvm/views/KVMDetails/KVMResources/KVMStorageCards";
 @import "~app/kvm/views/KVMDetails/KVMResources/NumaResources";
@@ -136,6 +138,7 @@
 @import "~app/kvm/views/KVMList/RAMColumn/RAMPopover";
 @import "~app/kvm/views/KVMList/StorageColumn/StoragePopover";
 @import "~app/kvm/views/KVMList/VirshTable";
+@include AuthenticationCard;
 @include CoreResources;
 @include CPUPopover;
 @include KVMComposeInterfacesTable;

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -87,6 +87,7 @@ export {
   networkDiscoveredIP,
   networkLink,
   pod,
+  podCertificate,
   podDetails,
   podMemoryResource,
   podNetworkInterface,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -20,6 +20,7 @@ import type {
 import { DiskTypes, PowerState, StorageLayout } from "app/store/machine/types";
 import type {
   Pod,
+  PodCertificate,
   PodDetails,
   PodMemoryResource,
   PodNetworkInterface,
@@ -416,6 +417,13 @@ export const podProject = define<PodProject>({
 export const podPowerParameters = define<PodPowerParameters>({
   power_address: "qemu+ssh://ubuntu@127.0.0.1/system",
   power_pass: "",
+});
+
+export const podCertificate = define<PodCertificate>({
+  CN: "certificate@vmhost",
+  expiration: "Wed, 19 Feb. 2020 11:59:19",
+  fingerprint:
+    "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
 });
 
 export const pod = extend<Model, Pod>(model, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2575,11 +2575,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.15.tgz#d5ebfb62a69074ebb85cbe0529ad917bb8f2bae8"
   integrity sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==
 
-"@types/node@14.17.15":
-  version "14.17.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.15.tgz#d5ebfb62a69074ebb85cbe0529ad917bb8f2bae8"
-  integrity sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==
-
 "@types/node@^14.14.31":
   version "14.17.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.14.tgz#6fda9785b41570eb628bac27be4b602769a3f938"
@@ -3698,18 +3693,6 @@ attr-accept@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
-
-autoprefixer@10.3.3:
-  version "10.3.3"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.3.3.tgz#4bac89c74ef98e6a40fe1c5b76c0d1c91db153ce"
-  integrity sha512-yRzjxfnggrP/+qVHlUuZz5FZzEbkT+Yt0/Df6ScEMnbbZBLzYB2W0KLxoQCW+THm1SpOsM1ZPcTHAwuvmibIsQ==
-  dependencies:
-    browserslist "^4.16.8"
-    caniuse-lite "^1.0.30001252"
-    colorette "^1.3.0"
-    fraction.js "^4.1.1"
-    normalize-range "^0.1.2"
-    postcss-value-parser "^4.1.0"
 
 autoprefixer@10.3.4:
   version "10.3.4"


### PR DESCRIPTION
## Done

- Added Authentication card to LXD VM hosts that use certificate authentication

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the config page of a LXD VM host that uses certificate authentication (e.g. "test" on bolla)
- Check that the "Authentication" card matches the [design](https://app.zeplin.io/project/610abd78c381eeafb70f5b43/screen/6127d59b0c2b43b325928375)

## Fixes

Fixes canonical-web-and-design/app-squad#255

## Screenshot
![Screenshot 2021-09-08 at 11-56-27 KVM test configuration bolla MAAS](https://user-images.githubusercontent.com/25733845/132447618-68ddbc73-55f9-4ac1-8954-ba095a965915.png)
