### PR TITLE
feat(ui): update pod to use new power_parameters shape

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
@@ -12,6 +12,7 @@ import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   podProject as podProjectFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
@@ -80,8 +81,10 @@ describe("SelectProjectFormFields", () => {
     state.pod = podStateFactory({
       items: [
         podFactory({
-          power_address: "192.168.1.1",
-          project: "default",
+          power_parameters: powerParametersFactory({
+            power_address: "192.168.1.1",
+            project: "default",
+          }),
           type: PodType.LXD,
         }),
       ],
@@ -136,13 +139,17 @@ describe("SelectProjectFormFields", () => {
     state.pod = podStateFactory({
       items: [
         podFactory({
-          power_address: "192.168.1.1",
-          project: "default",
+          power_parameters: powerParametersFactory({
+            power_address: "192.168.1.1",
+            project: "default",
+          }),
           type: PodType.LXD,
         }),
         podFactory({
-          power_address: "192.168.1.1",
-          project: "other",
+          power_parameters: powerParametersFactory({
+            power_address: "192.168.1.1",
+            project: "other",
+          }),
           type: PodType.LXD,
         }),
       ],
@@ -177,8 +184,10 @@ describe("SelectProjectFormFields", () => {
 
   it("disables radio and shows a link to an existing LXD project", async () => {
     const pod = podFactory({
-      power_address: "192.168.1.1",
-      project: "default",
+      power_parameters: powerParametersFactory({
+        power_address: "192.168.1.1",
+        project: "default",
+      }),
       type: PodType.LXD,
     });
     state.pod = podStateFactory({

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -31,7 +31,8 @@ export const SelectProjectFormFields = ({ authValues }: Props): JSX.Element => {
   const { setFieldValue } = useFormikContext();
   const [newProject, setNewProject] = useState(true);
   const freeProjects = projects.filter(
-    (project) => !podsInServer.some((pod) => pod.project === project.name)
+    (project) =>
+      !podsInServer.some((pod) => pod.power_parameters.project === project.name)
   );
 
   return (
@@ -90,7 +91,7 @@ export const SelectProjectFormFields = ({ authValues }: Props): JSX.Element => {
         />
         {projects.map((project) => {
           const projectPod = podsInServer.find(
-            (pod) => pod.project === project.name
+            (pod) => pod.power_parameters.project === project.name
           );
           return (
             <div className="u-flex" key={project.name}>

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
@@ -126,7 +126,6 @@ describe("KVMConfiguration", () => {
       submitFormikForm(wrapper, {
         cpu_over_commit_ratio: 2,
         memory_over_commit_ratio: 2,
-        password: "password",
         pool: "1",
         power_address: "192.168.1.1",
         tags: ["tag1", "tag2"],
@@ -147,7 +146,6 @@ describe("KVMConfiguration", () => {
           cpu_over_commit_ratio: 2,
           id: 1,
           memory_over_commit_ratio: 2,
-          password: "password", // lxd uses password key
           pool: 1,
           power_address: "192.168.1.1",
           power_pass: undefined,
@@ -181,9 +179,9 @@ describe("KVMConfiguration", () => {
       submitFormikForm(wrapper, {
         cpu_over_commit_ratio: 2,
         memory_over_commit_ratio: 2,
-        password: "password",
         pool: "1",
         power_address: "192.168.1.1",
+        power_pass: "password",
         tags: ["tag1", "tag2"],
         type: "virsh",
         zone: "2",
@@ -202,7 +200,6 @@ describe("KVMConfiguration", () => {
           cpu_over_commit_ratio: 2,
           id: 1,
           memory_over_commit_ratio: 2,
-          password: undefined,
           pool: 1,
           power_address: "192.168.1.1",
           power_pass: "password", // virsh uses power_pass key

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
@@ -9,6 +9,7 @@ import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   podState as podStateFactory,
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
@@ -40,8 +41,11 @@ describe("KVMConfigurationFields", () => {
     const state = { ...initialState };
     const pod = podFactory({
       id: 1,
+      power_parameters: powerParametersFactory({
+        power_address: "abc123",
+        power_pass: "maxpower",
+      }),
       type: PodType.VIRSH,
-      power_pass: "maxpower",
     });
     state.pod.items = [pod];
     const store = mockStore(state);
@@ -67,10 +71,10 @@ describe("KVMConfigurationFields", () => {
       pod.tags
     );
     expect(wrapper.find("Input[name='power_address']").props().value).toBe(
-      pod.power_address
+      pod.power_parameters.power_address
     );
-    expect(wrapper.find("Input[name='password']").props().value).toBe(
-      pod.power_pass
+    expect(wrapper.find("Input[name='power_pass']").props().value).toBe(
+      pod.power_parameters.power_pass
     );
     expect(
       wrapper.find("Slider[name='cpu_over_commit_ratio']").props().value
@@ -84,8 +88,10 @@ describe("KVMConfigurationFields", () => {
     const state = { ...initialState };
     const pod = podFactory({
       id: 1,
+      power_parameters: powerParametersFactory({
+        power_address: "abc123",
+      }),
       type: PodType.LXD,
-      password: "powerranger",
     });
     state.pod.items = [pod];
     const store = mockStore(state);
@@ -111,11 +117,9 @@ describe("KVMConfigurationFields", () => {
       pod.tags
     );
     expect(wrapper.find("Input[name='power_address']").props().value).toBe(
-      pod.power_address
+      pod.power_parameters.power_address
     );
-    expect(wrapper.find("Input[name='password']").props().value).toBe(
-      pod.password
-    );
+    expect(wrapper.find("Input[name='power_pass']").exists()).toBe(false);
     expect(
       wrapper.find("Slider[name='cpu_over_commit_ratio']").props().value
     ).toBe(pod.cpu_over_commit_ratio);

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx
@@ -10,6 +10,7 @@ import FormikField from "app/base/components/FormikField";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 import TagField from "app/base/components/TagField";
 import ZoneSelect from "app/base/components/ZoneSelect";
+import { PodType } from "app/store/pod/types";
 import { formatHostType } from "app/store/pod/utils";
 import tagSelectors from "app/store/tag/selectors";
 
@@ -33,11 +34,13 @@ const KVMConfigurationFields = (): JSX.Element => {
       </Col>
       <Col size={5}>
         <FormikField label="Address" name="power_address" type="text" />
-        <FormikField
-          label="Password (optional)"
-          name="password"
-          type="password"
-        />
+        {values.type === PodType.VIRSH && (
+          <FormikField
+            label="Password (optional)"
+            name="power_pass"
+            type="password"
+          />
+        )}
         <FormikField
           component={Slider}
           inputDisabled

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -10,6 +10,7 @@ import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   podResources as podResourcesFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
@@ -65,7 +66,13 @@ describe("KVMDetailsHeader", () => {
 
   it("displays pod name and address when loaded", () => {
     state.pod.items = [
-      podFactory({ id: 1, name: "pod-name", power_address: "192.168.1.1" }),
+      podFactory({
+        id: 1,
+        name: "pod-name",
+        power_parameters: powerParametersFactory({
+          power_address: "192.168.1.1",
+        }),
+      }),
     ];
     const store = mockStore(state);
     const wrapper = mount(
@@ -90,7 +97,13 @@ describe("KVMDetailsHeader", () => {
 
   it("displays action name if action selected", () => {
     state.pod.items = [
-      podFactory({ id: 1, name: "pod-name", power_address: "192.168.1.1" }),
+      podFactory({
+        id: 1,
+        name: "pod-name",
+        power_parameters: powerParametersFactory({
+          power_address: "192.168.1.1",
+        }),
+      }),
     ];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -111,7 +111,7 @@ const KVMDetailsHeader = ({
                 className="u-text--muted u-no-margin--bottom u-no-padding--top"
                 data-test="pod-address"
               >
-                {pod.power_address}
+                {pod.power_parameters.power_address}
               </p>
             )}
           </div>

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.test.tsx
@@ -12,6 +12,7 @@ import {
   configState as configStateFactory,
   pod as podFactory,
   podNuma as podNumaFactory,
+  podPowerParameters as powerParametersFactory,
   podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
@@ -48,7 +49,9 @@ describe("KVMResources", () => {
         items: [
           podFactory({
             id: 1,
-            project: "blair-witch",
+            power_parameters: powerParametersFactory({
+              project: "blair-witch",
+            }),
             type: PodType.LXD,
           }),
         ],

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.tsx
@@ -47,7 +47,7 @@ const KVMResources = ({ id }: Props): JSX.Element => {
         <Strip className={isLxd ? null : "u-no-padding--top"} shallow>
           <div className="u-flex--between u-flex--column-x-small">
             <h4 className="u-sv1" data-test="resources-title">
-              {isLxd ? pod.project : ""}
+              {isLxd ? pod.power_parameters?.project : ""}
             </h4>
             {canViewByNuma && (
               <Switch

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.test.tsx
@@ -8,6 +8,7 @@ import LxdProject from "./LxdProject";
 import { PodType } from "app/store/pod/types";
 import {
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -98,7 +99,13 @@ describe("LxdProject", () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [
-          podFactory({ id: 1, project: "blair-witch", type: PodType.LXD }),
+          podFactory({
+            id: 1,
+            power_parameters: powerParametersFactory({
+              project: "blair-witch",
+            }),
+            type: PodType.LXD,
+          }),
         ],
         loaded: true,
       }),

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
@@ -32,7 +32,7 @@ const LxdProject = ({
   );
   const podsLoaded = useSelector(podSelectors.loaded);
 
-  useWindowTitle(`LXD project ${pod?.project || ""}`);
+  useWindowTitle(`LXD project ${pod?.power_parameters?.project || ""}`);
 
   if (!podsLoaded) {
     return <Spinner text="Loading" />;
@@ -53,7 +53,7 @@ const LxdProject = ({
   return (
     <>
       <h4 className="u-sv1" data-test="project-name">
-        {pod.project}
+        {pod.power_parameters?.project}
       </h4>
       <ProjectSummaryCard id={id} />
       <ProjectVMs

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.test.tsx
@@ -8,6 +8,7 @@ import LxdTable from "./LxdTable";
 import { PodType } from "app/store/pod/types";
 import {
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -20,15 +21,21 @@ describe("LxdTable", () => {
       pod: podStateFactory({
         items: [
           podFactory({
-            power_address: "172.0.0.1",
+            power_parameters: powerParametersFactory({
+              power_address: "172.0.0.1",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
-            power_address: "172.0.0.1",
+            power_parameters: powerParametersFactory({
+              power_address: "172.0.0.1",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
-            power_address: "192.168.1.1",
+            power_parameters: powerParametersFactory({
+              power_address: "192.168.1.1",
+            }),
             type: PodType.LXD,
           }),
         ],
@@ -59,15 +66,21 @@ describe("LxdTable", () => {
       pod: podStateFactory({
         items: [
           podFactory({
-            power_address: "172.0.0.1",
+            power_parameters: powerParametersFactory({
+              power_address: "172.0.0.1",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
-            power_address: "0.0.0.0",
+            power_parameters: powerParametersFactory({
+              power_address: "0.0.0.0",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
-            power_address: "192.168.1.1",
+            power_parameters: powerParametersFactory({
+              power_address: "192.168.1.1",
+            }),
             type: PodType.LXD,
           }),
         ],
@@ -112,22 +125,32 @@ describe("LxdTable", () => {
         items: [
           podFactory({
             name: "pod-2",
-            power_address: "172.0.0.1",
+            power_parameters: powerParametersFactory({
+              power_address: "172.0.0.1",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
             name: "pod-3",
-            power_address: "192.168.1.1",
+            power_parameters: powerParametersFactory({
+              power_address: "192.168.1.1",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
             name: "pod-4",
-            power_address: "192.168.1.1",
+
+            power_parameters: powerParametersFactory({
+              power_address: "192.168.1.1",
+            }),
             type: PodType.LXD,
           }),
           podFactory({
             name: "pod-1",
-            power_address: "172.0.0.1",
+
+            power_parameters: powerParametersFactory({
+              power_address: "172.0.0.1",
+            }),
             type: PodType.LXD,
           }),
         ],

--- a/ui/src/app/kvm/views/KVMList/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/NameColumn/NameColumn.test.tsx
@@ -9,6 +9,7 @@ import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -44,7 +45,9 @@ describe("NameColumn", () => {
       podFactory({
         id: 1,
         name: "pod-1",
-        project: "group-project",
+        power_parameters: powerParametersFactory({
+          project: "group-project",
+        }),
         type: PodType.LXD,
       }),
     ];
@@ -68,7 +71,9 @@ describe("NameColumn", () => {
       podFactory({
         id: 1,
         name: "pod-1",
-        power_address: "172.0.0.1",
+        power_parameters: powerParametersFactory({
+          power_address: "172.0.0.1",
+        }),
         type: PodType.VIRSH,
       }),
     ];

--- a/ui/src/app/kvm/views/KVMList/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/NameColumn/NameColumn.tsx
@@ -27,9 +27,11 @@ const NameColumn = ({ id }: Props): JSX.Element | null => {
         }
         secondary={
           pod.type === PodType.VIRSH ? (
-            <span data-test="power-address">{pod.power_address}</span>
+            <span data-test="power-address">
+              {pod.power_parameters.power_address}
+            </span>
           ) : (
-            <span data-test="project">{pod.project}</span>
+            <span data-test="project">{pod.power_parameters.project}</span>
           )
         }
       />

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -7,6 +7,7 @@ import {
   machine as machineFactory,
   machineState as machineStateFactory,
   pod as podFactory,
+  podPowerParameters as powerParametersFactory,
   podProject as podProjectFactory,
   podResources as podResourcesFactory,
   podState as podStateFactory,
@@ -275,10 +276,30 @@ describe("pod selectors", () => {
   it("can group LXD pods by LXD server address", () => {
     const items = [
       podFactory({ type: PodType.VIRSH }),
-      podFactory({ power_address: "172.0.0.1", type: PodType.LXD }),
-      podFactory({ power_address: "172.0.0.1", type: PodType.LXD }),
-      podFactory({ power_address: "192.168.0.1:8000", type: PodType.LXD }),
-      podFactory({ power_address: "192.168.0.1:9000", type: PodType.LXD }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "172.0.0.1",
+        }),
+        type: PodType.LXD,
+      }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "172.0.0.1",
+        }),
+        type: PodType.LXD,
+      }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "192.168.0.1:8000",
+        }),
+        type: PodType.LXD,
+      }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "192.168.0.1:9000",
+        }),
+        type: PodType.LXD,
+      }),
     ];
     const state = rootStateFactory({
       pod: podStateFactory({
@@ -304,10 +325,30 @@ describe("pod selectors", () => {
   it("can get LXD pods by LXD server address", () => {
     const items = [
       podFactory({ type: PodType.VIRSH }),
-      podFactory({ power_address: "172.0.0.1", type: PodType.LXD }),
-      podFactory({ power_address: "172.0.0.1", type: PodType.LXD }),
-      podFactory({ power_address: "192.168.0.1:8000", type: PodType.LXD }),
-      podFactory({ power_address: "192.168.0.1:9000", type: PodType.LXD }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "172.0.0.1",
+        }),
+        type: PodType.LXD,
+      }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "172.0.0.1",
+        }),
+        type: PodType.LXD,
+      }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "192.168.0.1:8000",
+        }),
+        type: PodType.LXD,
+      }),
+      podFactory({
+        power_parameters: powerParametersFactory({
+          power_address: "192.168.0.1:9000",
+        }),
+        type: PodType.LXD,
+      }),
     ];
     const state = rootStateFactory({
       pod: podStateFactory({

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -198,13 +198,13 @@ const refreshing = createSelector(
 const groupByLxdServer = createSelector([lxd], (lxdPods) =>
   lxdPods.reduce<LxdServerGroup[]>((groups, lxdPod) => {
     const group = groups.find(
-      (group) => group.address === lxdPod.power_address
+      (group) => group.address === lxdPod.power_parameters.power_address
     );
     if (group) {
       group.pods.push(lxdPod);
     } else {
       const newGroup = {
-        address: lxdPod.power_address,
+        address: lxdPod.power_parameters.power_address,
         pods: [lxdPod],
       };
       groups.push(newGroup);

--- a/ui/src/app/store/pod/types/base.ts
+++ b/ui/src/app/store/pod/types/base.ts
@@ -77,8 +77,16 @@ export type PodResources = {
   vms: PodVM[];
 };
 
+export type PodPowerParameters = {
+  certificate?: string;
+  key?: string;
+  power_address: string;
+  power_pass?: string;
+  project?: string;
+};
+
 export type LxdServerGroup = {
-  address: Pod["power_address"];
+  address: PodPowerParameters["power_address"];
   pods: Pod[];
 };
 
@@ -97,13 +105,9 @@ export type BasePod = Model & {
   ip_address: number | string;
   memory_over_commit_ratio: number;
   name: string;
-  password?: string;
   permissions: string[];
   pool: number;
-  power_address: string;
-  power_pass?: string;
-  // Only LXD pods have the project parameter.
-  project?: string;
+  power_parameters: PodPowerParameters;
   resources: PodResources;
   storage_pools: PodStoragePool[];
   tags: string[];
@@ -118,6 +122,11 @@ export type BasePod = Model & {
 export type PodDetails = BasePod & {
   attached_vlans: number[];
   boot_vlans: number[];
+  certificate?: {
+    CN: string;
+    expiration: string;
+    fingerprint: string;
+  };
 };
 
 // Depending on where the user has navigated in the app, pods in state can

--- a/ui/src/app/store/pod/types/index.ts
+++ b/ui/src/app/store/pod/types/index.ts
@@ -17,6 +17,7 @@ export type {
   PodNumaHugepageMemory,
   PodNumaMemory,
   PodNumaResource,
+  PodPowerParameters,
   PodProject,
   PodProjects,
   PodResource,

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -95,6 +95,7 @@ export {
   podNumaGeneralMemory,
   podNumaHugepageMemory,
   podNumaMemory,
+  podPowerParameters,
   podProject,
   podResource,
   podResources,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -27,6 +27,7 @@ import type {
   PodNumaHugepageMemory,
   PodNumaMemory,
   PodNumaResource,
+  PodPowerParameters,
   PodProject,
   PodResource,
   PodResources,
@@ -412,6 +413,11 @@ export const podProject = define<PodProject>({
   name: "project-name",
 });
 
+export const podPowerParameters = define<PodPowerParameters>({
+  power_address: "qemu+ssh://ubuntu@127.0.0.1/system",
+  power_pass: "",
+});
+
 export const pod = extend<Model, Pod>(model, {
   architectures,
   capabilities,
@@ -426,8 +432,7 @@ export const pod = extend<Model, Pod>(model, {
   name: (i: number) => `pod${i}`,
   permissions,
   pool: 1,
-  power_address: "qemu+ssh://ubuntu@127.0.0.1/system",
-  power_pass: "",
+  power_parameters: podPowerParameters,
   resources: podResources,
   storage_pools,
   tags,


### PR DESCRIPTION
## Done

- Updated pod object to use new power_parameters shape
- Updated pod types
- Removed password field for LXD KVMs

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/kvm and check that LXD KVMs are grouped properly
- Check you can add a LXD KVM successfully
- Go to the KVM config page and check that the power address fills in correctly
- Check there is no password field for LXD KVMs

## Fixes

Fixes #3037 
