### PR TITLE
fix(ui): validate destination machine status before cloning

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
@@ -8,6 +8,12 @@
   .source-machine-select__table {
     max-height: 22rem;
     overflow: auto;
+
+    // The default <strong> font-weight is a bit subtle for highlighting
+    // substrings, so it's increased slightly here.
+    strong {
+      font-weight: 600;
+    }
   }
 
   .source-machine-select__row {

--- a/ui/src/app/machines/utils.test.ts
+++ b/ui/src/app/machines/utils.test.ts
@@ -1,6 +1,6 @@
 import { canOpenActionForm } from "./utils";
 
-import { NodeActions } from "app/store/types/node";
+import { NodeActions, NodeStatus } from "app/store/types/node";
 import { machine as machineFactory } from "testing/factories";
 
 describe("machines view utils", () => {
@@ -18,8 +18,26 @@ describe("machines view utils", () => {
     });
 
     it("handles whether a machine can open the clone action form", () => {
-      const machine = machineFactory({ actions: [] });
-      expect(canOpenActionForm(machine, NodeActions.CLONE)).toBe(true);
+      const machine1 = machineFactory({
+        actions: [NodeActions.CLONE],
+        status: NodeStatus.READY,
+      });
+      const machine2 = machineFactory({
+        actions: [],
+        status: NodeStatus.READY,
+      });
+      const machine3 = machineFactory({
+        actions: [NodeActions.CLONE],
+        status: NodeStatus.NEW,
+      });
+      const machine4 = machineFactory({
+        actions: [],
+        status: NodeStatus.NEW,
+      });
+      expect(canOpenActionForm(machine1, NodeActions.CLONE)).toBe(true);
+      expect(canOpenActionForm(machine2, NodeActions.CLONE)).toBe(true);
+      expect(canOpenActionForm(machine3, NodeActions.CLONE)).toBe(false);
+      expect(canOpenActionForm(machine4, NodeActions.CLONE)).toBe(false);
     });
   });
 });

--- a/ui/src/app/machines/utils.ts
+++ b/ui/src/app/machines/utils.ts
@@ -2,7 +2,7 @@ import { MachineHeaderViews } from "./constants";
 import type { MachineHeaderContent } from "./types";
 
 import type { Machine, MachineActions } from "app/store/machine/types";
-import { NodeActions } from "app/store/types/node";
+import { NodeActions, NodeStatus } from "app/store/types/node";
 
 /**
  * Determine whether a machine can open an action form for a particular action.
@@ -19,9 +19,12 @@ export const canOpenActionForm = (
   }
   // Cloning in the UI works inverse to the rest of the machine actions - we
   // select the destination machines first then when the form is open we select
-  // the machine to actually perform the clone action.
+  // the machine to actually perform the clone action. The destination machines
+  // can only be in a subset of statuses.
   if (actionName === NodeActions.CLONE) {
-    return true;
+    return [NodeStatus.READY, NodeStatus.FAILED_TESTING].includes(
+      machine.status
+    );
   }
   return machine.actions.includes(actionName);
 };


### PR DESCRIPTION
## Done

- Validate destination machine status is either Ready or Failed testing before cloning

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and select a bunch of machines including some that are Ready/Failed testing and some that are not
- Attempt to open the clone form and check that you get a prompt to change the selection
- Check that the remaining selection are either Ready or Failed testing

## Fixes

Fixes canonical-web-and-design/app-squad#205
