### PR TITLE
feat(ui): build Stepper component

### DIFF
--- a/ui/src/app/base/components/Stepper/Stepper.test.tsx
+++ b/ui/src/app/base/components/Stepper/Stepper.test.tsx
@@ -1,0 +1,35 @@
+import { shallow } from "enzyme";
+
+import Stepper from "./Stepper";
+
+describe("Stepper", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <Stepper
+        currentStep="step2"
+        items={[
+          { step: "step1", title: "Step 1" },
+          { step: "step2", title: "Step 2" },
+          { step: "step3", title: "Step 3" },
+        ]}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders a step as checked if the index of the current step is higher", () => {
+    const wrapper = shallow(
+      <Stepper
+        currentStep="step2"
+        items={[
+          { step: "step1", title: "Step 1" },
+          { step: "step2", title: "Step 2" },
+          { step: "step3", title: "Step 3" },
+        ]}
+      />
+    );
+    expect(wrapper.find("[aria-checked=true]").at(0).text()).toBe("Step 1");
+    expect(wrapper.find("[aria-checked=false]").at(0).text()).toBe("Step 2");
+    expect(wrapper.find("[aria-checked=false]").at(1).text()).toBe("Step 3");
+  });
+});

--- a/ui/src/app/base/components/Stepper/Stepper.tsx
+++ b/ui/src/app/base/components/Stepper/Stepper.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+import classNames from "classnames";
+
+type StepperItem = {
+  step: string;
+  title: ReactNode;
+};
+
+type Props = {
+  currentStep: string;
+  items: StepperItem[];
+};
+
+export const Stepper = ({ currentStep, items }: Props): JSX.Element => {
+  return (
+    <ol className="stepper">
+      {items.map((item, i) => {
+        const isComplete =
+          items.findIndex((item) => item.step === currentStep) > i;
+        return (
+          <li className="stepper__item" key={item.step}>
+            <p
+              aria-checked={isComplete}
+              className={classNames("stepper__title", {
+                "is-complete": isComplete,
+              })}
+            >
+              {item.title}
+            </p>
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+export default Stepper;

--- a/ui/src/app/base/components/Stepper/Stepper.tsx
+++ b/ui/src/app/base/components/Stepper/Stepper.tsx
@@ -16,13 +16,15 @@ export const Stepper = ({ currentStep, items }: Props): JSX.Element => {
   return (
     <ol className="stepper">
       {items.map((item, i) => {
+        const isActive = item.step === currentStep;
         const isComplete =
-          items.findIndex((item) => item.step === currentStep) > i;
+          items.findIndex(({ step }) => step === currentStep) > i;
         return (
           <li className="stepper__item" key={item.step}>
             <p
               aria-checked={isComplete}
               className={classNames("stepper__title", {
+                "is-active": isActive,
                 "is-complete": isComplete,
               })}
             >

--- a/ui/src/app/base/components/Stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/ui/src/app/base/components/Stepper/__snapshots__/Stepper.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Stepper renders 1`] = `
   >
     <p
       aria-checked={false}
-      className="stepper__title"
+      className="stepper__title is-active"
     >
       Step 2
     </p>

--- a/ui/src/app/base/components/Stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/ui/src/app/base/components/Stepper/__snapshots__/Stepper.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stepper renders 1`] = `
+<ol
+  className="stepper"
+>
+  <li
+    className="stepper__item"
+    key="step1"
+  >
+    <p
+      aria-checked={true}
+      className="stepper__title is-complete"
+    >
+      Step 1
+    </p>
+  </li>
+  <li
+    className="stepper__item"
+    key="step2"
+  >
+    <p
+      aria-checked={false}
+      className="stepper__title"
+    >
+      Step 2
+    </p>
+  </li>
+  <li
+    className="stepper__item"
+    key="step3"
+  >
+    <p
+      aria-checked={false}
+      className="stepper__title"
+    >
+      Step 3
+    </p>
+  </li>
+</ol>
+`;

--- a/ui/src/app/base/components/Stepper/_index.scss
+++ b/ui/src/app/base/components/Stepper/_index.scss
@@ -20,6 +20,14 @@
     .stepper__title {
       @extend .p-stepped-list__title;
 
+      &::before {
+        background-color: $color-light;
+      }
+
+      &.is-active::before {
+        background-color: $color-mid-x-light;
+      }
+
       &.is-complete {
         &::before {
           content: "";

--- a/ui/src/app/base/components/Stepper/_index.scss
+++ b/ui/src/app/base/components/Stepper/_index.scss
@@ -1,0 +1,41 @@
+@mixin Stepper {
+  .stepper {
+    @extend .p-stepped-list;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      flex-direction: row;
+    }
+
+    .stepper__item {
+      @extend .p-stepped-list__item;
+
+      padding-bottom: $spv-inner--x-small;
+      width: auto;
+
+      &:not(:last-of-type) {
+        margin-right: $sp-xx-large;
+      }
+    }
+
+    .stepper__title {
+      @extend .p-stepped-list__title;
+
+      &.is-complete {
+        &::before {
+          content: "";
+          height: 1.5rem;
+        }
+
+        &::after {
+          @include vf-icon-task-outstanding($color-dark);
+          @include vf-icon-size($default-icon-size);
+
+          content: "";
+          left: 3px;
+          position: absolute;
+          top: 10px;
+        }
+      }
+    }
+  }
+}

--- a/ui/src/app/base/components/Stepper/index.ts
+++ b/ui/src/app/base/components/Stepper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Stepper";

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AddLxd.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AddLxd.tsx
@@ -9,6 +9,7 @@ import CredentialsForm from "./CredentialsForm";
 import SelectProjectForm from "./SelectProjectForm";
 import type { AddLxdStepValues, NewPodValues } from "./types";
 
+import Stepper from "app/base/components/Stepper";
 import type { ClearHeaderContent } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
@@ -66,9 +67,18 @@ export const AddLxd = ({
     };
   }, [dispatch]);
 
-  switch (step) {
-    case AddLxdSteps.CREDENTIALS:
-      return (
+  return (
+    <>
+      <Stepper
+        items={[
+          { step: AddLxdSteps.CREDENTIALS, title: "Credentials" },
+          { step: AddLxdSteps.AUTHENTICATION, title: "Authentication" },
+          { step: AddLxdSteps.SELECT_PROJECT, title: "Project selection" },
+        ]}
+        currentStep={step}
+      />
+      <hr />
+      {step === AddLxdSteps.CREDENTIALS && (
         <CredentialsForm
           clearHeaderContent={clearHeaderContent}
           newPodValues={newPodValues}
@@ -76,25 +86,24 @@ export const AddLxd = ({
           setNewPodValues={setNewPodValues}
           setStep={setStep}
         />
-      );
-    case AddLxdSteps.AUTHENTICATION:
-      return (
+      )}
+      {step === AddLxdSteps.AUTHENTICATION && (
         <AuthenticationForm
           clearHeaderContent={clearHeaderContent}
           newPodValues={newPodValues}
           setNewPodValues={setNewPodValues}
           setStep={setStep}
         />
-      );
-    case AddLxdSteps.SELECT_PROJECT:
-      return (
+      )}
+      {step === AddLxdSteps.SELECT_PROJECT && (
         <SelectProjectForm
           clearHeaderContent={clearHeaderContent}
           newPodValues={newPodValues}
           setStep={setStep}
         />
-      );
-  }
+      )}
+    </>
+  );
 };
 
 export default AddLxd;

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -86,9 +86,9 @@ export const AuthenticationForm = ({
       <div className="u-flex--between">
         <div>
           <p>
-            LXD host:{" "}
-            {newPodValues.name && <strong>{newPodValues.name}</strong>} (
-            {newPodValues.power_address})
+            <strong>
+              LXD host: {newPodValues.name} ({newPodValues.power_address})
+            </strong>
           </p>
         </div>
         <div>

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -82,6 +82,7 @@
 @import "~app/base/components/Popover";
 @import "~app/base/components/Section";
 @import "~app/base/components/SSHKeyList";
+@import "~app/base/components/Stepper";
 @import "~app/base/components/TableMenu";
 @import "~app/base/components/TagSelector";
 @include ColumnToggle;
@@ -97,6 +98,7 @@
 @include Popover;
 @include Section;
 @include SSHKeyList;
+@include Stepper;
 @include TableMenu;
 @include TagSelector;
 


### PR DESCRIPTION
## Done

- Built `Stepper` component, which is just a horizontal version of `.p-stepped-list` with an extra bit of styling to show a tick instead of a number
- Used `Stepper` in the `AddLxd` form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click "Add KVM"
- Check that there is a stepped list on top of the form
- Fill in the first part of the form and click "Next"
- Check that the first step number has been replaced by a tick, as per [the design](https://app.zeplin.io/project/610abd78c381eeafb70f5b43/screen/6127ba8dff785fa0c17df50b)

## Fixes

Fixes canonical-web-and-design/app-squad#249

## Screenshot
![Screenshot 2021-09-14 at 19-04-39 KVM bolla MAAS](https://user-images.githubusercontent.com/25733845/133229021-78da9a70-cc0e-4e0c-bea0-1920c8d95022.png)
