### PR TITLE
feat(ui): add customised auth fields for LXD power type

### DIFF
--- a/ui/src/app/base/components/AuthenticationFields/AuthenticationFields.test.tsx
+++ b/ui/src/app/base/components/AuthenticationFields/AuthenticationFields.test.tsx
@@ -1,0 +1,74 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import AuthenticationFields from "./AuthenticationFields";
+
+describe("AuthenticationFields", () => {
+  it("renders password field if generating a certificate", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ certificate: "", key: "", password: "" }}
+        onSubmit={jest.fn()}
+      >
+        <AuthenticationFields
+          onShouldGenerateCert={jest.fn()}
+          shouldGenerateCert
+        />
+      </Formik>
+    );
+    expect(wrapper.find("input[name='password']").exists()).toBe(true);
+    expect(wrapper.find("textarea[name='certificate']").exists()).toBe(false);
+    expect(wrapper.find("textarea[name='key']").exists()).toBe(false);
+  });
+
+  it("can choose not to render the password field when generating certificate", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ certificate: "", key: "", password: "" }}
+        onSubmit={jest.fn()}
+      >
+        <AuthenticationFields
+          onShouldGenerateCert={jest.fn()}
+          shouldGenerateCert
+          showPassword={false}
+        />
+      </Formik>
+    );
+    expect(wrapper.find("input[name='password']").exists()).toBe(false);
+    expect(wrapper.find("textarea[name='certificate']").exists()).toBe(false);
+    expect(wrapper.find("textarea[name='key']").exists()).toBe(false);
+  });
+
+  it("renders certificate and key fields if not generating a certificate", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ certificate: "", key: "", password: "" }}
+        onSubmit={jest.fn()}
+      >
+        <AuthenticationFields
+          onShouldGenerateCert={jest.fn()}
+          shouldGenerateCert={false}
+        />
+      </Formik>
+    );
+    expect(wrapper.find("input[name='password']").exists()).toBe(false);
+    expect(wrapper.find("textarea[name='certificate']").exists()).toBe(true);
+    expect(wrapper.find("textarea[name='key']").exists()).toBe(true);
+  });
+
+  it("can be given different field names", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ certificate: "", key: "", password: "" }}
+        onSubmit={jest.fn()}
+      >
+        <AuthenticationFields
+          onShouldGenerateCert={jest.fn()}
+          passwordValueName="trust_password"
+          shouldGenerateCert
+        />
+      </Formik>
+    );
+    expect(wrapper.find("input[name='trust_password']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/AuthenticationFields/AuthenticationFields.tsx
+++ b/ui/src/app/base/components/AuthenticationFields/AuthenticationFields.tsx
@@ -1,0 +1,86 @@
+import { Button, Icon, Input, Textarea } from "@canonical/react-components";
+
+import FormikField from "app/base/components/FormikField";
+
+type Props = {
+  certificateValueName?: string;
+  onShouldGenerateCert: (shouldGenerateCert: boolean) => void;
+  passwordValueName?: string;
+  privateKeyValueName?: string;
+  shouldGenerateCert: boolean;
+  showPassword?: boolean;
+};
+
+export const AuthenticationFields = ({
+  certificateValueName = "certificate",
+  onShouldGenerateCert,
+  passwordValueName = "password",
+  privateKeyValueName = "key",
+  shouldGenerateCert,
+  showPassword = true,
+}: Props): JSX.Element => {
+  return (
+    <>
+      <p>Authentication</p>
+      <Input
+        checked={shouldGenerateCert}
+        id="generate-certificate"
+        label="Generate new certificate"
+        onChange={() => onShouldGenerateCert(true)}
+        type="radio"
+      />
+      {shouldGenerateCert && showPassword && (
+        <FormikField
+          label="LXD password (optional)"
+          name={passwordValueName}
+          placeholder="Enter trust password"
+          type="password"
+          wrapperClassName="u-nudge-right--x-large u-sv1"
+        />
+      )}
+      <Input
+        checked={!shouldGenerateCert}
+        id="provide-certificate"
+        label="Provide certificate and private key"
+        onChange={() => onShouldGenerateCert(false)}
+        type="radio"
+        wrapperClassName="u-sv2"
+      />
+      {!shouldGenerateCert && (
+        <>
+          {/*
+          TODO: Build proper upload fields.
+          https://github.com/canonical-web-and-design/app-squad/issues/244
+        */}
+          <Button>
+            <span className="u-nudge-left--small">
+              <Icon name="back-to-top" />
+            </span>
+            Upload certificate
+          </Button>
+          <FormikField
+            component={Textarea}
+            name={certificateValueName}
+            placeholder="Paste or upload a certificate."
+            rows={5}
+            wrapperClassName="u-sv2"
+          />
+          <Button>
+            <span className="u-nudge-left--small">
+              <Icon name="back-to-top" />
+            </span>
+            Upload private key
+          </Button>
+          <FormikField
+            component={Textarea}
+            name={privateKeyValueName}
+            placeholder="Paste or upload a private key."
+            rows={5}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default AuthenticationFields;

--- a/ui/src/app/base/components/AuthenticationFields/index.ts
+++ b/ui/src/app/base/components/AuthenticationFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AuthenticationFields";

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
@@ -379,4 +379,67 @@ describe("PowerTypeFields", () => {
       wrapper.find("input[name='power_parameters.parameter3']").prop("value")
     ).toBe("default4");
   });
+
+  it("shows custom LXD authentication fields if not configuring existing power parameters", () => {
+    const powerTypes = [
+      powerTypeFactory({
+        fields: [
+          powerFieldFactory({ name: "certificate" }),
+          powerFieldFactory({ name: "key" }),
+          powerFieldFactory({ name: "password" }),
+        ],
+        name: "lxd",
+      }),
+    ];
+    state.general.powerTypes.data = powerTypes;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{ power_parameters: {}, power_type: "lxd" }}
+          onSubmit={jest.fn()}
+        >
+          <PowerTypeFields forConfiguration={false} />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("AuthenticationFields").exists()).toBe(true);
+    expect(wrapper.find("[data-test='certificate-data']").exists()).toBe(false);
+  });
+
+  it("shows custom LXD certificate data if configuring existing power parameters", () => {
+    const powerTypes = [
+      powerTypeFactory({
+        fields: [
+          powerFieldFactory({ name: "certificate" }),
+          powerFieldFactory({ name: "key" }),
+          powerFieldFactory({ name: "password" }),
+        ],
+        name: "lxd",
+      }),
+    ];
+    state.general.powerTypes.data = powerTypes;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{
+            power_parameters: {
+              certificate: "certificate",
+              key: "key",
+              password: "password",
+            },
+            power_type: "lxd",
+          }}
+          onSubmit={jest.fn()}
+        >
+          <PowerTypeFields forConfiguration />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='certificate-data']").exists()).toBe(true);
+    expect(wrapper.find("AuthenticationFields").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 
-import { Input, Select, Spinner } from "@canonical/react-components";
+import { Input, Select, Spinner, Textarea } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
+import AuthenticationFields from "app/base/components/AuthenticationFields";
 import FormikField from "app/base/components/FormikField";
 import type { AnyObject } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
@@ -15,11 +17,20 @@ type Props = {
   disableFields?: boolean;
   disableSelect?: boolean;
   forChassis?: boolean;
+  forConfiguration?: boolean;
   powerParametersValueName?: string;
   powerTypeValueName?: string;
   fieldScopes?: PowerFieldScope[];
   showSelect?: boolean;
 };
+
+const CustomFields = {
+  LXD: {
+    CERTIFICATE: "certificate",
+    KEY: "key",
+    PASSWORD: "password",
+  },
+} as const;
 
 /**
  * Generate the fields to show, depending on the selected power type and the
@@ -28,54 +39,124 @@ type Props = {
  * @param disabled - whether all fields should be disabled.
  * @param fieldScopes - the scopes of the fields to show.
  * @param powerParametersValueName - the power parameters "name" in the Formik form
+ * @param forConfiguration - whether the fields are being used for configuration of existing power parameters
+ * @param generateCert - whether a certificate should be generated (LXD-only)
+ * @param onShouldGenerateCert - function to run when changing certificate radio (LXD-only)
  * @returns list of Formik fields relevant to the chosen power type and field scopes.
  */
 const generateFields = (
   selectedPowerType: PowerType,
   disabled: boolean,
   fieldScopes: PowerFieldScope[],
-  powerParametersValueName: string
-) =>
-  selectedPowerType?.fields
-    ?.filter((field) => fieldScopes.includes(field.scope))
-    .map((field) => {
-      const { choices, field_type, label, name, required } = field;
-      return (
-        <FormikField
-          component={field_type === "choice" ? Select : Input}
-          disabled={disabled}
-          key={name}
-          label={label}
-          name={`${powerParametersValueName}.${name}`}
-          options={
-            field_type === "choice"
-              ? choices.map((choice) => ({
-                  key: `${name}-${choice[0]}`,
-                  label: choice[1],
-                  value: choice[0],
-                }))
-              : undefined
-          }
-          required={required}
-          type={
-            (field_type === "string" && "text") ||
-            (field_type === "password" && "password") ||
-            undefined
-          }
+  powerParametersValueName: string,
+  forConfiguration: boolean,
+  shouldGenerateCert: boolean,
+  onShouldGenerateCert: (shouldGeneraterCert: boolean) => void
+) => {
+  const baseFields: ReactNode[] = [];
+  let customFields: ReactNode = null;
+  const fieldsInScope = selectedPowerType.fields.filter((field) =>
+    fieldScopes.includes(field.scope)
+  );
+  const isLxd = selectedPowerType.name === "lxd";
+
+  fieldsInScope.forEach((field) => {
+    // The authentication fields for the LXD power type are ignored here and
+    // special-cased below. All other power type fields are generated directly
+    // from the API data.
+    if (
+      isLxd &&
+      Object.values(CustomFields.LXD).some((val) => val === field.name)
+    ) {
+      return;
+    }
+    const { choices, field_type, label, name, required } = field;
+    baseFields.push(
+      <FormikField
+        component={field_type === "choice" ? Select : Input}
+        disabled={disabled}
+        key={name}
+        label={label}
+        name={`${powerParametersValueName}.${name}`}
+        options={
+          field_type === "choice"
+            ? choices.map((choice) => ({
+                key: `${name}-${choice[0]}`,
+                label: choice[1],
+                value: choice[0],
+              }))
+            : undefined
+        }
+        required={required}
+        type={
+          (field_type === "string" && "text") ||
+          (field_type === "password" && "password") ||
+          undefined
+        }
+      />
+    );
+  });
+  if (isLxd) {
+    if (forConfiguration) {
+      // TODO: Render custom certificate section.
+      // https://github.com/canonical-web-and-design/app-squad/issues/247
+      customFields = (
+        <div data-test="certificate-data">
+          <FormikField
+            disabled={disabled}
+            label="LXD password (optional)"
+            name={`${powerParametersValueName}.${CustomFields.LXD.PASSWORD}`}
+            type="password"
+          />
+          <FormikField
+            component={Textarea}
+            disabled={disabled}
+            label="LXD certificate (optional)"
+            name={`${powerParametersValueName}.${CustomFields.LXD.CERTIFICATE}`}
+            rows={5}
+          />
+          <FormikField
+            component={Textarea}
+            disabled={disabled}
+            label="LXD private key (optional)"
+            name={`${powerParametersValueName}.${CustomFields.LXD.KEY}`}
+            rows={5}
+          />
+        </div>
+      );
+    } else {
+      customFields = (
+        <AuthenticationFields
+          certificateValueName={`${powerParametersValueName}.${CustomFields.LXD.CERTIFICATE}`}
+          onShouldGenerateCert={onShouldGenerateCert}
+          passwordValueName={`${powerParametersValueName}.${CustomFields.LXD.PASSWORD}`}
+          privateKeyValueName={`${powerParametersValueName}.${CustomFields.LXD.KEY}`}
+          shouldGenerateCert={shouldGenerateCert}
+          showPassword
         />
       );
-    });
+    }
+  }
+  return (
+    <>
+      {baseFields}
+      {customFields}
+    </>
+  );
+};
 
 export const PowerTypeFields = <V extends AnyObject>({
   disableFields = false,
   disableSelect = false,
   forChassis = false,
+  forConfiguration = false,
   powerParametersValueName = "power_parameters",
   powerTypeValueName = "power_type",
   fieldScopes = [PowerFieldScope.BMC, PowerFieldScope.NODE],
   showSelect = true,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const [shouldGenerateCert, setShouldGenerateCert] = useState(true);
   const allPowerTypes = useSelector(powerTypesSelectors.get);
   const chassisPowerTypes = useSelector(powerTypesSelectors.canProbe);
   const powerTypesLoaded = useSelector(powerTypesSelectors.loaded);
@@ -88,6 +169,13 @@ export const PowerTypeFields = <V extends AnyObject>({
     setTouched,
     values,
   } = useFormikContext<V>();
+
+  const onShouldGenerateCert = (shouldGenerateCert: boolean) => {
+    setShouldGenerateCert(shouldGenerateCert);
+    setFieldValue(`${powerParametersValueName}.certificate`, "");
+    setFieldValue(`${powerParametersValueName}.key`, "");
+    setFieldValue(`${powerParametersValueName}.password`, "");
+  };
 
   // Only power types that can probe are suitable for use when adding a chassis.
   const powerTypes = forChassis ? chassisPowerTypes : allPowerTypes;
@@ -149,7 +237,10 @@ export const PowerTypeFields = <V extends AnyObject>({
           selectedPowerType,
           disableFields,
           fieldScopes,
-          powerParametersValueName
+          powerParametersValueName,
+          forConfiguration,
+          shouldGenerateCert,
+          onShouldGenerateCert
         )}
     </>
   );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AddLxd.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AddLxd.tsx
@@ -11,7 +11,6 @@ import type { AddLxdStepValues, NewPodValues } from "./types";
 
 import Stepper from "app/base/components/Stepper";
 import type { ClearHeaderContent } from "app/base/types";
-import { actions as generalActions } from "app/store/general";
 import { generatedCertificate as generatedCertificateSelectors } from "app/store/general/selectors";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
@@ -78,14 +77,11 @@ export const AddLxd = ({
     }
   }, [shouldGoToProjectStep]);
 
+  // We run the cleanup function here rather than in each form component
+  // because we want the errors to be able to persist across forms.
   useEffect(() => {
     return () => {
-      // We run the cleanup function here rather than in each form component
-      // because we want the errors to be able to persist across forms.
       dispatch(podActions.cleanup());
-      // The generated certificate is also cleared as we only store one in state
-      // at a time. This will prepare the form for the next added VM host.
-      dispatch(generalActions.clearGeneratedCertificate());
     };
   }, [dispatch]);
 

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -12,6 +12,7 @@ import AuthenticationFormFields from "./AuthenticationFormFields";
 import FormikForm from "app/base/components/FormikForm";
 import { useCycled } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
+import { actions as generalActions } from "app/store/general";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { PodType } from "app/store/pod/types";
@@ -49,6 +50,14 @@ export const AuthenticationForm = ({
       setStep(AddLxdSteps.CREDENTIALS);
     }
   }, [errors, hasTriedUsingPassword, setStep]);
+
+  // The generated certificate is cleared on unmount as we only store one in
+  // state at a time. This will prepare the form for the next added VM host.
+  useEffect(() => {
+    return () => {
+      dispatch(generalActions.clearGeneratedCertificate());
+    };
+  }, [dispatch]);
 
   return (
     <FormikForm<AuthenticationFormValues>

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsFormFields/CredentialsFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsFormFields/CredentialsFormFields.tsx
@@ -1,8 +1,9 @@
-import { Col, Input, Row, Textarea } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { CredentialsFormValues } from "../../types";
 
+import AuthenticationFields from "app/base/components/AuthenticationFields";
 import FormikField from "app/base/components/FormikField";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 import ZoneSelect from "app/base/components/ZoneSelect";
@@ -38,41 +39,15 @@ export const CredentialsFormFields = ({
           required
           type="text"
         />
-        <p>Authentication</p>
-        <Input
-          checked={shouldGenerateCert}
-          id="generate-certificate"
-          label="Generate new certificate"
-          onChange={() => {
-            setShouldGenerateCert(true);
+        <AuthenticationFields
+          onShouldGenerateCert={(shouldGenerateCert) => {
+            setShouldGenerateCert(shouldGenerateCert);
             setFieldValue("certificate", "");
             setFieldValue("key", "");
           }}
-          type="radio"
+          shouldGenerateCert={shouldGenerateCert}
+          showPassword={false}
         />
-        <Input
-          checked={!shouldGenerateCert}
-          id="provide-certificate"
-          label="Provide certificate and key"
-          onChange={() => {
-            setShouldGenerateCert(false);
-          }}
-          type="radio"
-        />
-        {/*
-          TODO: Build proper upload fields.
-          https://github.com/canonical-web-and-design/app-squad/issues/244
-        */}
-        {!shouldGenerateCert && (
-          <>
-            <FormikField
-              component={Textarea}
-              label="Certificate"
-              name="certificate"
-            />
-            <FormikField component={Textarea} label="Private key" name="key" />
-          </>
-        )}
       </Col>
     </Row>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
@@ -57,6 +57,7 @@ const PowerFormFields = ({ editing, machine }: Props): JSX.Element => {
           disableFields={!editing}
           disableSelect={!editing || machineInPod}
           fieldScopes={fieldScopes}
+          forConfiguration
           powerParametersValueName="powerParameters"
           powerTypeValueName="powerType"
         />

--- a/ui/src/app/store/general/slice.ts
+++ b/ui/src/app/store/general/slice.ts
@@ -99,7 +99,7 @@ const generalSlice = createSlice({
     fetchHweKernels: generatePrepareReducer("hwe_kernels"),
     fetchHweKernelsStart: generateStartReducer("hweKernels"),
     fetchHweKernelsError: generateErrorReducer("hweKernels"),
-    fetchHweKernelSuccess: generateSuccessReducer("hweKernels"),
+    fetchHweKernelsSuccess: generateSuccessReducer("hweKernels"),
     fetchKnownArchitectures: generatePrepareReducer("known_architectures"),
     fetchKnownArchitecturesStart: generateStartReducer("knownArchitectures"),
     fetchKnownArchitecturesError: generateErrorReducer("knownArchitectures"),

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -12,6 +12,7 @@
 @include vf-b-button;
 @include vf-b-grid-definitions;
 @include vf-p-icons-common;
+@include vf-p-icon-back-to-top;
 @include vf-p-icon-begin-downloading;
 @include vf-p-icon-change-version;
 @include vf-p-icon-inspector-debug;


### PR DESCRIPTION
## Done

- Added `AuthenticationFields` component and used in both "Add machine > LXD" and "Add KVM > LXD" forms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and click "Add hardware > Machine"
- Select LXD as the power type and check that there is a radio button section for authentication (upload functionality to be handled separately)
- Check that you can submit the form and add LXD machine
- Go to the Configuration tab of the new LXD machine and check that the values that show up are correct (note the design of this will change in a follow up)
- Go to the KVM list and click "Add KVM"
- Check that the form still works as expected

## Fixes

Fixes canonical-web-and-design/app-squad#243

## Screenshot
![Screenshot 2021-09-15 at 11-13-00 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/133355084-bab702da-86b4-410b-8a0e-b0a6eb82cefb.png)

