### PR TITLE
feat(ui): add ability to poll LXD server for authentication status

### DIFF
--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -43,6 +43,46 @@ describe("FormikFormContent", () => {
     expect(wrapper.find("FormikFormContent").exists()).toBe(true);
   });
 
+  it("disables cancel button while saving", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <FormikFormContent onCancel={jest.fn()} saving>
+              Content
+            </FormikFormContent>
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("button[data-test='cancel-action']").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("can override disabling cancel button while saving", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <FormikFormContent
+              cancelDisabled={false}
+              onCancel={jest.fn()}
+              saving
+            >
+              Content
+            </FormikFormContent>
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("button[data-test='cancel-action']").prop("disabled")
+    ).toBe(false);
+  });
+
   it("can display non-field errors from a string", () => {
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -69,6 +69,7 @@ const generateNonFieldError = <V, E = null>(
 const FormikFormContent = <V, E = null>({
   allowAllEmpty,
   allowUnchanged,
+  cancelDisabled,
   children,
   className,
   cleanup,
@@ -161,7 +162,7 @@ const FormikFormContent = <V, E = null>({
       {editable && (
         <FormikFormButtons
           {...buttonsProps}
-          cancelDisabled={saving}
+          cancelDisabled={cancelDisabled === false ? false : saving}
           inline={inline}
           saved={saved}
           saving={saving}

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AddLxd.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AddLxd.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import AddLxd from "./AddLxd";
 
+import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -141,5 +142,29 @@ describe("AddLxd", () => {
     expect(wrapper.find("CredentialsForm").exists()).toBe(false);
     expect(wrapper.find("AuthenticationForm").exists()).toBe(false);
     expect(wrapper.find("SelectProjectForm").exists()).toBe(true);
+  });
+
+  it("clears projects and runs cleanup on unmount", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <AddLxd clearHeaderContent={jest.fn()} setKvmType={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.unmount();
+
+    const expectedActions = [podActions.cleanup(), podActions.clearProjects()];
+    const actualActions = store.getActions();
+    expect(
+      actualActions.every((actualAction) =>
+        expectedActions.some(
+          (expectedAction) => expectedAction.type === actualAction.type
+        )
+      )
+    );
   });
 });

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationFormFields/AuthenticationFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationFormFields/AuthenticationFormFields.tsx
@@ -7,23 +7,25 @@ import {
   Row,
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import { useSelector } from "react-redux";
 
 import type { AuthenticationFormValues } from "../AuthenticationForm";
 
 import FormikField from "app/base/components/FormikField";
-import { generatedCertificate as generatedCertificateSelectors } from "app/store/general/selectors";
+import type { GeneratedCertificate } from "app/store/general/types";
 
 type Props = {
+  certificate: GeneratedCertificate | null;
+  disabled: boolean;
   setUseCertificate: (useCert: boolean) => void;
   useCertificate: boolean;
 };
 
 export const AuthenticationForm = ({
+  certificate,
+  disabled,
   setUseCertificate,
   useCertificate,
 }: Props): JSX.Element => {
-  const generatedCertificate = useSelector(generatedCertificateSelectors.get);
   const { setFieldTouched, setFieldValue } =
     useFormikContext<AuthenticationFormValues>();
 
@@ -32,6 +34,7 @@ export const AuthenticationForm = ({
       <Col className="p-divider__block" size={6}>
         <Input
           checked={useCertificate}
+          disabled={disabled}
           id="use-certificate"
           label="Add trust to LXD via command line"
           onChange={() => {
@@ -46,7 +49,7 @@ export const AuthenticationForm = ({
           <CodeSnippet
             blocks={[
               { code: "lxd config trust add - << EOF" },
-              { code: generatedCertificate?.certificate || "" },
+              { code: certificate?.certificate || "" },
               { code: "EOF" },
             ]}
             className="u-no-margin--bottom"
@@ -62,6 +65,7 @@ export const AuthenticationForm = ({
       <Col className="p-divider__block" size={6}>
         <Input
           checked={!useCertificate}
+          disabled={disabled}
           id="use-password"
           label="Use trust password (not secure!)"
           onChange={() => {
@@ -70,7 +74,7 @@ export const AuthenticationForm = ({
           type="radio"
         />
         <FormikField
-          disabled={useCertificate}
+          disabled={disabled || useCertificate}
           name="password"
           type="password"
         />

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -49,8 +49,9 @@ export const SelectProjectFormFields = ({
       )}
       <Col size={6}>
         <p data-test="lxd-host-details">
-          LXD host: {newPodValues.name && <strong>{newPodValues.name}</strong>}{" "}
-          ({newPodValues.power_address})
+          <strong>
+            LXD host: {newPodValues.name} ({newPodValues.power_address})
+          </strong>
         </p>
         <p className="u-text--muted">
           <span>Connected</span>

--- a/ui/src/app/store/pod/actions.test.ts
+++ b/ui/src/app/store/pod/actions.test.ts
@@ -1,4 +1,5 @@
 import { actions } from "./slice";
+import { PodMeta, PodType } from "./types";
 
 describe("pod actions", () => {
   it("can create an action for fetching pods", () => {
@@ -124,6 +125,23 @@ describe("pod actions", () => {
   it("can create an action for clearing projects", () => {
     expect(actions.clearProjects()).toEqual({
       type: "pod/clearProjects",
+    });
+  });
+
+  it("can create an action for polling a LXD server", () => {
+    expect(actions.pollLxdServer({ power_address: "172.0.0.1" })).toEqual({
+      type: "pod/pollLxdServer",
+      meta: {
+        method: "get_projects",
+        model: PodMeta.MODEL,
+        poll: true,
+      },
+      payload: {
+        params: {
+          power_address: "172.0.0.1",
+          type: PodType.LXD,
+        },
+      },
     });
   });
 });

--- a/ui/src/app/store/pod/reducers.test.ts
+++ b/ui/src/app/store/pod/reducers.test.ts
@@ -433,4 +433,39 @@ describe("pod reducer", () => {
       })
     );
   });
+
+  it("reduces pollLxdServerSuccess", () => {
+    const serverAddress = "192.168.1.1";
+    const newProjects = [podProjectFactory()];
+    const podState = podStateFactory({
+      items: [],
+      projects: {},
+    });
+
+    expect(
+      reducers(
+        podState,
+        actions.pollLxdServerSuccess(
+          { power_address: serverAddress, type: PodType.LXD },
+          newProjects
+        )
+      )
+    ).toEqual(
+      podStateFactory({
+        projects: { [serverAddress]: newProjects },
+      })
+    );
+  });
+
+  it("reduces pollLxdServerError", () => {
+    const podState = podStateFactory({
+      errors: null,
+    });
+
+    expect(reducers(podState, actions.pollLxdServerError("Error!"))).toEqual(
+      podStateFactory({
+        errors: null,
+      })
+    );
+  });
 });

--- a/ui/src/app/store/pod/types/actions.ts
+++ b/ui/src/app/store/pod/types/actions.ts
@@ -50,6 +50,8 @@ export type GetProjectsParams = {
   type: PodType;
 };
 
+export type PollLxdServerParams = Omit<GetProjectsParams, "type">;
+
 export type UpdateParams = CreateParams & {
   [PodMeta.PK]: Pod[PodMeta.PK];
 };

--- a/ui/src/app/store/pod/types/index.ts
+++ b/ui/src/app/store/pod/types/index.ts
@@ -3,6 +3,7 @@ export type {
   CreateParams,
   DeleteParams,
   GetProjectsParams,
+  PollLxdServerParams,
   UpdateParams,
 } from "./actions";
 

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -21,5 +21,6 @@ export { preparePayload } from "./preparePayload";
 export { simpleSortByKey } from "./simpleSortByKey";
 export { someInArray } from "./someInArray";
 export { someNotAll } from "./someNotAll";
+export { splitCertificateName } from "./splitCertificateName";
 export { toFormikNumber } from "./toFormikNumber";
 export { unindentString } from "./unindentString";

--- a/ui/src/app/utils/splitCertificateName.test.ts
+++ b/ui/src/app/utils/splitCertificateName.test.ts
@@ -1,0 +1,33 @@
+import { splitCertificateName } from "./splitCertificateName";
+
+import { generatedCertificate as certFactory } from "testing/factories";
+
+describe("splitCertificateName", () => {
+  it("handles null case", () => {
+    expect(splitCertificateName(null)).toStrictEqual(null);
+  });
+
+  it("handles missing host", () => {
+    expect(splitCertificateName(certFactory({ CN: "bad-cert" }))).toStrictEqual(
+      {
+        host: "",
+        name: "bad-cert",
+      }
+    );
+  });
+
+  it("can split a certificate name into name and host", () => {
+    expect(
+      splitCertificateName(certFactory({ CN: "machine@host" }))
+    ).toStrictEqual({
+      host: "host",
+      name: "machine",
+    });
+    expect(
+      splitCertificateName(certFactory({ CN: "machine@address@host" }))
+    ).toStrictEqual({
+      host: "host",
+      name: "machine@address",
+    });
+  });
+});

--- a/ui/src/app/utils/splitCertificateName.ts
+++ b/ui/src/app/utils/splitCertificateName.ts
@@ -1,0 +1,17 @@
+import type { GeneratedCertificate } from "app/store/general/types";
+import type { PodCertificate } from "app/store/pod/types";
+
+export const splitCertificateName = (
+  certificate: GeneratedCertificate | PodCertificate | null
+): { name: string; host: string } | null => {
+  if (!certificate) {
+    return null;
+  }
+  const split = certificate.CN.split("@");
+  if (split.length < 2) {
+    return { name: certificate.CN, host: "" };
+  }
+  const host = split[split.length - 1];
+  const name = split.slice(0, split.length - 1).join("@");
+  return { name, host };
+};


### PR DESCRIPTION
## Done

- Added `pollLxdServer` to pod slice, which continuously checks authentication status with a LXD server
- Moved `setStep` functionality out of `AddLxd` and in to the individual step components. Having it all handled in the parent was a bit too inconsistent.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click "Add KVM"
- Enter some details, make sure to keep "Generate new certificate" selected and click "Next"
- Make note of the certificate that was generated
- Keep "Add trust to LXD via command line" selected and click "Check authentication"
- Check that an action is dispatched to poll the server. If this is a new LXD server that MAAS doesn't know about, the poll action should be continuous until the code snippet is run on the server. Otherwise authentication should happen quickly.
- Select a project and click "Save"
- Check that the newly created LXD VM host's certificate is the same as what was generated before.

## Fixes

Fixes canonical-web-and-design/app-squad#253

## Screenshot
![Peek 2021-09-16 13-04](https://user-images.githubusercontent.com/25733845/133542936-05b2e464-ffbf-4394-9293-25ad44eca671.gif)
