### PR TITLE
fix(ui): prevent advancing "Add LXD" steps if errors are present

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -94,6 +94,7 @@ export const AuthenticationForm = ({
       }}
       onCancel={clearHeaderContent}
       onSubmit={(values) => {
+        dispatch(podActions.cleanup());
         setAuthenticating(true);
         if (useCertificate) {
           const certificate = generatedCertificate?.certificate || "";

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsForm.test.tsx
@@ -204,6 +204,41 @@ describe("CredentialsForm", () => {
     expect(setStep).toHaveBeenCalledWith(AddLxdSteps.AUTHENTICATION);
   });
 
+  it(`does not move to the authentication step if certificate successfully
+      generated but errors are present`, () => {
+    const setStep = jest.fn();
+    state.general.generatedCertificate.data = generatedCertificateFactory({
+      CN: "my-favourite-kvm@host",
+    });
+    state.pod.errors = "Failed to connect to LXD.";
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <CredentialsForm
+            clearHeaderContent={jest.fn()}
+            newPodValues={{
+              certificate: "",
+              key: "",
+              name: "my-favourite-kvm",
+              password: "",
+              pool: "0",
+              power_address: "192.168.1.1",
+              zone: "0",
+            }}
+            setNewPodValues={jest.fn()}
+            setKvmType={jest.fn()}
+            setStep={setStep}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(setStep).not.toHaveBeenCalled();
+  });
+
   it("moves to the project select step if projects exist for given LXD address", () => {
     const setStep = jest.fn();
     state.pod.projects = {
@@ -235,5 +270,40 @@ describe("CredentialsForm", () => {
     );
 
     expect(setStep).toHaveBeenCalledWith(AddLxdSteps.SELECT_PROJECT);
+  });
+
+  it(`does not move to the project select step if projects exist for given LXD
+      address but errors are present`, () => {
+    const setStep = jest.fn();
+    state.pod.projects = {
+      "192.168.1.1": [podProjectFactory()],
+    };
+    state.pod.errors = "Failed to fetch projects.";
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <CredentialsForm
+            clearHeaderContent={jest.fn()}
+            newPodValues={{
+              certificate: "certificate",
+              key: "key",
+              name: "my-favourite-kvm",
+              password: "",
+              pool: "0",
+              power_address: "192.168.1.1",
+              zone: "0",
+            }}
+            setNewPodValues={jest.fn()}
+            setKvmType={jest.fn()}
+            setStep={setStep}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(setStep).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsForm.tsx
@@ -59,7 +59,8 @@ export const CredentialsForm = ({
   // Once a generated certificate for the new pod exists in state, the user
   // should be sent to the auth trust step.
   const splitCertName = splitCertificateName(generatedCertificate);
-  const shouldGoToAuthStep = splitCertName?.name === newPodValues.name;
+  const shouldGoToAuthStep =
+    !errors && splitCertName?.name === newPodValues.name;
   useEffect(() => {
     if (shouldGoToAuthStep) {
       setStep(AddLxdSteps.AUTHENTICATION);
@@ -69,9 +70,8 @@ export const CredentialsForm = ({
   // User is considered "authenticated" if they have set a LXD server address
   // and projects for it exist in state. Once "authenticated", they should
   // be sent to the project selection step.
-  const shouldGoToProjectStep = !!(
-    newPodValues.power_address && projects.length >= 1
-  );
+  const shouldGoToProjectStep =
+    !errors && !!newPodValues.power_address && projects.length >= 1;
   useEffect(() => {
     if (shouldGoToProjectStep) {
       setStep(AddLxdSteps.SELECT_PROJECT);


### PR DESCRIPTION
## Done

- Fixed a race condition where the generated certificate was not getting cleared in time when reverting from the Authentication step to the Credentials step.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click Add KVM
- Enter bogus details, including a malformed LXD address
- Click "Use trust password", enter anything then click "Check authentication"
- You should be sent back to the first step with an error
