### PR TITLE
feat(ui): split PowerTypeFields into subcomponents that allow for customisation

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
@@ -1,0 +1,70 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import BasePowerField from "./BasePowerField";
+
+import { PowerFieldType } from "app/store/general/types";
+import { powerField as powerFieldFactory } from "testing/factories";
+
+describe("BasePowerField", () => {
+  it("can be disabled", () => {
+    const field = powerFieldFactory();
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <BasePowerField disabled field={field} />
+      </Formik>
+    );
+    expect(wrapper.find("input").prop("disabled")).toBe(true);
+  });
+
+  it("can be given a custom power parameters name", () => {
+    const field = powerFieldFactory({ name: "field-name" });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <BasePowerField
+          field={field}
+          powerParametersValueName="custom-power-parameters"
+        />
+      </Formik>
+    );
+    expect(wrapper.find("input").prop("name")).toBe(
+      "custom-power-parameters.field-name"
+    );
+  });
+
+  it("correctly renders a string field type", () => {
+    const field = powerFieldFactory({ field_type: PowerFieldType.STRING });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <BasePowerField field={field} />
+      </Formik>
+    );
+    expect(wrapper.find("input[type='text']").exists()).toBe(true);
+    expect(wrapper.find("input[type='password']").exists()).toBe(false);
+    expect(wrapper.find("select").exists()).toBe(false);
+  });
+
+  it("correctly renders a password field type", () => {
+    const field = powerFieldFactory({ field_type: PowerFieldType.PASSWORD });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <BasePowerField field={field} />
+      </Formik>
+    );
+    expect(wrapper.find("input[type='text']").exists()).toBe(false);
+    expect(wrapper.find("input[type='password']").exists()).toBe(true);
+    expect(wrapper.find("select").exists()).toBe(false);
+  });
+
+  it("correctly renders a choice field type", () => {
+    const field = powerFieldFactory({ field_type: PowerFieldType.CHOICE });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <BasePowerField field={field} />
+      </Formik>
+    );
+    expect(wrapper.find("input[type='text']").exists()).toBe(false);
+    expect(wrapper.find("input[type='password']").exists()).toBe(false);
+    expect(wrapper.find("select").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
@@ -1,0 +1,45 @@
+import { Input, Select } from "@canonical/react-components";
+
+import FormikField from "app/base/components/FormikField";
+import type { PowerField as PowerFieldType } from "app/store/general/types";
+
+type Props = {
+  disabled?: boolean;
+  field: PowerFieldType;
+  powerParametersValueName?: string;
+};
+
+export const BasePowerField = ({
+  disabled = false,
+  field,
+  powerParametersValueName = "power_parameters",
+}: Props): JSX.Element => {
+  const { choices, field_type, label, name, required } = field;
+
+  return (
+    <FormikField
+      component={field_type === "choice" ? Select : Input}
+      disabled={disabled}
+      key={name}
+      label={label}
+      name={`${powerParametersValueName}.${name}`}
+      options={
+        field_type === "choice"
+          ? choices.map((choice) => ({
+              key: `${name}-${choice[0]}`,
+              label: choice[1],
+              value: choice[0],
+            }))
+          : undefined
+      }
+      required={required}
+      type={
+        (field_type === "string" && "text") ||
+        (field_type === "password" && "password") ||
+        undefined
+      }
+    />
+  );
+};
+
+export default BasePowerField;

--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/index.ts
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BasePowerField";

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.test.tsx
@@ -1,0 +1,58 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import LXDPowerFields from "./LXDPowerFields";
+
+import { powerField as powerFieldFactory } from "testing/factories";
+
+describe("LXDPowerFields", () => {
+  it("can be disabled", () => {
+    const field = powerFieldFactory({ name: "field" });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <LXDPowerFields disabled fields={[field]} />
+      </Formik>
+    );
+    expect(
+      wrapper.find("input[name='power_parameters.field']").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("can be given a custom power parameters name", () => {
+    const field = powerFieldFactory({ name: "field" });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <LXDPowerFields
+          disabled
+          fields={[field]}
+          powerParametersValueName="custom-power-parameters"
+        />
+      </Formik>
+    );
+    expect(
+      wrapper.find("input[name='custom-power-parameters.field']").exists()
+    ).toBe(true);
+  });
+
+  it("renders certificate data if being used for configuration", () => {
+    const field = powerFieldFactory({ name: "field" });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <LXDPowerFields disabled fields={[field]} forConfiguration />
+      </Formik>
+    );
+    expect(wrapper.find("[data-test='certificate-data']").exists()).toBe(true);
+    expect(wrapper.find("AuthenticationFields").exists()).toBe(false);
+  });
+
+  it("renders authentication fields if not being used for configuration", () => {
+    const field = powerFieldFactory({ name: "field" });
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <LXDPowerFields disabled fields={[field]} forConfiguration={false} />
+      </Formik>
+    );
+    expect(wrapper.find("[data-test='certificate-data']").exists()).toBe(false);
+    expect(wrapper.find("AuthenticationFields").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import { Textarea } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import BasePowerField from "../BasePowerField";
+
+import AuthenticationFields from "app/base/components/AuthenticationFields";
+import FormikField from "app/base/components/FormikField";
+import type { AnyObject } from "app/base/types";
+import type { PowerField as PowerFieldType } from "app/store/general/types";
+
+export type Props = {
+  disabled?: boolean;
+  fields: PowerFieldType[];
+  forConfiguration?: boolean;
+  powerParametersValueName?: string;
+};
+
+const CustomFields = {
+  CERTIFICATE: "certificate",
+  KEY: "key",
+  PASSWORD: "password",
+} as const;
+
+export const LXDPowerFields = <V extends AnyObject>({
+  disabled = false,
+  fields,
+  forConfiguration = false,
+  powerParametersValueName = "power_parameters",
+}: Props): JSX.Element | null => {
+  const [shouldGenerateCert, setShouldGenerateCert] = useState(true);
+  const { setFieldValue } = useFormikContext<V>();
+  const certName = `${powerParametersValueName}.${CustomFields.CERTIFICATE}`;
+  const keyName = `${powerParametersValueName}.${CustomFields.KEY}`;
+  const passwordName = `${powerParametersValueName}.${CustomFields.PASSWORD}`;
+
+  const baseFields = fields.reduce<ReactNode[]>((content, field) => {
+    const isCustom = Object.values(CustomFields).some(
+      (val) => val === field.name
+    );
+    if (!isCustom) {
+      content.push(
+        <BasePowerField
+          disabled={disabled}
+          field={field}
+          key={field.name}
+          powerParametersValueName={powerParametersValueName}
+        />
+      );
+    }
+    return content;
+  }, []);
+  let customFields: ReactNode = null;
+
+  if (forConfiguration) {
+    // TODO: Render custom certificate section.
+    // https://github.com/canonical-web-and-design/app-squad/issues/247
+    customFields = (
+      <div data-test="certificate-data">
+        <FormikField
+          disabled={disabled}
+          label="LXD password (optional)"
+          name={passwordName}
+          type="password"
+        />
+        <FormikField
+          component={Textarea}
+          disabled={disabled}
+          label="LXD certificate (optional)"
+          name={certName}
+          rows={5}
+        />
+        <FormikField
+          component={Textarea}
+          disabled={disabled}
+          label="LXD private key (optional)"
+          name={keyName}
+          rows={5}
+        />
+      </div>
+    );
+  } else {
+    customFields = (
+      <AuthenticationFields
+        certificateValueName={certName}
+        onShouldGenerateCert={(shouldGenerateCert) => {
+          setShouldGenerateCert(shouldGenerateCert);
+          setFieldValue(certName, "");
+          setFieldValue(keyName, "");
+          setFieldValue(passwordName, "");
+        }}
+        passwordValueName={passwordName}
+        privateKeyValueName={keyName}
+        shouldGenerateCert={shouldGenerateCert}
+        showPassword
+      />
+    );
+  }
+  return (
+    <>
+      {baseFields}
+      {customFields}
+    </>
+  );
+};
+
+export default LXDPowerFields;

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/index.ts
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./LXDPowerFields";
+export type { Props as LXDPowerFieldsProps } from "./LXDPowerFields";

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
@@ -4,7 +4,8 @@ import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import PowerTypeFields from "../PowerTypeFields";
+import LXDPowerFields from "./LXDPowerFields";
+import PowerTypeFields from "./PowerTypeFields";
 
 import { PowerFieldScope, PowerFieldType } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
@@ -29,54 +30,6 @@ describe("PowerTypeFields", () => {
         }),
       }),
     });
-  });
-
-  it("gives fields the correct types", () => {
-    const powerTypes = [
-      powerTypeFactory({
-        fields: [
-          powerFieldFactory({
-            field_type: PowerFieldType.STRING,
-            name: "field1",
-          }),
-          powerFieldFactory({
-            field_type: PowerFieldType.PASSWORD,
-            name: "field2",
-          }),
-          powerFieldFactory({
-            choices: [
-              ["choice1", "Choice 1"],
-              ["choice2", "Choice 2"],
-            ],
-            field_type: PowerFieldType.CHOICE,
-            name: "field3",
-          }),
-        ],
-        name: "fake_power_type",
-      }),
-    ];
-    state.general.powerTypes.data = powerTypes;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{ power_type: "fake_power_type" }}
-          onSubmit={jest.fn()}
-        >
-          <PowerTypeFields />
-        </Formik>
-      </Provider>
-    );
-
-    expect(
-      wrapper.find("Input[name='power_parameters.field1']").props().type
-    ).toBe("text");
-    expect(
-      wrapper.find("Input[name='power_parameters.field2']").props().type
-    ).toBe("password");
-    expect(
-      wrapper.find("Select[name='power_parameters.field3']").props().type
-    ).toBe(undefined);
   });
 
   it("correctly generates power options from power type", () => {
@@ -380,7 +333,7 @@ describe("PowerTypeFields", () => {
     ).toBe("default4");
   });
 
-  it("shows custom LXD authentication fields if not configuring existing power parameters", () => {
+  it("renders LXD power fields with custom props if selected", () => {
     const powerTypes = [
       powerTypeFactory({
         fields: [
@@ -399,47 +352,14 @@ describe("PowerTypeFields", () => {
           initialValues={{ power_parameters: {}, power_type: "lxd" }}
           onSubmit={jest.fn()}
         >
-          <PowerTypeFields forConfiguration={false} />
+          <PowerTypeFields
+            customFieldProps={{ lxd: { forConfiguration: true } }}
+          />
         </Formik>
       </Provider>
     );
 
-    expect(wrapper.find("AuthenticationFields").exists()).toBe(true);
-    expect(wrapper.find("[data-test='certificate-data']").exists()).toBe(false);
-  });
-
-  it("shows custom LXD certificate data if configuring existing power parameters", () => {
-    const powerTypes = [
-      powerTypeFactory({
-        fields: [
-          powerFieldFactory({ name: "certificate" }),
-          powerFieldFactory({ name: "key" }),
-          powerFieldFactory({ name: "password" }),
-        ],
-        name: "lxd",
-      }),
-    ];
-    state.general.powerTypes.data = powerTypes;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{
-            power_parameters: {
-              certificate: "certificate",
-              key: "key",
-              password: "password",
-            },
-            power_type: "lxd",
-          }}
-          onSubmit={jest.fn()}
-        >
-          <PowerTypeFields forConfiguration />
-        </Formik>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='certificate-data']").exists()).toBe(true);
-    expect(wrapper.find("AuthenticationFields").exists()).toBe(false);
+    expect(wrapper.find(LXDPowerFields).exists()).toBe(true);
+    expect(wrapper.find(LXDPowerFields).prop("forConfiguration")).toBe(true);
   });
 });

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -1,162 +1,44 @@
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-import { Input, Select, Spinner, Textarea } from "@canonical/react-components";
+import { Select, Spinner } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
-import AuthenticationFields from "app/base/components/AuthenticationFields";
+import BasePowerField from "./BasePowerField";
+import type { LXDPowerFieldsProps } from "./LXDPowerFields";
+import LXDPowerFields from "./LXDPowerFields";
+
 import FormikField from "app/base/components/FormikField";
 import type { AnyObject } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
-import type { PowerType } from "app/store/general/types";
 import { PowerFieldScope } from "app/store/general/types";
 
 type Props = {
+  customFieldProps?: {
+    lxd?: Partial<LXDPowerFieldsProps>;
+  };
   disableFields?: boolean;
   disableSelect?: boolean;
   forChassis?: boolean;
-  forConfiguration?: boolean;
   powerParametersValueName?: string;
   powerTypeValueName?: string;
   fieldScopes?: PowerFieldScope[];
   showSelect?: boolean;
 };
 
-const CustomFields = {
-  LXD: {
-    CERTIFICATE: "certificate",
-    KEY: "key",
-    PASSWORD: "password",
-  },
-} as const;
-
-/**
- * Generate the fields to show, depending on the selected power type and the
- * given field scopes.
- * @param selectedPowerType - the power type that is selected.
- * @param disabled - whether all fields should be disabled.
- * @param fieldScopes - the scopes of the fields to show.
- * @param powerParametersValueName - the power parameters "name" in the Formik form
- * @param forConfiguration - whether the fields are being used for configuration of existing power parameters
- * @param generateCert - whether a certificate should be generated (LXD-only)
- * @param onShouldGenerateCert - function to run when changing certificate radio (LXD-only)
- * @returns list of Formik fields relevant to the chosen power type and field scopes.
- */
-const generateFields = (
-  selectedPowerType: PowerType,
-  disabled: boolean,
-  fieldScopes: PowerFieldScope[],
-  powerParametersValueName: string,
-  forConfiguration: boolean,
-  shouldGenerateCert: boolean,
-  onShouldGenerateCert: (shouldGeneraterCert: boolean) => void
-) => {
-  const baseFields: ReactNode[] = [];
-  let customFields: ReactNode = null;
-  const fieldsInScope = selectedPowerType.fields.filter((field) =>
-    fieldScopes.includes(field.scope)
-  );
-  const isLxd = selectedPowerType.name === "lxd";
-
-  fieldsInScope.forEach((field) => {
-    // The authentication fields for the LXD power type are ignored here and
-    // special-cased below. All other power type fields are generated directly
-    // from the API data.
-    if (
-      isLxd &&
-      Object.values(CustomFields.LXD).some((val) => val === field.name)
-    ) {
-      return;
-    }
-    const { choices, field_type, label, name, required } = field;
-    baseFields.push(
-      <FormikField
-        component={field_type === "choice" ? Select : Input}
-        disabled={disabled}
-        key={name}
-        label={label}
-        name={`${powerParametersValueName}.${name}`}
-        options={
-          field_type === "choice"
-            ? choices.map((choice) => ({
-                key: `${name}-${choice[0]}`,
-                label: choice[1],
-                value: choice[0],
-              }))
-            : undefined
-        }
-        required={required}
-        type={
-          (field_type === "string" && "text") ||
-          (field_type === "password" && "password") ||
-          undefined
-        }
-      />
-    );
-  });
-  if (isLxd) {
-    if (forConfiguration) {
-      // TODO: Render custom certificate section.
-      // https://github.com/canonical-web-and-design/app-squad/issues/247
-      customFields = (
-        <div data-test="certificate-data">
-          <FormikField
-            disabled={disabled}
-            label="LXD password (optional)"
-            name={`${powerParametersValueName}.${CustomFields.LXD.PASSWORD}`}
-            type="password"
-          />
-          <FormikField
-            component={Textarea}
-            disabled={disabled}
-            label="LXD certificate (optional)"
-            name={`${powerParametersValueName}.${CustomFields.LXD.CERTIFICATE}`}
-            rows={5}
-          />
-          <FormikField
-            component={Textarea}
-            disabled={disabled}
-            label="LXD private key (optional)"
-            name={`${powerParametersValueName}.${CustomFields.LXD.KEY}`}
-            rows={5}
-          />
-        </div>
-      );
-    } else {
-      customFields = (
-        <AuthenticationFields
-          certificateValueName={`${powerParametersValueName}.${CustomFields.LXD.CERTIFICATE}`}
-          onShouldGenerateCert={onShouldGenerateCert}
-          passwordValueName={`${powerParametersValueName}.${CustomFields.LXD.PASSWORD}`}
-          privateKeyValueName={`${powerParametersValueName}.${CustomFields.LXD.KEY}`}
-          shouldGenerateCert={shouldGenerateCert}
-          showPassword
-        />
-      );
-    }
-  }
-  return (
-    <>
-      {baseFields}
-      {customFields}
-    </>
-  );
-};
-
 export const PowerTypeFields = <V extends AnyObject>({
+  customFieldProps,
   disableFields = false,
   disableSelect = false,
   forChassis = false,
-  forConfiguration = false,
   powerParametersValueName = "power_parameters",
   powerTypeValueName = "power_type",
   fieldScopes = [PowerFieldScope.BMC, PowerFieldScope.NODE],
   showSelect = true,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const [shouldGenerateCert, setShouldGenerateCert] = useState(true);
   const allPowerTypes = useSelector(powerTypesSelectors.get);
   const chassisPowerTypes = useSelector(powerTypesSelectors.canProbe);
   const powerTypesLoaded = useSelector(powerTypesSelectors.loaded);
@@ -170,32 +52,54 @@ export const PowerTypeFields = <V extends AnyObject>({
     values,
   } = useFormikContext<V>();
 
-  const onShouldGenerateCert = (shouldGenerateCert: boolean) => {
-    setShouldGenerateCert(shouldGenerateCert);
-    setFieldValue(`${powerParametersValueName}.certificate`, "");
-    setFieldValue(`${powerParametersValueName}.key`, "");
-    setFieldValue(`${powerParametersValueName}.password`, "");
-  };
-
-  // Only power types that can probe are suitable for use when adding a chassis.
-  const powerTypes = forChassis ? chassisPowerTypes : allPowerTypes;
-  const selectedPowerType = powerTypes.find(
-    (type) => type.name === values[powerTypeValueName]
-  );
-
   useEffect(() => {
     dispatch(generalActions.fetchPowerTypes());
   }, [dispatch]);
 
+  // Only power types that can probe are suitable for use when adding a chassis.
+  const powerTypes = forChassis ? chassisPowerTypes : allPowerTypes;
+
+  // Generate field content depending on loading status, custom field content
+  // if provided, or on the fields of the selected power type.
+  let fieldContent: ReactNode = null;
+  const selectedPowerType = powerTypes.find(
+    (type) => type.name === values[powerTypeValueName]
+  );
   if (!powerTypesLoaded) {
-    return <Spinner text="Loading..." />;
+    fieldContent = <Spinner text="Loading..." />;
+  } else if (selectedPowerType) {
+    const fieldsInScope = selectedPowerType.fields.filter((field) =>
+      fieldScopes.includes(field.scope)
+    );
+    switch (selectedPowerType.name) {
+      case "lxd":
+        fieldContent = (
+          <LXDPowerFields
+            disabled={disableFields}
+            fields={fieldsInScope}
+            powerParametersValueName={powerParametersValueName}
+            {...(customFieldProps?.lxd || {})}
+          />
+        );
+        break;
+      default:
+        fieldContent = fieldsInScope.map((field) => (
+          <BasePowerField
+            disabled={disableFields}
+            field={field}
+            key={field.name}
+            powerParametersValueName={powerParametersValueName}
+          />
+        ));
+    }
   }
+
   return (
     <>
       {showSelect && (
         <FormikField
           component={Select}
-          disabled={disableSelect}
+          disabled={!powerTypesLoaded || disableSelect}
           label="Power type"
           name={powerTypeValueName}
           options={[
@@ -220,7 +124,7 @@ export const PowerTypeFields = <V extends AnyObject>({
             // This is necessary because some field names are shared across
             // power types (e.g. "power_address"), meaning the value would otherwise
             // persist and appear to be a default value, even though it isn't.
-            if (powerType?.fields.length) {
+            if (powerType) {
               powerType.fields.forEach((field) => {
                 setFieldValue(
                   `${powerParametersValueName}.${field.name}`,
@@ -232,16 +136,7 @@ export const PowerTypeFields = <V extends AnyObject>({
           required
         />
       )}
-      {selectedPowerType &&
-        generateFields(
-          selectedPowerType,
-          disableFields,
-          fieldScopes,
-          powerParametersValueName,
-          forConfiguration,
-          shouldGenerateCert,
-          onShouldGenerateCert
-        )}
+      {fieldContent}
     </>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
@@ -54,10 +54,14 @@ const PowerFormFields = ({ editing, machine }: Props): JSX.Element => {
           </Notification>
         )}
         <PowerTypeFields<PowerFormValues>
+          customFieldProps={{
+            lxd: {
+              forConfiguration: true,
+            },
+          }}
           disableFields={!editing}
           disableSelect={!editing || machineInPod}
           fieldScopes={fieldScopes}
-          forConfiguration
           powerParametersValueName="powerParameters"
           powerTypeValueName="powerType"
         />


### PR DESCRIPTION
## Done

- Created two subcomponents from `PowerTypeFields`
  - `BasePowerField` which generates a field directly from the API
  - `LXDPowerFields` which customises power fields specifically for LXD

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that nothing has changed
  - Adding a LXD machine shows authentication radios
  - Editing a LXD machine shows textareas for certificate and key

## Fixes

Fixes canonical-web-and-design/app-squad#270
