### PR TITLE
feat(ui): add tooltip to power column if machine power is in error state

### DIFF
--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.tsx
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.tsx
@@ -49,10 +49,15 @@ describe("ScriptStatus", () => {
 
   it("makes the icon inline if children are provided", () => {
     const wrapper = shallow(
-      <ScriptStatus status={ScriptResultStatus.PASSED}>
-        I'm a child!
-      </ScriptStatus>
+      <ScriptStatus status={ScriptResultStatus.PASSED}>{0}</ScriptStatus>
     );
     expect(wrapper.find("Icon").prop("className")).toBe("is-inline");
+  });
+
+  it("does not make the icon inline if children are not provided", () => {
+    const wrapper = shallow(
+      <ScriptStatus status={ScriptResultStatus.PASSED} />
+    );
+    expect(wrapper.find("Icon").prop("className")).toBe("");
   });
 });

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.tsx
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@canonical/react-components";
+import classNames from "classnames";
 
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import { TestStatusStatus } from "app/store/types/node";
@@ -46,7 +47,12 @@ const ScriptStatus = ({ children, status }: Props): JSX.Element => {
   return (
     <span>
       {iconName && (
-        <Icon className={children ? "is-inline" : null} name={iconName} />
+        <Icon
+          className={classNames({
+            "is-inline": children !== null && children !== undefined,
+          })}
+          name={iconName}
+        />
       )}
       {children}
     </span>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.tsx
@@ -181,4 +181,21 @@ describe("PowerColumn", () => {
 
     expect(wrapper.find("TableMenu").exists()).toBe(false);
   });
+
+  it("shows a status tooltip if machine power is in error state", () => {
+    state.machine.items[0].power_state = PowerState.ERROR;
+    state.machine.items[0].status_message = "It's not working";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Tooltip").prop("message")).toBe("It's not working");
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from "react";
 
+import { Tooltip } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -12,6 +13,7 @@ import type { Machine } from "app/store/machine/types";
 import { PowerState } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
+import { breakLines } from "app/utils";
 
 type Props = {
   onToggleMenu?: (systemId: Machine["system_id"], open: boolean) => void;
@@ -89,7 +91,15 @@ export const PowerColumn = ({
   return (
     <DoubleRow
       icon={
-        <PowerIcon powerState={powerState} showSpinner={updating !== null} />
+        <Tooltip
+          message={
+            powerState === PowerState.ERROR
+              ? breakLines(machine.status_message)
+              : null
+          }
+        >
+          <PowerIcon powerState={powerState} showSpinner={updating !== null} />
+        </Tooltip>
       }
       iconSpace={true}
       menuClassName="p-table-menu--hasIcon"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
@@ -7,10 +7,14 @@ exports[`PowerColumn renders 1`] = `
 >
   <DoubleRow
     icon={
-      <PowerIcon
-        powerState="on"
-        showSpinner={false}
-      />
+      <Tooltip
+        message={null}
+      >
+        <PowerIcon
+          powerState="on"
+          showSpinner={false}
+        />
+      </Tooltip>
     }
     iconSpace={true}
     menuClassName="p-table-menu--hasIcon"
@@ -55,21 +59,27 @@ exports[`PowerColumn renders 1`] = `
       <div
         className="p-double-row__icon"
       >
-        <PowerIcon
-          powerState="on"
-          showSpinner={false}
+        <Tooltip
+          message={null}
         >
           <span>
-            <Icon
-              className=""
-              name="power-on"
+            <PowerIcon
+              powerState="on"
+              showSpinner={false}
             >
-              <i
-                className="p-icon--power-on"
-              />
-            </Icon>
+              <span>
+                <Icon
+                  className=""
+                  name="power-on"
+                >
+                  <i
+                    className="p-icon--power-on"
+                  />
+                </Icon>
+              </span>
+            </PowerIcon>
           </span>
-        </PowerIcon>
+        </Tooltip>
       </div>
       <div
         className="p-double-row__rows-container"


### PR DESCRIPTION
## Done

- Added a tooltip to the power column if a machine power is in error state
- Driveby fix in `ScriptStatus`, where if the given children was the number `0` it wouldn't be inline since it's falsy

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- If your MAAS doesn't have a machine in error state, edit a machine's power config with incorrect credentials
- Go to the machine list and hover over the power error icon and check that a tooltip displays

## Fixes

Fixes canonical-web-and-design/app-squad#245
