### PR TITLE
feat(ui): move lxd and virsh tables to tabs

### DIFF
--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -85,15 +85,15 @@ const SectionHeader = ({
           </ul>
         )}
       </div>
-      {headerContent && (
+      {headerContent ? (
         <Row data-test="section-header-content">
           <Col size={12}>
             <hr />
             {headerContent}
           </Col>
         </Row>
-      )}
-      {tabLinks?.length && (
+      ) : null}
+      {tabLinks?.length ? (
         <Row data-test="section-header-tabs">
           <Col size={12}>
             <hr className="u-no-margin--bottom" />
@@ -104,7 +104,7 @@ const SectionHeader = ({
             />
           </Col>
         </Row>
-      )}
+      ) : null}
     </>
   );
 };

--- a/ui/src/app/kvm/urls.ts
+++ b/ui/src/app/kvm/urls.ts
@@ -5,8 +5,10 @@ const urls = {
   details: argPath<{ id: BasePod["id"] }>("/kvm/:id"),
   edit: argPath<{ id: BasePod["id"] }>("/kvm/:id/edit"),
   kvm: "/kvm",
+  lxd: "/kvm/lxd",
   project: argPath<{ id: BasePod["id"] }>("/kvm/:id/project"),
   resources: argPath<{ id: BasePod["id"] }>("/kvm/:id/resources"),
+  virsh: "/kvm/virsh",
 };
 
 export default urls;

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -9,7 +9,7 @@ import kvmURLs from "app/kvm/urls";
 const KVM = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={kvmURLs.kvm}>
+      <Route exact path={[kvmURLs.kvm, kvmURLs.lxd, kvmURLs.virsh]}>
         <KVMList />
       </Route>
       <Route

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -10,6 +10,7 @@ import type { SetSearchFilter } from "app/base/types";
 import KVMHeaderForms from "app/kvm/components/KVMHeaderForms";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
 import { getHeaderTitle } from "app/kvm/utils";
 import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/constants";
@@ -76,25 +77,25 @@ const KVMDetailsHeader = ({
         ...(pod?.type === PodType.LXD
           ? [
               {
-                active: location.pathname.endsWith(`/kvm/${id}/project`),
+                active: location.pathname.endsWith(kvmURLs.project({ id })),
                 component: Link,
                 "data-test": "projects-tab",
                 label: "Project",
-                to: `/kvm/${id}/project`,
+                to: kvmURLs.project({ id }),
               },
             ]
           : []),
         {
-          active: location.pathname.endsWith(`/kvm/${id}/resources`),
+          active: location.pathname.endsWith(kvmURLs.resources({ id })),
           component: Link,
           label: "Resources",
-          to: `/kvm/${id}/resources`,
+          to: kvmURLs.resources({ id }),
         },
         {
-          active: location.pathname.endsWith(`/kvm/${id}/edit`),
+          active: location.pathname.endsWith(kvmURLs.edit({ id })),
           component: Link,
           label: "Settings",
-          to: `/kvm/${id}/edit`,
+          to: kvmURLs.edit({ id }),
         },
       ]}
       title={

--- a/ui/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -1,10 +1,12 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { Router } from "react-router";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import KVMList from "./KVMList";
 
+import kvmURLs from "app/kvm/urls";
 import { PodType } from "app/store/pod/constants";
 import {
   pod as podFactory,
@@ -34,7 +36,7 @@ describe("KVMList", () => {
     ).toBe(true);
   });
 
-  it("shows a LXD table if there are any LXD pods", () => {
+  it("shows a LXD table when viewing the LXD tab", () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [podFactory({ type: PodType.LXD })],
@@ -43,7 +45,9 @@ describe("KVMList", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.lxd, key: "testKey" }]}
+        >
           <KVMList />
         </MemoryRouter>
       </Provider>
@@ -52,7 +56,7 @@ describe("KVMList", () => {
     expect(wrapper.find("[data-test='lxd-table']").exists()).toBe(true);
   });
 
-  it("shows a virsh table if there are any virsh pods", () => {
+  it("shows a virsh table when viewing the Virsh tab", () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [podFactory({ type: PodType.VIRSH })],
@@ -61,12 +65,97 @@ describe("KVMList", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.virsh, key: "testKey" }]}
+        >
           <KVMList />
         </MemoryRouter>
       </Provider>
     );
 
     expect(wrapper.find("[data-test='virsh-table']").exists()).toBe(true);
+  });
+
+  it("redirects to the LXD tab if there are LXD pods", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ type: PodType.LXD })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
+        >
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      kvmURLs.lxd
+    );
+  });
+
+  it("redirects to the Virsh tab if there are Virsh pods", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ type: PodType.VIRSH })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
+        >
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      kvmURLs.virsh
+    );
+  });
+
+  it("displays a message if there are no pods", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
+        >
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(false);
+    expect(wrapper.find("[data-test='no-hosts']").exists()).toBe(true);
+  });
+
+  it("displays a spinner when loading pods", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        loading: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
+        >
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(false);
+    expect(wrapper.find("[data-test='no-hosts']").exists()).toBe(false);
+    expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import KVMListHeader from "./KVMListHeader";
 
+import kvmURLs from "app/kvm/urls";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
@@ -55,6 +56,82 @@ describe("KVMListHeader", () => {
     );
     expect(wrapper.find('[data-test="section-header-subtitle"]').text()).toBe(
       "2 VM hosts available"
+    );
+  });
+
+  it("can show a LXD tab", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.lxd, key: "testKey" }]}
+        >
+          <KVMListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            showLXDtab
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='lxd-tab']").exists()).toBe(true);
+  });
+
+  it("can show a Virsh tab", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.virsh, key: "testKey" }]}
+        >
+          <KVMListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            showVirshtab
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='virsh-tab']").exists()).toBe(true);
+  });
+
+  it("sets the LXD tab as active when at the LXD URL", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.lxd, key: "testKey" }]}
+        >
+          <KVMListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            showLXDtab
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("a[data-test='lxd-tab']").prop("aria-selected")).toBe(
+      true
+    );
+  });
+
+  it("sets the Virsh tab as active when at the Virsh URL", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: kvmURLs.virsh, key: "testKey" }]}
+        >
+          <KVMListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            showVirshtab
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("a[data-test='virsh-tab']").prop("aria-selected")).toBe(
+      true
     );
   });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -3,11 +3,13 @@ import { useEffect } from "react";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
+import { Link, useLocation } from "react-router-dom";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import KVMHeaderForms from "app/kvm/components/KVMHeaderForms";
 import { KVMHeaderViews } from "app/kvm/constants";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
 import { getHeaderTitle } from "app/kvm/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
@@ -15,13 +17,18 @@ import podSelectors from "app/store/pod/selectors";
 type Props = {
   headerContent: KVMHeaderContent | null;
   setHeaderContent: KVMSetHeaderContent;
+  showLXDtab?: boolean;
+  showVirshtab?: boolean;
 };
 
 const KVMListHeader = ({
   headerContent,
   setHeaderContent,
+  showLXDtab,
+  showVirshtab,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const location = useLocation();
   const kvms = useSelector(podSelectors.kvms);
   const podsLoaded = useSelector(podSelectors.loaded);
 
@@ -51,6 +58,30 @@ const KVMListHeader = ({
       }
       loading={!podsLoaded}
       subtitle={`${pluralize("VM host", kvms.length, true)} available`}
+      tabLinks={[
+        ...(showLXDtab
+          ? [
+              {
+                active: location.pathname.endsWith(kvmURLs.lxd),
+                component: Link,
+                "data-test": "lxd-tab",
+                label: "LXD",
+                to: kvmURLs.lxd,
+              },
+            ]
+          : []),
+        ...(showVirshtab
+          ? [
+              {
+                active: location.pathname.endsWith(kvmURLs.virsh),
+                component: Link,
+                "data-test": "virsh-tab",
+                label: "Virsh",
+                to: kvmURLs.virsh,
+              },
+            ]
+          : []),
+      ]}
       title={getHeaderTitle("KVM", headerContent)}
     />
   );


### PR DESCRIPTION
## Done

- Update the KVM list to display the LXD and Virsh tables on different tabs.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click on LXD in the header.
- If you have LXD pods it should redirect to /kvm/lxd.
- You should see the LXD table.
- If there are Virsh pods there should also be a virsh tab.
- Clicking on the Virsh tab should dispaly the Virsh table.

## Fixes

Fixes: canonical-web-and-design/app-squad#286.

## Screenshots

<img width="1308" alt="Screen Shot 2021-09-29 at 1 26 43 pm" src="https://user-images.githubusercontent.com/361637/135198119-acef985f-c695-4bd1-ab75-5eb006f7baca.png">
