### PR TITLE
feat(ui): use datalist for LXD address select

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsFormFields/CredentialsFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/CredentialsForm/CredentialsFormFields/CredentialsFormFields.tsx
@@ -1,5 +1,6 @@
 import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
 
 import type { CredentialsFormValues } from "../../types";
 
@@ -10,6 +11,7 @@ import ZoneSelect from "app/base/components/ZoneSelect";
 import type { SetKvmType } from "app/kvm/components/KVMHeaderForms/AddKVM";
 import KvmTypeSelect from "app/kvm/components/KVMHeaderForms/AddKVM/KvmTypeSelect";
 import { PodType } from "app/store/pod/constants";
+import podSelectors from "app/store/pod/selectors";
 
 type Props = {
   setKvmType: SetKvmType;
@@ -22,6 +24,9 @@ export const CredentialsFormFields = ({
   setShouldGenerateCert,
   shouldGenerateCert,
 }: Props): JSX.Element => {
+  const lxdAddresses = useSelector(podSelectors.groupByLxdServer).map(
+    (group) => group.address
+  );
   const { setFieldValue } = useFormikContext<CredentialsFormValues>();
 
   return (
@@ -34,11 +39,20 @@ export const CredentialsFormFields = ({
         <ZoneSelect name="zone" required valueKey="id" />
         <ResourcePoolSelect name="pool" required valueKey="id" />
         <FormikField
+          autoComplete="off"
           label="LXD address"
+          list="lxd-addresses"
           name="power_address"
           required
           type="text"
         />
+        <datalist id="lxd-addresses">
+          {lxdAddresses.map((address) => (
+            <option key={address} value={address}>
+              {address}
+            </option>
+          ))}
+        </datalist>
         <CertificateFields
           onShouldGenerateCert={(shouldGenerateCert) => {
             setShouldGenerateCert(shouldGenerateCert);


### PR DESCRIPTION
## Done

- Added `datalist` to LXD address input

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click "Add KVM"
- Check that you can select an existing LXD address from the dropdown or create a new one

## Fixes

Fixes canonical-web-and-design/app-squad#251
