### PR TITLE
fix(ui): fix textarea styling in update LXD certificate form

### DIFF
--- a/ui/src/app/base/components/CertificateDetails/CertificateDetails.tsx
+++ b/ui/src/app/base/components/CertificateDetails/CertificateDetails.tsx
@@ -47,7 +47,7 @@ const CertificateDetails = ({
       </p>
       <CertificateMetadata metadata={metadata} />
       <Textarea
-        className="certificate-details__textarea"
+        className="p-textarea--readonly"
         id="lxd-cert"
         readOnly
         rows={5}
@@ -56,7 +56,7 @@ const CertificateDetails = ({
       <p>Private key</p>
       {showKey && (
         <Textarea
-          className="certificate-details__textarea"
+          className="p-textarea--readonly"
           data-test="private-key"
           id="lxd-key"
           readOnly

--- a/ui/src/app/base/components/CertificateDetails/_index.scss
+++ b/ui/src/app/base/components/CertificateDetails/_index.scss
@@ -1,8 +1,0 @@
-@mixin CertificateDetails {
-  .certificate-details {
-    .certificate-details__textarea {
-      @extend %small-text;
-      color: $color-dark;
-    }
-  }
-}

--- a/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/UpdateCertificate/UpdateCertificateFields/UpdateCertificateFields.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/UpdateCertificate/UpdateCertificateFields/UpdateCertificateFields.tsx
@@ -53,7 +53,7 @@ const UpdateCertificateFields = ({
             )}
             <p>Private key</p>
             <Textarea
-              className="authentication-card__textarea"
+              className="p-textarea--readonly"
               id="private-key"
               readOnly
               rows={5}

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -88,4 +88,11 @@
       }
     }
   }
+
+  // Override Vanilla's default light text for readonly textareas and make text
+  // small. Used for displaying very long strings, e.g. certificates.
+  .p-textarea--readonly {
+    @extend %small-text;
+    color: $color-dark !important;
+  }
 }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -70,7 +70,6 @@
 
 // Import and include MAAS component styles
 // base
-@import "~app/base/components/CertificateDetails";
 @import "~app/base/components/CertificateDownload";
 @import "~app/base/components/CertificateMetadata";
 @import "~app/base/components/ColumnToggle";
@@ -89,7 +88,6 @@
 @import "~app/base/components/Stepper";
 @import "~app/base/components/TableMenu";
 @import "~app/base/components/TagSelector";
-@include CertificateDetails;
 @include CertificateDownload;
 @include CertificateMetadata;
 @include ColumnToggle;


### PR DESCRIPTION
## Done

- Fixed textarea styling in LXD certificate form (forgot to update class)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the config of a LXD KVM
- Click Update certificate and generate a new certificate
- Check that the private key textarea looks right

## Fixes

Fixes #3087 

