### PR TITLE
WIP: Form error handling exploration

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
@@ -13,7 +13,7 @@ import type { Machine, MachineMeta } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import zoneSelectors from "app/store/zone/selectors";
-import type { Zone, ZoneMeta } from "app/store/zone/types";
+import type { ZonePK } from "app/store/zone/types";
 
 type Props = {
   onToggleMenu?: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
@@ -41,7 +41,7 @@ export const ZoneColumn = ({
   systemId,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const [updating, setUpdating] = useState<Zone[ZoneMeta.PK] | null>(null);
+  const [updating, setUpdating] = useState<ZonePK | null>(null);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );

--- a/ui/src/app/store/controller/types/actions.ts
+++ b/ui/src/app/store/controller/types/actions.ts
@@ -1,12 +1,12 @@
 import type { Controller } from "./base";
 import type { ControllerMeta } from "./enum";
 
-import type { Zone, ZoneMeta } from "app/store/zone/types";
+import type { ZonePK } from "app/store/zone/types";
 
 export type CreateParams = {
   description?: Controller["description"];
   domain?: Controller["domain"];
-  zone?: Zone[ZoneMeta.PK];
+  zone?: ZonePK;
 };
 
 export type UpdateParams = CreateParams & {

--- a/ui/src/app/store/device/types/actions.ts
+++ b/ui/src/app/store/device/types/actions.ts
@@ -6,7 +6,7 @@ import type { Domain } from "app/store/domain/types";
 import type { Machine, MachineMeta } from "app/store/machine/types";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import type { NetworkInterface } from "app/store/types/node";
-import type { Zone, ZoneMeta } from "app/store/zone/types";
+import type { ZonePK } from "app/store/zone/types";
 
 export type CreateParams = {
   mac_addresses?: string[];
@@ -23,7 +23,7 @@ export type CreateParams = {
   parent?: Controller[ControllerMeta.PK] | Machine[MachineMeta.PK];
   primary_mac?: string;
   swap_size?: string;
-  zone?: { name: Zone[ZoneMeta.PK] };
+  zone?: { name: ZonePK };
 };
 
 export type CreateInterfaceParams = {

--- a/ui/src/app/store/pod/types/actions.ts
+++ b/ui/src/app/store/pod/types/actions.ts
@@ -2,7 +2,7 @@ import type { Pod, PodPowerParameters, PodVM } from "./base";
 import type { PodMeta } from "./enum";
 
 import type { Domain, DomainMeta } from "app/store/domain/types";
-import type { Zone, ZoneMeta } from "app/store/zone/types";
+import type { ZonePK } from "app/store/zone/types";
 
 export type ComposeParams = {
   architecture?: Pod["architectures"][0];
@@ -17,7 +17,7 @@ export type ComposeParams = {
   pool?: Pod["pool"];
   skip_commissioning?: boolean;
   storage?: string;
-  zone?: Zone[ZoneMeta.PK];
+  zone?: ZonePK;
 };
 
 export type CreateParams = {

--- a/ui/src/app/store/root/types.ts
+++ b/ui/src/app/store/root/types.ts
@@ -61,7 +61,8 @@ import type { TagState, TagMeta } from "app/store/tag/types";
 import type { TokenState, TokenMeta } from "app/store/token/types";
 import type { UserState, UserMeta } from "app/store/user/types";
 import type { VLANState, VLANMeta } from "app/store/vlan/types";
-import type { ZoneState, ZoneMeta } from "app/store/zone/types";
+import type { ZONE_MODEL } from "app/store/zone/constants";
+import type { ZoneState } from "app/store/zone/types";
 
 export type RootState = {
   [BootResourceMeta.MODEL]: BootResourceState;
@@ -96,5 +97,5 @@ export type RootState = {
   [TokenMeta.MODEL]: TokenState;
   [UserMeta.MODEL]: UserState;
   [VLANMeta.MODEL]: VLANState;
-  [ZoneMeta.MODEL]: ZoneState;
+  [ZONE_MODEL]: ZoneState;
 };

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -14,6 +14,7 @@ import type { NodeScriptResultMeta } from "app/store/nodescriptresult/types";
 import type { PodMeta, PodStatus } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import type { StatusMeta } from "app/store/status/types";
+import type { ZONE_MODEL } from "app/store/zone/constants";
 
 export type GenericItemMeta<I> = {
   item: I;
@@ -36,6 +37,7 @@ export type CommonStates = Omit<
   | MessageMeta.MODEL
   | NodeScriptResultMeta.MODEL
   | StatusMeta.MODEL
+  | typeof ZONE_MODEL
 >;
 
 // Get the types of the common models. e.g. "DHCPSnippetState".

--- a/ui/src/app/store/zone/constants.ts
+++ b/ui/src/app/store/zone/constants.ts
@@ -1,0 +1,18 @@
+export const ZONE_MODEL = "zone";
+
+export const ZONE_PK = "id";
+
+export const ZONE_ACTIONS = {
+  cleanup: "cleanup",
+  create: "create",
+  delete: "delete",
+  fetch: "fetch",
+  update: "update",
+} as const;
+
+export const ZONE_WEBSOCKET_METHODS = {
+  create: "create",
+  delete: "delete",
+  list: "list",
+  update: "update",
+} as const;

--- a/ui/src/app/store/zone/selectors.ts
+++ b/ui/src/app/store/zone/selectors.ts
@@ -1,13 +1,82 @@
-import { generateBaseSelectors } from "app/store/utils";
-import { ZoneMeta } from "app/store/zone/types";
-import type { Zone, ZoneState } from "app/store/zone/types";
+import { createSelector } from "@reduxjs/toolkit";
 
-const searchFunction = (zone: Zone, term: string) => zone.name.includes(term);
+import { ZONE_ACTIONS, ZONE_MODEL, ZONE_PK } from "./constants";
+import type { ZonePK, ZoneState } from "./types";
 
-const selectors = generateBaseSelectors<ZoneState, Zone, ZoneMeta.PK>(
-  ZoneMeta.MODEL,
-  ZoneMeta.PK,
-  searchFunction
+import type { RootState } from "app/store/root/types";
+
+const all = (state: RootState): ZoneState["items"] => state[ZONE_MODEL].items;
+
+const loading = (state: RootState): ZoneState["loading"] =>
+  state[ZONE_MODEL].loading;
+
+const loaded = (state: RootState): ZoneState["loaded"] =>
+  state[ZONE_MODEL].loaded;
+
+const saving = (state: RootState): ZoneState["saving"] =>
+  state[ZONE_MODEL].saving;
+
+const saved = (state: RootState): ZoneState["saved"] => state[ZONE_MODEL].saved;
+
+const processes = (state: RootState): ZoneState["processes"] =>
+  state[ZONE_MODEL].processes;
+
+const errors = (state: RootState): ZoneState["errors"] =>
+  state[ZONE_MODEL].errors;
+
+const count = createSelector([all], (zones) => zones.length);
+
+const getById = createSelector(
+  [all, (_state: RootState, id: ZonePK | null | undefined) => id],
+  (zones, id) => {
+    if (id === null || id === undefined) {
+      return null;
+    }
+    return zones.find((zone) => zone[ZONE_PK] === id) || null;
+  }
 );
+
+const getLatestFormError = createSelector(
+  [errors, (_state: RootState, formId: string) => formId],
+  (errors, formId) =>
+    errors.find((error) => error.formId === formId)?.error || null
+);
+
+const deleted = createSelector(
+  [processes],
+  (processes) => processes[ZONE_ACTIONS.delete].successful
+);
+
+const deleting = createSelector(
+  [processes],
+  (processes) => processes[ZONE_ACTIONS.delete].processing
+);
+
+const updated = createSelector(
+  [processes],
+  (processes) => processes[ZONE_ACTIONS.update].successful
+);
+
+const updating = createSelector(
+  [processes],
+  (processes) => processes[ZONE_ACTIONS.update].processing
+);
+
+const selectors = {
+  all,
+  count,
+  deleted,
+  deleting,
+  errors,
+  getById,
+  getLatestFormError,
+  loaded,
+  loading,
+  processes,
+  saved,
+  saving,
+  updated,
+  updating,
+};
 
 export default selectors;

--- a/ui/src/app/store/zone/slice.ts
+++ b/ui/src/app/store/zone/slice.ts
@@ -1,22 +1,261 @@
+import type { ValueOf } from "@canonical/react-components";
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
-import { ZoneMeta } from "./types";
-import type { CreateParams, UpdateParams, ZoneState } from "./types";
-
 import {
-  generateCommonReducers,
-  genericInitialState,
-} from "app/store/utils/slice";
+  ZONE_ACTIONS,
+  ZONE_MODEL,
+  ZONE_PK,
+  ZONE_WEBSOCKET_METHODS,
+} from "./constants";
+import type {
+  CreateParams,
+  DeleteParams,
+  UpdateParams,
+  Zone,
+  ZoneAPIMeta,
+  ZoneAPIError,
+  ZoneAPISuccess,
+  ZonePK,
+  ZoneProcesses,
+  ZoneState,
+} from "./types";
+
+import type { APIError } from "app/base/types";
+
+const {
+  cleanup: cleanupAction,
+  create: createAction,
+  delete: deleteAction,
+  fetch: fetchAction,
+  update: updateAction,
+} = ZONE_ACTIONS;
+
+const addError = (
+  state: ZoneState,
+  action: ValueOf<typeof ZONE_ACTIONS>,
+  error: APIError,
+  formId: string | null = null,
+  modelPk: ZonePK | null = null
+) => {
+  state.errors.unshift({
+    action,
+    error,
+    formId,
+    modelPk,
+  });
+};
+
+const processStart = (
+  state: ZoneState,
+  processKey: keyof ZoneProcesses,
+  modelPk: ZonePK | null
+) => {
+  if (modelPk !== null) {
+    const { processing } = state.processes[processKey];
+    processing.push(modelPk);
+  }
+};
+
+const processSuccess = (
+  state: ZoneState,
+  processKey: keyof ZoneProcesses,
+  modelPk: ZonePK | null
+) => {
+  if (modelPk !== null) {
+    const { processing, successful } = state.processes[processKey];
+    if (processing.indexOf(modelPk) > -1) {
+      processing.splice(processing.indexOf(modelPk), 1);
+    }
+    successful.push(modelPk);
+  }
+};
+
+const processError = (
+  state: ZoneState,
+  processKey: keyof ZoneProcesses,
+  error: APIError,
+  formId: string | null,
+  modelPk: ZonePK | null
+) => {
+  addError(state, processKey, error, formId, modelPk);
+  if (modelPk !== null) {
+    const { processing, successful } = state.processes[processKey];
+    if (processing.indexOf(modelPk) > -1) {
+      processing.splice(processing.indexOf(modelPk), 1);
+    }
+    if (successful.indexOf(modelPk) > -1) {
+      successful.splice(successful.indexOf(modelPk), 1);
+    }
+  }
+};
 
 const zoneSlice = createSlice({
-  name: ZoneMeta.MODEL,
-  initialState: genericInitialState as ZoneState,
-  reducers: generateCommonReducers<
-    ZoneState,
-    ZoneMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(ZoneMeta.MODEL, ZoneMeta.PK),
+  name: ZONE_MODEL,
+  initialState: {
+    errors: [],
+    items: [],
+    loaded: false,
+    loading: false,
+    processes: {
+      [deleteAction]: { processing: [], successful: [] },
+      [updateAction]: { processing: [], successful: [] },
+    },
+    saved: false,
+    saving: false,
+  } as ZoneState,
+  reducers: {
+    [fetchAction]: {
+      prepare: () => ({
+        meta: {
+          model: ZONE_MODEL,
+          method: ZONE_WEBSOCKET_METHODS.list,
+        },
+        payload: null,
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    [`${fetchAction}Start`]: (state) => {
+      state.loading = true;
+    },
+    [`${fetchAction}Error`]: (state, action: PayloadAction<ZoneAPIError>) => {
+      state.loading = false;
+      addError(state, fetchAction, action.payload.error);
+    },
+    [`${fetchAction}Success`]: (
+      state,
+      action: PayloadAction<ZoneAPISuccess<Zone[]>>
+    ) => {
+      state.loading = false;
+      state.loaded = true;
+      state.items = action.payload.result;
+    },
+    [createAction]: {
+      prepare: (params: CreateParams, formId: string) => ({
+        meta: {
+          model: ZONE_MODEL,
+          method: ZONE_WEBSOCKET_METHODS.create,
+        },
+        payload: {
+          formId,
+          params,
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    [`${createAction}Start`]: (state) => {
+      state.saving = true;
+    },
+    [`${createAction}Error`]: (state, action: PayloadAction<ZoneAPIError>) => {
+      state.saving = false;
+      addError(
+        state,
+        createAction,
+        action.payload.error,
+        action.payload.formId
+      );
+    },
+    [`${createAction}Success`]: (state) => {
+      state.saved = true;
+      state.saving = false;
+    },
+    [`${createAction}Notify`]: (state, action: PayloadAction<Zone>) => {
+      const existingIdx = state.items.findIndex(
+        (existingItem) => existingItem[ZONE_PK] === action.payload[ZONE_PK]
+      );
+      if (existingIdx !== -1) {
+        state.items[existingIdx] = action.payload;
+      } else {
+        state.items.push(action.payload);
+      }
+    },
+    [updateAction]: {
+      prepare: (params: UpdateParams, formId: string) => ({
+        meta: {
+          model: ZONE_MODEL,
+          method: ZONE_WEBSOCKET_METHODS.update,
+        },
+        payload: {
+          formId,
+          modelPk: params[ZONE_PK],
+          params,
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    [`${updateAction}Start`]: (state, action: PayloadAction<ZoneAPIMeta>) => {
+      processStart(state, updateAction, action.payload.modelPk);
+    },
+    [`${updateAction}Error`]: (state, action: PayloadAction<ZoneAPIError>) => {
+      processError(
+        state,
+        updateAction,
+        action.payload.error,
+        action.payload.formId,
+        action.payload.modelPk
+      );
+    },
+    [`${updateAction}Success`]: (state, action: PayloadAction<ZoneAPIMeta>) => {
+      processSuccess(state, updateAction, action.payload.modelPk);
+    },
+    [`${updateAction}Notify`]: (state, action: PayloadAction<Zone>) => {
+      state.items.forEach((zone, i) => {
+        if (zone[ZONE_PK] === action.payload[ZONE_PK]) {
+          state.items[i] = action.payload;
+        }
+      });
+    },
+    [deleteAction]: {
+      prepare: (params: DeleteParams, formId: string) => ({
+        meta: {
+          model: ZONE_MODEL,
+          method: ZONE_WEBSOCKET_METHODS.delete,
+        },
+        payload: {
+          formId,
+          modelPk: params[ZONE_PK],
+          params,
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    [`${deleteAction}Start`]: (state, action: PayloadAction<ZoneAPIMeta>) => {
+      processStart(state, deleteAction, action.payload.modelPk);
+    },
+    [`${deleteAction}Error`]: (state, action: PayloadAction<ZoneAPIError>) => {
+      processError(
+        state,
+        deleteAction,
+        action.payload.error,
+        action.payload.formId,
+        action.payload.modelPk
+      );
+    },
+    [`${deleteAction}Success`]: (state, action: PayloadAction<ZoneAPIMeta>) => {
+      processSuccess(state, deleteAction, action.payload.modelPk);
+    },
+    [`${deleteAction}Notify`]: (state, action: PayloadAction<ZonePK>) => {
+      const index = state.items.findIndex(
+        (item) => item[ZONE_PK] === action.payload
+      );
+      state.items.splice(index, 1);
+    },
+    [cleanupAction]: (state, _action: PayloadAction<undefined>) => {
+      state.errors = [];
+      state.processes[deleteAction] = { processing: [], successful: [] };
+      state.processes[updateAction] = { processing: [], successful: [] };
+      state.saved = false;
+      state.saving = false;
+    },
+  },
 });
 
 export const { actions } = zoneSlice;

--- a/ui/src/app/store/zone/types/actions.ts
+++ b/ui/src/app/store/zone/types/actions.ts
@@ -1,11 +1,18 @@
-import type { Zone } from "./base";
-import type { ZoneMeta } from "./enum";
+import type { ZONE_PK } from "../constants";
+
+import type { Zone, ZonePK } from "./base";
 
 export type CreateParams = {
   description?: Zone["description"];
   name: Zone["name"];
 };
 
-export type UpdateParams = CreateParams & {
-  [ZoneMeta.PK]: Zone[ZoneMeta.PK];
+export type DeleteParams = {
+  [ZONE_PK]: ZonePK;
+};
+
+export type UpdateParams = {
+  [ZONE_PK]: ZonePK;
+  description?: Zone["description"];
+  name?: Zone["name"];
 };

--- a/ui/src/app/store/zone/types/base.ts
+++ b/ui/src/app/store/zone/types/base.ts
@@ -1,6 +1,9 @@
+import type { ValueOf } from "@canonical/react-components";
+
+import type { ZONE_ACTIONS, ZONE_PK } from "../constants";
+
 import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
-import type { GenericState } from "app/store/types/state";
 
 export type Zone = Model & {
   controllers_count: number;
@@ -12,4 +15,41 @@ export type Zone = Model & {
   updated: string;
 };
 
-export type ZoneState = GenericState<Zone, APIError>;
+export type ZonePK = Zone[typeof ZONE_PK];
+
+export type ZoneProcess = {
+  processing: ZonePK[];
+  successful: ZonePK[];
+};
+
+export type ZoneProcesses = {
+  [ZONE_ACTIONS.delete]: ZoneProcess;
+  [ZONE_ACTIONS.update]: ZoneProcess;
+};
+
+export type ZoneAPIMeta = {
+  formId: string | null;
+  modelPk: ZonePK | null;
+};
+
+export type ZoneAPISuccess<R> = {
+  result: R;
+};
+
+export type ZoneAPIError = ZoneAPIMeta & {
+  error: APIError;
+};
+
+export type ZoneStateError = ZoneAPIError & {
+  action: ValueOf<typeof ZONE_ACTIONS>;
+};
+
+export type ZoneState = {
+  errors: ZoneStateError[];
+  items: Zone[];
+  loaded: boolean;
+  loading: boolean;
+  processes: ZoneProcesses;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/zone/types/enum.ts
+++ b/ui/src/app/store/zone/types/enum.ts
@@ -1,4 +1,0 @@
-export enum ZoneMeta {
-  MODEL = "zone",
-  PK = "id",
-}

--- a/ui/src/app/store/zone/types/index.ts
+++ b/ui/src/app/store/zone/types/index.ts
@@ -1,5 +1,12 @@
-export type { CreateParams, UpdateParams } from "./actions";
+export type { CreateParams, DeleteParams, UpdateParams } from "./actions";
 
-export type { Zone, ZoneState } from "./base";
-
-export { ZoneMeta } from "./enum";
+export type {
+  Zone,
+  ZoneAPIError,
+  ZoneAPIMeta,
+  ZoneAPISuccess,
+  ZonePK,
+  ZoneProcesses,
+  ZoneState,
+  ZoneStateError,
+} from "./base";

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
 import { useSelector, useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 
@@ -18,9 +19,10 @@ type Props = {
 };
 
 const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
+  const formId = useRef(nanoid());
   const [showConfirm, setShowConfirm] = useState(false);
   const zonesLoaded = useSelector(zoneSelectors.loaded);
-  const zonesSaved = useSelector(zoneSelectors.saved);
+  const zoneDeleted = useSelector(zoneSelectors.deleted).includes(id);
   const zone = useSelector((state: RootState) =>
     zoneSelectors.getById(state, Number(id))
   );
@@ -32,18 +34,18 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (zonesSaved) {
+    if (zoneDeleted) {
       dispatch(zoneActions.cleanup());
       history.push({ pathname: zonesURLs.index });
     }
-  }, [dispatch, zonesSaved, history]);
+  }, [dispatch, history, zoneDeleted]);
 
   const isAdmin = useSelector(authSelectors.isAdmin);
   const isDefaultZone = id === 1;
 
   const deleteZone = () => {
     if (isAdmin && !isDefaultZone) {
-      dispatch(zoneActions.delete(id));
+      dispatch(zoneActions.delete({ id }, formId.current));
     }
   };
 

--- a/ui/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.tsx
@@ -1,10 +1,12 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import { Row, Col, Textarea } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
+import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 
@@ -18,8 +20,11 @@ export type CreateZoneValues = {
 };
 
 const ZonesListForm = ({ closeForm }: Props): JSX.Element => {
+  const formId = useRef(nanoid());
   const dispatch = useDispatch();
-  const errors = useSelector(zoneSelectors.errors);
+  const error = useSelector((state: RootState) =>
+    zoneSelectors.getLatestFormError(state, formId.current)
+  );
   const saved = useSelector(zoneSelectors.saved);
   const saving = useSelector(zoneSelectors.saving);
   const cleanup = useCallback(() => zoneActions.cleanup(), []);
@@ -29,7 +34,7 @@ const ZonesListForm = ({ closeForm }: Props): JSX.Element => {
       buttonsAlign="right"
       buttonsBordered={false}
       cleanup={cleanup}
-      errors={errors}
+      errors={error}
       initialValues={{
         description: "",
         name: "",
@@ -38,10 +43,13 @@ const ZonesListForm = ({ closeForm }: Props): JSX.Element => {
       onSuccess={closeForm}
       onSubmit={(values) => {
         dispatch(
-          zoneActions.create({
-            description: values.description,
-            name: values.name,
-          })
+          zoneActions.create(
+            {
+              description: values.description,
+              name: values.name,
+            },
+            formId.current
+          )
         );
       }}
       resetOnSave={true}

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -58,6 +58,7 @@ import type { TokenState } from "app/store/token/types";
 import type { EventError } from "app/store/types/state";
 import type { AuthState, UserState } from "app/store/user/types";
 import type { VLANState } from "app/store/vlan/types";
+import { ZONE_ACTIONS } from "app/store/zone/constants";
 import type { ZoneState } from "app/store/zone/types";
 
 const defaultState = {
@@ -356,7 +357,16 @@ export const vlanState = define<VLANState>({
 });
 
 export const zoneState = define<ZoneState>({
-  ...defaultState,
+  errors: [],
+  items: [],
+  loaded: false,
+  loading: false,
+  processes: {
+    [ZONE_ACTIONS.delete]: { processing: [], successful: [] },
+    [ZONE_ACTIONS.update]: { processing: [], successful: [] },
+  },
+  saved: false,
+  saving: false,
 });
 
 export const locationState = define<RouterLocation<unknown>>({

--- a/ui/src/websocket-client.ts
+++ b/ui/src/websocket-client.ts
@@ -59,6 +59,8 @@ export type WebSocketActionParams = AnyObject | AnyObject[];
 
 export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
   {
+    formId?: string;
+    modelPk?: number | string;
     params: P;
   },
   string,


### PR DESCRIPTION
This was *meant* to just be an exploration of how we could link a form component with an API error after having gone through the Redux/websocket gauntlet... but it's come out a bit broader than that because I can't help myself. I don't intend for this PR to get merged - the code is kinda half-baked and we're too close to the end of cycle for major architectural changes, but I've wanted to figure this out for a while. Anyway I've made a bunch of changes to the `zone` selectors/slice/types and hoping to get some feedback on the ideas.

@hatched @huwshimi interested to get your thoughts - I'll run through it on our next maas-ui sync.

Example shape in state:
``` typescript
const state = {
  zone: {
    errors: [
      {
        action: "update",
        error: {
          name: ["Physical zone with this Name already exists."],
        },
        formId: "fPfd4mRJxoixiNHCeuy0v",
        modelPk: 1,
      },
    ],
    items: [
      {
        id: 1,
        created: "Thu, 13 Feb. 2020 14:55:31",
        updated: "Thu, 13 Feb. 2020 14:55:31",
        name: "default",
        description: "",
        devices_count: 2,
        machines_count: 12,
        controllers_count: 0,
      },
      {
        id: 2,
        created: "Tue, 09 Jun. 2020 04:04:02",
        updated: "Fri, 18 Jun. 2021 07:38:41",
        name: "danger",
        description: "it's the best, beats the rest",
        devices_count: 0,
        machines_count: 0,
        controllers_count: 1,
      },
    ],
    loaded: true,
    loading: false,
    processes: {
      delete: {
        processing: [2],
        successful: [],
      },
      update: {
        processing: [],
        successful: [],
      },
    },
    saved: false,
    saving: false,
  },
};
```