### PR TITLE
feat(ui): update vm table columns

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
@@ -55,6 +55,9 @@ const generateRows = (vms: Machine[], podId: Pod["id"]) =>
           content: <StatusColumn systemId={vm.system_id} />,
         },
         {
+          // TODO: VM host column will go here.
+        },
+        {
           className: "ipv4-col",
           content: <IPColumn systemId={vm.system_id} version={4} />,
         },
@@ -71,27 +74,32 @@ const generateRows = (vms: Machine[], podId: Pod["id"]) =>
           content: <CoresColumn machineId={vm.system_id} podId={podId} />,
         },
         {
-          className: "ram-col u-align--right",
+          className: "ram-col",
           content: (
-            <>
-              <span>{memory.value} </span>
-              <small className="u-text--muted">{memory.unit}</small>
-            </>
-          ),
-        },
-        {
-          className: "storage-col u-align--right",
-          content: (
-            <>
-              <span>{storage.value} </span>
-              <small className="u-text--muted">{storage.unit}</small>
-            </>
+            <DoubleRow
+              primary={
+                <>
+                  <span>{memory.value} </span>
+                  <small className="u-text--muted">{memory.unit}</small>
+                </>
+              }
+              secondary={
+                <>
+                  <span>{storage.value} </span>
+                  <small className="u-text--muted">{storage.unit}</small>
+                </>
+              }
+            />
           ),
         },
         {
           className: "pool-col",
           content: (
-            <DoubleRow primary={vm.pool.name} secondary={vm.zone.name} />
+            <DoubleRow
+              primary={vm.pool.name}
+              secondary={vm.tags.join(", ")}
+              secondaryTitle={vm.tags.join(", ")}
+            />
           ),
         },
       ],
@@ -149,7 +157,7 @@ const VMsTable = ({ currentPage, id, searchFilter }: Props): JSX.Element => {
                     onClick={() => updateSort("hostname")}
                     sortKey="hostname"
                   >
-                    Name
+                    VM name
                   </TableHeader>
                 </div>
               </div>
@@ -169,6 +177,9 @@ const VMsTable = ({ currentPage, id, searchFilter }: Props): JSX.Element => {
             ),
           },
           {
+            // TODO: VM host column will go here.
+          },
+          {
             className: "ipv4-col",
             content: <TableHeader>IPv4</TableHeader>,
           },
@@ -185,27 +196,18 @@ const VMsTable = ({ currentPage, id, searchFilter }: Props): JSX.Element => {
             content: <TableHeader>Cores</TableHeader>,
           },
           {
-            className: "ram-col u-align--right",
+            className: "ram-col",
             content: (
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => updateSort("memory")}
-                sortKey="memory"
-              >
-                RAM
-              </TableHeader>
-            ),
-          },
-          {
-            className: "storage-col u-align--right",
-            content: (
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => updateSort("storage")}
-                sortKey="storage"
-              >
-                Storage
-              </TableHeader>
+              <>
+                <TableHeader
+                  currentSort={currentSort}
+                  onClick={() => updateSort("memory")}
+                  sortKey="memory"
+                >
+                  RAM
+                </TableHeader>
+                <TableHeader>Storage</TableHeader>
+              </>
             ),
           },
           {
@@ -217,9 +219,9 @@ const VMsTable = ({ currentPage, id, searchFilter }: Props): JSX.Element => {
                   onClick={() => updateSort("pool")}
                   sortKey="pool"
                 >
-                  Resource pool
+                  Pool
                 </TableHeader>
-                <TableHeader>AZ</TableHeader>
+                <TableHeader>Tag</TableHeader>
               </>
             ),
           },


### PR DESCRIPTION
## Done

- Replace AZs with tags.
- Combine ram and storage columns.
- Rename "Name" to "VM name".
- Rename "Resource pool" column to "Pool".

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a LXD kvm details page.
- On the project tab go down to the list of kvms.
- Check that the last column header has "Pool" and "Tag".
- Check that the tags are shown below the pool for the vm rows.
- Check that the Ram and Storage columns are combined.
- Check that the first column header is "VM name".

## Fixes

Fixes: canonical-web-and-design/app-squad#314.
Fixes: canonical-web-and-design/app-squad#312.
Fixes: canonical-web-and-design/app-squad#313.
Fixes: canonical-web-and-design/app-squad#315.

## Screenshots

<img width="1287" alt="Screen Shot 2021-10-04 at 12 42 51 pm" src="https://user-images.githubusercontent.com/361637/135781947-3e821d2b-7b62-465f-8ab2-08240f245781.png">

