### PR TITLE
feat(ui): make total vms a link

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/ProjectResourcesCard/ProjectResourcesCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/ProjectResourcesCard/ProjectResourcesCard.tsx
@@ -34,28 +34,30 @@ const ProjectResourcesCard = ({ id }: Props): JSX.Element => {
     );
     const hugepages = memory.hugepages; // Hugepages do not take over-commit into account
     return (
-      <div className="project-resources-card">
-        <RamResources
-          dynamicLayout
-          general={{
-            allocated: general.allocated_tracked,
-            free: general.free,
-          }}
-          hugepages={{
-            allocated: hugepages.allocated_tracked,
-            free: hugepages.free,
-          }}
-        />
-        <CoreResources
-          cores={{
-            allocated: cores.allocated_tracked,
-            free: cores.free,
-          }}
-          dynamicLayout
-        />
-        <VfResources dynamicLayout interfaces={interfaces} />
+      <>
+        <div className="project-resources-card">
+          <RamResources
+            dynamicLayout
+            general={{
+              allocated: general.allocated_tracked,
+              free: general.free,
+            }}
+            hugepages={{
+              allocated: hugepages.allocated_tracked,
+              free: hugepages.free,
+            }}
+          />
+          <CoreResources
+            cores={{
+              allocated: cores.allocated_tracked,
+              free: cores.free,
+            }}
+            dynamicLayout
+          />
+          <VfResources dynamicLayout interfaces={interfaces} />
+        </div>
         <VmResources vms={podVMs} />
-      </div>
+      </>
     );
   }
   return <Spinner text="Loading" />;

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/ProjectResourcesCard/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/ProjectResourcesCard/_index.scss
@@ -6,8 +6,7 @@
     grid-template-areas:
       "ram ram ram ram"
       "cor cor cor cor"
-      "vfs vfs vfs vfs"
-      "vms vms vms vms";
+      "vfs vfs vfs vfs";
     grid-template-columns: repeat(4, minmax(0, 1fr));
     grid-template-rows: min-content;
 
@@ -25,27 +24,20 @@
       grid-area: vfs;
     }
 
-    .vm-resources {
-      border-top: $border;
-      grid-area: vms;
-    }
-
     @media only screen and (min-width: $breakpoint-medium) {
       grid-template-areas:
         "ram ram ram ram ram ram"
         "cor cor cor cor cor cor"
-        "vfs vfs vfs vfs vfs vfs"
-        "vms vms vms vms vms vms";
+        "vfs vfs vfs vfs vfs vfs";
       grid-template-columns: repeat(6, minmax(0, 1fr));
     }
 
     @media only screen and (min-width: $breakpoint-large) {
-      grid-template-areas: "ram ram ram ram cor cor cor vfs vfs vfs vms vms";
+      grid-template-areas: "ram ram ram ram cor cor cor cor vfs vfs vfs vfs";
       grid-template-columns: repeat(12, minmax(0, 1fr));
 
       .core-resources,
-      .vf-resources,
-      .vm-resources {
+      .vf-resources {
         border-left: $border;
         border-top: 0;
       }

--- a/ui/src/app/kvm/views/KVMDetails/VmResources/VmResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/VmResources/VmResources.tsx
@@ -10,16 +10,14 @@ export type Props = {
 const VmResources = ({ vms }: Props): JSX.Element => {
   return (
     <div className="vm-resources">
-      <h4 className="vm-resources__header p-heading--small">Total VMs</h4>
       <div className="vm-resources__dropdown-container">
         <ContextualMenu
           data-test="vms-dropdown"
           dropdownClassName="vm-resources__dropdown"
-          hasToggleIcon
           toggleAppearance="base"
-          toggleClassName="vm-resources__toggle is-dense"
+          toggleClassName="vm-resources__toggle is-dense p-button--link"
           toggleDisabled={vms.length === 0}
-          toggleLabel={`${vms.length}`}
+          toggleLabel={`Total VMs: ${vms.length}`}
         >
           <MachineListTable
             hiddenColumns={[

--- a/ui/src/app/kvm/views/KVMDetails/VmResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/VmResources/_index.scss
@@ -1,26 +1,6 @@
 @mixin VmResources {
   .vm-resources {
-    display: flex;
-    flex-direction: column;
-    padding: $spv-inner--medium $sph-inner;
-
-    @media only screen and (min-width: $breakpoint-large) {
-      flex-direction: row;
-    }
-  }
-
-  .vm-resources__dropdown-container {
-    position: relative;
-    top: -$spv-inner--x-small;
-
-    .vm-resources__toggle {
-      padding-left: $sph-inner--small;
-      padding-right: $sph-inner--small;
-    }
-
-    @media only screen and (min-width: $breakpoint-large) {
-      margin-left: $sph-inner;
-    }
+    padding: $sph-inner;
   }
 
   .p-contextual-menu .vm-resources__dropdown {


### PR DESCRIPTION
## Done

- Move total vms to a link under the resources card.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the resources tab in a LXD kvm's details.
- The "Total VMs" link should be below the "default" card.
- Toggle to view by numa node.
- The total vms link should be inside the card.

## Fixes

Fixes: canonical-web-and-design/app-squad#299.

## Screenshots

<img width="1266" alt="Screen Shot 2021-10-04 at 3 13 24 pm" src="https://user-images.githubusercontent.com/361637/135793843-6a2abc84-7ad9-4699-9877-fd255dddb51b.png">

<img width="634" alt="Screen Shot 2021-10-04 at 3 20 39 pm" src="https://user-images.githubusercontent.com/361637/135794072-a8900a54-dd1f-445b-a04f-0386aa7ddc3f.png">

