### PR TITLE
fix(ui): update KVMDetailsHeader to latest design

### DIFF
--- a/ui/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -44,27 +44,7 @@ describe("KVMDetailsHeader", () => {
     });
   });
 
-  it("renders title block content if no header content has been selected", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <KVMDetailsHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-            tabLinks={[]}
-            titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("[data-test='title-blocks']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='form-title']").exists()).toBe(false);
-    expect(wrapper.find("KVMHeaderForms").exists()).toBe(false);
-  });
-
-  it("renders header forms and name if header content has been selected", () => {
+  it("renders header forms and no extra title blocks if header content has been selected", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -74,17 +54,19 @@ describe("KVMDetailsHeader", () => {
             setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
             tabLinks={[]}
+            title="Title"
             titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
           />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("KVMHeaderForms").exists()).toBe(true);
-    expect(wrapper.find("[data-test='form-title']").text()).toBe("Compose");
-    expect(wrapper.find("[data-test='title-blocks']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='extra-title-block']").exists()).toBe(
+      false
+    );
   });
 
-  it("mutes the second title onward", () => {
+  it("renders extra title blocks if no header content has been selected", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -94,23 +76,13 @@ describe("KVMDetailsHeader", () => {
             setHeaderContent={jest.fn()}
             setSearchFilter={jest.fn()}
             tabLinks={[]}
-            titleBlocks={[
-              { title: "Not muted" },
-              { title: "Muted" },
-              { title: "Muted" },
-            ]}
+            title="Title"
+            titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
           />
         </MemoryRouter>
       </Provider>
     );
-    const getTitleClassName = (i: number) =>
-      wrapper
-        .find("[data-test='block-title']")
-        .at(i)
-        .prop("className") as string;
-
-    expect(getTitleClassName(0).includes("u-text--muted")).toBe(false);
-    expect(getTitleClassName(1).includes("u-text--muted")).toBe(true);
-    expect(getTitleClassName(2).includes("u-text--muted")).toBe(true);
+    expect(wrapper.find("[data-test='extra-title-block']").exists()).toBe(true);
+    expect(wrapper.find("KVMHeaderForms").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import classNames from "classnames";
 import { useLocation } from "react-router-dom";
 
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
@@ -10,7 +9,6 @@ import SectionHeader from "app/base/components/SectionHeader";
 import type { SetSearchFilter } from "app/base/types";
 import KVMHeaderForms from "app/kvm/components/KVMHeaderForms";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
-import { getFormTitle } from "app/kvm/utils";
 
 type TitleBlock = {
   title: ReactNode;
@@ -23,6 +21,7 @@ type Props = {
   setHeaderContent: KVMSetHeaderContent;
   setSearchFilter?: SetSearchFilter;
   tabLinks: SectionHeaderProps["tabLinks"];
+  title: ReactNode;
   titleBlocks: TitleBlock[];
 };
 
@@ -32,6 +31,7 @@ const KVMDetailsHeader = ({
   setHeaderContent,
   setSearchFilter,
   tabLinks,
+  title,
   titleBlocks,
 }: Props): JSX.Element => {
   const location = useLocation();
@@ -59,35 +59,32 @@ const KVMDetailsHeader = ({
       }
       tabLinks={tabLinks}
       title={
-        headerContent ? (
-          <span className="p-heading--4" data-test="form-title">
-            {getFormTitle(headerContent)}
-          </span>
-        ) : (
-          <div
-            className="kvm-details-header__title-blocks"
-            data-test="title-blocks"
-          >
-            {titleBlocks.map((block, i) => (
+        <div className="kvm-details-header__title-blocks p-divider u-no-margin--bottom">
+          <div className="kvm-details-header__title-block p-divider__block">
+            <h1 className="p-heading--4 u-no-margin--bottom">{title}</h1>
+          </div>
+          {!headerContent &&
+            titleBlocks.map((block, i) => (
               <div
-                className="kvm-details-header__title-block"
+                className="kvm-details-header__title-block p-divider__block"
+                data-test="extra-title-block"
                 key={`title-block-${i}`}
               >
-                <h4
-                  className={classNames("u-no-margin--bottom", {
-                    "u-text--muted": i !== 0,
-                  })}
+                <p
+                  className="u-text--muted u-no-margin u-no-padding"
                   data-test="block-title"
                 >
                   {block.title}
-                </h4>
-                <span className="u-text--muted" data-test="block-subtitle">
+                </p>
+                <p
+                  className="u-no-margin u-no-padding"
+                  data-test="block-subtitle"
+                >
                   {block.subtitle || " "}
-                </span>
+                </p>
               </div>
             ))}
-          </div>
-        )
+        </div>
       }
     />
   );

--- a/ui/src/app/kvm/components/KVMDetailsHeader/_index.scss
+++ b/ui/src/app/kvm/components/KVMDetailsHeader/_index.scss
@@ -10,18 +10,8 @@
     }
 
     .kvm-details-header__title-block {
-      border-right: $border;
-      padding-left: $sph-inner--large;
-      padding-right: $sph-inner--large;
-
-      &:first-of-type {
-        padding-left: 0;
-      }
-
-      &:last-of-type {
-        border-right: 0;
-        padding-right: 0;
-      }
+      padding-left: $sph-inner--small;
+      padding-right: $sph-inner--small;
     }
   }
 }

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -1,4 +1,3 @@
-import { Icon } from "@canonical/react-components";
 import { Link, useLocation } from "react-router-dom";
 
 import KVMDetailsHeader from "app/kvm/components/KVMDetailsHeader";
@@ -47,22 +46,24 @@ const LXDClusterDetailsHeader = ({
         },
       ]}
       setHeaderContent={setHeaderContent}
+      title="Cluster name"
       titleBlocks={[
         // TODO: Use actual cluster data
         {
-          title: "Cluster name",
-          subtitle: "Project: project-name",
+          title: "Cluster:",
+          subtitle: "15 members",
         },
         {
-          title: "12 VMs available",
-          subtitle: (
-            <>
-              <span className="u-nudge-left--small">
-                <Icon name="bundle" />
-              </span>
-              Cluster x 15
-            </>
-          ),
+          title: "VMs:",
+          subtitle: "12 available",
+        },
+        {
+          title: "AZ:",
+          subtitle: "euw-02",
+        },
+        {
+          title: "LXD project:",
+          subtitle: "default",
         },
       ]}
     />

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
@@ -15,6 +15,7 @@ import {
   podStatus as podStatusFactory,
   podStatuses as podStatusesFactory,
   podVmCount as podVmCountFactory,
+  zone as zoneFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -84,7 +85,7 @@ describe("LXDSingleDetailsHeader", () => {
       </Provider>
     );
     expect(wrapper.find("[data-test='block-subtitle']").at(0).text()).toBe(
-      "Project: Manhattan"
+      "Manhattan"
     );
   });
 
@@ -107,8 +108,31 @@ describe("LXDSingleDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("[data-test='block-title']").at(1).text()).toBe(
-      "5 VMs available"
+    expect(wrapper.find("[data-test='block-subtitle']").at(1).text()).toBe(
+      "5 available"
+    );
+  });
+
+  it("displays the pod's zone's name", () => {
+    state.zone.items = [zoneFactory({ id: 101, name: "danger" })];
+    state.pod.items[0].zone = 101;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
+        >
+          <LXDSingleDetailsHeader
+            id={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='block-subtitle']").at(2).text()).toBe(
+      "danger"
     );
   });
 });

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
@@ -16,6 +16,7 @@ import {
   podStatuses as podStatusesFactory,
   podVmCount as podVmCountFactory,
   rootState as rootStateFactory,
+  zone as zoneFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -104,8 +105,30 @@ describe("VirshDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("[data-test='block-title']").at(1).text()).toBe(
-      "5 VMs available"
+    expect(wrapper.find("[data-test='block-subtitle']").at(1).text()).toBe(
+      "5 available"
+    );
+  });
+
+  it("displays the pod's zone's name", () => {
+    state.zone.items = [zoneFactory({ id: 101, name: "danger" })];
+    state.pod.items[0].zone = 101;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
+        >
+          <VirshDetailsHeader
+            id={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='block-subtitle']").at(2).text()).toBe(
+      "danger"
     );
   });
 });

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -14,10 +14,8 @@
 @include vf-p-icons-common;
 @include vf-p-icon-back-to-top;
 @include vf-p-icon-begin-downloading;
-@include vf-p-icon-bundle;
 @include vf-p-icon-change-version;
 @include vf-p-icon-inspector-debug;
-@include vf-p-icon-machines;
 @include vf-p-icon-restart;
 @include vf-p-icon-success-grey;
 @include vf-p-lists;


### PR DESCRIPTION
## Done

- Updated KVMDetailsHeader to latest [design](https://app.zeplin.io/project/610abd78c381eeafb70f5b43/screen/615d8ac95c9ffe46f21f8dff)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a LXD and virsh KVM and check that the headers look like the new design
- Go to `/MAAS/r/kvm/lxd/cluster/1` and check that the header looks good there too

## Fixes

Fixes canonical-web-and-design/app-squad#336
Fixes canonical-web-and-design/app-squad#351

## Screenshot
### LXD single
![Screenshot 2021-10-07 at 15-58-17 KVM bolla MAAS](https://user-images.githubusercontent.com/25733845/136328173-63d22f1f-797a-4049-b694-f2ba66a2b80c.png)

### LXD cluster
![Screenshot 2021-10-07 at 15-58-44 MAAS](https://user-images.githubusercontent.com/25733845/136328189-dd8df59f-b867-4d5e-92a5-1b9af16b8358.png)

### Virsh
![Screenshot 2021-10-07 at 15-58-29 KVM resources test-virsh bolla MAAS](https://user-images.githubusercontent.com/25733845/136328179-3d85e5d6-87a6-4c1a-aadb-3553f2229fc7.png)

