### PR TITLE
feat(ui): build LXDHostToolbar component

### DIFF
--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/LXDHostToolbar.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/LXDHostToolbar.test.tsx
@@ -1,0 +1,188 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDHostToolbar from "./LXDHostToolbar";
+
+import { KVMHeaderViews } from "app/kvm/constants";
+import kvmURLs from "app/kvm/urls";
+import { PodType } from "app/store/pod/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDHostToolbar", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            pool: 2,
+            type: PodType.LXD,
+          }),
+        ],
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory({ id: 2, name: "swimming" })],
+      }),
+    });
+  });
+
+  it("shows a spinner if pools haven't loaded yet", () => {
+    state.resourcepool.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
+          ]}
+        >
+          <LXDHostToolbar hostId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='pod-pool'] Spinner").exists()).toBe(true);
+  });
+
+  it("can shows the host's pool's name", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
+          ]}
+        >
+          <LXDHostToolbar hostId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='pod-pool']").text()).toBe("swimming");
+  });
+
+  it("can link to a host's settings page if in cluster view", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.vms.host({
+                clusterId: 2,
+                hostId: 1,
+              }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDHostToolbar
+            clusterId={2}
+            hostId={1}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Button[data-test='settings-link']").prop("to")).toBe(
+      kvmURLs.lxd.cluster.host.edit({ clusterId: 2, hostId: 1 })
+    );
+  });
+
+  it("does not show a link to host's settings page if in single host view", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
+          ]}
+        >
+          <LXDHostToolbar hostId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='settings-link']").exists()).toBe(false);
+  });
+
+  it("shows tags in single host view", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
+          ]}
+        >
+          <LXDHostToolbar hostId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='pod-tags']").exists()).toBe(true);
+  });
+
+  it("does not shows tags in cluster view", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.vms.host({
+                clusterId: 2,
+                hostId: 1,
+              }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDHostToolbar
+            clusterId={2}
+            hostId={1}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='pod-tags']").exists()).toBe(false);
+  });
+
+  it("can open the compose VM form", () => {
+    const setHeaderContent = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
+          ]}
+        >
+          <LXDHostToolbar hostId={1} setHeaderContent={setHeaderContent} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("button[data-test='add-virtual-machine']").simulate("click");
+
+    expect(setHeaderContent).toHaveBeenCalledWith({
+      view: KVMHeaderViews.COMPOSE_VM,
+    });
+  });
+});

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/LXDHostToolbar.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/LXDHostToolbar.tsx
@@ -1,0 +1,111 @@
+import { useEffect } from "react";
+
+import { Button, Icon, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import Switch from "app/base/components/Switch";
+import { KVMHeaderViews } from "app/kvm/constants";
+import type { KVMSetHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import { actions as resourcePoolActions } from "app/store/resourcepool";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import type { RootState } from "app/store/root/types";
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId?: VMCluster["id"];
+  hostId: Pod["id"];
+  setHeaderContent: KVMSetHeaderContent;
+};
+
+const LXDHostToolbar = ({
+  clusterId,
+  hostId,
+  setHeaderContent,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, hostId)
+  );
+  const pool = useSelector((state: RootState) =>
+    resourcePoolSelectors.getById(state, pod?.pool)
+  );
+  const inClusterView = clusterId !== undefined;
+
+  useEffect(() => {
+    dispatch(resourcePoolActions.fetch());
+  }, [dispatch]);
+
+  if (!pod) {
+    return null;
+  }
+
+  return (
+    <div className="lxd-host-toolbar">
+      <div className="lxd-host-toolbar__title">
+        <h2 className="p-heading--4">VMs on {pod.name}</h2>
+        <span className="u-nudge-left--small u-nudge-right--small">
+          {inClusterView && (
+            <Button
+              appearance="base"
+              data-test="settings-link"
+              element={Link}
+              hasIcon
+              to={kvmURLs.lxd.cluster.host.edit({ clusterId, hostId })}
+            >
+              <Icon name="settings" />
+            </Button>
+          )}
+        </span>
+      </div>
+      <div className="lxd-host-toolbar__blocks p-divider">
+        <div className="p-divider__block">
+          <p className="u-text--muted u-no-margin u-no-padding">LXD version:</p>
+          <p className="u-no-margin u-no-padding">{pod.version}</p>
+        </div>
+        <div className="p-divider__block">
+          <p className="u-text--muted u-no-margin u-no-padding">
+            Resource pool:
+          </p>
+          <p className="u-no-margin u-no-padding" data-test="pod-pool">
+            {pool?.name || <Spinner />}
+          </p>
+        </div>
+        {!inClusterView && (
+          <div className="p-divider__block">
+            <p className="u-text--muted u-no-margin u-no-padding">Tags:</p>
+            <p className="u-no-margin u-no-padding" data-test="pod-tags">
+              {pod.tags.join(", ")}
+            </p>
+          </div>
+        )}
+        <div className="p-divider__block">
+          <Button
+            data-test="add-virtual-machine"
+            hasIcon
+            onClick={() =>
+              setHeaderContent({ view: KVMHeaderViews.COMPOSE_VM })
+            }
+          >
+            <Icon name="plus" />
+            <span>Add virtual machine</span>
+          </Button>
+        </div>
+      </div>
+      <div className="lxd-host-toolbar__switch">
+        {/* TODO: Implement NUMA view */}
+        <Switch
+          checked={false}
+          className="p-switch--inline-label"
+          label="View by NUMA node"
+          onChange={() => null}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default LXDHostToolbar;

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/_index.scss
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/_index.scss
@@ -1,0 +1,43 @@
+@mixin LXDHostToolbar {
+  .lxd-host-toolbar {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: $spv-inner--medium 0 $spv-inner--medium 0;
+
+    .p-divider__block:not(:first-child)::before {
+      background-color: $color-mid-x-light;
+    }
+  }
+
+  .lxd-host-toolbar__title {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    margin-right: $sph-outer;
+  }
+
+  .lxd-host-toolbar__blocks {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  @media only screen and (min-width: $breakpoint-medium) {
+    .lxd-host-toolbar__blocks,
+    .lxd-host-toolbar__title {
+      flex-direction: row;
+    }
+  }
+
+
+  @media only screen and (min-width: $breakpoint-x-large) {
+    .lxd-host-toolbar {
+      flex-direction: row;
+    }
+
+    .lxd-host-toolbar__switch {
+      flex-shrink: 0;
+      margin-left: $sph-outer;
+    }
+  }
+}

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/index.ts
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostToolbar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDHostToolbar";

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
@@ -34,7 +34,7 @@ describe("LXDHostVMs", () => {
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
           <LXDHostVMs
-            id={1}
+            hostId={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}
@@ -75,7 +75,7 @@ describe("LXDHostVMs", () => {
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
           <LXDHostVMs
-            id={1}
+            hostId={1}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
@@ -1,6 +1,8 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import LXDHostToolbar from "./LXDHostToolbar";
+
 import type { SetSearchFilter } from "app/base/types";
 import LXDVMsSummaryCard from "app/kvm/components/LXDVMsSummaryCard";
 import LXDVMsTable from "app/kvm/components/LXDVMsTable";
@@ -9,28 +11,31 @@ import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import { resourceWithOverCommit } from "app/store/pod/utils";
 import type { RootState } from "app/store/root/types";
+import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
-  id: Pod["id"];
+  clusterId?: VMCluster["id"];
+  hostId: Pod["id"];
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
   setHeaderContent: KVMSetHeaderContent;
 };
 
 const LXDHostVMs = ({
-  id,
+  clusterId,
+  hostId,
   searchFilter,
   setSearchFilter,
   setHeaderContent,
 }: Props): JSX.Element => {
   const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, Number(id))
+    podSelectors.getById(state, hostId)
   );
   const vms = useSelector((state: RootState) =>
-    podSelectors.filteredVMs(state, id, searchFilter)
+    podSelectors.filteredVMs(state, hostId, searchFilter)
   );
   const sortedPools = useSelector((state: RootState) =>
-    podSelectors.getSortedPools(state, id)
+    podSelectors.getSortedPools(state, hostId)
   );
 
   if (pod) {
@@ -47,6 +52,11 @@ const LXDHostVMs = ({
     const hugepages = memory.hugepages; // Hugepages do not take over-commit into account
     return (
       <>
+        <LXDHostToolbar
+          clusterId={clusterId}
+          hostId={hostId}
+          setHeaderContent={setHeaderContent}
+        />
         <LXDVMsSummaryCard
           cores={{
             allocated: cores.allocated_other + cores.allocated_tracked,

--- a/ui/src/app/kvm/urls.ts
+++ b/ui/src/app/kvm/urls.ts
@@ -10,11 +10,11 @@ const urls = {
       index: argPath<{ id: VMCluster["id"] }>("/kvm/lxd/cluster/:id"),
       hosts: argPath<{ id: VMCluster["id"] }>("/kvm/lxd/cluster/:id/hosts"),
       host: {
-        index: argPath<{ id: VMCluster["id"]; hostId: BasePod["id"] }>(
-          "/kvm/lxd/cluster/:id/host/:hostId"
+        index: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
+          "/kvm/lxd/cluster/:clusterId/host/:hostId"
         ),
-        edit: argPath<{ id: VMCluster["id"]; hostId: BasePod["id"] }>(
-          "/kvm/lxd/cluster/:id/host/:hostId/edit"
+        edit: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
+          "/kvm/lxd/cluster/:clusterId/host/:hostId/edit"
         ),
       },
       resources: argPath<{ id: VMCluster["id"] }>(
@@ -22,8 +22,8 @@ const urls = {
       ),
       vms: {
         index: argPath<{ id: VMCluster["id"] }>("/kvm/lxd/cluster/:id/vms"),
-        host: argPath<{ id: VMCluster["id"]; hostId: BasePod["id"] }>(
-          "/kvm/lxd/cluster/:id/vms/:hostId"
+        host: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
+          "/kvm/lxd/cluster/:clusterId/vms/:hostId"
         ),
       },
     },

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -70,7 +70,7 @@ const LXDSingleDetails = (): JSX.Element => {
         <Switch>
           <Route exact path={kvmURLs.lxd.single.vms(null, true)}>
             <LXDHostVMs
-              id={id}
+              hostId={id}
               searchFilter={searchFilter}
               setSearchFilter={setSearchFilter}
               setHeaderContent={setHeaderContent}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -17,6 +17,7 @@
 @include vf-p-icon-change-version;
 @include vf-p-icon-inspector-debug;
 @include vf-p-icon-restart;
+@include vf-p-icon-settings;
 @include vf-p-icon-success-grey;
 @include vf-p-lists;
 @include vf-u-baseline-grid;
@@ -129,6 +130,7 @@
 @import "~app/kvm/components/KVMResources/OverallResourcesCard/OverallCores";
 @import "~app/kvm/components/KVMResources/OverallResourcesCard/OverallRam";
 @import "~app/kvm/components/KVMResources/ProjectResourcesCard";
+@import "~app/kvm/components/LXDHostVMs/LXDHostToolbar";
 @import "~app/kvm/components/LXDVMsSummaryCard";
 @import "~app/kvm/components/LXDVMsTable/VMsActionBar";
 @import "~app/kvm/components/LXDVMsTable/VMsTable";
@@ -152,6 +154,7 @@
 @include KVMPoolSelect;
 @include KVMStorageCards;
 @include KVMSubnetSelect;
+@include LXDHostToolbar;
 @include LxdTable;
 @include LXDVMsSummaryCard;
 @include NumaResources;


### PR DESCRIPTION
## Done

- Built `LXDHostToolbar` component that shows just below the tabs in "Virtual machines"
- Removed "Settings" tab from `LXDSingleDetailsHeader` because it can now be accessed from the toolbar
- NUMA switch functionality to come later

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the "Virtual machines" tab of a LXD single host
- Check that the toolbar (below tabs, above card) looks like the [design](https://app.zeplin.io/project/610abd78c381eeafb70f5b43/screen/615d8ad67e36c23ab8f3630b)
- Check that clicking the gear button takes you to settings
- Check that clicking the "Add virtual machine" button opens the Compose VM form


## Fixes

Fixes canonical-web-and-design/app-squad#309
Fixes canonical-web-and-design/app-squad#318

## Screenshot
![Screenshot 2021-10-07 at 17-31-40 KVM bolla MAAS](https://user-images.githubusercontent.com/25733845/136341075-76e37223-8257-481d-a888-084b75d2a15b.png)
