### PR TITLE
fix(ui): fix stale RAID form values and swap fs selection

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
@@ -35,7 +35,8 @@ const generateSchema = (availableSize: number) =>
     fstype: Yup.string(),
     mountOptions: Yup.string(),
     mountPoint: Yup.string().when("fstype", {
-      is: (val: AddLogicalVolumeValues["fstype"]) => Boolean(val),
+      is: (val: AddLogicalVolumeValues["fstype"]) =>
+        Boolean(val) && val !== "swap",
       then: Yup.string().matches(/^\//, "Mount point must start with /"),
     }),
     name: Yup.string().required("Name is required"),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -33,7 +33,7 @@ const generateSchema = (availableSize: number) =>
     fstype: Yup.string(),
     mountOptions: Yup.string(),
     mountPoint: Yup.string().when("fstype", {
-      is: (val: AddPartitionValues["fstype"]) => !!val,
+      is: (val: AddPartitionValues["fstype"]) => Boolean(val) && val !== "swap",
       then: Yup.string().matches(/^\//, "Mount point must start with /"),
     }),
     partitionSize: Yup.number()

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.tsx
@@ -59,7 +59,7 @@ const CreateRaidSchema = Yup.object().shape({
   level: Yup.string().required("RAID level is required"),
   mountOptions: Yup.string(),
   mountPoint: Yup.string().when("fstype", {
-    is: (val: CreateRaidValues["fstype"]) => Boolean(val),
+    is: (val: CreateRaidValues["fstype"]) => Boolean(val) && val !== "swap",
     then: Yup.string().matches(/^\//, "Mount point must start with /"),
   }),
   name: Yup.string().required("Name is required"),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
@@ -1,4 +1,4 @@
-import { Col, Input, Row, Select } from "@canonical/react-components";
+import { Col, Icon, Input, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import FilesystemFields from "../../../FilesystemFields";
@@ -57,7 +57,8 @@ export const CreateRaidFields = ({
   storageDevices,
   systemId,
 }: Props): JSX.Element => {
-  const { setFieldValue, values } = useFormikContext<CreateRaidValues>();
+  const { handleChange, initialValues, setFieldValue, values } =
+    useFormikContext<CreateRaidValues>();
   const {
     blockDeviceIds,
     level,
@@ -123,10 +124,25 @@ export const CreateRaidFields = ({
       <Row>
         <Col size={5}>
           <FormikField label="Name" name="name" required type="text" />
-          <FormikField
+          <FormikField<typeof Select>
             component={Select}
             label="RAID level"
             name="level"
+            onChange={(e) => {
+              handleChange(e);
+              // We reset the block/partition id values on RAID level change
+              // to prevent stale values from existing in the form state.
+              setFieldValue("blockDeviceIds", initialValues.blockDeviceIds);
+              setFieldValue("partitionIds", initialValues.partitionIds);
+              setFieldValue(
+                "spareBlockDeviceIds",
+                initialValues.spareBlockDeviceIds
+              );
+              setFieldValue(
+                "sparePartitionIds",
+                initialValues.sparePartitionIds
+              );
+            }}
             options={availableRaidModes.map((raidMode) => ({
               label: raidMode.label,
               key: raidMode.level,
@@ -178,11 +194,11 @@ export const CreateRaidFields = ({
                     <td>{formatType(storageDevice)}</td>
                     {maxSpares > 0 && (
                       <>
-                        <td data-test="active-storage-device">
+                        <td data-test="active-status">
                           {isSpareDevice ? (
-                            <i className="p-icon--close"></i>
+                            <Icon data-test="is-spare" name="close" />
                           ) : (
-                            <i className="p-icon--tick"></i>
+                            <Icon data-test="is-active" name="tick" />
                           )}
                         </td>
                         <td data-test="spare-storage-device">

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.tsx
@@ -40,7 +40,7 @@ const CreateBcacheSchema = Yup.object().shape({
   fstype: Yup.string(),
   mountOptions: Yup.string(),
   mountPoint: Yup.string().when("fstype", {
-    is: (val: CreateBcacheValues["fstype"]) => Boolean(val),
+    is: (val: CreateBcacheValues["fstype"]) => Boolean(val) && val !== "swap",
     then: Yup.string().matches(/^\//, "Mount point must start with /"),
   }),
   name: Yup.string().required("Name is required"),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDisk.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDisk.tsx
@@ -27,7 +27,7 @@ const EditDiskSchema = Yup.object().shape({
   fstype: Yup.string(),
   mountOptions: Yup.string(),
   mountPoint: Yup.string().when("fstype", {
-    is: (val: EditDiskValues["fstype"]) => Boolean(val),
+    is: (val: EditDiskValues["fstype"]) => Boolean(val) && val !== "swap",
     then: Yup.string().matches(/^\//, "Mount point must start with /"),
   }),
   tags: Yup.array().of(Yup.string()),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.tsx
@@ -29,7 +29,7 @@ const EditPartitionSchema = Yup.object().shape({
   fstype: Yup.string(),
   mountOptions: Yup.string(),
   mountPoint: Yup.string().when("fstype", {
-    is: (val: EditPartitionValues["fstype"]) => Boolean(val),
+    is: (val: EditPartitionValues["fstype"]) => Boolean(val) && val !== "swap",
     then: Yup.string().matches(/^\//, "Mount point must start with /"),
   }),
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/FilesystemFields/FilesystemFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/FilesystemFields/FilesystemFields.test.tsx
@@ -10,6 +10,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -79,7 +80,7 @@ describe("FilesystemFields", () => {
     );
   });
 
-  it("disables mount point field if swap fstype selected", () => {
+  it("sets mount point to 'none' and disables field if swap fstype selected", async () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
@@ -94,7 +95,7 @@ describe("FilesystemFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <Formik
-          initialValues={{ fstype: "swap", mountOptions: "", mountPoint: "" }}
+          initialValues={{ fstype: "", mountOptions: "", mountPoint: "" }}
           onSubmit={jest.fn()}
         >
           <FilesystemFields systemId="abc123" />
@@ -102,14 +103,17 @@ describe("FilesystemFields", () => {
       </Provider>
     );
 
+    wrapper
+      .find("select[name='fstype']")
+      .simulate("change", { target: { name: "fstype", value: "swap" } });
+    await waitForComponentToPaint(wrapper);
+
     expect(wrapper.find("Input[name='mountOptions']").prop("disabled")).toBe(
       false
     );
     expect(wrapper.find("Input[name='mountPoint']").prop("disabled")).toBe(
       true
     );
-    expect(wrapper.find("Input[name='mountPoint']").prop("placeholder")).toBe(
-      "none"
-    );
+    expect(wrapper.find("Input[name='mountPoint']").prop("value")).toBe("none");
   });
 });


### PR DESCRIPTION
## Done

- Fixed RAID form not clearing values on RAID level change
- Fixed swap filesystem creation not working correctly with API

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready machine
- Create 4 partitions (or just go to http://0.0.0.0:8400/MAAS/r/machine/eqw33x/storage on using bolla)
- Select all 4 partitions and click "Create RAID"
- Select "RAID 1" as the RAID level and check some checkboxes
- Select "RAID 5" as the RAID level and see that the checkboxes are all cleared
- Select "swap" as the filesystem type and check that the mount point is automatically set to "none"
- Create the RAID and check that the swap shows up in the filesystems table

## Fixes

Fixes #3111 
Fixes #3120 
