### PR TITLE
feat(ui): build scaffolding components for LXD cluster details

### DIFF
--- a/ui/src/app/kvm/urls.ts
+++ b/ui/src/app/kvm/urls.ts
@@ -7,8 +7,15 @@ const urls = {
   lxd: {
     index: "/kvm/lxd",
     cluster: {
-      index: argPath<{ id: VMCluster["id"] }>("/kvm/lxd/cluster/:id"),
-      hosts: argPath<{ id: VMCluster["id"] }>("/kvm/lxd/cluster/:id/hosts"),
+      index: argPath<{ clusterId: VMCluster["id"] }>(
+        "/kvm/lxd/cluster/:clusterId"
+      ),
+      edit: argPath<{ clusterId: VMCluster["id"] }>(
+        "/kvm/lxd/cluster/:clusterId/edit"
+      ),
+      hosts: argPath<{ clusterId: VMCluster["id"] }>(
+        "/kvm/lxd/cluster/:clusterId/hosts"
+      ),
       host: {
         index: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
           "/kvm/lxd/cluster/:clusterId/host/:hostId"
@@ -17,11 +24,13 @@ const urls = {
           "/kvm/lxd/cluster/:clusterId/host/:hostId/edit"
         ),
       },
-      resources: argPath<{ id: VMCluster["id"] }>(
-        "/kvm/lxd/cluster/:id/resources"
+      resources: argPath<{ clusterId: VMCluster["id"] }>(
+        "/kvm/lxd/cluster/:clusterId/resources"
       ),
       vms: {
-        index: argPath<{ id: VMCluster["id"] }>("/kvm/lxd/cluster/:id/vms"),
+        index: argPath<{ clusterId: VMCluster["id"] }>(
+          "/kvm/lxd/cluster/:clusterId/vms"
+        ),
         host: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
           "/kvm/lxd/cluster/:clusterId/vms/:hostId"
         ),

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -18,6 +18,7 @@ const KVM = (): JSX.Element => {
         exact
         path={[
           kvmURLs.lxd.cluster.index(null, true),
+          kvmURLs.lxd.cluster.edit(null, true),
           kvmURLs.lxd.cluster.host.edit(null, true),
           kvmURLs.lxd.cluster.host.index(null, true),
           kvmURLs.lxd.cluster.hosts(null, true),

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -1,16 +1,21 @@
 import { useState } from "react";
 
-import { useParams } from "react-router";
+import { Redirect, Route, Switch, useParams } from "react-router-dom";
 
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
+import LXDClusterHosts from "./LXDClusterHosts";
+import LXDClusterResources from "./LXDClusterResources";
+import LXDClusterSettings from "./LXDClusterSettings";
+import LXDClusterVMs from "./LXDClusterVMs";
+import type { ClusterRouteParams } from "./types";
 
 import Section from "app/base/components/Section";
-import type { RouteParams } from "app/base/types";
 import type { KVMHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
 
 const LXDClusterDetails = (): JSX.Element => {
-  const params = useParams<RouteParams>();
-  const id = Number(params.id);
+  const params = useParams<ClusterRouteParams>();
+  const clusterId = Number(params.clusterId);
   const [headerContent, setHeaderContent] = useState<KVMHeaderContent | null>(
     null
   );
@@ -19,13 +24,36 @@ const LXDClusterDetails = (): JSX.Element => {
     <Section
       header={
         <LXDClusterDetailsHeader
+          clusterId={clusterId}
           headerContent={headerContent}
-          id={id}
           setHeaderContent={setHeaderContent}
         />
       }
       headerClassName="u-no-padding--bottom"
-    />
+    >
+      <Switch>
+        <Route exact path={kvmURLs.lxd.cluster.hosts(null, true)}>
+          <LXDClusterHosts clusterId={clusterId} />
+        </Route>
+        <Route exact path={kvmURLs.lxd.cluster.vms.index(null, true)}>
+          <LXDClusterVMs clusterId={clusterId} />
+        </Route>
+        <Route exact path={kvmURLs.lxd.cluster.resources(null, true)}>
+          <LXDClusterResources clusterId={clusterId} />
+        </Route>
+        <Route exact path={kvmURLs.lxd.cluster.edit(null, true)}>
+          <LXDClusterSettings clusterId={clusterId} />
+        </Route>
+        <Redirect
+          from={kvmURLs.lxd.cluster.index(null, true)}
+          to={kvmURLs.lxd.cluster.hosts(null, true)}
+        />
+        <Redirect
+          from={kvmURLs.lxd.cluster.host.index(null, true)}
+          to={kvmURLs.lxd.cluster.host.edit(null, true)}
+        />
+      </Switch>
+    </Section>
   );
 };
 

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -6,14 +6,14 @@ import kvmURLs from "app/kvm/urls";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
+  clusterId: VMCluster["id"];
   headerContent: KVMHeaderContent | null;
-  id: VMCluster["id"];
   setHeaderContent: KVMSetHeaderContent;
 };
 
 const LXDClusterDetailsHeader = ({
+  clusterId,
   headerContent,
-  id,
   setHeaderContent,
 }: Props): JSX.Element => {
   const location = useLocation();
@@ -23,26 +23,36 @@ const LXDClusterDetailsHeader = ({
       headerContent={headerContent}
       tabLinks={[
         {
-          active: location.pathname.endsWith(kvmURLs.lxd.cluster.hosts({ id })),
+          active: location.pathname.endsWith(
+            kvmURLs.lxd.cluster.hosts({ clusterId })
+          ),
           component: Link,
-          label: "KVM hosts",
-          to: kvmURLs.lxd.cluster.hosts({ id }),
+          label: "VM hosts",
+          to: kvmURLs.lxd.cluster.hosts({ clusterId }),
         },
         {
-          active: location.pathname.endsWith(
-            kvmURLs.lxd.cluster.vms.index({ id })
+          active: location.pathname.includes(
+            kvmURLs.lxd.cluster.vms.index({ clusterId })
           ),
           component: Link,
           label: "Virtual machines",
-          to: kvmURLs.lxd.cluster.vms.index({ id }),
+          to: kvmURLs.lxd.cluster.vms.index({ clusterId }),
         },
         {
           active: location.pathname.endsWith(
-            kvmURLs.lxd.cluster.resources({ id })
+            kvmURLs.lxd.cluster.resources({ clusterId })
           ),
           component: Link,
           label: "Resources",
-          to: kvmURLs.lxd.cluster.resources({ id }),
+          to: kvmURLs.lxd.cluster.resources({ clusterId }),
+        },
+        {
+          active: location.pathname.endsWith(
+            kvmURLs.lxd.cluster.edit({ clusterId })
+          ),
+          component: Link,
+          label: "Settings",
+          to: kvmURLs.lxd.cluster.edit({ clusterId }),
         },
       ]}
       setHeaderContent={setHeaderContent}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -1,0 +1,11 @@
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+};
+
+const LXDClusterHosts = ({ clusterId }: Props): JSX.Element => {
+  return <h4>LXD cluster {clusterId} VM hosts</h4>;
+};
+
+export default LXDClusterHosts;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterHosts";

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/LXDClusterResources.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/LXDClusterResources.tsx
@@ -1,0 +1,11 @@
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+};
+
+const LXDClusterResources = ({ clusterId }: Props): JSX.Element => {
+  return <h4>LXD cluster {clusterId} resources</h4>;
+};
+
+export default LXDClusterResources;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterResources";

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
@@ -1,0 +1,11 @@
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+};
+
+const LXDClusterSettings = ({ clusterId }: Props): JSX.Element => {
+  return <h4>LXD cluster {clusterId} settings</h4>;
+};
+
+export default LXDClusterSettings;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterSettings";

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -1,0 +1,11 @@
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+};
+
+const LXDClusterVMs = ({ clusterId }: Props): JSX.Element => {
+  return <h4>LXD cluster {clusterId} virtual machines</h4>;
+};
+
+export default LXDClusterVMs;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterVMs";

--- a/ui/src/app/kvm/views/LXDClusterDetails/types.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/types.ts
@@ -1,0 +1,4 @@
+export type ClusterRouteParams = {
+  clusterId: string;
+  hostId?: string;
+};


### PR DESCRIPTION
## Done

- Added some basic scaffolding components for the different LXD cluster details tabs
- Added cluster settings URL, and fixed the URLs so that they all use `clusterId`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/MAAS/r/kvm/lxd/cluster/1` and check that you can click between the tabs and a header shows up

## Fixes

Fixes canonical-web-and-design/app-squad#392
