### PR TITLE
feat(ui): update LXD VM table toolbar to latest design

### DIFF
--- a/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -51,14 +51,12 @@ const LXDVMsTable = ({
         setHeaderContent={setHeaderContent}
         vms={vms}
       />
-      <Strip shallow>
-        <VMsTable
-          currentPage={currentPage}
-          getResources={getResources}
-          searchFilter={searchFilter}
-          vms={vms}
-        />
-      </Strip>
+      <VMsTable
+        currentPage={currentPage}
+        getResources={getResources}
+        searchFilter={searchFilter}
+        vms={vms}
+      />
     </Strip>
   );
 };

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
@@ -14,30 +14,6 @@ import {
 const mockStore = configureStore();
 
 describe("VMsActionBar", () => {
-  it("can open the 'Compose VM' form", () => {
-    const setHeaderContent = jest.fn();
-    const state = rootStateFactory();
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <VMsActionBar
-          currentPage={1}
-          searchFilter=""
-          setCurrentPage={jest.fn()}
-          setSearchFilter={jest.fn()}
-          setHeaderContent={setHeaderContent}
-          vms={[]}
-        />
-      </Provider>
-    );
-
-    wrapper.find("button[data-test='compose-vm']").simulate("click");
-
-    expect(setHeaderContent).toHaveBeenCalledWith({
-      view: KVMHeaderViews.COMPOSE_VM,
-    });
-  });
-
   it("can open the 'Refresh KVM' form", () => {
     const setHeaderContent = jest.fn();
     const state = rootStateFactory();

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -37,15 +37,6 @@ const VMsActionBar = ({
   return (
     <div className="vms-action-bar">
       <div className="vms-action-bar__actions">
-        <Button
-          className="u-no-margin--bottom"
-          data-test="compose-vm"
-          hasIcon
-          onClick={() => setHeaderContent({ view: KVMHeaderViews.COMPOSE_VM })}
-        >
-          <Icon name="plus" />
-          <span>Compose VM</span>
-        </Button>
         <VmActionMenu
           appearance="vmTable"
           data-test="vm-actions"

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/_index.scss
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/_index.scss
@@ -43,6 +43,7 @@
 
       .vms-action-bar__search {
         margin: 0 $sph-inner;
+        max-width: 50rem;
       }
     }
   }

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -279,8 +279,6 @@ describe("TakeActionMenu", () => {
 
     expect(getMenuProp("position")).toBe("right");
     expect(getMenuProp("toggleAppearance")).toBe("positive");
-    expect(getMenuProp("toggleClassName")).toBe(undefined);
-    expect(getMenuProp("toggleLabel")).toBe("Take action");
   });
 
   it("can display the VM table variation", () => {
@@ -304,13 +302,8 @@ describe("TakeActionMenu", () => {
       "Select VMs below to perform an action."
     );
     expect(getTooltipProp("position")).toBe("top-left");
-
     expect(getMenuProp("position")).toBe("left");
-    expect(getMenuProp("toggleAppearance")).toBe("base");
-    expect(getMenuProp("toggleClassName")).toBe(
-      "take-action-menu--vm-table is-small"
-    );
-    expect(getMenuProp("toggleLabel")).toBe("");
+    expect(getMenuProp("toggleAppearance")).toBe("neutral");
   });
 
   it("can exclude actions from being shown", () => {

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -138,16 +138,12 @@ export const TakeActionMenu = ({
       ? {
           position: "right" as const,
           toggleAppearance: "positive",
-          toggleClassName: undefined,
-          toggleLabel: "Take action",
           tooltipMessage: "Select machines below to perform an action.",
           tooltipPosition: "left" as const,
         }
       : {
           position: "left" as const,
-          toggleAppearance: "base",
-          toggleClassName: "take-action-menu--vm-table is-small",
-          toggleLabel: "",
+          toggleAppearance: "neutral",
           tooltipMessage: "Select VMs below to perform an action.",
           tooltipPosition: "top-left" as const,
         };
@@ -167,9 +163,8 @@ export const TakeActionMenu = ({
         )}
         position={variations.position}
         toggleAppearance={variations.toggleAppearance}
-        toggleClassName={variations.toggleClassName}
         toggleDisabled={!machinesToAction.length}
-        toggleLabel={variations.toggleLabel}
+        toggleLabel="Take action"
       />
     </Tooltip>
   );

--- a/ui/src/app/machines/components/TakeActionMenu/_index.scss
+++ b/ui/src/app/machines/components/TakeActionMenu/_index.scss
@@ -1,5 +1,0 @@
-@mixin TakeActionMenu {
-  .take-action-menu--vm-table i {
-    @include vf-icon-menu($color-mid-dark);
-  }
-}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -185,7 +185,6 @@
 @import "~app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect";
 @import "~app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults";
 @import "~app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
-@import "~app/machines/components/TakeActionMenu";
 @import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
 @import "~app/machines/views/MachineDetails/MachineLogs/DownloadMenu";
 @import "~app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable";
@@ -214,7 +213,6 @@
 @include NumaCard;
 @include OverviewCard;
 @include SourceMachineSelect;
-@include TakeActionMenu;
 
 // preferences
 @import "~app/preferences/views/APIKeys/APIKeyList";


### PR DESCRIPTION
## Done

- Updated VM table toolbar to latest design
  - Removed "Compose VM" button
  - Take action menu now more closely resembles the machine list version

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the VMs tab of a LXD single host
- Check that the table toolbar matches the [design](https://www.figma.com/file/QNQ3ZsYLR0tamnFzCo8VP6/%5B21.10%5D-LXD-Clusters?node-id=629%3A21661)
- Check that you can still refresh the host and perform actions on VMs

## Fixes

Fixes canonical-web-and-design/app-squad#304

## Screenshot

![Screenshot 2021-10-12 at 11-52-48 KVM bolla MAAS](https://user-images.githubusercontent.com/25733845/136877896-b112abba-9f5f-4908-a17c-ecd9a5857aa8.png)
