### PR TITLE
fix(cypress): use correct location for add machine form

### DIFF
--- a/integration/cypress/integration/machines/add.spec.ts
+++ b/integration/cypress/integration/machines/add.spec.ts
@@ -8,7 +8,9 @@ const nanoid = customAlphabet("1234567890abcdefghi", 10);
 context("Machine add", () => {
   beforeEach(() => {
     login();
-    cy.visit(generateNewURL("/machines/add"));
+    cy.visit(generateNewURL("/machines"));
+    cy.get("[data-test='add-hardware-dropdown'] button").click();
+    cy.get(".p-contextual-menu__link").contains("Machine").click();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Done

- Fixed "Add machine" cypress test which was using a deprecated URL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the UI with `yarn ui`
- Edit the login details in `integration/cypress.json` to match whatever MAAS you're connected to
- Open Cypress with `yarn cypress-open`
- Run the tests at `machines/add.spec.ts` and check that they pass. Note that this will actually create a machine in the MAAS you're connected to, so you might want to delete it afterwards.

## Fixes

Fixes #3080 
