### PR TITLE
feat(ui): display cluster data in header

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -1,0 +1,42 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDClusterDetails from "./LXDClusterDetails";
+
+import kvmURLs from "app/kvm/urls";
+import {
+  vmClusterState as vmClusterStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterDetails", () => {
+  it("redirects to KVM list if clusters have loaded but cluster is not in state", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterDetails />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find("Redirect").props().to).toBe(kvmURLs.kvm);
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useDispatch, useSelector } from "react-redux";
 import { Redirect, Route, Switch, useParams } from "react-router-dom";
 
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
@@ -12,13 +13,34 @@ import type { ClusterRouteParams } from "./types";
 import Section from "app/base/components/Section";
 import type { KVMHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
+import { actions as podActions } from "app/store/pod";
+import type { RootState } from "app/store/root/types";
+import { actions as vmClusterActions } from "app/store/vmcluster";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 
 const LXDClusterDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
   const params = useParams<ClusterRouteParams>();
   const clusterId = Number(params.clusterId);
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const clustersLoaded = useSelector(vmClusterSelectors.loaded);
   const [headerContent, setHeaderContent] = useState<KVMHeaderContent | null>(
     null
   );
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+    // TODO: Update with "get" when api is fixed.
+    // https://bugs.launchpad.net/maas/+bug/1946914
+    dispatch(vmClusterActions.fetch());
+  }, [dispatch]);
+
+  // If cluster has been deleted, redirect to KVM list.
+  if (clustersLoaded && !cluster) {
+    return <Redirect to={kvmURLs.kvm} />;
+  }
 
   return (
     <Section

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -1,0 +1,185 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
+
+import kvmURLs from "app/kvm/urls";
+import { PodType } from "app/store/pod/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podPowerParameters as powerParametersFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmHost as vmHostFactory,
+  vmClusterState as vmClusterStateFactory,
+  virtualMachine as virtualMachineFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterDetailsHeader", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    const zone = zoneFactory({ id: 111, name: "danger" });
+    const pod = podFactory({
+      id: 11,
+      name: "vm-cluster",
+      power_parameters: powerParametersFactory({ project: "cluster-project" }),
+      type: PodType.LXD,
+      zone: zone.id,
+    });
+    const cluster = vmClusterFactory({
+      id: 1,
+      name: pod.name,
+      project: pod.power_parameters.project,
+    });
+    state = rootStateFactory({
+      pod: podStateFactory({
+        items: [pod],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+      }),
+      zone: zoneStateFactory({
+        items: [zone],
+      }),
+    });
+  });
+
+  it("displays a spinner if cluster hasn't loaded", () => {
+    state.vmcluster.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterDetailsHeader
+            clusterId={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays the cluster member count", () => {
+    state.vmcluster.items[0].hosts = [vmHostFactory(), vmHostFactory()];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterDetailsHeader
+            clusterId={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='block-subtitle']").at(0).text()).toBe(
+      "2 members"
+    );
+  });
+
+  it("displays the tracked VMs count", () => {
+    state.vmcluster.items[0].virtual_machines = [
+      virtualMachineFactory(),
+      virtualMachineFactory(),
+      virtualMachineFactory(),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterDetailsHeader
+            clusterId={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='block-subtitle']").at(1).text()).toBe(
+      "3 available"
+    );
+  });
+
+  it("displays the cluster's zone's name", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterDetailsHeader
+            clusterId={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='block-subtitle']").at(2).text()).toBe(
+      "danger"
+    );
+  });
+
+  it("displays the cluster's project", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterDetailsHeader
+            clusterId={1}
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='block-subtitle']").at(3).text()).toBe(
+      "cluster-project"
+    );
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -1,9 +1,22 @@
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { Icon, Spinner } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
 import KVMDetailsHeader from "app/kvm/components/KVMDetailsHeader";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
+import { getFormTitle } from "app/kvm/utils";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
+import { actions as zoneActions } from "app/store/zone";
+import zoneSelectors from "app/store/zone/selectors";
 
 type Props = {
   clusterId: VMCluster["id"];
@@ -16,7 +29,38 @@ const LXDClusterDetailsHeader = ({
   headerContent,
   setHeaderContent,
 }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const lxdPods = useSelector(podSelectors.lxd);
+  // TODO: Replace with selector that gets the pod associated with a cluster.
+  const clusterPod =
+    (cluster &&
+      lxdPods.find(
+        (pod) =>
+          pod.name === cluster.name &&
+          pod.power_parameters.project === cluster.project
+      )) ||
+    null;
+  const zone = useSelector((state: RootState) =>
+    zoneSelectors.getById(state, clusterPod?.zone)
+  );
   const location = useLocation();
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+    dispatch(zoneActions.fetch());
+  }, [dispatch]);
+
+  let title: ReactNode = <Spinner text="Loading..." />;
+  if (cluster) {
+    if (headerContent) {
+      title = getFormTitle(headerContent);
+    } else {
+      title = cluster.name;
+    }
+  }
 
   return (
     <KVMDetailsHeader
@@ -56,26 +100,38 @@ const LXDClusterDetailsHeader = ({
         },
       ]}
       setHeaderContent={setHeaderContent}
-      title="Cluster name"
-      titleBlocks={[
-        // TODO: Use actual cluster data
-        {
-          title: "Cluster:",
-          subtitle: "15 members",
-        },
-        {
-          title: "VMs:",
-          subtitle: "12 available",
-        },
-        {
-          title: "AZ:",
-          subtitle: "euw-02",
-        },
-        {
-          title: "LXD project:",
-          subtitle: "default",
-        },
-      ]}
+      title={title}
+      titleBlocks={
+        cluster
+          ? [
+              {
+                title: (
+                  <>
+                    <Icon name="cluster" />
+                    <span className="u-nudge-right--small">Cluster:</span>
+                  </>
+                ),
+                subtitle: (
+                  <span className="u-nudge-right--large" data-test="members">
+                    {pluralize("member", cluster.hosts.length, true)}
+                  </span>
+                ),
+              },
+              {
+                title: "VMs:",
+                subtitle: `${cluster.virtual_machines.length} available`,
+              },
+              {
+                title: "AZ:",
+                subtitle: zone?.name || <Spinner />,
+              },
+              {
+                title: "LXD project:",
+                subtitle: cluster.project,
+              },
+            ]
+          : []
+      }
     />
   );
 };

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
@@ -84,7 +84,7 @@ describe("LXDSingleDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("[data-test='block-subtitle']").at(0).text()).toBe(
+    expect(wrapper.find("[data-test='block-subtitle']").at(3).text()).toBe(
       "Manhattan"
     );
   });

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
@@ -85,8 +85,12 @@ const LXDSingleDetailsHeader = ({
         pod
           ? [
               {
-                title: "LXD project:",
-                subtitle: pod.power_parameters.project,
+                title: (
+                  <>
+                    <Icon name="single-host" />
+                    <span className="u-nudge-right--small">Single host</span>
+                  </>
+                ),
               },
               {
                 title: "VMs:",
@@ -95,6 +99,10 @@ const LXDSingleDetailsHeader = ({
               {
                 title: "AZ:",
                 subtitle: zone?.name || <Spinner />,
+              },
+              {
+                title: "LXD project:",
+                subtitle: pod.power_parameters.project,
               },
             ]
           : []

--- a/ui/src/scss/_patterns_icons.scss
+++ b/ui/src/scss/_patterns_icons.scss
@@ -1,3 +1,18 @@
+@mixin maas-icon-circle($color) {
+  @extend %icon;
+  @include vf-icon-size(0.5rem);
+  background-color: $color;
+  border-radius: 100%;
+  margin-bottom: $spv-inner--x-small;
+  margin-top: $spv-inner--x-small;
+}
+
+@mixin maas-icon-cluster($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='14' height='16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m7 .872 3.845 2.22v3.74l2.96 1.708v4.44L9.96 15.2 7 13.49 4.04 15.2.195 12.98V8.54l2.96-1.709V3.092L7 .872Zm-2.96 7.18L1.695 9.406v2.707l2.345 1.354 2.074-1.199V9.25L4.04 8.052Zm5.92 0L7.884 9.248v3.021l2.074 1.198 2.345-1.354V9.406L9.96 8.052ZM7 2.604 4.654 3.958v2.708L7 8.019l2.345-1.353V3.958L7 2.604Z' fill='" + vf-url-friendly-color(
+      $color
+    ) + "'/%3E%3C/svg%3E");
+}
+
 @mixin maas-icon-edit($color) {
   background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg width='22' height='22' viewBox='0 0 22 22' xmlns='http://www.w3.org/2000/svg'%3e%3ctitle%3eedit%3c/title%3e%3cg fill='" + vf-url-friendly-color(
       $color
@@ -16,6 +31,12 @@
     ) + "%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
 }
 
+@mixin maas-icon-single-host($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='15' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m6 .911 5.966 3.445v6.888L6 14.69.034 11.244V4.356L6 .91Zm-.001 1.732L1.534 5.221v5.157l4.465 2.578 4.466-2.578V5.221L5.999 2.643Z' fill='" + vf-url-friendly-color(
+      $color
+    ) + "'/%3E%3C/svg%3E");
+}
+
 @mixin maas-icon-tick($color) {
   background-image: url("data:image/svg+xml,%3Csvg width='22' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h24v24H-1z'/%3E%3Cpath fill='" + vf-url-friendly-color(
       $color
@@ -28,18 +49,14 @@
     ) + "'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
 
-@mixin maas-icon-circle($color) {
-  @extend %icon;
-  @include vf-icon-size(0.5rem);
-  background-color: $color;
-  border-radius: 100%;
-  margin-bottom: $spv-inner--x-small;
-  margin-top: $spv-inner--x-small;
-}
-
 @mixin maas-icons {
   $color-link--faded: #d3e4ed;
   $color-positive--faded: #4dab4d;
+
+  .p-icon--cluster {
+    @extend %icon;
+    @include maas-icon-cluster($color-mid-dark);
+  }
 
   .p-icon--edit {
     @extend %icon;
@@ -79,6 +96,11 @@
   .p-icon--running {
     @extend %icon;
     background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Erunning%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='smoke-testing-status' transform='translate%28-62.000000, -159.000000%29'%3E%3Cg id='running' transform='translate%2850.000000, 144.000000%29'%3E%3Cg transform='translate%2812.000000, 15.000000%29'%3E%3Crect id='rect6425' x='9.99999997e-06' y='9.99999989e-06' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle6427' stroke='%230E8420' stroke-width='1.5' fill='%230E8420' fill-rule='nonzero' cx='8.00001' cy='8.00001' r='7.2500086'%3E%3C/circle%3E%3Cpolygon id='path6429' fill='%23FFFFFF' fill-rule='nonzero' points='6.00002 12.00001 6.00002 4.00001 12.00002 8.00001'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  }
+
+  .p-icon--single-host {
+    @extend %icon;
+    @include maas-icon-single-host($color-mid-dark);
   }
 
   .p-icon--tick {


### PR DESCRIPTION
## Done

- Replaced dummy data in `LXDClusterDetailsHeader` with real data
- Updated to latest header design for cluster and single host (hopefully the last change)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to http://0.0.0.0:8400/MAAS/r/kvm/lxd/cluster/1
- Check that the data that shows in the header is correct
- Navigate to http://0.0.0.0:8400/MAAS/r/kvm/lxd/cluster/123123 and check that you get redirected to the KVM list

## Fixes

Fixes canonical-web-and-design/app-squad#387

## Launchpad issue

vmcluster.get websocket API doesn't work
[lp#1946914](https://bugs.launchpad.net/maas/+bug/1946914)

## Screenshot
![Screenshot 2021-10-13 at 15-38-01 MAAS](https://user-images.githubusercontent.com/25733845/137075433-e3f69903-5255-41b6-9566-699ff35e7e45.png)

