### PR TITLE
feat(ui): build LXD cluster host VMs section

### DIFF
--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
@@ -8,7 +8,6 @@ import NumaResources from "./NumaResources";
 import type { SetSearchFilter } from "app/base/types";
 import LXDVMsSummaryCard from "app/kvm/components/LXDVMsSummaryCard";
 import LXDVMsTable from "app/kvm/components/LXDVMsTable";
-import { KVMHeaderViews } from "app/kvm/constants";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
@@ -19,6 +18,7 @@ import type { VMCluster } from "app/store/vmcluster/types";
 type Props = {
   clusterId?: VMCluster["id"];
   hostId: Pod["id"];
+  onRefreshClick: () => void;
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
   setHeaderContent: KVMSetHeaderContent;
@@ -27,6 +27,7 @@ type Props = {
 const LXDHostVMs = ({
   clusterId,
   hostId,
+  onRefreshClick,
   searchFilter,
   setSearchFilter,
   setHeaderContent,
@@ -106,12 +107,7 @@ const LXDHostVMs = ({
               unpinnedCores: resources?.unpinned_cores || 0,
             };
           }}
-          onRefreshClick={() =>
-            setHeaderContent({
-              view: KVMHeaderViews.REFRESH_KVM,
-              extras: { hostId },
-            })
-          }
+          onRefreshClick={onRefreshClick}
           searchFilter={searchFilter}
           setSearchFilter={setSearchFilter}
           setHeaderContent={setHeaderContent}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LXDClusterDetails from "./LXDClusterDetails";
@@ -38,5 +38,35 @@ describe("LXDClusterDetails", () => {
     );
     expect(wrapper.find("Redirect").exists()).toBe(true);
     expect(wrapper.find("Redirect").props().to).toBe(kvmURLs.kvm);
+  });
+
+  it("sets the search filter from the URL", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              key: "testKey",
+              pathname: kvmURLs.lxd.cluster.vms.host({
+                clusterId: 1,
+                hostId: 2,
+              }),
+              search: "?q=test+search",
+            },
+          ]}
+        >
+          <Route
+            exact
+            path={kvmURLs.lxd.cluster.vms.host(null, true)}
+            component={() => <LXDClusterDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("LXDClusterHostVMs").prop("searchFilter")).toBe(
+      "test search"
+    );
   });
 });

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -6,6 +6,7 @@ import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
+import type { SetSearchFilter } from "app/base/types";
 import KVMDetailsHeader from "app/kvm/components/KVMDetailsHeader";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
@@ -22,12 +23,14 @@ type Props = {
   clusterId: VMCluster["id"];
   headerContent: KVMHeaderContent | null;
   setHeaderContent: KVMSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
 };
 
 const LXDClusterDetailsHeader = ({
   clusterId,
   headerContent,
   setHeaderContent,
+  setSearchFilter,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const cluster = useSelector((state: RootState) =>
@@ -65,6 +68,8 @@ const LXDClusterDetailsHeader = ({
   return (
     <KVMDetailsHeader
       headerContent={headerContent}
+      setHeaderContent={setHeaderContent}
+      setSearchFilter={setSearchFilter}
       tabLinks={[
         {
           active: location.pathname.endsWith(
@@ -99,7 +104,6 @@ const LXDClusterDetailsHeader = ({
           to: kvmURLs.lxd.cluster.edit({ clusterId }),
         },
       ]}
-      setHeaderContent={setHeaderContent}
       title={title}
       titleBlocks={
         cluster

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
@@ -1,0 +1,17 @@
+import type { Pod } from "app/store/pod/types";
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+  hostId: Pod["id"];
+};
+
+const LXDClusterHostSettings = ({ clusterId, hostId }: Props): JSX.Element => {
+  return (
+    <h4>
+      Host {hostId} in cluster {clusterId} settings
+    </h4>
+  );
+};
+
+export default LXDClusterHostSettings;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterHostSettings";

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
@@ -1,0 +1,90 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDClusterHostVMs from "./LXDClusterHostVMs";
+
+import kvmURLs from "app/kvm/urls";
+import {
+  rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmClusterState as vmClusterStateFactory,
+  vmHost as vmHostFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterHostVMs", () => {
+  it("renders the LXD host VM table if the host is part of the cluster", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [vmClusterFactory({ id: 1, hosts: [vmHostFactory({ id: 2 })] })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <LXDClusterHostVMs
+            clusterId={1}
+            hostId={2}
+            searchFilter=""
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("LXDHostVMs").exists()).toBe(true);
+  });
+
+  it("renders a spinner if cluster hasn't loaded", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <LXDClusterHostVMs
+            clusterId={1}
+            hostId={2}
+            searchFilter=""
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("redirects to cluster VM list if host is not part of cluster", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [vmClusterFactory({ id: 1, hosts: [vmHostFactory({ id: 2 })] })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <LXDClusterHostVMs
+            clusterId={1}
+            hostId={3}
+            searchFilter=""
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find("Redirect").prop("to")).toBe(
+      kvmURLs.lxd.cluster.vms.index({ clusterId: 1 })
+    );
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
@@ -1,0 +1,67 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Redirect } from "react-router-dom";
+
+import { useWindowTitle } from "app/base/hooks";
+import type { SetSearchFilter } from "app/base/types";
+import LXDHostVMs from "app/kvm/components/LXDHostVMs";
+import { useActivePod } from "app/kvm/hooks";
+import type { KVMSetHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+  hostId: Pod["id"];
+  searchFilter: string;
+  setHeaderContent: KVMSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
+};
+
+const LXDClusterHostVMs = ({
+  clusterId,
+  hostId,
+  searchFilter,
+  setHeaderContent,
+  setSearchFilter,
+}: Props): JSX.Element => {
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, hostId)
+  );
+  useWindowTitle(
+    `${pod?.name || "Host"} in ${cluster?.name || "cluster"} virtual machines`
+  );
+  useActivePod(hostId);
+
+  if (!cluster) {
+    return <Spinner text="Loading..." />;
+  }
+
+  const hostInCluster = cluster.hosts.some((host) => host.id === hostId);
+  if (!hostInCluster) {
+    return <Redirect to={kvmURLs.lxd.cluster.vms.index({ clusterId })} />;
+  }
+
+  return (
+    <LXDHostVMs
+      clusterId={clusterId}
+      hostId={hostId}
+      onRefreshClick={() => {
+        // TODO: Open cluster refresh form.
+        return null;
+      }}
+      searchFilter={searchFilter}
+      setSearchFilter={setSearchFilter}
+      setHeaderContent={setHeaderContent}
+    />
+  );
+};
+
+export default LXDClusterHostVMs;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterHostVMs";

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -67,6 +67,8 @@ describe("LXDSingleDetails", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("LXDHostVMs").prop("searchFilter")).toBe("test search");
+    expect(wrapper.find("LXDSingleVMs").prop("searchFilter")).toBe(
+      "test search"
+    );
   });
 });

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -13,10 +13,10 @@ import {
 import LXDSingleDetailsHeader from "./LXDSingleDetailsHeader";
 import LXDSingleResources from "./LXDSingleResources";
 import LXDSingleSettings from "./LXDSingleSettings";
+import LXDSingleVMs from "./LXDSingleVMs";
 
 import Section from "app/base/components/Section";
 import type { RouteParams, SetSearchFilter } from "app/base/types";
-import LXDHostVMs from "app/kvm/components/LXDHostVMs";
 import { useActivePod } from "app/kvm/hooks";
 import type { KVMHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
@@ -69,8 +69,8 @@ const LXDSingleDetails = (): JSX.Element => {
       {pod && (
         <Switch>
           <Route exact path={kvmURLs.lxd.single.vms(null, true)}>
-            <LXDHostVMs
-              hostId={id}
+            <LXDSingleVMs
+              id={id}
               searchFilter={searchFilter}
               setSearchFilter={setSearchFilter}
               setHeaderContent={setHeaderContent}

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleVMs/LXDSingleVMs.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleVMs/LXDSingleVMs.tsx
@@ -1,0 +1,46 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import type { SetSearchFilter } from "app/base/types";
+import LXDHostVMs from "app/kvm/components/LXDHostVMs";
+import { KVMHeaderViews } from "app/kvm/constants";
+import type { KVMSetHeaderContent } from "app/kvm/types";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  id: Pod["id"];
+  searchFilter: string;
+  setHeaderContent: KVMSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
+};
+
+const LXDSingleVMs = ({
+  id,
+  searchFilter,
+  setHeaderContent,
+  setSearchFilter,
+}: Props): JSX.Element => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, id)
+  );
+  useWindowTitle(`${pod?.name || "LXD"} virtual machines`);
+
+  return (
+    <LXDHostVMs
+      hostId={id}
+      onRefreshClick={() =>
+        setHeaderContent({
+          view: KVMHeaderViews.REFRESH_KVM,
+          extras: { hostId: id },
+        })
+      }
+      searchFilter={searchFilter}
+      setSearchFilter={setSearchFilter}
+      setHeaderContent={setHeaderContent}
+    />
+  );
+};
+
+export default LXDSingleVMs;

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleVMs/index.ts
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleVMs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDSingleVMs";


### PR DESCRIPTION
## Done

- Built `LXDClusterHostVMs` component, which shows the VMs of the currently selected host in a cluster
- Added a dummy component for `LXDClusterHostSettings`, which will eventually show the settings of a host in a cluster

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to http://0.0.0.0:8400/MAAS/r/kvm/lxd/cluster/1/vms/457
- Check that the VMs displayed are correct
- Check that you can open the add VM form and perform actions on the VMs. Refreshing will come later as it will function a bit different to the normal pod refresh form.
- Click the cog and check that you get taken to the correct url for editing a host in a cluster

## Fixes

Fixes canonical-web-and-design/app-squad#398

## Screenshot
![Screenshot 2021-10-13 at 17-44-43 karura in lxd-cluster virtual machines bolla MAAS](https://user-images.githubusercontent.com/25733845/137089402-caff1bc3-f25f-4979-8c33-9d50c7a67161.png)
