### PR TITLE
feat(ui): add a selector for getting all pods in a cluster

### DIFF
--- a/ui/src/app/kvm/urls.ts
+++ b/ui/src/app/kvm/urls.ts
@@ -39,7 +39,6 @@ const urls = {
     single: {
       index: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id"),
       edit: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/edit"),
-      hosts: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/hosts"),
       resources: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/resources"),
       vms: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/vms"),
     },

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -93,22 +93,22 @@ const LXDClusterDetails = (): JSX.Element => {
         <Route exact path={kvmURLs.lxd.cluster.edit(null, true)}>
           <LXDClusterSettings clusterId={clusterId} />
         </Route>
-        {hostId !== null && (
-          <>
-            <Route exact path={kvmURLs.lxd.cluster.vms.host(null, true)}>
-              <LXDClusterHostVMs
-                clusterId={clusterId}
-                hostId={hostId}
-                searchFilter={searchFilter}
-                setHeaderContent={setHeaderContent}
-                setSearchFilter={setSearchFilter}
-              />
-            </Route>
-            <Route exact path={kvmURLs.lxd.cluster.host.edit(null, true)}>
-              <LXDClusterHostSettings clusterId={clusterId} hostId={hostId} />
-            </Route>
-          </>
-        )}
+        <Route exact path={kvmURLs.lxd.cluster.vms.host(null, true)}>
+          {hostId !== null && (
+            <LXDClusterHostVMs
+              clusterId={clusterId}
+              hostId={hostId}
+              searchFilter={searchFilter}
+              setHeaderContent={setHeaderContent}
+              setSearchFilter={setSearchFilter}
+            />
+          )}
+        </Route>
+        <Route exact path={kvmURLs.lxd.cluster.host.edit(null, true)}>
+          {hostId !== null && (
+            <LXDClusterHostSettings clusterId={clusterId} hostId={hostId} />
+          )}
+        </Route>
         <Redirect
           from={kvmURLs.lxd.cluster.index(null, true)}
           to={kvmURLs.lxd.cluster.hosts(null, true)}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -70,6 +70,7 @@ describe("LXDClusterDetailsHeader", () => {
             clusterId={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -94,6 +95,7 @@ describe("LXDClusterDetailsHeader", () => {
             clusterId={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -124,6 +126,7 @@ describe("LXDClusterDetailsHeader", () => {
             clusterId={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -149,6 +152,7 @@ describe("LXDClusterDetailsHeader", () => {
             clusterId={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -174,6 +178,7 @@ describe("LXDClusterDetailsHeader", () => {
             clusterId={1}
             headerContent={null}
             setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -100,7 +100,7 @@ const LXDClusterDetailsHeader = ({
             kvmURLs.lxd.cluster.edit({ clusterId })
           ),
           component: Link,
-          label: "Settings",
+          label: "Cluster settings",
           to: kvmURLs.lxd.cluster.edit({ clusterId }),
         },
       ]}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
@@ -1,0 +1,83 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDClusterHosts from "./LXDClusterHosts";
+
+import kvmURLs from "app/kvm/urls";
+import { PodType } from "app/store/pod/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmHost as vmHostFactory,
+  vmClusterState as vmClusterStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterHosts", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    const pods = [
+      podFactory({ id: 111, name: "cluster-member-1", type: PodType.LXD }),
+      podFactory({ id: 222, name: "cluster-member-2", type: PodType.LXD }),
+    ];
+    const cluster = vmClusterFactory({
+      id: 1,
+      hosts: pods.map((pod) => vmHostFactory({ id: pod.id, name: pod.name })),
+    });
+    state = rootStateFactory({
+      pod: podStateFactory({
+        items: pods,
+        loaded: true,
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a spinner if pods haven't loaded", () => {
+    state.pod.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }) },
+          ]}
+        >
+          <LXDClusterHosts clusterId={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("links to cluster members' VMs tab", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterHosts clusterId={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='cluster-member-link']").at(0).prop("to")
+    ).toBe(kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 111 }));
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -1,3 +1,12 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import { useWindowTitle } from "app/base/hooks";
+import kvmURLs from "app/kvm/urls";
+import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
@@ -5,7 +14,33 @@ type Props = {
 };
 
 const LXDClusterHosts = ({ clusterId }: Props): JSX.Element => {
-  return <h4>LXD cluster {clusterId} VM hosts</h4>;
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const clusterHosts = useSelector((state: RootState) =>
+    podSelectors.lxdHostsInClusterById(state, clusterId)
+  );
+  const podsLoaded = useSelector(podSelectors.loaded);
+  useWindowTitle(`${cluster?.name || "LXD cluster"} VM hosts`);
+
+  if (!cluster || !podsLoaded) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return (
+    <ul>
+      {clusterHosts.map((host) => (
+        <li key={`${host.name}-${host.id}`}>
+          <Link
+            data-test="cluster-member-link"
+            to={kvmURLs.lxd.cluster.vms.host({ clusterId, hostId: host.id })}
+          >
+            {host.name}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
 };
 
 export default LXDClusterHosts;

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -459,4 +459,28 @@ describe("pod selectors", () => {
     });
     expect(pod.getSortedPools(state, 1)).toEqual([defaultPool, aPool, bPool]);
   });
+
+  it("can get the LXD hosts that are in a given cluster", () => {
+    const inCluster = [
+      podFactory({ type: PodType.LXD }),
+      podFactory({ type: PodType.LXD }),
+    ];
+    const notInCluster = [
+      podFactory({ type: PodType.LXD }),
+      podFactory({ type: PodType.VIRSH }),
+    ];
+    const cluster = vmClusterFactory({
+      hosts: inCluster.map((pod) => vmHostFactory({ id: pod.id })),
+    });
+
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [...inCluster, ...notInCluster],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+      }),
+    });
+    expect(pod.lxdHostsInClusterById(state, cluster.id)).toEqual(inCluster);
+  });
 });

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -12,6 +12,7 @@ import type { RootState } from "app/store/root/types";
 import type { Host } from "app/store/types/host";
 import { generateBaseSelectors } from "app/store/utils";
 import vmcluster from "app/store/vmcluster/selectors";
+import type { VMCluster } from "app/store/vmcluster/types";
 
 const searchFunction = (pod: Pod, term: string) => pod.name.includes(term);
 
@@ -59,6 +60,30 @@ const lxdSingleHosts = createSelector(
       }
       return singleHosts;
     }, [])
+);
+
+/**
+ * Returns all LXD hosts in a given cluster.
+ * @param state - The redux state.
+ * @returns The LXD hosts in a cluster.
+ */
+const lxdHostsInClusterById = createSelector(
+  (state: RootState, clusterId: VMCluster["id"]) => ({
+    lxdHosts: lxd(state),
+    cluster: vmcluster.getById(state, clusterId),
+  }),
+  ({ lxdHosts, cluster }) => {
+    if (!cluster) {
+      return [];
+    }
+    return cluster.hosts.reduce<Pod[]>((clusterHosts, clusterHost) => {
+      const host = lxdHosts.find((lxdHost) => lxdHost.id === clusterHost.id);
+      if (host) {
+        clusterHosts.push(host);
+      }
+      return clusterHosts;
+    }, []);
+  }
 );
 
 /**
@@ -339,6 +364,7 @@ const selectors = {
   groupByLxdServer,
   kvms,
   lxd,
+  lxdHostsInClusterById,
   lxdSingleHosts,
   projects,
   refreshing,


### PR DESCRIPTION
## Done

- Added a selector to get all pods in a cluster given the cluster's id
- Added a basic list to the cluster details VM host tab

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to /MAAS/r/kvm/lxd/cluster/1 and check that you get redirected to /MAAS/r/kvm/lxd/cluster/1/hosts
- Check that the list of VM hosts are correct
- Click on a VM host and check that you get taken to that host's VMs tab

## Fixes

Fixes canonical-web-and-design/app-squad#322
Fixes canonical-web-and-design/app-squad#348
