### PR TITLE
feat(ui): add "get" action/reducer to vmcluster slice

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -58,10 +58,8 @@ const LXDClusterDetails = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(podActions.fetch());
-    // TODO: Update with "get" when api is fixed.
-    // https://bugs.launchpad.net/maas/+bug/1946914
-    dispatch(vmClusterActions.fetch());
-  }, [dispatch]);
+    dispatch(vmClusterActions.get(clusterId));
+  }, [clusterId, dispatch]);
 
   // If cluster has been deleted, redirect to KVM list.
   if (clustersLoaded && !cluster) {

--- a/ui/src/app/store/vmcluster/actions.test.ts
+++ b/ui/src/app/store/vmcluster/actions.test.ts
@@ -12,6 +12,19 @@ describe("vmcluster actions", () => {
     });
   });
 
+  it("can create a get action", () => {
+    expect(actions.get(1)).toEqual({
+      type: "vmcluster/get",
+      meta: {
+        model: "vmcluster",
+        method: "get",
+      },
+      payload: {
+        params: { id: 1 },
+      },
+    });
+  });
+
   it("can create a cleanup action", () => {
     expect(actions.cleanup()).toEqual({
       type: "vmcluster/cleanup",

--- a/ui/src/app/store/vmcluster/reducers.test.ts
+++ b/ui/src/app/store/vmcluster/reducers.test.ts
@@ -24,63 +24,134 @@ describe("vmCluster reducers", () => {
     });
   });
 
-  it("reduces fetchStart", () => {
-    expect(
-      reducers(
-        vmClusterStateFactory({
-          loading: false,
-        }),
-        actions.fetchStart()
-      )
-    ).toEqual(
-      vmClusterStateFactory({
-        loading: true,
-      })
-    );
-  });
-
-  it("reduces fetchSuccess", () => {
-    const items = [vmClusterFactory()];
-    expect(
-      reducers(
-        vmClusterStateFactory({
-          loaded: false,
-          loading: true,
-        }),
-        actions.fetchSuccess([items])
-      )
-    ).toEqual(
-      vmClusterStateFactory({
-        items,
-        loading: false,
-        loaded: true,
-        physicalClusters: [[items[0].id]],
-        statuses: vmClusterStatusesFactory({
-          getting: false,
-        }),
-      })
-    );
-  });
-
-  it("reduces fetchError", () => {
-    expect(
-      reducers(
-        vmClusterStateFactory({
-          loading: true,
-        }),
-        actions.fetchError("Could not fetch")
-      )
-    ).toEqual(
-      vmClusterStateFactory({
-        eventErrors: [
-          vmClusterEventErrorFactory({
-            error: "Could not fetch",
-            event: "fetch",
+  describe("fetch", () => {
+    it("reduces fetchStart", () => {
+      expect(
+        reducers(
+          vmClusterStateFactory({
+            loading: false,
           }),
-        ],
-        errors: "Could not fetch",
-        loading: false,
-      })
-    );
+          actions.fetchStart()
+        )
+      ).toEqual(
+        vmClusterStateFactory({
+          loading: true,
+        })
+      );
+    });
+
+    it("reduces fetchSuccess", () => {
+      const items = [vmClusterFactory()];
+      expect(
+        reducers(
+          vmClusterStateFactory({
+            loaded: false,
+            loading: true,
+          }),
+          actions.fetchSuccess([items])
+        )
+      ).toEqual(
+        vmClusterStateFactory({
+          items,
+          loading: false,
+          loaded: true,
+          physicalClusters: [[items[0].id]],
+          statuses: vmClusterStatusesFactory({
+            getting: false,
+          }),
+        })
+      );
+    });
+
+    it("reduces fetchError", () => {
+      expect(
+        reducers(
+          vmClusterStateFactory({
+            loading: true,
+          }),
+          actions.fetchError("Could not fetch")
+        )
+      ).toEqual(
+        vmClusterStateFactory({
+          eventErrors: [
+            vmClusterEventErrorFactory({
+              error: "Could not fetch",
+              event: "fetch",
+            }),
+          ],
+          errors: "Could not fetch",
+          loading: false,
+        })
+      );
+    });
+  });
+
+  describe("get", () => {
+    it("reduces getStart", () => {
+      expect(
+        reducers(
+          vmClusterStateFactory({
+            statuses: vmClusterStatusesFactory({
+              getting: false,
+            }),
+          }),
+          actions.getStart()
+        )
+      ).toEqual(
+        vmClusterStateFactory({
+          statuses: vmClusterStatusesFactory({
+            getting: true,
+          }),
+        })
+      );
+    });
+
+    it("reduces getSuccess", () => {
+      const cluster = vmClusterFactory();
+      expect(
+        reducers(
+          vmClusterStateFactory({
+            items: [],
+            statuses: vmClusterStatusesFactory({
+              getting: true,
+            }),
+          }),
+          actions.getSuccess(cluster)
+        )
+      ).toEqual(
+        vmClusterStateFactory({
+          items: [cluster],
+          statuses: vmClusterStatusesFactory({
+            getting: false,
+          }),
+        })
+      );
+    });
+
+    it("reduces getError", () => {
+      expect(
+        reducers(
+          vmClusterStateFactory({
+            statuses: vmClusterStatusesFactory({
+              getting: true,
+            }),
+          }),
+          actions.getError("Could not get")
+        )
+      ).toEqual(
+        vmClusterStateFactory({
+          eventErrors: [
+            vmClusterEventErrorFactory({
+              error: "Could not get",
+              event: "get",
+            }),
+          ],
+          errors: "Could not get",
+          statuses: vmClusterStatusesFactory({
+            getting: false,
+          }),
+        })
+      );
+    });
   });
 });

--- a/ui/src/app/store/vmcluster/slice.ts
+++ b/ui/src/app/store/vmcluster/slice.ts
@@ -72,6 +72,45 @@ const vmClusterSlice = createSlice({
         cluster.map((host) => host[VMClusterMeta.PK])
       );
     },
+    get: {
+      prepare: (id: VMCluster["id"]) => ({
+        meta: {
+          model: VMClusterMeta.MODEL,
+          method: "get",
+        },
+        payload: {
+          params: { id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    getError: (
+      state: VMClusterState,
+      action: PayloadAction<VMClusterEventError["error"]>
+    ) => {
+      state.errors = action.payload;
+      state.statuses.getting = false;
+      state.eventErrors.push({
+        error: action.payload,
+        event: "get",
+      });
+    },
+    getStart: (state: VMClusterState) => {
+      state.statuses.getting = true;
+    },
+    getSuccess: (state: VMClusterState, action: PayloadAction<VMCluster>) => {
+      state.statuses.getting = false;
+      const cluster = action.payload;
+      // Add or replace cluster in state.
+      const i = state.items.findIndex((item) => item.id === cluster.id);
+      if (i !== -1) {
+        state.items[i] = cluster;
+      } else {
+        state.items.push(cluster);
+      }
+    },
   },
 });
 


### PR DESCRIPTION
## Done

- Added "get" to vmcluster slice
- Used get in LXD cluster details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to /MAAS/r/kvm/lxd/cluster/1/hosts and check that the cluster is successfully loaded into the Redux store

## Fixes

Fixes canonical-web-and-design/app-squad#389
