### PR TITLE
feat(ui): support resources without "other" data

### DIFF
--- a/ui/src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
@@ -12,6 +12,7 @@ import {
   podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
+  vmClusterResource as vmClusterResourceFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -103,5 +104,22 @@ describe("CPUColumn", () => {
       "4 of 3 allocated"
     );
     expect(wrapper.find("Meter").prop("max")).toBe(3);
+  });
+
+  it("can display correct cpu core information for vmclusters", () => {
+    const resources = vmClusterResourceFactory({
+      free: 3,
+      total: 5,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CPUColumn cores={resources} />
+      </Provider>
+    );
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
+      "2 of 5 allocated"
+    );
+    expect(wrapper.find("Meter").prop("max")).toBe(5);
   });
 });

--- a/ui/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
+++ b/ui/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
@@ -2,7 +2,10 @@ import { mount } from "enzyme";
 
 import CPUPopover from "./CPUPopover";
 
-import { podResource as podResourceFactory } from "testing/factories";
+import {
+  podResource as podResourceFactory,
+  vmClusterResource as vmClusterResourceFactory,
+} from "testing/factories";
 
 describe("CPUPopover", () => {
   it("renders", () => {
@@ -86,5 +89,27 @@ describe("CPUPopover", () => {
     );
     wrapper.find("Popover").simulate("focus");
     expect(wrapper.find("[data-test='overcommit']").exists()).toBe(false);
+  });
+
+  it("displays cores for a vmcluster", () => {
+    const wrapper = mount(
+      <CPUPopover
+        cores={vmClusterResourceFactory({
+          free: 3,
+          total: 5,
+        })}
+        overCommit={1}
+      >
+        Child
+      </CPUPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
+      "Allocated"
+    );
+    expect(wrapper.find("[data-test='allocated']").text()).toBe("2");
+    expect(wrapper.find("[data-test='free']").text()).toBe("3");
+    expect(wrapper.find("[data-test='total']").text()).toBe("5");
+    expect(wrapper.find("[data-test='other']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/CPUColumn/CPUPopover/__snapshots__/CPUPopover.test.tsx.snap
+++ b/ui/src/app/kvm/components/CPUColumn/CPUPopover/__snapshots__/CPUPopover.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`CPUPopover renders 1`] = `
             className="u-align--right"
             data-test="free"
           >
-            9
+            3
           </div>
           <div
             className="u-vertically-center"
@@ -184,7 +184,7 @@ exports[`CPUPopover renders 1`] = `
                     class="u-align--right"
                     data-test="free"
                   >
-                    9
+                    3
                   </div>
                   <div
                     class="u-vertically-center"
@@ -299,7 +299,7 @@ exports[`CPUPopover renders 1`] = `
                 className="u-align--right"
                 data-test="free"
               >
-                9
+                3
               </div>
               <div
                 className="u-vertically-center"

--- a/ui/src/app/kvm/components/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMColumn.test.tsx
@@ -13,6 +13,8 @@ import {
   podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
+  vmClusterResource as vmClusterResourceFactory,
+  vmClusterResourcesMemory as vmClusterResourcesMemoryFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -130,5 +132,28 @@ describe("RAMColumn", () => {
       "7 of 5B allocated"
     );
     expect(wrapper.find("Meter").prop("max")).toBe(5);
+  });
+
+  it("can display correct memory for a vmcluster", () => {
+    const memory = vmClusterResourcesMemoryFactory({
+      general: vmClusterResourceFactory({
+        free: 1,
+        total: 4,
+      }),
+      hugepages: vmClusterResourceFactory({
+        free: 3,
+        total: 5,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RAMColumn memory={memory} />
+      </Provider>
+    );
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
+      "5 of 9B allocated"
+    );
+    expect(wrapper.find("Meter").prop("max")).toBe(9);
   });
 });

--- a/ui/src/app/kvm/components/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMColumn.tsx
@@ -11,16 +11,30 @@ export type Props = {
     hugepages: KVMResource;
     general: KVMResource;
   };
-  overCommit: number;
+  overCommit?: number;
 };
 
 const RAMColumn = ({ memory, overCommit }: Props): JSX.Element | null => {
   const { general, hugepages } = memory;
-  const generalOver = resourceWithOverCommit(general, overCommit);
-  const allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
-  const other = generalOver.allocated_other + hugepages.allocated_other;
-  const free = generalOver.free + hugepages.free;
-  const total = allocated + other + free;
+  let total = 0;
+  let allocated = 0;
+  let other = 0;
+  let free = 0;
+  if (
+    overCommit &&
+    "allocated_other" in general &&
+    "allocated_other" in hugepages
+  ) {
+    const generalOver = resourceWithOverCommit(general, overCommit);
+    allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
+    other = generalOver.allocated_other + hugepages.allocated_other;
+    free = generalOver.free + hugepages.free;
+    total = allocated + other + free;
+  } else if ("total" in general && "total" in hugepages) {
+    free = general.free + hugepages.free;
+    total = general.total + hugepages.total;
+    allocated = total - free;
+  }
   const formattedTotal = formatBytes(total, "B", { binary: true });
   const formattedAllocated = formatBytes(allocated, "B", {
     binary: true,

--- a/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.test.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.test.tsx
@@ -5,6 +5,8 @@ import RAMPopover from "./RAMPopover";
 import {
   podMemoryResource as podMemoryResourceFactory,
   podResource as podResourceFactory,
+  vmClusterResource as vmClusterResourceFactory,
+  vmClusterResourcesMemory as vmClusterResourcesMemoryFactory,
 } from "testing/factories";
 
 describe("RAMPopover", () => {
@@ -92,5 +94,27 @@ describe("RAMPopover", () => {
     );
     wrapper.find("Popover").simulate("focus");
     expect(wrapper.find("[data-test='overcommit']").exists()).toBe(false);
+  });
+
+  it("displays memory for a vmcluster", () => {
+    const memory = vmClusterResourcesMemoryFactory({
+      general: vmClusterResourceFactory({
+        free: 1,
+        total: 4,
+      }),
+      hugepages: vmClusterResourceFactory({
+        free: 3,
+        total: 5,
+      }),
+    });
+    const wrapper = mount(<RAMPopover memory={memory}>Child</RAMPopover>);
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
+      "Allocated"
+    );
+    expect(wrapper.find("[data-test='allocated']").text()).toBe("5B");
+    expect(wrapper.find("[data-test='free']").text()).toBe("4B");
+    expect(wrapper.find("[data-test='total']").text()).toBe("9B");
+    expect(wrapper.find("[data-test='other']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.tsx
@@ -11,24 +11,40 @@ type Props = {
     hugepages: KVMResource;
     general: KVMResource;
   };
-  overCommit: number;
+  overCommit?: number;
 };
 
 const RAMPopover = ({ children, memory, overCommit }: Props): JSX.Element => {
   const { general, hugepages } = memory;
-  const hostGeneral =
-    general.allocated_other + general.allocated_tracked + general.free;
-  const hostHugepages =
-    hugepages.allocated_other + hugepages.allocated_tracked + hugepages.free;
-  const hostTotal = hostGeneral + hostHugepages;
-  const generalOver = resourceWithOverCommit(general, overCommit);
-  const allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
-  const other = generalOver.allocated_other + hugepages.allocated_other;
-  const free = generalOver.free + hugepages.free;
-  const total = allocated + other + free;
-  const showOther =
-    general.allocated_other > 0 || hugepages.allocated_other > 0;
-  const hasOverCommit = overCommit !== 1;
+  let total = 0;
+  let allocated = 0;
+  let other = 0;
+  let free = 0;
+  let hostTotal = 0;
+  let showOther = false;
+  let hasOverCommit = false;
+  if (
+    overCommit &&
+    "allocated_other" in general &&
+    "allocated_other" in hugepages
+  ) {
+    const hostGeneral =
+      general.allocated_other + general.allocated_tracked + general.free;
+    const hostHugepages =
+      hugepages.allocated_other + hugepages.allocated_tracked + hugepages.free;
+    hostTotal = hostGeneral + hostHugepages;
+    const generalOver = resourceWithOverCommit(general, overCommit);
+    allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
+    other = generalOver.allocated_other + hugepages.allocated_other;
+    free = generalOver.free + hugepages.free;
+    total = allocated + other + free;
+    showOther = general.allocated_other > 0 || hugepages.allocated_other > 0;
+    hasOverCommit = overCommit !== 1;
+  } else if ("total" in general && "total" in hugepages) {
+    free = general.free + hugepages.free;
+    total = general.total + hugepages.total;
+    allocated = total - free;
+  }
 
   return (
     <Popover

--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.test.tsx
@@ -10,6 +10,7 @@ import {
   podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
+  vmClusterResource as vmClusterResourceFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -46,5 +47,22 @@ describe("StorageColumn", () => {
       "0.1 of 1 TB allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(1000000000000);
+  });
+
+  it("displays correct storage information for a vmcluster", () => {
+    const resources = vmClusterResourceFactory({
+      free: 300000000000,
+      total: 500000000000,
+    });
+    const store = mockStore(rootStateFactory());
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageColumn storage={resources} />
+      </Provider>
+    );
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
+      "200 of 500 GB allocated"
+    );
+    expect(wrapper.find("Meter").props().max).toBe(500000000000);
   });
 });

--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
@@ -24,10 +24,19 @@ const StorageColumn = ({
     podSelectors.getSortedPools(state, Number(podId))
   );
 
-  const { allocated_other, allocated_tracked, free } = storage;
-  const totalInBytes = allocated_other + allocated_tracked + free;
+  let totalInBytes = 0;
+  let allocated = 0;
+  if ("allocated_other" in storage) {
+    totalInBytes =
+      storage.allocated_other + storage.allocated_tracked + storage.free;
+    allocated = storage.allocated_tracked;
+  } else if ("total" in storage) {
+    totalInBytes = storage.total;
+    allocated = totalInBytes - storage.free;
+  }
+
   const totalStorage = formatBytes(totalInBytes, "B", { decimals: 1 });
-  const allocatedStorage = formatBytes(allocated_tracked, "B", {
+  const allocatedStorage = formatBytes(allocated, "B", {
     convertTo: totalStorage.unit,
     decimals: 1,
   });
@@ -37,7 +46,7 @@ const StorageColumn = ({
       className="u-no-margin--bottom"
       data={[
         {
-          value: allocated_tracked,
+          value: allocated,
         },
       ]}
       label={

--- a/ui/src/app/kvm/types.ts
+++ b/ui/src/app/kvm/types.ts
@@ -4,7 +4,8 @@ import type { KVMHeaderViews } from "./constants";
 
 import type { HeaderContent, SetHeaderContent } from "app/base/types";
 import type { MachineHeaderContent } from "app/machines/types";
-import type { Pod } from "app/store/pod/types";
+import type { Pod, PodResource } from "app/store/pod/types";
+import type { VMClusterResource } from "app/store/vmcluster/types";
 
 export type KVMHeaderContent =
   | HeaderContent<ValueOf<typeof KVMHeaderViews>, { hostId?: Pod["id"] }>
@@ -12,8 +13,4 @@ export type KVMHeaderContent =
 
 export type KVMSetHeaderContent = SetHeaderContent<KVMHeaderContent>;
 
-export type KVMResource = {
-  allocated_other: number;
-  allocated_tracked: number;
-  free: number;
-};
+export type KVMResource = PodResource | VMClusterResource;

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
@@ -43,6 +43,11 @@ type Props = {
 
 type SortKey = "name" | "cpu" | "pool" | "ram" | "storage" | "vms";
 
+const calculateResources = (resource: KVMResource) =>
+  "allocated_tracked" in resource
+    ? resource.allocated_tracked
+    : resource.total - resource.free;
+
 const getSortValue = (
   sortKey: SortKey,
   row: LxdKVMHostTableRow,
@@ -53,14 +58,14 @@ const getSortValue = (
     case "pool":
       return pool?.name || "unknown";
     case "cpu":
-      return row.cpuCores.allocated_tracked;
+      return calculateResources(row.cpuCores);
     case "ram":
       return (
-        row.memory.general.allocated_tracked +
-        row.memory.hugepages.allocated_tracked
+        calculateResources(row.memory.general) +
+        calculateResources(row.memory.hugepages)
       );
     case "storage":
-      return row.storage.allocated_tracked;
+      return calculateResources(row.storage);
   }
   const value = row[sortKey];
   return isComparable(value) ? value : null;

--- a/ui/src/app/store/pod/utils.ts
+++ b/ui/src/app/store/pod/utils.ts
@@ -1,6 +1,10 @@
-import type { KVMResource } from "app/kvm/types";
 import { PodType } from "app/store/pod/constants";
-import type { Pod, PodDetails, PodNuma } from "app/store/pod/types";
+import type {
+  Pod,
+  PodDetails,
+  PodNuma,
+  PodResource,
+} from "app/store/pod/types";
 
 export const formatHostType = (type: Pod["type"]): string => {
   switch (type) {
@@ -38,9 +42,9 @@ export const getCoreIndices = (
  * @returns the resource's usage with over-commit.
  */
 export const resourceWithOverCommit = (
-  resource: KVMResource,
-  overCommit: number
-): KVMResource => {
+  resource: PodResource,
+  overCommit = 1
+): PodResource => {
   if (overCommit === 1) {
     return resource;
   }


### PR DESCRIPTION
## Done

- Update the KVM list columns to support resources from the vmcluster model.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Connect your ui to Bolla and visit /MAAS/r/kvm/lxd.
- Check that you see "other" data for the bolla pod columns.
- Check that you don't see "other" data for the lxd-cluster pod columns.

## Fixes

Fixes: canonical-web-and-design/app-squad#399.