### PR TITLE
feat(ui): build LXD cluster VM hosts table

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -80,7 +80,10 @@ const LXDClusterDetails = (): JSX.Element => {
     >
       <Switch>
         <Route exact path={kvmURLs.lxd.cluster.hosts(null, true)}>
-          <LXDClusterHosts clusterId={clusterId} />
+          <LXDClusterHosts
+            clusterId={clusterId}
+            setHeaderContent={setHeaderContent}
+          />
         </Route>
         <Route exact path={kvmURLs.lxd.cluster.vms.index(null, true)}>
           <LXDClusterVMs clusterId={clusterId} />

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
@@ -53,31 +53,10 @@ describe("LXDClusterHosts", () => {
             { pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }) },
           ]}
         >
-          <LXDClusterHosts clusterId={1} />
+          <LXDClusterHosts clusterId={1} setHeaderContent={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
-  });
-
-  it("links to cluster members' VMs tab", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
-              key: "testKey",
-            },
-          ]}
-        >
-          <LXDClusterHosts clusterId={1} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      wrapper.find("[data-test='cluster-member-link']").at(0).prop("to")
-    ).toBe(kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 111 }));
   });
 });

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -1,45 +1,36 @@
-import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+
+import LXDClusterHostsTable from "./LXDClusterHostsTable";
 
 import { useWindowTitle } from "app/base/hooks";
-import kvmURLs from "app/kvm/urls";
-import podSelectors from "app/store/pod/selectors";
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import type { RootState } from "app/store/root/types";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
   clusterId: VMCluster["id"];
+  setHeaderContent: KVMSetHeaderContent;
 };
 
-const LXDClusterHosts = ({ clusterId }: Props): JSX.Element => {
+const LXDClusterHosts = ({
+  clusterId,
+  setHeaderContent,
+}: Props): JSX.Element => {
   const cluster = useSelector((state: RootState) =>
     vmClusterSelectors.getById(state, clusterId)
   );
-  const clusterHosts = useSelector((state: RootState) =>
-    podSelectors.lxdHostsInClusterById(state, clusterId)
-  );
-  const podsLoaded = useSelector(podSelectors.loaded);
   useWindowTitle(`${cluster?.name || "LXD cluster"} VM hosts`);
 
-  if (!cluster || !podsLoaded) {
-    return <Spinner text="Loading..." />;
-  }
-
   return (
-    <ul>
-      {clusterHosts.map((host) => (
-        <li key={`${host.name}-${host.id}`}>
-          <Link
-            data-test="cluster-member-link"
-            to={kvmURLs.lxd.cluster.vms.host({ clusterId, hostId: host.id })}
-          >
-            {host.name}
-          </Link>
-        </li>
-      ))}
-    </ul>
+    <>
+      {/* TODO: Add resources card */}
+      {/* TODO: Add hosts toolbar */}
+      <LXDClusterHostsTable
+        clusterId={clusterId}
+        setHeaderContent={setHeaderContent}
+      />
+    </>
   );
 };
 

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
@@ -1,0 +1,163 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDClusterHostsTable from "./LXDClusterHostsTable";
+
+import { KVMHeaderViews } from "app/kvm/constants";
+import kvmURLs from "app/kvm/urls";
+import { PodType } from "app/store/pod/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmClusterState as vmClusterStateFactory,
+  vmHost as vmHostFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterHostsTable", () => {
+  let state: RootState;
+  beforeEach(() => {
+    const host = podFactory({
+      id: 22,
+      name: "cluster-host",
+      pool: 333,
+      type: PodType.LXD,
+    });
+    state = rootStateFactory({
+      pod: podStateFactory({
+        items: [host],
+        loaded: true,
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory({ id: 333, name: "swimming" })],
+        loaded: true,
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [
+          vmClusterFactory({
+            id: 1,
+            hosts: [vmHostFactory({ id: host.id, name: host.name })],
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("shows a spinner if pods or pools haven't loaded yet", () => {
+    const store = mockStore(state);
+    state.resourcepool.loaded = false;
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterHostsTable clusterId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='loading']").exists()).toBe(true);
+  });
+
+  it("can link to a host's VMs tab", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterHostsTable clusterId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("NameColumn Link").at(0).prop("to")).toBe(
+      kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 22 })
+    );
+  });
+
+  it("can show the name of the host's pool", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterHostsTable clusterId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='host-pool-name']").text()).toBe(
+      "swimming"
+    );
+  });
+
+  it("can open the compose VM form for a host", () => {
+    const setHeaderContent = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterHostsTable
+            clusterId={1}
+            setHeaderContent={setHeaderContent}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("button[data-test='vm-host-compose']").simulate("click");
+    expect(setHeaderContent).toHaveBeenCalledWith({
+      view: KVMHeaderViews.COMPOSE_VM,
+      extras: { hostId: 22 },
+    });
+  });
+
+  it("can link to a host's settings page", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterHostsTable clusterId={1} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Link[data-test='vm-host-settings']").prop("to")).toBe(
+      kvmURLs.lxd.cluster.host.edit({ clusterId: 1, hostId: 22 })
+    );
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
@@ -1,0 +1,310 @@
+import { useEffect } from "react";
+
+import {
+  Button,
+  Col,
+  Icon,
+  MainTable,
+  Row,
+  Spinner,
+  Strip,
+} from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
+import { SortDirection } from "app/base/types";
+import CPUColumn from "app/kvm/components/CPUColumn";
+import NameColumn from "app/kvm/components/NameColumn";
+import RAMColumn from "app/kvm/components/RAMColumn";
+import StorageColumn from "app/kvm/components/StorageColumn";
+import TagsColumn from "app/kvm/components/TagsColumn";
+import { KVMHeaderViews } from "app/kvm/constants";
+import type { KVMSetHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import { actions as poolActions } from "app/store/resourcepool";
+import poolSelectors from "app/store/resourcepool/selectors";
+import type { ResourcePool } from "app/store/resourcepool/types";
+import type { RootState } from "app/store/root/types";
+import type { VMCluster } from "app/store/vmcluster/types";
+import { isComparable } from "app/utils";
+
+type Props = {
+  clusterId: VMCluster["id"];
+  setHeaderContent: KVMSetHeaderContent;
+};
+
+type SortKey = keyof Pod | "cpu" | "pool" | "ram" | "storage" | "vms";
+
+const getSortValue = (
+  sortKey: SortKey,
+  pod: Pod,
+  pools?: ResourcePool[]
+): string | number | null => {
+  const { cores, memory, storage, vm_count } = pod.resources;
+  const pool = pools?.find((pool) => pod.pool === pool.id);
+  switch (sortKey) {
+    case "pool":
+      return pool?.name || "unknown";
+    case "cpu":
+      return cores.allocated_tracked;
+    case "ram":
+      return (
+        memory.general.allocated_tracked + memory.hugepages.allocated_tracked
+      );
+    case "storage":
+      return storage.allocated_tracked;
+    case "vms":
+      return vm_count.tracked;
+  }
+  const value = pod[sortKey];
+  return isComparable(value) ? value : null;
+};
+
+const generateRows = (
+  clusterId: VMCluster["id"],
+  clusterHosts: Pod[],
+  pools: ResourcePool[],
+  setHeaderContent: KVMSetHeaderContent
+) =>
+  clusterHosts.map((host) => {
+    const pool = pools.find((pool) => pool.id === host.pool);
+    return {
+      key: `cluster-host-${host.id}`,
+      columns: [
+        {
+          className: "name-col",
+          content: (
+            <NameColumn
+              name={host.name}
+              secondary={host.power_parameters.power_address}
+              url={kvmURLs.lxd.cluster.vms.host({ clusterId, hostId: host.id })}
+            />
+          ),
+        },
+        {
+          className: "vms-col u-align--right",
+          content: host.resources.vm_count.tracked,
+        },
+        {
+          className: "tags-col",
+          content: <TagsColumn tags={host.tags} />,
+        },
+        {
+          className: "pool-col",
+          content: <span data-test="host-pool-name">{pool?.name}</span>,
+        },
+        {
+          className: "cpu-col",
+          content: (
+            <CPUColumn
+              cores={host.resources.cores}
+              overCommit={host.cpu_over_commit_ratio}
+            />
+          ),
+        },
+        {
+          className: "ram-col",
+          content: (
+            <RAMColumn
+              memory={host.resources.memory}
+              overCommit={host.memory_over_commit_ratio}
+            />
+          ),
+        },
+        {
+          className: "storage-col",
+          content: (
+            <StorageColumn
+              defaultPoolID={host.default_storage_pool}
+              podId={host.id}
+              storage={host.resources.storage}
+            />
+          ),
+        },
+        {
+          className: "actions-col",
+          content: (
+            <div className="u-flex--end">
+              <Button
+                className="u-no-margin"
+                hasIcon
+                data-test="vm-host-compose"
+                onClick={() =>
+                  setHeaderContent({
+                    view: KVMHeaderViews.COMPOSE_VM,
+                    extras: { hostId: host.id },
+                  })
+                }
+              >
+                <Icon name="plus" />
+              </Button>
+              <div className="u-nudge-right--small">
+                <Button
+                  className="u-no-margin"
+                  data-test="vm-host-settings"
+                  element={Link}
+                  hasIcon
+                  to={kvmURLs.lxd.cluster.host.edit({
+                    clusterId,
+                    hostId: host.id,
+                  })}
+                >
+                  <Icon name="settings" />
+                </Button>
+              </div>
+            </div>
+          ),
+        },
+      ],
+    };
+  });
+
+const LXDClusterHostsTable = ({
+  clusterId,
+  setHeaderContent,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const clusterHosts = useSelector((state: RootState) =>
+    podSelectors.lxdHostsInClusterById(state, clusterId)
+  );
+  const pools = useSelector(poolSelectors.all);
+  const podsLoaded = useSelector(podSelectors.loaded);
+  const poolsLoaded = useSelector(poolSelectors.loaded);
+  const loaded = poolsLoaded && podsLoaded;
+  const { currentSort, sortRows, updateSort } = useTableSort<
+    Pod,
+    SortKey,
+    ResourcePool[]
+  >(getSortValue, {
+    key: "name",
+    direction: SortDirection.DESCENDING,
+  });
+  const sortedClusterHosts = sortRows(clusterHosts, pools);
+
+  useEffect(() => {
+    dispatch(poolActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Row>
+      <Col size={12}>
+        <MainTable
+          className="lxd-cluster-hosts-table"
+          headers={[
+            {
+              className: "name-col",
+              content: (
+                <>
+                  <TableHeader
+                    currentSort={currentSort}
+                    data-test="name-header"
+                    onClick={() => updateSort("name")}
+                    sortKey="name"
+                  >
+                    KVM host
+                  </TableHeader>
+                  <TableHeader>Address</TableHeader>
+                </>
+              ),
+            },
+            {
+              className: "vms-col u-align--right",
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="vms-header"
+                  onClick={() => updateSort("vms")}
+                  sortKey="vms"
+                >
+                  VM<span className="u-no-text-transform">s</span>
+                </TableHeader>
+              ),
+            },
+            {
+              className: "tags-col",
+              content: <TableHeader data-test="tags-header">Tags</TableHeader>,
+            },
+            {
+              className: "pool-col",
+              content: (
+                <TableHeader
+                  data-test="pool-header"
+                  currentSort={currentSort}
+                  onClick={() => updateSort("pool")}
+                  sortKey="pool"
+                >
+                  Resource pool
+                </TableHeader>
+              ),
+            },
+            {
+              className: "cpu-col",
+              content: (
+                <TableHeader
+                  data-test="cpu-header"
+                  currentSort={currentSort}
+                  onClick={() => updateSort("cpu")}
+                  sortKey="cpu"
+                >
+                  CPU cores
+                </TableHeader>
+              ),
+            },
+            {
+              className: "ram-col",
+              content: (
+                <TableHeader
+                  data-test="ram-header"
+                  currentSort={currentSort}
+                  onClick={() => updateSort("ram")}
+                  sortKey="ram"
+                >
+                  RAM
+                </TableHeader>
+              ),
+            },
+            {
+              className: "storage-col",
+              content: (
+                <TableHeader
+                  data-test="storage-header"
+                  currentSort={currentSort}
+                  onClick={() => updateSort("storage")}
+                  sortKey="storage"
+                >
+                  Storage
+                </TableHeader>
+              ),
+            },
+            {
+              className: "actions-col",
+              content: null,
+            },
+          ]}
+          paginate={50}
+          rows={
+            loaded
+              ? generateRows(
+                  clusterId,
+                  sortedClusterHosts,
+                  pools,
+                  setHeaderContent
+                )
+              : []
+          }
+        />
+        {!loaded && (
+          <Strip className="u-align--center" data-test="loading" shallow>
+            <Spinner text="Loading..." />
+          </Strip>
+        )}
+      </Col>
+    </Row>
+  );
+};
+
+export default LXDClusterHostsTable;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/_index.scss
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/_index.scss
@@ -1,0 +1,35 @@
+@mixin LXDClusterHostsTable {
+  .lxd-cluster-hosts-table {
+    .name-col {
+      @include breakpoint-widths(100%, 60%, 50%, 35%, 35%);
+    }
+
+    .vms-col {
+      @include breakpoint-widths(0, 0, 0, 0, 4rem);
+    }
+
+    .tags-col {
+      @include breakpoint-widths(0, 40%, 50%, 35%, 35%);
+    }
+
+    .pool-col {
+      @include breakpoint-widths(0, 0, 0, 30%, 30%);
+    }
+
+    .cpu-col {
+      @include breakpoint-widths(0, 0, 5rem, 9rem, 9rem);
+    }
+
+    .ram-col {
+      @include breakpoint-widths(0, 0, 8rem, 11rem, 11rem);
+    }
+
+    .storage-col {
+      @include breakpoint-widths(0, 0, 8rem, 11rem, 11rem);
+    }
+
+    .actions-col {
+      width: 7rem;
+    }
+  }
+}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterHostsTable";

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -37,6 +37,11 @@
     justify-content: space-between;
   }
 
+  .u-flex--end {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .u-flex--vertically {
     display: flex;
     flex-direction: column;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -143,6 +143,7 @@
 @import "~app/kvm/components/VmResources";
 @import "~app/kvm/views/KVMList/LxdTable/LxdKVMHostTable";
 @import "~app/kvm/views/KVMList/VirshTable";
+@import "~app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable";
 @include CoreResources;
 @include CPUPopover;
 @include KVMComposeInterfacesTable;
@@ -152,6 +153,7 @@
 @include KVMResourcesCard;
 @include KVMStorageCards;
 @include KVMSubnetSelect;
+@include LXDClusterHostsTable;
 @include LXDHostToolbar;
 @include LxdKVMHostTable;
 @include LXDVMsSummaryCard;


### PR DESCRIPTION
## Done

- Built `LXDClusterHostsTable` component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to /MAAS/r/kvm/lxd/cluster/1/hosts
- Check that the VM host data is correct and it matches the [design](https://www.figma.com/file/QNQ3ZsYLR0tamnFzCo8VP6/%5B21.10%5D-LXD-Clusters?node-id=629%3A21661)
- Check that clicking on a VM host name takes you to the VMs tab with that host selected
- Check that clicking on the "plus" button opens the Compose form for that VM host
- Check that clicking the "gear" button takes you to the settings page of that host

## Fixes

Fixes canonical-web-and-design/app-squad#325
Fixes canonical-web-and-design/app-squad#326
Fixes canonical-web-and-design/app-squad#327

## Screenshot

![Screenshot 2021-10-14 at 16-13-05 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/137261901-a536e4a3-37c5-4ff3-b09c-a89336e5d229.png)

