### PR TITLE
fix(ui): fix kvm list refetching clusters

### DIFF
--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
@@ -70,6 +70,9 @@ const LxdTable = (): JSX.Element | null => {
   const rows = generateSingleHostRows(singleHosts).concat(
     generateClusterRows(vmclusters)
   );
+  console.log("singleHostsLoading", singleHostsLoading);
+  console.log("vmclustersLoading", vmclustersLoading);
+
   if (singleHostsLoading || vmclustersLoading) {
     return <Spinner data-test="loading-table" text="Loading..." />;
   }

--- a/ui/src/app/store/vmcluster/actions.test.ts
+++ b/ui/src/app/store/vmcluster/actions.test.ts
@@ -5,6 +5,7 @@ describe("vmcluster actions", () => {
     expect(actions.fetch()).toEqual({
       type: "vmcluster/fetch",
       meta: {
+        cache: true,
         model: "vmcluster",
         method: "list_by_physical_cluster",
       },

--- a/ui/src/app/store/vmcluster/slice.ts
+++ b/ui/src/app/store/vmcluster/slice.ts
@@ -33,6 +33,7 @@ const vmClusterSlice = createSlice({
     fetch: {
       prepare: () => ({
         meta: {
+          cache: true,
           model: VMClusterMeta.MODEL,
           method: "list_by_physical_cluster",
         },


### PR DESCRIPTION
## Done

- Fix the vmcluster fetch action so that it caches the request.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /MAAS/r/kvm/lxd.
- Click on a host.
- Click on KVM in the header.
- The lxd list should be displayed again and you shouldn't see a spinner.

## Fixes

Fixes: canonical-web-and-design/app-squad#407.