### PR TITLE
feat(ui): support refreshing multiple hosts

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -105,7 +105,7 @@ describe("KVMHeaderForms", () => {
     expect(wrapper.find("DeleteForm").exists()).toBe(true);
   });
 
-  it("renders RefreshForm if refresh header content and host id provided", () => {
+  it("renders RefreshForm if refresh header content and host ids provided", () => {
     const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
@@ -114,7 +114,7 @@ describe("KVMHeaderForms", () => {
           <KVMHeaderForms
             headerContent={{
               view: KVMHeaderViews.REFRESH_KVM,
-              extras: { hostId: 1 },
+              extras: { hostIds: [1] },
             }}
             setHeaderContent={jest.fn()}
           />

--- a/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -51,16 +51,23 @@ const getFormComponent = (
         return (
           <DeleteForm clearHeaderContent={clearHeaderContent} hostId={hostId} />
         );
-      case KVMHeaderViews.REFRESH_KVM:
-        return (
-          <RefreshForm
-            clearHeaderContent={clearHeaderContent}
-            hostId={hostId}
-          />
-        );
       default:
         return null;
     }
+  }
+
+  if (
+    headerContent.view === KVMHeaderViews.REFRESH_KVM &&
+    headerContent.extras &&
+    "hostIds" in headerContent.extras &&
+    headerContent.extras.hostIds?.length
+  ) {
+    return (
+      <RefreshForm
+        clearHeaderContent={clearHeaderContent}
+        hostIds={headerContent.extras.hostIds}
+      />
+    );
   }
   // We need to explicitly cast headerContent here - TypeScript doesn't
   // seem to be able to infer remaining object tuple values as with string

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.test.tsx
@@ -31,7 +31,7 @@ describe("RefreshForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <RefreshForm clearHeaderContent={jest.fn()} hostId={1} />
+          <RefreshForm clearHeaderContent={jest.fn()} hostIds={[1]} />
         </MemoryRouter>
       </Provider>
     );
@@ -57,7 +57,7 @@ describe("RefreshForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <RefreshForm clearHeaderContent={jest.fn()} hostId={1} />
+          <RefreshForm clearHeaderContent={jest.fn()} hostIds={[1, 2]} />
         </MemoryRouter>
       </Provider>
     );
@@ -65,18 +65,32 @@ describe("RefreshForm", () => {
     wrapper.find("Formik").simulate("submit");
     await waitForComponentToPaint(wrapper);
     expect(
-      store.getActions().find((action) => action.type === "pod/refresh")
-    ).toStrictEqual({
-      type: "pod/refresh",
-      meta: {
-        model: "pod",
-        method: "refresh",
-      },
-      payload: {
-        params: {
-          id: pod.id,
+      store.getActions().filter((action) => action.type === "pod/refresh")
+    ).toStrictEqual([
+      {
+        type: "pod/refresh",
+        meta: {
+          model: "pod",
+          method: "refresh",
+        },
+        payload: {
+          params: {
+            id: 1,
+          },
         },
       },
-    });
+      {
+        type: "pod/refresh",
+        meta: {
+          model: "pod",
+          method: "refresh",
+        },
+        payload: {
+          params: {
+            id: 2,
+          },
+        },
+      },
+    ]);
   });
 });

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 
+import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -7,54 +8,49 @@ import type { ClearHeaderContent, EmptyObject } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 
 type Props = {
   clearHeaderContent: ClearHeaderContent;
-  hostId: Pod["id"];
+  hostIds: Pod["id"][];
 };
 
 const RefreshForm = ({
   clearHeaderContent,
-  hostId,
+  hostIds,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, hostId)
-  );
   const errors = useSelector(podSelectors.errors);
   const refreshing = useSelector(podSelectors.refreshing);
   const cleanup = useCallback(() => podActions.cleanup(), []);
 
-  if (pod) {
-    return (
-      <ActionForm<EmptyObject>
-        actionName="refresh"
-        cleanup={cleanup}
-        clearHeaderContent={clearHeaderContent}
-        errors={errors}
-        initialValues={{}}
-        modelName="KVM"
-        onSaveAnalytics={{
-          action: "Submit",
-          category: "KVM details action form",
-          label: "Refresh",
-        }}
-        onSubmit={() => {
-          dispatch(podActions.refresh(pod.id));
-        }}
-        processingCount={refreshing.length}
-        selectedCount={refreshing.length}
-      >
-        <p>
-          Refreshing KVMs will cause MAAS to recalculate usage metrics, update
-          information about storage pools, and commission any machines present
-          in the KVMs that are not yet known to MAAS.
-        </p>
-      </ActionForm>
-    );
-  }
-  return null;
+  return (
+    <ActionForm<EmptyObject>
+      actionName="refresh"
+      cleanup={cleanup}
+      clearHeaderContent={clearHeaderContent}
+      errors={errors}
+      initialValues={{}}
+      modelName={pluralize("KVM", hostIds.length)}
+      onSaveAnalytics={{
+        action: "Submit",
+        category: "KVM details action form",
+        label: "Refresh",
+      }}
+      onSubmit={() => {
+        hostIds.forEach((id) => {
+          dispatch(podActions.refresh(id));
+        });
+      }}
+      processingCount={refreshing.length}
+      selectedCount={refreshing.length}
+    >
+      <p>
+        Refreshing KVMs will cause MAAS to recalculate usage metrics, update
+        information about storage pools, and commission any machines present in
+        the KVMs that are not yet known to MAAS.
+      </p>
+    </ActionForm>
+  );
 };
 
 export default RefreshForm;

--- a/ui/src/app/kvm/types.ts
+++ b/ui/src/app/kvm/types.ts
@@ -1,5 +1,3 @@
-import type { ValueOf } from "@canonical/react-components";
-
 import type { KVMHeaderViews } from "./constants";
 
 import type { HeaderContent, SetHeaderContent } from "app/base/types";
@@ -7,8 +5,15 @@ import type { MachineHeaderContent } from "app/machines/types";
 import type { Pod, PodResource } from "app/store/pod/types";
 import type { VMClusterResource } from "app/store/vmcluster/types";
 
+type HeaderViews = typeof KVMHeaderViews;
+
 export type KVMHeaderContent =
-  | HeaderContent<ValueOf<typeof KVMHeaderViews>, { hostId?: Pod["id"] }>
+  | HeaderContent<
+      HeaderViews["COMPOSE_VM"] | HeaderViews["DELETE_KVM"],
+      { hostId?: Pod["id"] }
+    >
+  | HeaderContent<HeaderViews["ADD_KVM"]>
+  | HeaderContent<HeaderViews["REFRESH_KVM"], { hostIds?: Pod["id"][] }>
   | MachineHeaderContent;
 
 export type KVMSetHeaderContent = SetHeaderContent<KVMHeaderContent>;

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleVMs/LXDSingleVMs.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleVMs/LXDSingleVMs.tsx
@@ -33,7 +33,7 @@ const LXDSingleVMs = ({
       onRefreshClick={() =>
         setHeaderContent({
           view: KVMHeaderViews.REFRESH_KVM,
-          extras: { hostId: id },
+          extras: { hostIds: [id] },
         })
       }
       searchFilter={searchFilter}

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsActionMenu/VirshDetailsActionMenu.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsActionMenu/VirshDetailsActionMenu.tsx
@@ -31,7 +31,7 @@ const PodDetailsActionMenu = ({
           onClick: () =>
             setHeaderContent({
               view: KVMHeaderViews.REFRESH_KVM,
-              extras: { hostId },
+              extras: { hostIds: [hostId] },
             }),
         },
         {


### PR DESCRIPTION
## Done

- Update the refresh form and state to handle multiple host ids.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the kvm list and click on a single host.
- Click the refresh icon at the top of the vm table.
- The form should open and you should be able to submit it (when I tested it the API returned an error but this seems to be a backend issue - it's happening on master as well).

## Fixes

Fixes: canonical-web-and-design/app-squad#412.