### PR TITLE
fix(ui): address LXD authentication QA issues

### DIFF
--- a/ui/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
+++ b/ui/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
@@ -15,28 +15,6 @@ import {
 const mockStore = configureStore();
 
 describe("CertificateDetails", () => {
-  it("can toggle displaying the private key", () => {
-    const state = rootStateFactory();
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <CertificateDetails
-          certificate="certificate"
-          eventCategory="eventCategory"
-          metadata={metadataFactory()}
-          privateKey="private-key"
-        />
-      </Provider>
-    );
-    expect(wrapper.find("[data-test='private-key']").exists()).toBe(false);
-
-    wrapper.find("Button[data-test='toggle-key']").simulate("click");
-    expect(wrapper.find("[data-test='private-key']").exists()).toBe(true);
-
-    wrapper.find("Button[data-test='toggle-key']").simulate("click");
-    expect(wrapper.find("[data-test='private-key']").exists()).toBe(false);
-  });
-
   it(`sends an analytics event when clicking the 'read more' link if analytics
     is enabled`, () => {
     const mockSendAnalytics = jest.fn();
@@ -55,7 +33,6 @@ describe("CertificateDetails", () => {
           certificate="certificate"
           eventCategory="eventCategory"
           metadata={metadataFactory()}
-          privateKey="private-key"
         />
       </Provider>
     );

--- a/ui/src/app/base/components/CertificateDetails/CertificateDetails.tsx
+++ b/ui/src/app/base/components/CertificateDetails/CertificateDetails.tsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
+import { Link } from "@canonical/react-components";
 
-import { Button, Icon, Link, Textarea } from "@canonical/react-components";
-
+import CertificateDownload from "app/base/components/CertificateDownload";
 import CertificateMetadata from "app/base/components/CertificateMetadata";
 import { useSendAnalytics } from "app/base/hooks";
 import type {
@@ -13,16 +12,13 @@ type Props = {
   certificate: CertificateData["certificate"];
   eventCategory: string;
   metadata: CertificateMetadataType;
-  privateKey: CertificateData["private_key"];
 };
 
 const CertificateDetails = ({
   certificate,
   eventCategory,
   metadata,
-  privateKey,
 }: Props): JSX.Element => {
-  const [showKey, setShowKey] = useState(false);
   const sendAnalytics = useSendAnalytics();
 
   return (
@@ -46,40 +42,7 @@ const CertificateDetails = ({
         </Link>
       </p>
       <CertificateMetadata metadata={metadata} />
-      <Textarea
-        className="p-textarea--readonly"
-        id="lxd-cert"
-        readOnly
-        rows={5}
-        value={certificate}
-      />
-      <p>Private key</p>
-      {showKey && (
-        <Textarea
-          className="p-textarea--readonly"
-          data-test="private-key"
-          id="lxd-key"
-          readOnly
-          rows={5}
-          value={privateKey}
-        />
-      )}
-      <Button
-        data-test="toggle-key"
-        onClick={() => setShowKey(!showKey)}
-        type="button"
-      >
-        {showKey ? (
-          "Close"
-        ) : (
-          <>
-            <span className="u-nudge-left--small">
-              <Icon name="begin-downloading" />
-            </span>
-            Fetch private key
-          </>
-        )}
-      </Button>
+      <CertificateDownload certificate={certificate} filename={metadata.CN} />
     </div>
   );
 };

--- a/ui/src/app/base/components/CertificateDownload/CertificateDownload.test.tsx
+++ b/ui/src/app/base/components/CertificateDownload/CertificateDownload.test.tsx
@@ -3,21 +3,26 @@ import * as fileDownload from "js-file-download";
 
 import CertificateDownload from "./CertificateDownload";
 
+import type { GeneratedCertificate } from "app/store/general/types";
 import { generatedCertificate as certFactory } from "testing/factories";
 
 jest.mock("js-file-download", () => jest.fn());
 
 describe("CertificateDownload", () => {
+  let certificate: GeneratedCertificate;
+
+  beforeEach(() => {
+    certificate = certFactory({
+      certificate: "certificate",
+      CN: "name@host",
+    });
+  });
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
   it("can generate a download based on the certificate details", () => {
     const downloadSpy = jest.spyOn(fileDownload, "default");
-    const certificate = certFactory({
-      certificate: "certificate",
-      CN: "name@host",
-    });
     const wrapper = mount(
       <CertificateDownload
         certificate={certificate.certificate}
@@ -32,5 +37,39 @@ describe("CertificateDownload", () => {
       certificate.certificate,
       certificate.CN
     );
+  });
+
+  it("shows as a code snippet if certificate was generated", () => {
+    const wrapper = mount(
+      <CertificateDownload
+        certificate={certificate.certificate}
+        filename={certificate.CN}
+        isGenerated
+      />
+    );
+
+    expect(
+      wrapper.find("[data-test='certificate-code-snippet']").exists()
+    ).toBe(true);
+    expect(wrapper.find("[data-test='certificate-textarea']").exists()).toBe(
+      false
+    );
+  });
+
+  it("shows as a textarea if certificate was not generated", () => {
+    const wrapper = mount(
+      <CertificateDownload
+        certificate={certificate.certificate}
+        filename={certificate.CN}
+        isGenerated={false}
+      />
+    );
+
+    expect(wrapper.find("[data-test='certificate-textarea']").exists()).toBe(
+      true
+    );
+    expect(
+      wrapper.find("[data-test='certificate-code-snippet']").exists()
+    ).toBe(false);
   });
 });

--- a/ui/src/app/base/components/CertificateDownload/CertificateDownload.tsx
+++ b/ui/src/app/base/components/CertificateDownload/CertificateDownload.tsx
@@ -1,4 +1,9 @@
-import { Button, CodeSnippet, Icon } from "@canonical/react-components";
+import {
+  Button,
+  CodeSnippet,
+  Icon,
+  Textarea,
+} from "@canonical/react-components";
 import fileDownload from "js-file-download";
 
 import type { CertificateData } from "app/store/general/types";
@@ -6,21 +11,38 @@ import type { CertificateData } from "app/store/general/types";
 type Props = {
   certificate: CertificateData["certificate"];
   filename: string;
+  isGenerated?: boolean;
 };
 
-const CertificateDownload = ({ certificate, filename }: Props): JSX.Element => {
+const CertificateDownload = ({
+  certificate,
+  filename,
+  isGenerated = false,
+}: Props): JSX.Element => {
   return (
     <>
-      <div className="certificate-download">
-        <CodeSnippet
-          blocks={[
-            { code: "lxc config trust add - <<EOF" },
-            { code: certificate },
-            { code: "EOF" },
-          ]}
-          className="u-no-margin--bottom"
+      {isGenerated ? (
+        <div className="certificate-download">
+          <CodeSnippet
+            blocks={[
+              { code: "lxc config trust add - <<EOF" },
+              { code: certificate },
+              { code: "EOF" },
+            ]}
+            className="u-no-margin--bottom"
+            data-test="certificate-code-snippet"
+          />
+        </div>
+      ) : (
+        <Textarea
+          className="p-textarea--readonly"
+          data-test="certificate-textarea"
+          id="lxd-cert"
+          readOnly
+          rows={5}
+          value={certificate}
         />
-      </div>
+      )}
       <Button
         data-test="certificate-download-button"
         onClick={() => {

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.tsx
@@ -70,7 +70,6 @@ export const LXDPowerFields = <V extends AnyObject>({
       <CertificateDetails
         certificate={machine.power_parameters.certificate as string}
         eventCategory="Machine configuration"
-        privateKey={machine.power_parameters.key as string}
         metadata={machine.certificate}
       />
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationFormFields/AuthenticationFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddKVM/AddLxd/AuthenticationForm/AuthenticationFormFields/AuthenticationFormFields.tsx
@@ -43,6 +43,7 @@ export const AuthenticationFormFields = ({
           <CertificateDownload
             certificate={generatedCertificate.certificate}
             filename={generatedCertificate.CN}
+            isGenerated
           />
         )}
       </Col>

--- a/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/AuthenticationCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/AuthenticationCard.tsx
@@ -31,8 +31,8 @@ const AuthenticationCard = ({ pod }: Props): JSX.Element => {
       {showUpdateCertificate || !hasCertificateData ? (
         <UpdateCertificate
           closeForm={() => setShowUpdateCertificate(false)}
+          hasCertificateData={hasCertificateData}
           pod={pod}
-          showCancel={hasCertificateData}
         />
       ) : (
         <Row>
@@ -41,7 +41,6 @@ const AuthenticationCard = ({ pod }: Props): JSX.Element => {
               certificate={power_parameters.certificate as string}
               eventCategory="KVM configuration"
               metadata={certificateMetadata}
-              privateKey={power_parameters.key as string}
             />
           </Col>
           <hr />

--- a/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
@@ -47,7 +47,11 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate closeForm={jest.fn()} pod={pod} showCancel />
+          <UpdateCertificate
+            closeForm={jest.fn()}
+            hasCertificateData
+            pod={pod}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -76,7 +80,11 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate closeForm={jest.fn()} pod={pod} showCancel />
+          <UpdateCertificate
+            closeForm={jest.fn()}
+            hasCertificateData
+            pod={pod}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +113,11 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate closeForm={jest.fn()} pod={pod} showCancel />
+          <UpdateCertificate
+            closeForm={jest.fn()}
+            hasCertificateData
+            pod={pod}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -127,5 +139,74 @@ describe("UpdateCertificate", () => {
     expect(
       actualActions.find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);
+  });
+
+  it("closes the form on cancel if pod has a certificate", () => {
+    const closeForm = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
+        >
+          <UpdateCertificate
+            closeForm={closeForm}
+            hasCertificateData
+            pod={pod}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='cancel-action']").exists()).toBe(true);
+    wrapper.find("button[data-test='cancel-action']").simulate("click");
+    expect(closeForm).toHaveBeenCalled();
+  });
+
+  it(`clears generated certificate on cancel if pod has no certificate and a
+      certificate has been generated`, () => {
+    state.general.generatedCertificate.data = generatedCertificateFactory();
+    const closeForm = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
+        >
+          <UpdateCertificate
+            closeForm={closeForm}
+            hasCertificateData={false}
+            pod={pod}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='cancel-action']").exists()).toBe(true);
+    wrapper.find("button[data-test='cancel-action']").simulate("click");
+
+    const expectedAction = generalActions.clearGeneratedCertificate();
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+  it(`does not show a cancel button if pod has no certificate and no certificate
+      has been generated`, () => {
+    state.general.generatedCertificate.data = null;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
+        >
+          <UpdateCertificate
+            closeForm={jest.fn()}
+            hasCertificateData={false}
+            pod={pod}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='cancel-action']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/UpdateCertificate/UpdateCertificateFields/UpdateCertificateFields.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/UpdateCertificate/UpdateCertificateFields/UpdateCertificateFields.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, Col, Row, Textarea } from "@canonical/react-components";
+import { Button, Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { UpdateCertificateValues } from "../UpdateCertificate";
@@ -41,6 +41,7 @@ const UpdateCertificateFields = ({
             <CertificateDownload
               certificate={generatedCertificate.certificate}
               filename={generatedCertificate.CN}
+              isGenerated
             />
             <FormikField
               disabled={!usePassword}
@@ -51,14 +52,6 @@ const UpdateCertificateFields = ({
             {!usePassword && (
               <Button onClick={() => setUsePassword(true)}>Add</Button>
             )}
-            <p>Private key</p>
-            <Textarea
-              className="p-textarea--readonly"
-              id="private-key"
-              readOnly
-              rows={5}
-              value={generatedCertificate.private_key}
-            />
           </div>
         ) : (
           <CertificateFields

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -92,7 +92,7 @@
   // Override Vanilla's default light text for readonly textareas and make text
   // small. Used for displaying very long strings, e.g. certificates.
   .p-textarea--readonly {
-    @extend %small-text;
     color: $color-dark !important;
+    font-size: #{map-get($font-sizes, small)}rem;
   }
 }


### PR DESCRIPTION
## Done

- No longer surface certificate private key in UI
- Include download button for existing certificates, not just generated certificates
- Fix cancel action in update certificate form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the settings page of a LXD machine and check that you can download the certificate and there is no longer a section for private key.
- Go to the settings page of a LXD pod and check that you can download the certificate and there is no longer a section for private key.
- Open `app/kvm/views/KVMDetails/KVMSettings/AuthenticationCard/AuthenticationCard.tsx` and edit line 34 to `hasCertificateData={!hasCertificateData}` in order to appear as a pod that doesn't have certificate data already
- Check that there is no cancel button by default
- Generate a certificate and check that clicking "Cancel" takes you back to the generate certificate step

## Fixes

Fixes #3104 
Fixes canonical-web-and-design/app-squad#279
