### PR TITLE
fix(ui): don't overwrite the active pod details

### DIFF
--- a/ui/src/app/store/pod/reducers.test.ts
+++ b/ui/src/app/store/pod/reducers.test.ts
@@ -57,6 +57,36 @@ describe("pod reducer", () => {
     );
   });
 
+  it("does not override the active pod when reducing fetchSuccess", () => {
+    const activePod = podDetailsFactory();
+    const podState = podStateFactory({
+      active: activePod.id,
+      items: [activePod],
+      statuses: {
+        [activePod.id]: podStatusFactory({ refreshing: true }),
+      },
+    });
+    const pods = [
+      // The fetch response will include the non-details version of the pod.
+      podFactory({ id: activePod.id }),
+      podFactory(),
+      podFactory(),
+    ];
+    expect(reducers(podState, actions.fetchSuccess(pods))).toEqual(
+      podStateFactory({
+        active: activePod.id,
+        loading: false,
+        loaded: true,
+        statuses: {
+          [activePod.id]: podStatusFactory({ refreshing: true }),
+          [pods[1].id]: podStatusFactory(),
+          [pods[2].id]: podStatusFactory(),
+        },
+        items: [activePod, pods[1], pods[2]],
+      })
+    );
+  });
+
   it("reduces fetchError", () => {
     const podState = podStateFactory({
       errors: null,

--- a/ui/src/app/store/pod/slice.ts
+++ b/ui/src/app/store/pod/slice.ts
@@ -135,7 +135,15 @@ const podSlice = createSlice({
           (draftItem: Pod) => draftItem.id === newItem.id
         );
         if (existingIdx !== -1) {
-          state.items[existingIdx] = newItem;
+          // Don't update the item if it is active so that we don't overwrite
+          // the pod details that have already been fetched.
+          const hasActive = !!state.active || state.active === 0;
+          if (
+            !hasActive ||
+            (hasActive && state.active !== state.items[existingIdx].id)
+          ) {
+            state.items[existingIdx] = newItem;
+          }
         } else {
           state.items.push(newItem);
           // Set up the statuses for this machine.


### PR DESCRIPTION
## Done

- When reducing the fetchSuccess action then don't overwrite the active pod details with the list version of the pod.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the settings tab for a LXD single host.
- Refresh the page.
- The settings form should load.

## Fixes

Fixes: canonical-web-and-design/app-squad#413.