### PR TITLE
feat(ui): add LXD cluster VMs table

### DIFF
--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
@@ -37,6 +37,7 @@ describe("LXDHostVMs", () => {
         >
           <LXDHostVMs
             hostId={1}
+            onRefreshClick={jest.fn()}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}
@@ -78,6 +79,7 @@ describe("LXDHostVMs", () => {
         >
           <LXDHostVMs
             hostId={1}
+            onRefreshClick={jest.fn()}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}
@@ -114,6 +116,7 @@ describe("LXDHostVMs", () => {
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <LXDHostVMs
             hostId={1}
+            onRefreshClick={jest.fn()}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
@@ -97,24 +97,26 @@ const LXDHostVMs = ({
             }}
           />
         )}
-        <LXDVMsTable
-          getResources={(vm) => {
-            const resources =
-              pod.resources.vms.find(
-                ({ system_id }) => system_id === vm.system_id
-              ) || null;
-            return {
-              hugepagesBacked: resources?.hugepages_backed || false,
-              pinnedCores: resources?.pinned_cores || [],
-              unpinnedCores: resources?.unpinned_cores || 0,
-            };
-          }}
-          onRefreshClick={onRefreshClick}
-          searchFilter={searchFilter}
-          setSearchFilter={setSearchFilter}
-          setHeaderContent={setHeaderContent}
-          vms={vms}
-        />
+        <Strip shallow>
+          <LXDVMsTable
+            getResources={(vm) => {
+              const resources =
+                pod.resources.vms.find(
+                  ({ system_id }) => system_id === vm.system_id
+                ) || null;
+              return {
+                hugepagesBacked: resources?.hugepages_backed || false,
+                pinnedCores: resources?.pinned_cores || [],
+                unpinnedCores: resources?.unpinned_cores || 0,
+              };
+            }}
+            onRefreshClick={onRefreshClick}
+            searchFilter={searchFilter}
+            setSearchFilter={setSearchFilter}
+            setHeaderContent={setHeaderContent}
+            vms={vms}
+          />
+        </Strip>
       </>
     );
   }

--- a/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { Strip } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 
 import VMsActionBar from "./VMsActionBar";
@@ -44,7 +43,7 @@ const LXDVMsTable = ({
   }, [dispatch]);
 
   return (
-    <Strip shallow>
+    <>
       <VMsActionBar
         currentPage={currentPage}
         onRefreshClick={onRefreshClick}
@@ -60,7 +59,7 @@ const LXDVMsTable = ({
         searchFilter={searchFilter}
         vms={vms}
       />
-    </Strip>
+    </>
   );
 };
 

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -86,7 +86,12 @@ const LXDClusterDetails = (): JSX.Element => {
           />
         </Route>
         <Route exact path={kvmURLs.lxd.cluster.vms.index(null, true)}>
-          <LXDClusterVMs clusterId={clusterId} />
+          <LXDClusterVMs
+            clusterId={clusterId}
+            searchFilter={searchFilter}
+            setHeaderContent={setHeaderContent}
+            setSearchFilter={setSearchFilter}
+          />
         </Route>
         <Route exact path={kvmURLs.lxd.cluster.resources(null, true)}>
           <LXDClusterResources clusterId={clusterId} />

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
@@ -1,0 +1,71 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LXDClusterVMs from "./LXDClusterVMs";
+
+import LXDVMsTable from "app/kvm/components/LXDVMsTable";
+import kvmURLs from "app/kvm/urls";
+import {
+  machine as machineFactory,
+  rootState as rootStateFactory,
+  virtualMachine as clusterVMFactory,
+  vmCluster as vmClusterFactory,
+  vmClusterState as vmClusterStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterVMs", () => {
+  it("can get resources for a cluster VM", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [
+          vmClusterFactory({
+            id: 1,
+            virtual_machines: [
+              clusterVMFactory({
+                hugepages_backed: true,
+                pinned_cores: [2],
+                system_id: "abc123",
+                unpinned_cores: 3,
+              }),
+            ],
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.vms.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterVMs
+            clusterId={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find(LXDVMsTable).invoke("getResources")(
+        machineFactory({ system_id: "abc123" })
+      )
+    ).toStrictEqual({
+      hugepagesBacked: true,
+      pinnedCores: [2],
+      unpinnedCores: 3,
+    });
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -1,11 +1,63 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import type { SetSearchFilter } from "app/base/types";
+import LXDVMsTable from "app/kvm/components/LXDVMsTable";
+import type { KVMSetHeaderContent } from "app/kvm/types";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
   clusterId: VMCluster["id"];
+  searchFilter: string;
+  setHeaderContent: KVMSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
 };
 
-const LXDClusterVMs = ({ clusterId }: Props): JSX.Element => {
-  return <h4>LXD cluster {clusterId} virtual machines</h4>;
+const LXDClusterVMs = ({
+  clusterId,
+  searchFilter,
+  setHeaderContent,
+  setSearchFilter,
+}: Props): JSX.Element | null => {
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const clusterVMs = useSelector((state: RootState) =>
+    vmClusterSelectors.getFilteredVMs(state, clusterId, searchFilter)
+  );
+  useWindowTitle(`${cluster?.name || "Cluster"} virtual machines`);
+
+  if (!cluster) {
+    return null;
+  }
+  return (
+    <>
+      {/* TODO: Add LXD cluster resource card */}
+      <LXDVMsTable
+        getResources={(machine) => {
+          const vmInCluster =
+            cluster?.virtual_machines.find(
+              (vm) => vm.system_id === machine.system_id
+            ) || null;
+          return {
+            hugepagesBacked: vmInCluster?.hugepages_backed || false,
+            pinnedCores: vmInCluster?.pinned_cores || [],
+            unpinnedCores: vmInCluster?.unpinned_cores || 0,
+          };
+        }}
+        onRefreshClick={() => {
+          // TODO: Open cluster refresh form.
+          return null;
+        }}
+        searchFilter={searchFilter}
+        setSearchFilter={setSearchFilter}
+        setHeaderContent={setHeaderContent}
+        vms={clusterVMs}
+      />
+    </>
+  );
 };
 
 export default LXDClusterVMs;

--- a/ui/src/app/store/vmcluster/selectors.test.ts
+++ b/ui/src/app/store/vmcluster/selectors.test.ts
@@ -1,7 +1,10 @@
 import selectors from "./selectors";
 
 import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
   rootState as rootStateFactory,
+  virtualMachine as clusterVMFactory,
   vmCluster as vmClusterFactory,
   vmClusterEventError as vmClusterEventErrorFactory,
   vmClusterState as vmClusterStateFactory,
@@ -62,6 +65,64 @@ describe("vmcluster selectors", () => {
     });
     expect(selectors.eventError(state, "listByPhysicalCluster")).toStrictEqual([
       eventError,
+    ]);
+  });
+
+  it("can get a cluster's VMs", () => {
+    const cluster = vmClusterFactory({
+      virtual_machines: [
+        clusterVMFactory({ system_id: "abc123" }),
+        clusterVMFactory({ system_id: "def456" }),
+      ],
+    });
+    const clusterVMs = [
+      machineFactory({ system_id: "abc123" }),
+      machineFactory({ system_id: "def456" }),
+    ];
+    const otherMachine = machineFactory({ system_id: "ghi789" });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [...clusterVMs, otherMachine],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+      }),
+    });
+    expect(selectors.getVMs(state, cluster.id)).toStrictEqual(clusterVMs);
+  });
+
+  it("can get a filtered list of cluster VMs", () => {
+    const cluster = vmClusterFactory({
+      virtual_machines: [
+        clusterVMFactory({ system_id: "abc123" }),
+        clusterVMFactory({ system_id: "def456" }),
+      ],
+    });
+    const clusterVMs = [
+      machineFactory({ system_id: "abc123", hostname: "foo" }),
+      machineFactory({ system_id: "def456", hostname: "bar" }),
+    ];
+    const otherMachine = machineFactory({
+      system_id: "ghi789",
+      hostname: "baz",
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [...clusterVMs, otherMachine],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+      }),
+    });
+    expect(
+      selectors.getFilteredVMs(state, cluster.id, "hostname:(=foo)")
+    ).toStrictEqual([clusterVMs[0]]);
+    expect(
+      selectors.getFilteredVMs(state, cluster.id, "hostname:(ba)")
+    ).toStrictEqual([clusterVMs[1]]);
+    expect(selectors.getFilteredVMs(state, cluster.id, "")).toStrictEqual([
+      clusterVMs[0],
+      clusterVMs[1],
     ]);
   });
 });

--- a/ui/src/app/store/vmcluster/types/base.ts
+++ b/ui/src/app/store/vmcluster/types/base.ts
@@ -1,6 +1,7 @@
 import type { VMClusterMeta } from "./enum";
 
 import type { APIError } from "app/base/types";
+import type { Machine } from "app/store/machine/types";
 import type { Pod, PodPowerParameters } from "app/store/pod/types";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import type { Model } from "app/store/types/model";
@@ -32,9 +33,13 @@ export type VMHost = Model & {
   availability_zone: Zone["name"];
 };
 
-export type VirtualMachine = Model & {
+export type VirtualMachine = {
+  hugepages_backed: boolean;
   name: string;
+  pinned_cores: number[];
   project: string;
+  system_id: Machine["system_id"];
+  unpinned_cores: number;
 };
 
 export type VMCluster = Model & {

--- a/ui/src/testing/factories/vmcluster.ts
+++ b/ui/src/testing/factories/vmcluster.ts
@@ -21,9 +21,13 @@ export const vmHost = extend<Model, VMHost>(model, {
   availability_zone: "default",
 });
 
-export const virtualMachine = extend<Model, VirtualMachine>(model, {
+export const virtualMachine = define<VirtualMachine>({
+  hugepages_backed: false,
   name: "my-virtual-machine",
+  pinned_cores: [],
   project: "my-project",
+  system_id: "abc123",
+  unpinned_cores: 0,
 });
 
 export const vmClusterResource = define<VMClusterResource>({


### PR DESCRIPTION
## Done

- Added LXD cluster VMs table
- Added vmcluster selectors for getting cluster VMs and getting filtered cluster VMs

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to `/MAAS/r/kvm/lxd/cluster/1/vms` and check that the list of VMs is correct
- Check that you can filter the VMs using the normal search syntax
- Check that you can perform actions on the VMs

## Fixes

Fixes canonical-web-and-design/app-squad#362

## Screenshot
![Screenshot 2021-10-19 at 12-20-13 lxd-cluster virtual machines bolla MAAS](https://user-images.githubusercontent.com/25733845/137833264-e30886fd-fa9f-49d1-aec2-690553bfabd9.png)

