### PR TITLE
feat(ui): add cluster host settings

### DIFF
--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.tsx
@@ -38,9 +38,10 @@ export type KVMConfigurationValues = {
 
 type Props = {
   pod: PodDetails;
+  zoneDisabled?: boolean;
 };
 
-const KVMConfigurationCard = ({ pod }: Props): JSX.Element => {
+const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const podErrors = useSelector(podSelectors.errors);
   const podSaved = useSelector(podSelectors.saved);
@@ -86,7 +87,7 @@ const KVMConfigurationCard = ({ pod }: Props): JSX.Element => {
         submitLabel="Save changes"
         validationSchema={KVMConfigurationSchema}
       >
-        <KVMConfigurationCardFields />
+        <KVMConfigurationCardFields zoneDisabled={zoneDisabled} />
       </FormikForm>
     </FormCard>
   );

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.test.tsx
@@ -101,4 +101,26 @@ describe("KVMConfigurationCardFields", () => {
       wrapper.find("Slider[name='memory_over_commit_ratio']").props().value
     ).toBe(pod.memory_over_commit_ratio);
   });
+
+  it("can disable the zone field", () => {
+    const pod = podFactory({
+      id: 1,
+      power_parameters: powerParametersFactory({
+        power_address: "abc123",
+      }),
+      type: PodType.LXD,
+    });
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <KVMConfigurationCard pod={pod} zoneDisabled />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Select[name='zone']").props().disabled).toBe(true);
+  });
 });

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.tsx
@@ -14,7 +14,13 @@ import { PodType } from "app/store/pod/constants";
 import { formatHostType } from "app/store/pod/utils";
 import tagSelectors from "app/store/tag/selectors";
 
-const KVMConfigurationCardFields = (): JSX.Element => {
+type Props = {
+  zoneDisabled?: boolean;
+};
+
+const KVMConfigurationCardFields = ({
+  zoneDisabled = false,
+}: Props): JSX.Element => {
   const tags = useSelector(tagSelectors.all);
   const { setFieldValue, values } = useFormikContext<KVMConfigurationValues>();
 
@@ -28,12 +34,22 @@ const KVMConfigurationCardFields = (): JSX.Element => {
           value={formatHostType(values.type)}
           type="text"
         />
-        <ZoneSelect name="zone" required valueKey="id" />
+        <ZoneSelect
+          disabled={zoneDisabled}
+          name="zone"
+          required
+          valueKey="id"
+        />
         <ResourcePoolSelect name="pool" required valueKey="id" />
         <TagField tagList={tags.map(({ name }) => name)} />
       </Col>
       <Col size={5}>
-        <FormikField label="Address" name="power_address" type="text" />
+        <FormikField
+          disabled
+          label="Address"
+          name="power_address"
+          type="text"
+        />
         {values.type === PodType.VIRSH && (
           <FormikField
             label="Password (optional)"

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
@@ -1,0 +1,49 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import LXDClusterHostSettings from "./LXDClusterHostSettings";
+
+import KVMConfigurationCard from "app/kvm/components/KVMConfigurationCard";
+import type { RootState } from "app/store/root/types";
+import {
+  podDetails as podDetailsFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterHostSettings", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podDetailsFactory({ id: 1, name: "pod1" })],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a spinner if data is loading", () => {
+    state.pod.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <LXDClusterHostSettings clusterId={2} hostId={1} />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("has a disabled zone field", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <LXDClusterHostSettings clusterId={2} hostId={1} />
+      </Provider>
+    );
+    expect(wrapper.find(KVMConfigurationCard).prop("zoneDisabled")).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
@@ -1,6 +1,7 @@
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import KVMConfigurationCard from "app/kvm/components/KVMConfigurationCard";
 import LXDHostToolbar from "app/kvm/components/LXDHostToolbar";
 import { useActivePod } from "app/kvm/hooks";
 import podSelectors from "app/store/pod/selectors";
@@ -21,15 +22,13 @@ const LXDClusterHostSettings = ({ clusterId, hostId }: Props): JSX.Element => {
   const loading = useSelector(podSelectors.loading);
   useActivePod(hostId);
 
-  console.log("pod", pod);
-  console.log("isPodDetails(pod)", isPodDetails(pod));
-
   if (loading || !isPodDetails(pod)) {
     return <Spinner text="Loading..." />;
   }
   return (
     <Strip className="u-no-padding--top" shallow>
       <LXDHostToolbar clusterId={clusterId} hostId={hostId} showBasic />
+      <KVMConfigurationCard pod={pod} zoneDisabled />
     </Strip>
   );
 };


### PR DESCRIPTION
## Done

- Add the settings form for the cluster vm host.
- Disable the address field for the pod settings form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the settings tab for a LXD single host.
- The address field should be disabled and the zone field should be enabled.
- Go to the vm host list for a cluster and click on the cog in one of the host rows.
- You should see host header and form.
- The address and zone fields should be disabled.
- You should be able to change something and save the form (there is currently an error about the mac_address field being blank: https://bugs.launchpad.net/maas/+bug/1947656).

## Fixes

Fixes: canonical-web-and-design/app-squad#383.
Fixes: canonical-web-and-design/app-squad#405.