### PR TITLE
fix(ui): get the cluster's zone from the vmcluster

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -6,12 +6,8 @@ import configureStore from "redux-mock-store";
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
 
 import kvmURLs from "app/kvm/urls";
-import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
 import {
-  pod as podFactory,
-  podPowerParameters as powerParametersFactory,
-  podState as podStateFactory,
   rootState as rootStateFactory,
   vmCluster as vmClusterFactory,
   vmHost as vmHostFactory,
@@ -28,22 +24,13 @@ describe("LXDClusterDetailsHeader", () => {
 
   beforeEach(() => {
     const zone = zoneFactory({ id: 111, name: "danger" });
-    const pod = podFactory({
-      id: 11,
-      name: "vm-cluster",
-      power_parameters: powerParametersFactory({ project: "cluster-project" }),
-      type: PodType.LXD,
-      zone: zone.id,
-    });
     const cluster = vmClusterFactory({
+      availability_zone: zone.id,
       id: 1,
-      name: pod.name,
-      project: pod.power_parameters.project,
+      name: "vm-cluster",
+      project: "cluster-project",
     });
     state = rootStateFactory({
-      pod: podStateFactory({
-        items: [pod],
-      }),
       vmcluster: vmClusterStateFactory({
         items: [cluster],
       }),

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -11,8 +11,6 @@ import KVMDetailsHeader from "app/kvm/components/KVMDetailsHeader";
 import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
 import { getFormTitle } from "app/kvm/utils";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
@@ -36,23 +34,12 @@ const LXDClusterDetailsHeader = ({
   const cluster = useSelector((state: RootState) =>
     vmClusterSelectors.getById(state, clusterId)
   );
-  const lxdPods = useSelector(podSelectors.lxd);
-  // TODO: Replace with selector that gets the pod associated with a cluster.
-  const clusterPod =
-    (cluster &&
-      lxdPods.find(
-        (pod) =>
-          pod.name === cluster.name &&
-          pod.power_parameters.project === cluster.project
-      )) ||
-    null;
   const zone = useSelector((state: RootState) =>
-    zoneSelectors.getById(state, clusterPod?.zone)
+    zoneSelectors.getById(state, cluster?.availability_zone)
   );
   const location = useLocation();
 
   useEffect(() => {
-    dispatch(podActions.fetch());
     dispatch(zoneActions.fetch());
   }, [dispatch]);
 

--- a/ui/src/testing/factories/vmcluster.ts
+++ b/ui/src/testing/factories/vmcluster.ts
@@ -24,7 +24,7 @@ export const vmHost = extend<Model, VMHost>(model, {
 export const virtualMachine = define<VirtualMachine>({
   hugepages_backed: false,
   name: "my-virtual-machine",
-  pinned_cores: [],
+  pinned_cores: () => [],
   project: "my-project",
   system_id: "abc123",
   unpinned_cores: 0,


### PR DESCRIPTION
## Done

- Update the cluster header to get the zone from the vmcluster model.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click on a cluster.
- In the cluster details header you should see the zone.

## Fixes

Fixes: canonical-web-and-design/app-squad#403.