### PR TITLE
feat(ui): build LXD cluster summary card

### DIFF
--- a/ui/src/app/kvm/components/VfResources/VfResources.test.tsx
+++ b/ui/src/app/kvm/components/VfResources/VfResources.test.tsx
@@ -69,4 +69,18 @@ describe("VfResources", () => {
       wrapper.find("tbody tr").at(1).find("[data-test='has-no-vfs']").exists()
     ).toBe(true);
   });
+
+  it("can render as an aggregated meter", () => {
+    const wrapper = shallow(<VfResources interfaces={[]} showAggregated />);
+    expect(wrapper.find("[data-test='iface-meter']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='iface-table']").exists()).toBe(false);
+  });
+
+  it("can render as a table", () => {
+    const wrapper = shallow(
+      <VfResources interfaces={[]} showAggregated={false} />
+    );
+    expect(wrapper.find("[data-test='iface-table']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='iface-meter']").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/kvm/components/VfResources/__snapshots__/VfResources.test.tsx.snap
+++ b/ui/src/app/kvm/components/VfResources/__snapshots__/VfResources.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`VfResources renders 1`] = `
 >
   <div
     className="vf-resources__table-container"
+    data-test="iface-table"
   >
     <table
       className="vf-resources__table"

--- a/ui/src/app/kvm/components/VfResources/_index.scss
+++ b/ui/src/app/kvm/components/VfResources/_index.scss
@@ -49,6 +49,10 @@
       .vf-resources__table-container {
         flex: 3;
       }
+
+      .vf-resources__meter {
+        flex: 3;
+      }
     }
 
     @media only screen and (min-width: $breakpoint-kvm-resources-card) {
@@ -61,6 +65,10 @@
 
       .vf-resources__table-container {
         flex: 1;
+      }
+
+      .vf-resources__meter {
+        flex: 0;
       }
     }
   }

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -1,4 +1,7 @@
+import { Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+
+import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 
 import LXDClusterHostsTable from "./LXDClusterHostsTable";
 
@@ -24,7 +27,9 @@ const LXDClusterHosts = ({
 
   return (
     <>
-      {/* TODO: Add resources card */}
+      <Strip shallow>
+        <LXDClusterSummaryCard clusterId={clusterId} />
+      </Strip>
       {/* TODO: Add hosts toolbar */}
       <LXDClusterHostsTable
         clusterId={clusterId}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/LXDClusterResources.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/LXDClusterResources.tsx
@@ -1,3 +1,7 @@
+import { Strip } from "@canonical/react-components";
+
+import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
+
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
@@ -5,7 +9,12 @@ type Props = {
 };
 
 const LXDClusterResources = ({ clusterId }: Props): JSX.Element => {
-  return <h4>LXD cluster {clusterId} resources</h4>;
+  return (
+    <Strip shallow>
+      <LXDClusterSummaryCard clusterId={clusterId} showStorage={false} />
+      {/* TODO: Add generic storage cards section */}
+    </Strip>
+  );
 };
 
 export default LXDClusterResources;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
@@ -1,0 +1,100 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import LXDClusterSummaryCard from "./LXDClusterSummaryCard";
+
+import VfResources from "app/kvm/components/VfResources";
+import { PodType } from "app/store/pod/constants";
+import {
+  pod as podFactory,
+  podNetworkInterface as interfaceFactory,
+  podResources as podResourcesFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmClusterState as vmClusterStateFactory,
+  vmHost as vmHostFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterSummaryCard", () => {
+  it("can show the section for storage", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [vmClusterFactory({ id: 1 })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <LXDClusterSummaryCard clusterId={1} showStorage />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='lxd-cluster-storage']").exists()).toBe(
+      true
+    );
+  });
+
+  it("can hide the section for storage", () => {
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [vmClusterFactory({ id: 1 })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <LXDClusterSummaryCard clusterId={1} showStorage={false} />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='lxd-cluster-storage']").exists()).toBe(
+      false
+    );
+  });
+
+  it("aggregates the interfaces in the cluster hosts", () => {
+    const interfaces = [interfaceFactory(), interfaceFactory()];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 11,
+            resources: podResourcesFactory({
+              interfaces: [interfaces[0]],
+            }),
+            type: PodType.LXD,
+          }),
+          podFactory({
+            id: 22,
+            resources: podResourcesFactory({
+              interfaces: [interfaces[1]],
+            }),
+            type: PodType.LXD,
+          }),
+        ],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [
+          vmClusterFactory({
+            id: 1,
+            hosts: [vmHostFactory({ id: 11 }), vmHostFactory({ id: 22 })],
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <LXDClusterSummaryCard clusterId={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find(VfResources).prop("interfaces")).toStrictEqual(
+      interfaces
+    );
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx
@@ -1,0 +1,89 @@
+import classNames from "classnames";
+import { useSelector } from "react-redux";
+
+import CoreResources from "app/kvm/components/CoreResources";
+import RamResources from "app/kvm/components/RamResources";
+import StorageResources from "app/kvm/components/StorageResources";
+import VfResources from "app/kvm/components/VfResources";
+import podSelectors from "app/store/pod/selectors";
+import type { PodNetworkInterface } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
+import type { VMCluster } from "app/store/vmcluster/types";
+
+type Props = {
+  clusterId: VMCluster["id"];
+  showStorage?: boolean;
+};
+
+const LXDClusterSummaryCard = ({
+  clusterId,
+  showStorage = true,
+}: Props): JSX.Element | null => {
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const clusterHosts = useSelector((state: RootState) =>
+    podSelectors.lxdHostsInClusterById(state, clusterId)
+  );
+
+  if (!cluster) {
+    return null;
+  }
+
+  const { cpu, memory, storage } = cluster.total_resources;
+  const interfaces = clusterHosts.reduce<PodNetworkInterface[]>(
+    (interfaces, host) => {
+      host.resources.interfaces.forEach((hostIface) => {
+        const existingIface = interfaces.find(
+          (iface) => iface.id === hostIface.id
+        );
+        if (!existingIface) {
+          interfaces.push(hostIface);
+        }
+      });
+      return interfaces;
+    },
+    []
+  );
+  return (
+    <div
+      className={classNames("lxd-cluster-summary-card", {
+        "show-storage": showStorage,
+      })}
+    >
+      <RamResources
+        dynamicLayout
+        general={{
+          allocated: memory.general.total - memory.general.free,
+          free: memory.general.free,
+        }}
+        hugepages={{
+          allocated: memory.hugepages.total - memory.hugepages.free,
+          free: memory.hugepages.free,
+        }}
+      />
+      <CoreResources
+        cores={{
+          allocated: cpu.total - cpu.free,
+          free: cpu.free,
+        }}
+        dynamicLayout
+      />
+      {showStorage && (
+        <StorageResources
+          data-test="lxd-cluster-storage"
+          storage={{
+            allocated: storage.total - storage.free,
+            free: storage.free,
+            // TODO: Update with generic storage pool data
+            pools: [],
+          }}
+        />
+      )}
+      <VfResources dynamicLayout interfaces={interfaces} showAggregated />
+    </div>
+  );
+};
+
+export default LXDClusterSummaryCard;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/_index.scss
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/_index.scss
@@ -1,0 +1,73 @@
+@mixin LXDClusterSummaryCard {
+  .lxd-cluster-summary-card {
+    @extend %vf-is-bordered;
+    @extend %vf-bg--x-light;
+    display: grid;
+    grid-template-areas:
+      "ram ram ram ram"
+      "cor cor cor cor"
+      "vfs vfs vfs vfs";
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-rows: min-content;
+
+    &.show-storage {
+      grid-template-areas:
+        "ram ram ram ram"
+        "cor cor cor cor"
+        "sto sto sto sto"
+        "vfs vfs vfs vfs";
+    }
+
+    .ram-resources {
+      grid-area: ram;
+    }
+
+    .core-resources {
+      border-top: $border;
+      grid-area: cor;
+    }
+
+    .storage-resources {
+      border-top: $border;
+      grid-area: sto;
+    }
+
+    .vf-resources {
+      border-top: $border;
+      grid-area: vfs;
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      grid-template-areas:
+        "ram ram ram ram ram ram"
+        "cor cor cor cor cor cor"
+        "vfs vfs vfs vfs vfs vfs";
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+
+      &.show-storage {
+        grid-template-areas:
+          "ram ram ram ram ram ram"
+          "cor cor cor cor cor cor"
+          "vfs vfs vfs vfs vfs vfs"
+          "sto sto sto sto sto sto";
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-kvm-resources-card) {
+      grid-template-areas: "ram cor vfs";
+      grid-template-columns: 1fr 1fr 1fr;
+
+      &.show-storage {
+        grid-template-areas: "ram cor sto vfs";
+        grid-template-columns: 26fr 20fr 22fr 20fr;
+      }
+
+      .core-resources,
+      .storage-resources,
+      .vf-resources {
+        border-left: $border;
+        border-top: 0;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/index.ts
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LXDClusterSummaryCard";

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -1,4 +1,7 @@
+import { Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+
+import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
@@ -34,7 +37,9 @@ const LXDClusterVMs = ({
   }
   return (
     <>
-      {/* TODO: Add LXD cluster resource card */}
+      <Strip shallow>
+        <LXDClusterSummaryCard clusterId={clusterId} />
+      </Strip>
       <LXDVMsTable
         getResources={(machine) => {
           const vmInCluster =

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -144,6 +144,7 @@
 @import "~app/kvm/views/KVMList/LxdTable/LxdKVMHostTable";
 @import "~app/kvm/views/KVMList/VirshTable";
 @import "~app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable";
+@import "~app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard";
 @include CoreResources;
 @include CPUPopover;
 @include KVMComposeInterfacesTable;
@@ -154,6 +155,7 @@
 @include KVMStorageCards;
 @include KVMSubnetSelect;
 @include LXDClusterHostsTable;
+@include LXDClusterSummaryCard;
 @include LXDHostToolbar;
 @include LxdKVMHostTable;
 @include LXDVMsSummaryCard;


### PR DESCRIPTION
## Done

- Built LXDClusterSummaryCard which shows in the VM hosts, Virtual machines and Resources tabs of a cluster
- Currently missing the storage cards because it needs to be made generic first

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to `/MAAS/r/kvm/lxd/cluster/1/hosts` and check that the summary card matches the [wireframe](https://www.figma.com/file/QNQ3ZsYLR0tamnFzCo8VP6/%5B21.10%5D-LXD-Clusters?node-id=340%3A8982) and the data is correct)
- Go to the Virtual machines tab and check that the card does not change
- Go to the Resources tab and check that the storage section no longer shows in the card

## Fixes

Fixes canonical-web-and-design/app-squad#323

## Screenshots
### Default
![Screenshot 2021-10-19 at 15-06-23 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/137847604-f30048e8-adbe-4209-b457-34a8be9f86d3.png)


### Without storage
![Screenshot 2021-10-19 at 15-06-28 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/137847611-b5b3fb51-ec45-44a1-b033-96ee773ff114.png)

