### PR TITLE
feat(ui): add VM host column to cluster VM list

### DIFF
--- a/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
@@ -21,6 +21,7 @@ describe("LXDVMsTable", () => {
         >
           <LXDVMsTable
             getResources={jest.fn()}
+            onRefreshClick={jest.fn()}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}
@@ -45,6 +46,7 @@ describe("LXDVMsTable", () => {
         >
           <LXDVMsTable
             getResources={jest.fn()}
+            onRefreshClick={jest.fn()}
             searchFilter=""
             setSearchFilter={jest.fn()}
             setHeaderContent={jest.fn()}

--- a/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 
 import VMsActionBar from "./VMsActionBar";
 import VMsTable from "./VMsTable";
-import type { GetResources } from "./VMsTable/VMsTable";
+import type { GetHostColumn, GetResources } from "./VMsTable/VMsTable";
 
 import type { SetSearchFilter } from "app/base/types";
 import type { KVMSetHeaderContent } from "app/kvm/types";
@@ -12,6 +12,7 @@ import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
 
 type Props = {
+  getHostColumn?: GetHostColumn;
   getResources: GetResources;
   onRefreshClick: () => void;
   searchFilter: string;
@@ -23,6 +24,7 @@ type Props = {
 export const VMS_PER_PAGE = 10;
 
 const LXDVMsTable = ({
+  getHostColumn,
   getResources,
   onRefreshClick,
   searchFilter,
@@ -55,6 +57,7 @@ const LXDVMsTable = ({
       />
       <VMsTable
         currentPage={currentPage}
+        getHostColumn={getHostColumn}
         getResources={getResources}
         searchFilter={searchFilter}
         vms={vms}

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -244,4 +244,48 @@ describe("VMsTable", () => {
       "No VMs in this VM host match the search criteria."
     );
   });
+
+  it("renders a column for the host if function provided to render it", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable
+            currentPage={1}
+            getHostColumn={jest.fn()}
+            getResources={getResources}
+            searchFilter=""
+            vms={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='host-column']").exists()).toBe(true);
+  });
+
+  it("does not render a column for the host if no function provided to render it", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable
+            currentPage={1}
+            getHostColumn={undefined}
+            getResources={getResources}
+            searchFilter=""
+            vms={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='host-column']").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/_index.scss
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/_index.scss
@@ -1,22 +1,25 @@
 @mixin VMsTable {
   .vms-table {
     .name-col {
-      @include breakpoint-widths(40%, 40%, 18%, 18%, 15%);
+      @include breakpoint-widths(50%, 30%, 17%, 16%, 14%);
     }
     .status-col {
-      @include breakpoint-widths(60%, 60%, 22%, 20%, 17%);
+      @include breakpoint-widths(0, 40%, 19%, 18%, 16%);
+    }
+    .host-col {
+      @include breakpoint-widths(50%, 30%, 15%, 14%, 12%);
     }
     .ipv4-col {
-      @include breakpoint-widths(0, 0, 20%, 19%, 16%);
+      @include breakpoint-widths(0, 0, 16%, 14%, 12%);
     }
     .ipv6-col {
-      @include breakpoint-widths(0, 0, 40%, 31%, 29%);
+      @include breakpoint-widths(0, 0, 35%, 27%, 25%);
     }
     .hugepages-col {
       @include breakpoint-widths(0, 0, 0, 0, 6rem);
     }
     .cores-col {
-      @include breakpoint-widths(0, 0, 0, 12%, 10%);
+      @include breakpoint-widths(0, 0, 0, 11%, 9%);
     }
     .ram-col {
       @include breakpoint-widths(0, 0, 0, 4.5rem, 4.5rem);
@@ -25,7 +28,7 @@
       @include breakpoint-widths(0, 0, 0, 4.5rem, 4.5rem);
     }
     .pool-col {
-      @include breakpoint-widths(0, 0, 0, 0, 13%);
+      @include breakpoint-widths(0, 0, 0, 0, 12%);
     }
   }
 }

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
@@ -9,6 +9,7 @@ import LXDVMsTable from "app/kvm/components/LXDVMsTable";
 import kvmURLs from "app/kvm/urls";
 import {
   machine as machineFactory,
+  machineState as machineStateFactory,
   rootState as rootStateFactory,
   virtualMachine as clusterVMFactory,
   vmCluster as vmClusterFactory,
@@ -67,5 +68,50 @@ describe("LXDClusterVMs", () => {
       pinnedCores: [2],
       unpinnedCores: 3,
     });
+  });
+
+  it("renders a link to a cluster's host's VM page", () => {
+    const machine = machineFactory({
+      pod: { id: 11, name: "podrick" },
+      system_id: "abc123",
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [
+          vmClusterFactory({
+            id: 1,
+            virtual_machines: [clusterVMFactory({ system_id: "abc123" })],
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.vms.index({ clusterId: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDClusterVMs
+            clusterId={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Link[data-test='host-link']").prop("to")).toBe(
+      kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 11 })
+    );
   });
 });

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -1,5 +1,6 @@
 import { Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 
@@ -7,6 +8,7 @@ import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import LXDVMsTable from "app/kvm/components/LXDVMsTable";
 import type { KVMSetHeaderContent } from "app/kvm/types";
+import kvmURLs from "app/kvm/urls";
 import type { RootState } from "app/store/root/types";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
@@ -41,6 +43,22 @@ const LXDClusterVMs = ({
         <LXDClusterSummaryCard clusterId={clusterId} />
       </Strip>
       <LXDVMsTable
+        getHostColumn={(machine) => {
+          if (machine.pod) {
+            return (
+              <Link
+                data-test="host-link"
+                to={kvmURLs.lxd.cluster.vms.host({
+                  clusterId,
+                  hostId: machine.pod.id,
+                })}
+              >
+                {machine.pod.name}
+              </Link>
+            );
+          }
+          return "";
+        }}
         getResources={(machine) => {
           const vmInCluster =
             cluster?.virtual_machines.find(


### PR DESCRIPTION
## Done

- Added a column for VM host in the cluster VM list

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to `/MAAS/r/kvm/lxd/cluster/1/vms`
- Check that there is a column for "VM host"
- Click one of the VM host names and check that you get taken to the VM list for that VM host
- Check that this VM list does not have a VM host column

## Fixes

Fixes canonical-web-and-design/app-squad#311

## Screenshot
![Screenshot 2021-10-19 at 17-47-48 lxd-cluster virtual machines bolla MAAS](https://user-images.githubusercontent.com/25733845/137867087-67f90fae-e199-4a5d-b6fb-9398226e4ce8.png)

