### PR TITLE
feat(ui): rename LXD single host settings tab to "VM host settings"

### DIFF
--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
@@ -76,7 +76,7 @@ const LXDSingleDetailsHeader = ({
         {
           active: location.pathname.endsWith(kvmURLs.lxd.single.edit({ id })),
           component: Link,
-          label: "Settings",
+          label: "VM host settings",
           to: kvmURLs.lxd.single.edit({ id }),
         },
       ]}


### PR DESCRIPTION
## Done

- Renamed "Settings" to "VM host settings" for LXD single hosts

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Code check should be enough

## Fixes

Fixes canonical-web-and-design/app-squad#404

