### PR TITLE
fix(ui): remove the white background from host table buttons

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
@@ -130,7 +130,7 @@ const generateRows = (
           content: (
             <div className="u-flex--end">
               <Button
-                className="u-no-margin"
+                className="no-background u-no-margin"
                 hasIcon
                 data-test="vm-host-compose"
                 onClick={() =>
@@ -144,7 +144,7 @@ const generateRows = (
               </Button>
               <div className="u-nudge-right--small">
                 <Button
-                  className="u-no-margin"
+                  className="no-background u-no-margin"
                   data-test="vm-host-settings"
                   element={Link}
                   hasIcon

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -57,6 +57,10 @@
     }
   }
 
+  [class*="p-button"].no-background {
+    background-color: transparent;
+  }
+
   table .p-button--link {
     margin: 0;
     padding-bottom: 0;


### PR DESCRIPTION
## Done

- Remove the white background from the config and compose buttons in the cluster host table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the kvm list and click on a cluster.
- In the list of VM hosts the cog and plus icons should have a grey backround.
 
## Fixes

Fixes: canonical-web-and-design/app-squad#408.

## Screenshots

<img width="328" alt="Screen Shot 2021-10-20 at 11 59 37 am" src="https://user-images.githubusercontent.com/361637/138010989-144ab471-12c1-467f-9a11-692e6aa3df7d.png">
