### PR TITLE
feat(ui): move the host settings link under the title

### DIFF
--- a/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
+++ b/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
@@ -62,24 +62,29 @@ const LXDHostToolbar = ({
   return (
     <div className="lxd-host-toolbar">
       <div className="lxd-host-toolbar__title">
-        <h2 className="p-heading--4" data-test="toolbar-title">
+        <h2
+          className="p-heading--4 u-no-margin--bottom u-no-padding--top"
+          data-test="toolbar-title"
+        >
           {title ? title : pod.name}
         </h2>
-        <span className="u-nudge-left--small u-nudge-right--small">
-          {inClusterView && !showBasic && (
+        {inClusterView && !showBasic && (
+          <div className="u-nudge-up--x-small">
+            <Link to={kvmURLs.lxd.cluster.host.edit({ clusterId, hostId })}>
+              <Icon name="settings" />
+            </Link>{" "}
             <Button
-              appearance="base"
+              appearance="link"
               data-test="settings-link"
               element={Link}
-              hasIcon
               to={kvmURLs.lxd.cluster.host.edit({ clusterId, hostId })}
             >
-              <Icon name="settings" />
+              Host settings
             </Button>
-          )}
-        </span>
+          </div>
+        )}
       </div>
-      <div className="lxd-host-toolbar__blocks p-divider">
+      <div className="lxd-host-toolbar__blocks p-divider u-nudge-down--x-small">
         <div className="p-divider__block" data-test="lxd-version">
           <p className="u-text--muted u-no-margin u-no-padding">LXD version:</p>
           <p className="u-no-margin u-no-padding">{pod.version}</p>

--- a/ui/src/app/kvm/components/LXDHostToolbar/_index.scss
+++ b/ui/src/app/kvm/components/LXDHostToolbar/_index.scss
@@ -11,8 +11,6 @@
   }
 
   .lxd-host-toolbar__title {
-    display: flex;
-    flex-direction: column;
     flex-shrink: 0;
     margin-right: $sph-outer;
   }
@@ -21,14 +19,12 @@
     display: flex;
     flex-direction: column;
   }
-  
+
   @media only screen and (min-width: $breakpoint-medium) {
-    .lxd-host-toolbar__blocks,
-    .lxd-host-toolbar__title {
+    .lxd-host-toolbar__blocks {
       flex-direction: row;
     }
   }
-
 
   @media only screen and (min-width: $breakpoint-kvm-resources-card) {
     .lxd-host-toolbar {

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -125,6 +125,10 @@
     padding-left: $sp-x-small !important;
   }
 
+  .u-nudge-up--x-small {
+    margin-top: -$sp-x-small !important;
+  }
+
   .u-rotate-left {
     transform: rotate(-90deg) !important;
   }


### PR DESCRIPTION




## Done

- Update the vm host settings link to be under the title.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list.
- Click on a cluster.
- Click on a vm host.
- You should see the vm host title and under the title should be the settings link as seen in [the design](https://www.figma.com/file/QNQ3ZsYLR0tamnFzCo8VP6/%5B21.10%5D-LXD-Clusters?node-id=340%3A8982).

## Fixes

Fixes: canonical-web-and-design/app-squad#416.

## Screenshots

<img width="791" alt="Screen Shot 2021-10-20 at 2 02 20 pm" src="https://user-images.githubusercontent.com/361637/138021299-3d2821c2-df32-4fc1-a900-b3fe06bc02cb.png">
