### PR TITLE
feat(ui): add storage pool information to LXD cluster components

### DIFF
--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.test.tsx
@@ -16,7 +16,7 @@ import {
 const mockStore = configureStore();
 
 describe("StorageColumn", () => {
-  it("displays correct storage information", () => {
+  it("displays correct storage information for a pod", () => {
     const pod = podFactory({
       id: 1,
       name: "pod-1",

--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
@@ -7,22 +7,29 @@ import type { KVMResource } from "app/kvm/types";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod, PodMeta } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import type { VMCluster, VMClusterMeta } from "app/store/vmcluster/types";
 import { formatBytes } from "app/utils";
 
 type Props = {
+  clusterId?: VMCluster[VMClusterMeta.PK];
   defaultPoolID?: Pod["default_storage_pool"];
   podId?: Pod[PodMeta.PK];
   storage: KVMResource;
 };
 
 const StorageColumn = ({
+  clusterId,
   defaultPoolID,
   podId,
   storage,
 }: Props): JSX.Element | null => {
-  const sortedPools = useSelector((state: RootState) =>
-    podSelectors.getSortedPools(state, Number(podId))
+  const sortedClusterPools = useSelector((state: RootState) =>
+    podSelectors.getSortedClusterPools(state, clusterId ?? null)
   );
+  const sortedPodPools = useSelector((state: RootState) =>
+    podSelectors.getSortedPools(state, podId ?? null)
+  );
+  const pools = clusterId !== undefined ? sortedClusterPools : sortedPodPools;
 
   let totalInBytes = 0;
   let allocated = 0;
@@ -60,12 +67,10 @@ const StorageColumn = ({
     />
   );
 
-  return sortedPools && defaultPoolID ? (
-    <StoragePopover defaultPoolID={defaultPoolID} pools={sortedPools}>
+  return (
+    <StoragePopover defaultPoolID={defaultPoolID} pools={pools}>
       {meter}
     </StoragePopover>
-  ) : (
-    meter
   );
 };
 

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
@@ -14,7 +14,8 @@ import StorageColumn from "app/kvm/components/StorageColumn";
 import TagsColumn from "app/kvm/components/TagsColumn";
 import VMsColumn from "app/kvm/components/VMsColumn";
 import type { KVMResource } from "app/kvm/types";
-import type { Pod } from "app/store/pod/types";
+import type { Pod, PodMeta } from "app/store/pod/types";
+import type { VMCluster, VMClusterMeta } from "app/store/vmcluster/types";
 import zoneSelectors from "app/store/zone/selectors";
 import type { Zone } from "app/store/zone/types";
 import { isComparable } from "app/utils";
@@ -25,6 +26,7 @@ export enum LxdKVMHostType {
 }
 
 export type LxdKVMHostTableRow = {
+  clusterId?: VMCluster[VMClusterMeta.PK];
   cpuCores: KVMResource;
   cpuOverCommit?: number;
   defaultPoolID?: Pod["default_storage_pool"];
@@ -34,7 +36,7 @@ export type LxdKVMHostTableRow = {
   memory: RAMColumnProps["memory"];
   memoryOverCommit?: number;
   name: string;
-  podId?: Pod["id"];
+  podId?: Pod[PodMeta.PK];
   pool?: number | null;
   project?: string;
   storage: KVMResource;
@@ -140,6 +142,7 @@ const generateRows = (rows: LxdKVMHostTableRow[]) =>
           className: "storage-col",
           content: (
             <StorageColumn
+              clusterId={row.clusterId}
               defaultPoolID={row.defaultPoolID}
               podId={row.podId}
               storage={row.storage}

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
@@ -38,6 +38,7 @@ export const generateClusterRows = (
   vmclusters: VMCluster[]
 ): LxdKVMHostTableRow[] =>
   vmclusters.map((vmcluster) => ({
+    clusterId: vmcluster.id,
     cpuCores: vmcluster.total_resources.cpu,
     hostType: LxdKVMHostType.Cluster,
     hostsCount: vmcluster.hosts.length,

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/LXDClusterResources.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterResources/LXDClusterResources.tsx
@@ -1,7 +1,13 @@
 import { Strip } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 
+import { useWindowTitle } from "app/base/hooks";
+import KVMStorageCards from "app/kvm/components/KVMStorageCards";
+import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
@@ -9,11 +15,23 @@ type Props = {
 };
 
 const LXDClusterResources = ({ clusterId }: Props): JSX.Element => {
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const sortedPools = useSelector((state: RootState) =>
+    podSelectors.getSortedClusterPools(state, clusterId)
+  );
+  useWindowTitle(`${cluster?.name || "Cluster"} resources`);
+
   return (
-    <Strip shallow>
-      <LXDClusterSummaryCard clusterId={clusterId} showStorage={false} />
-      {/* TODO: Add generic storage cards section */}
-    </Strip>
+    <>
+      <Strip shallow>
+        <LXDClusterSummaryCard clusterId={clusterId} showStorage={false} />
+      </Strip>
+      <Strip shallow>
+        <KVMStorageCards pools={sortedPools} />
+      </Strip>
+    </>
   );
 };
 

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx
@@ -26,6 +26,9 @@ const LXDClusterSummaryCard = ({
   const clusterHosts = useSelector((state: RootState) =>
     podSelectors.lxdHostsInClusterById(state, clusterId)
   );
+  const sortedPools = useSelector((state: RootState) =>
+    podSelectors.getSortedClusterPools(state, clusterId)
+  );
 
   if (!cluster) {
     return null;
@@ -76,8 +79,7 @@ const LXDClusterSummaryCard = ({
           storage={{
             allocated: storage.total - storage.free,
             free: storage.free,
-            // TODO: Update with generic storage pool data
-            pools: [],
+            pools: sortedPools,
           }}
         />
       )}


### PR DESCRIPTION
## Done

- Added a selector for getting sorted storage pools in a cluster and used in a few cluster components

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to the LXD KVM list
- Hover over the storage meter for the cluster (`lxd-cluster`) and check that a storage popover shows up
- Go to the details page of the cluster and check that a storage section shows in the main summary card
- Go to the resources tab of the cluster and check that a list of storage cards shows underneath the main summary card

## Fixes

Fixes canonical-web-and-design/app-squad#414
Fixes canonical-web-and-design/app-squad#415

## Screenshots
### LXD list
![2021-10-21_11-30](https://user-images.githubusercontent.com/25733845/138196155-2b9f049e-95ff-4499-9cab-a54bf2e213e0.png)


### Cluster summary card
![2021-10-21_11-30_1](https://user-images.githubusercontent.com/25733845/138196175-22950226-9a77-429b-9bbb-029576cf9d4f.png)


### Cluster resources tab
![2021-10-21_11-30_2](https://user-images.githubusercontent.com/25733845/138196185-3a1c84ee-8632-45b0-80e4-0a6c21f267bd.png)

