### PR TITLE
feat(ui): add ability to refresh all hosts in a cluster

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
@@ -16,6 +16,7 @@ import StorageTable from "./StorageTable";
 import ActionForm from "app/base/components/ActionForm";
 import type { ClearHeaderContent } from "app/base/types";
 import { RANGE_REGEX } from "app/base/validation";
+import { useActivePod } from "app/kvm/hooks";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import { actions as fabricActions } from "app/store/fabric";
@@ -26,7 +27,11 @@ import { actions as messageActions } from "app/store/message";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
-import { getCoreIndices, resourceWithOverCommit } from "app/store/pod/utils";
+import {
+  getCoreIndices,
+  isPodDetails,
+  resourceWithOverCommit,
+} from "app/store/pod/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import type { ResourcePool } from "app/store/resourcepool/types";
@@ -200,6 +205,7 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
   const zonesLoaded = useSelector(zoneSelectors.loaded);
   const [machineName, setMachineName] = useState("");
   const cleanup = useCallback(() => podActions.cleanup(), []);
+  useActivePod(hostId);
 
   useEffect(() => {
     dispatch(domainActions.fetch());
@@ -223,7 +229,7 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
     vlansLoaded &&
     zonesLoaded;
 
-  if (!!pod && "boot_vlans" in pod && loaded) {
+  if (isPodDetails(pod) && loaded) {
     const powerType = powerTypes.find((type) => type.name === pod.type);
     const { cpu_over_commit_ratio, memory_over_commit_ratio, resources } = pod;
     const { cores, memory } = resources;

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
 
-import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -30,7 +29,7 @@ const RefreshForm = ({
       clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{}}
-      modelName={pluralize("KVM", hostIds.length)}
+      modelName="KVM"
       onSaveAnalytics={{
         action: "Submit",
         category: "KVM details action form",
@@ -42,7 +41,7 @@ const RefreshForm = ({
         });
       }}
       processingCount={refreshing.length}
-      selectedCount={refreshing.length}
+      selectedCount={hostIds.length}
     >
       <p>
         Refreshing KVMs will cause MAAS to recalculate usage metrics, update

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
@@ -5,6 +5,7 @@ import { Redirect } from "react-router-dom";
 import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import LXDHostVMs from "app/kvm/components/LXDHostVMs";
+import { KVMHeaderViews } from "app/kvm/constants";
 import { useActivePod, useKVMDetailsRedirect } from "app/kvm/hooks";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import podSelectors from "app/store/pod/selectors";
@@ -51,8 +52,12 @@ const LXDClusterHostVMs = ({
       clusterId={clusterId}
       hostId={hostId}
       onRefreshClick={() => {
-        // TODO: Open cluster refresh form.
-        return null;
+        if (cluster.hosts.length) {
+          setHeaderContent({
+            view: KVMHeaderViews.REFRESH_KVM,
+            extras: { hostIds: cluster.hosts.map((host) => host.id) },
+          });
+        }
       }}
       searchFilter={searchFilter}
       setSearchFilter={setSearchFilter}

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
@@ -146,7 +146,7 @@ const generateRows = (
               </Button>
               <div className="u-nudge-right--small">
                 <Link
-                  className="p-button--neutral has-icon u-no-margin"
+                  className="p-button--neutral no-background has-icon u-no-margin"
                   data-test="vm-host-settings"
                   to={{
                     pathname: kvmURLs.lxd.cluster.host.edit({

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -7,6 +7,7 @@ import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import LXDVMsTable from "app/kvm/components/LXDVMsTable";
+import { KVMHeaderViews } from "app/kvm/constants";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
 import type { RootState } from "app/store/root/types";
@@ -71,8 +72,12 @@ const LXDClusterVMs = ({
           };
         }}
         onRefreshClick={() => {
-          // TODO: Open cluster refresh form.
-          return null;
+          if (cluster.hosts.length) {
+            setHeaderContent({
+              view: KVMHeaderViews.REFRESH_KVM,
+              extras: { hostIds: cluster.hosts.map((host) => host.id) },
+            });
+          }
         }}
         searchFilter={searchFilter}
         setSearchFilter={setSearchFilter}


### PR DESCRIPTION
## Done

- Open the refresh form with all cluster host ids when in LXD cluster details pages

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to the lxd-cluster details page and go to the Virtual machines tab
- Click the refresh icon and submit the form
- Check that the hosts get refreshed successfully
- Go to the VM list of a host in the cluster (i.e. click "KVM hosts" then click "karura") and check that clicking the refresh icon here also opens the refresh form

## Fixes

Fixes canonical-web-and-design/app-squad#328
