### PR TITLE
feat(ui): add a form to delete a cluster

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -12,13 +12,16 @@ import {
   podStatus as podStatusFactory,
   podStatuses as podStatusesFactory,
   rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmClusterState as vmClusterStateFactory,
+  vmClusterStatuses as vmClusterStatusesFactory,
 } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
 describe("DeleteForm", () => {
-  it("can show the processing status when deleting the given KVM", async () => {
+  it("can show the processing status when deleting the given pod", async () => {
     const pod = podFactory({ id: 1 });
     const state = rootStateFactory({
       pod: podStateFactory({
@@ -44,6 +47,32 @@ describe("DeleteForm", () => {
     );
   });
 
+  it("can show the processing status when deleting the given cluster", async () => {
+    const cluster = vmClusterFactory({ id: 1 });
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+        statuses: vmClusterStatusesFactory({
+          deleting: true,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Formik").simulate("submit");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="saving-label"]').text()).toBe(
+      "Removing cluster..."
+    );
+  });
+
   it("shows a decompose checkbox if deleting a LXD pod", async () => {
     const pod = podFactory({ id: 1, type: PodType.LXD });
     const state = rootStateFactory({
@@ -59,6 +88,28 @@ describe("DeleteForm", () => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
           <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("FormikField[name='decompose']").exists()).toBe(true);
+  });
+
+  it("shows a decompose checkbox if deleting a cluster", async () => {
+    const cluster = vmClusterFactory({ id: 1 });
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+        statuses: vmClusterStatusesFactory({
+          deleting: false,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
         </MemoryRouter>
       </Provider>
     );
@@ -121,6 +172,44 @@ describe("DeleteForm", () => {
         params: {
           decompose: false,
           id: pod.id,
+        },
+      },
+    });
+  });
+
+  it("correctly dispatches actions to delete a cluster", async () => {
+    const cluster = vmClusterFactory({ id: 1 });
+    const state = rootStateFactory({
+      vmcluster: vmClusterStateFactory({
+        items: [cluster],
+        statuses: vmClusterStatusesFactory({
+          deleting: false,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("Formik").simulate("submit");
+    await waitForComponentToPaint(wrapper);
+    expect(
+      store.getActions().find((action) => action.type === "vmcluster/delete")
+    ).toStrictEqual({
+      type: "vmcluster/delete",
+      meta: {
+        model: "vmcluster",
+        method: "delete",
+      },
+      payload: {
+        params: {
+          decompose: false,
+          id: cluster.id,
         },
       },
     });

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -10,8 +10,11 @@ import type { ClearHeaderContent } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/constants";
 import podSelectors from "app/store/pod/selectors";
-import type { Pod } from "app/store/pod/types";
+import type { Pod, PodMeta } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import { actions as vmClusterActions } from "app/store/vmcluster";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
+import type { VMCluster, VMClusterMeta } from "app/store/vmcluster/types";
 
 type DeleteFormValues = {
   decompose: boolean;
@@ -19,7 +22,8 @@ type DeleteFormValues = {
 
 type Props = {
   clearHeaderContent: ClearHeaderContent;
-  hostId: Pod["id"];
+  clusterId?: VMCluster[VMClusterMeta.PK] | null;
+  hostId?: Pod[PodMeta.PK] | null;
 };
 
 const DeleteFormSchema = Yup.object().shape({
@@ -28,72 +32,94 @@ const DeleteFormSchema = Yup.object().shape({
 
 const DeleteForm = ({
   clearHeaderContent,
+  clusterId,
   hostId,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, hostId)
   );
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
   const errors = useSelector(podSelectors.errors);
-  const deleting = useSelector(podSelectors.deleting);
+  const podsDeleting = useSelector(podSelectors.deleting);
+  const clusterDeleting = useSelector((state: RootState) =>
+    vmClusterSelectors.status(state, "deleting")
+  );
   const cleanup = useCallback(() => podActions.cleanup(), []);
+  const showRemoveMessage = (pod && pod.type === PodType.LXD) || cluster;
+  const clusterDeletingCount = clusterDeleting ? 1 : 0;
+  const deletingCount = pod ? podsDeleting.length : clusterDeletingCount;
 
-  if (pod) {
-    return (
-      <ActionForm<DeleteFormValues>
-        actionName="remove"
-        allowAllEmpty
-        allowUnchanged
-        cleanup={cleanup}
-        clearHeaderContent={clearHeaderContent}
-        errors={errors}
-        initialValues={{
-          decompose: false,
-        }}
-        modelName="KVM"
-        onSaveAnalytics={{
-          action: "Submit",
-          category: "KVM details action form",
-          label: "Remove KVM",
-        }}
-        onSubmit={(values: DeleteFormValues) => {
-          const params = {
-            decompose: values.decompose,
-            id: pod.id,
-          };
-          dispatch(podActions.delete(params));
-        }}
-        processingCount={deleting.length}
-        selectedCount={deleting.length}
-        submitAppearance="negative"
-        validationSchema={DeleteFormSchema}
-      >
-        {pod && pod.type === PodType.LXD && (
-          <Strip shallow>
-            <Col size={6}>
-              <p>
-                <Icon className="is-inline" name="warning" />
-                Once a KVM is removed, you can still access all VMs in this
-                project from the LXD server.
-              </p>
-              <FormikField
-                label={
-                  <>
-                    Selecting this option will delete all VMs in{" "}
-                    <strong>{pod.name}</strong> along with their storage.
-                  </>
-                }
-                name="decompose"
-                type="checkbox"
-                wrapperClassName="u-nudge-right--large"
-              />
-            </Col>
-          </Strip>
-        )}
-      </ActionForm>
-    );
+  if (!pod && !cluster) {
+    return null;
   }
-  return null;
+
+  return (
+    <ActionForm<DeleteFormValues>
+      actionName="remove"
+      allowAllEmpty
+      allowUnchanged
+      cleanup={cleanup}
+      clearHeaderContent={clearHeaderContent}
+      errors={errors}
+      initialValues={{
+        decompose: false,
+      }}
+      modelName={pod ? "KVM" : "cluster"}
+      onSaveAnalytics={{
+        action: "Submit",
+        category: "KVM details action form",
+        label: `Remove ${pod ? "KVM" : "cluster"}`,
+      }}
+      onSubmit={(values: DeleteFormValues) => {
+        if (pod) {
+          dispatch(
+            podActions.delete({
+              decompose: values.decompose,
+              id: pod.id,
+            })
+          );
+        } else if (cluster) {
+          dispatch(
+            vmClusterActions.delete({
+              decompose: values.decompose,
+              id: cluster.id,
+            })
+          );
+        }
+      }}
+      processingCount={deletingCount}
+      selectedCount={deletingCount}
+      submitAppearance="negative"
+      validationSchema={DeleteFormSchema}
+    >
+      {showRemoveMessage && (
+        <Strip shallow>
+          <Col size={6}>
+            <p>
+              <Icon className="is-inline" name="warning" />
+              Once a {pod ? "KVM" : "cluster"} is removed, you can still access
+              all VMs in this {pod ? "project" : "cluster"} from the LXD server.
+            </p>
+            <FormikField
+              label={
+                <>
+                  Selecting this option will delete all VMs in{" "}
+                  <strong>{pod?.name || cluster?.name}</strong> along with their
+                  storage.
+                </>
+              }
+              name="decompose"
+              type="checkbox"
+              wrapperClassName="u-nudge-right--large"
+            />
+          </Col>
+        </Strip>
+      )}
+    </ActionForm>
+  );
 };
 
 export default DeleteForm;

--- a/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -18,10 +18,10 @@ import {
 const mockStore = configureStore();
 
 describe("KVMHeaderForms", () => {
-  let initialState = rootStateFactory();
+  let state = rootStateFactory();
 
   beforeEach(() => {
-    initialState = rootStateFactory({
+    state = rootStateFactory({
       pod: podStateFactory({
         items: [
           podFactory({ id: 1, name: "pod-1", type: PodType.LXD }),
@@ -36,7 +36,6 @@ describe("KVMHeaderForms", () => {
   });
 
   it("does not render if headerContent is not defined", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -51,7 +50,6 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders AddLxd if Add LXD host header content provided", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -68,7 +66,6 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders AddVirsh if Add Virsh host header content provided", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -85,7 +82,6 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders ComposeForm if Compose header content and host id provided", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -104,7 +100,6 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders DeleteForm if delete header content and host id provided", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -122,8 +117,25 @@ describe("KVMHeaderForms", () => {
     expect(wrapper.find("DeleteForm").exists()).toBe(true);
   });
 
+  it("renders DeleteForm if delete header content and cluster id provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMHeaderForms
+            headerContent={{
+              view: KVMHeaderViews.DELETE_KVM,
+              extras: { clusterId: 1 },
+            }}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("DeleteForm").exists()).toBe(true);
+  });
+
   it("renders RefreshForm if refresh header content and host ids provided", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -142,7 +154,6 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders machine action forms if a machine action is selected", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -37,28 +37,34 @@ const getFormComponent = (
     return <AddVirsh clearHeaderContent={clearHeaderContent} />;
   }
 
+  // The following forms require that a host or cluster id be passed to it.
+  const hostId =
+    headerContent.extras && "hostId" in headerContent.extras
+      ? headerContent.extras.hostId
+      : null;
+  const clusterId =
+    headerContent.extras && "clusterId" in headerContent.extras
+      ? headerContent.extras.clusterId
+      : null;
   if (
-    headerContent.extras &&
-    "hostId" in headerContent.extras &&
-    headerContent.extras.hostId !== undefined
+    headerContent.view === KVMHeaderViews.COMPOSE_VM &&
+    (hostId || hostId === 0)
   ) {
-    // The following forms require that a host id be passed to it.
-    const { hostId } = headerContent.extras;
-    switch (headerContent.view) {
-      case KVMHeaderViews.COMPOSE_VM:
-        return (
-          <ComposeForm
-            clearHeaderContent={clearHeaderContent}
-            hostId={hostId}
-          />
-        );
-      case KVMHeaderViews.DELETE_KVM:
-        return (
-          <DeleteForm clearHeaderContent={clearHeaderContent} hostId={hostId} />
-        );
-      default:
-        return null;
-    }
+    return (
+      <ComposeForm clearHeaderContent={clearHeaderContent} hostId={hostId} />
+    );
+  }
+  if (
+    headerContent.view === KVMHeaderViews.DELETE_KVM &&
+    (hostId || hostId === 0 || clusterId || clusterId === 0)
+  ) {
+    return (
+      <DeleteForm
+        clearHeaderContent={clearHeaderContent}
+        clusterId={clusterId}
+        hostId={hostId}
+      />
+    );
   }
 
   if (

--- a/ui/src/app/kvm/types.ts
+++ b/ui/src/app/kvm/types.ts
@@ -3,14 +3,19 @@ import type { KVMHeaderViews } from "./constants";
 import type { HeaderContent, SetHeaderContent } from "app/base/types";
 import type { MachineHeaderContent } from "app/machines/types";
 import type { Pod, PodResource } from "app/store/pod/types";
-import type { VMClusterResource } from "app/store/vmcluster/types";
+import type {
+  VMCluster,
+  VMClusterMeta,
+  VMClusterResource,
+} from "app/store/vmcluster/types";
 
 type HeaderViews = typeof KVMHeaderViews;
 
 export type KVMHeaderContent =
+  | HeaderContent<HeaderViews["COMPOSE_VM"], { hostId?: Pod["id"] }>
   | HeaderContent<
-      HeaderViews["COMPOSE_VM"] | HeaderViews["DELETE_KVM"],
-      { hostId?: Pod["id"] }
+      HeaderViews["DELETE_KVM"],
+      { clusterId?: VMCluster[VMClusterMeta.PK]; hostId?: Pod["id"] }
     >
   | HeaderContent<HeaderViews["ADD_LXD_HOST"] | HeaderViews["ADD_VIRSH_HOST"]>
   | HeaderContent<HeaderViews["REFRESH_KVM"], { hostIds?: Pod["id"][] }>

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -97,7 +97,10 @@ const LXDClusterDetails = (): JSX.Element => {
           <LXDClusterResources clusterId={clusterId} />
         </Route>
         <Route exact path={kvmURLs.lxd.cluster.edit(null, true)}>
-          <LXDClusterSettings clusterId={clusterId} />
+          <LXDClusterSettings
+            clusterId={clusterId}
+            setHeaderContent={setHeaderContent}
+          />
         </Route>
         <Route exact path={kvmURLs.lxd.cluster.vms.host(null, true)}>
           {hostId !== null && (

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -67,10 +67,9 @@ const LXDClusterDetailsHeader = ({
           to: kvmURLs.lxd.cluster.hosts({ clusterId }),
         },
         {
-          active:
-            location.pathname.includes(
-              kvmURLs.lxd.cluster.vms.index({ clusterId })
-            ) || location.pathname.endsWith("edit"),
+          active: location.pathname.includes(
+            kvmURLs.lxd.cluster.vms.index({ clusterId })
+          ),
           component: Link,
           label: "Virtual machines",
           to: kvmURLs.lxd.cluster.vms.index({ clusterId }),

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
@@ -1,15 +1,36 @@
 import { Strip } from "@canonical/react-components";
 
+import DangerZoneCard from "../../LXDSingleDetails/LXDSingleSettings/DangerZoneCard";
+
+import type { KVMSetHeaderContent } from "app/kvm/types";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
   clusterId: VMCluster["id"];
+  setHeaderContent: KVMSetHeaderContent;
 };
 
-const LXDClusterSettings = ({ clusterId }: Props): JSX.Element => {
+const LXDClusterSettings = ({
+  clusterId,
+  setHeaderContent,
+}: Props): JSX.Element => {
   return (
     <Strip className="u-no-padding--top" shallow>
-      <h4>LXD cluster {clusterId} settings</h4>
+      <DangerZoneCard
+        clusterId={clusterId}
+        message={
+          <>
+            <p>
+              <strong>Remove this LXD cluster</strong>
+            </p>
+            <p>
+              All VM hosts in this LXD cluster will be removed, you can still
+              access this project from the LXD server.
+            </p>
+          </>
+        }
+        setHeaderContent={setHeaderContent}
+      />
     </Strip>
   );
 };

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard/DangerZoneCard.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard/DangerZoneCard.test.tsx
@@ -8,7 +8,11 @@ describe("DangerZoneCard", () => {
   it("can open the delete KVM form", () => {
     const setHeaderContent = jest.fn();
     const wrapper = mount(
-      <DangerZoneCard hostId={1} setHeaderContent={setHeaderContent} />
+      <DangerZoneCard
+        hostId={1}
+        message="Delete KVM"
+        setHeaderContent={setHeaderContent}
+      />
     );
 
     wrapper.find("button[data-test='remove-kvm']").simulate("click");
@@ -18,5 +22,17 @@ describe("DangerZoneCard", () => {
         hostId: 1,
       },
     });
+  });
+
+  it("can display message", () => {
+    const setHeaderContent = jest.fn();
+    const wrapper = mount(
+      <DangerZoneCard
+        hostId={1}
+        message={<span data-test="message">Delete KVM</span>}
+        setHeaderContent={setHeaderContent}
+      />
+    );
+    expect(wrapper.find("[data-test='message']").exists()).toBe(true);
   });
 });

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard/DangerZoneCard.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard/DangerZoneCard.tsx
@@ -1,36 +1,39 @@
+import type { ReactNode } from "react";
+
 import { Button, Col, Row } from "@canonical/react-components";
 
 import FormCard from "app/base/components/FormCard";
 import { KVMHeaderViews } from "app/kvm/constants";
 import type { KVMSetHeaderContent } from "app/kvm/types";
-import type { Pod } from "app/store/pod/types";
+import type { Pod, PodMeta } from "app/store/pod/types";
+import type { VMCluster, VMClusterMeta } from "app/store/vmcluster/types";
 
 type Props = {
-  hostId: Pod["id"];
+  clusterId?: VMCluster[VMClusterMeta.PK];
+  hostId?: Pod[PodMeta.PK];
+  message: ReactNode;
   setHeaderContent: KVMSetHeaderContent;
 };
 
-const DangerZoneCard = ({ hostId, setHeaderContent }: Props): JSX.Element => {
+const DangerZoneCard = ({
+  clusterId,
+  hostId,
+  message,
+  setHeaderContent,
+}: Props): JSX.Element => {
   return (
     <FormCard highlighted={false} sidebar={false} title="Danger zone">
       <Row>
-        <Col size={5}>
-          <p>
-            <strong>Remove this KVM</strong>
-          </p>
-          <p>
-            Once a KVM is removed, you can still access this project from the
-            LXD server.
-          </p>
-        </Col>
-        <Col className="u-align--right u-flex--column-align-end" size={5}>
+        <Col size={5}>{message}</Col>
+        <Col className="u-align--right u-vertically-center" size={5}>
           <Button
             appearance="neutral"
+            className="u-no-margin--bottom"
             data-test="remove-kvm"
             onClick={() =>
               setHeaderContent({
                 view: KVMHeaderViews.DELETE_KVM,
-                extras: { hostId },
+                extras: { clusterId, hostId },
               })
             }
           >

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.tsx
@@ -54,7 +54,21 @@ const LXDSingleSettings = ({
       <LXDHostToolbar hostId={id} showBasic />
       <KVMConfigurationCard pod={pod} />
       <AuthenticationCard pod={pod} />
-      <DangerZoneCard hostId={id} setHeaderContent={setHeaderContent} />
+      <DangerZoneCard
+        hostId={id}
+        message={
+          <>
+            <p>
+              <strong>Remove this VM host</strong>
+            </p>
+            <p>
+              Once a VM host is removed, you can still access this project from
+              the LXD server.
+            </p>
+          </>
+        }
+        setHeaderContent={setHeaderContent}
+      />
     </Strip>
   );
 };


### PR DESCRIPTION
## Done

- Add a delete form to the cluster settings tab.
- Update the delete form to handle clusters.

## QA

This isn't really possible as we don't want to remove the cluster on Bolla. I've tested this locally (and it worked).

## Fixes

Fixes: canonical-web-and-design/app-squad#385.

## Screenshots

<img width="1242" alt="Screen Shot 2021-10-27 at 10 32 16 am" src="https://user-images.githubusercontent.com/361637/138975632-797434f3-7b57-46ae-b4f4-3112a6ee25fa.png">
