### PR TITLE
feat(ui): add cluster to BasePod type and remove pod.getCluster selector

### DIFF
--- a/ui/src/app/kvm/hooks.test.tsx
+++ b/ui/src/app/kvm/hooks.test.tsx
@@ -15,9 +15,6 @@ import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
-  vmCluster as vmClusterFactory,
-  vmClusterState as vmClusterStateFactory,
-  vmHost as vmHostFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -75,7 +72,7 @@ describe("kvm hooks", () => {
   });
 
   describe("useKVMDetailsRedirect", () => {
-    it("returns null if pods or clusters have not yet loaded", () => {
+    it("returns null if pods have not yet loaded", () => {
       const state = rootStateFactory({
         pod: podStateFactory({ loaded: false }),
       });
@@ -87,10 +84,9 @@ describe("kvm hooks", () => {
       expect(result.current).toBe(null);
     });
 
-    it("redirects to KVM list if pods and clusters have loaded but pod can't be found", () => {
+    it("redirects to KVM list if pods have loaded but pod can't be found", () => {
       const state = rootStateFactory({
         pod: podStateFactory({ items: [], loaded: true }),
-        vmcluster: vmClusterStateFactory({ items: [], loaded: true }),
       });
       const store = mockStore(state);
       const { result } = renderHook(() => useKVMDetailsRedirect(1), {
@@ -103,13 +99,7 @@ describe("kvm hooks", () => {
     it("can redirect to cluster host page", () => {
       const state = rootStateFactory({
         pod: podStateFactory({
-          items: [podFactory({ id: 1, type: PodType.LXD })],
-          loaded: true,
-        }),
-        vmcluster: vmClusterStateFactory({
-          items: [
-            vmClusterFactory({ id: 2, hosts: [vmHostFactory({ id: 1 })] }),
-          ],
+          items: [podFactory({ cluster: 2, id: 1, type: PodType.LXD })],
           loaded: true,
         }),
       });
@@ -131,9 +121,6 @@ describe("kvm hooks", () => {
           items: [podFactory({ id: 1, type: PodType.LXD })],
           loaded: true,
         }),
-        vmcluster: vmClusterStateFactory({
-          loaded: true,
-        }),
       });
       const store = mockStore(state);
       const { result } = renderHook(() => useKVMDetailsRedirect(1), {
@@ -148,9 +135,6 @@ describe("kvm hooks", () => {
       const state = rootStateFactory({
         pod: podStateFactory({
           items: [podFactory({ id: 1, type: PodType.VIRSH })],
-          loaded: true,
-        }),
-        vmcluster: vmClusterStateFactory({
           loaded: true,
         }),
       });

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
@@ -26,6 +26,7 @@ describe("LXDClusterHostsTable", () => {
   let state: RootState;
   beforeEach(() => {
     const host = podFactory({
+      cluster: 1,
       id: 22,
       name: "cluster-host",
       pool: 333,

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
@@ -62,6 +62,7 @@ describe("LXDClusterSummaryCard", () => {
       pod: podStateFactory({
         items: [
           podFactory({
+            cluster: 1,
             id: 11,
             resources: podResourcesFactory({
               interfaces: [interfaces[0]],
@@ -69,6 +70,7 @@ describe("LXDClusterSummaryCard", () => {
             type: PodType.LXD,
           }),
           podFactory({
+            cluster: 1,
             id: 22,
             resources: podResourcesFactory({
               interfaces: [interfaces[1]],

--- a/ui/src/app/store/pod/types/base.ts
+++ b/ui/src/app/store/pod/types/base.ts
@@ -10,6 +10,7 @@ import type {
 import type { Model } from "app/store/types/model";
 import type { Node } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
+import type { VMCluster, VMClusterMeta } from "app/store/vmcluster/types";
 
 export type PodStoragePool = {
   available: number;
@@ -102,6 +103,7 @@ export type LxdServerGroup = {
 export type BasePod = Model & {
   architectures: string[];
   capabilities: string[];
+  cluster?: VMCluster[VMClusterMeta.PK];
   cpu_over_commit_ratio: number;
   cpu_speed: number;
   created: string;


### PR DESCRIPTION
## Done

- Added `cluster` to `BasePod` type
- Removed `pod.getCluster` selector, which is now redundant given we can just use `vmcluster.getById` with `pod.cluster`
- Updated `useKVMDetailsRedirect` to use `pod.cluster` and no longer fetch clusters

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that redirects still work, e.g. using bolla:
  - http://0.0.0.0:8400/MAAS/r/kvm/lxd/484 redirects to http://0.0.0.0:8400/MAAS/r/kvm/lxd/cluster/22/vms/484
  - http://0.0.0.0:8400/MAAS/r/kvm/lxd/cluster/22/vms/336 redirects to http://0.0.0.0:8400/MAAS/r/kvm/lxd/336/vms
  - http://0.0.0.0:8400/MAAS/r/kvm/lxd/455 redirects to http://0.0.0.0:8400/MAAS/r/kvm/virsh/455/resources

## Fixes

Fixes canonical-web-and-design/app-squad#426
