### PR TITLE
refactor(ui): make the kvm action bar reusable

### DIFF
--- a/ui/src/app/kvm/components/KVMActionBar/KVMActionBar.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionBar/KVMActionBar.test.tsx
@@ -1,0 +1,29 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import KVMActionBar from "./KVMActionBar";
+
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("KVMActionBar", () => {
+  it("displays provided actions", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <KVMActionBar
+          actions={<span data-test="actions">Actions</span>}
+          currentPage={1}
+          itemCount={10}
+          onSearchChange={jest.fn()}
+          searchFilter=""
+          setCurrentPage={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='actions']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/components/KVMActionBar/KVMActionBar.tsx
+++ b/ui/src/app/kvm/components/KVMActionBar/KVMActionBar.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+
+import type { SearchBoxProps } from "@canonical/react-components";
+import { SearchBox } from "@canonical/react-components";
+
+import { VMS_PER_PAGE } from "../LXDVMsTable";
+
+import ArrowPagination from "app/base/components/ArrowPagination";
+
+type Props = {
+  actions: ReactNode;
+  currentPage: number;
+  loading?: boolean;
+  itemCount: number;
+  onSearchChange: SearchBoxProps["onChange"];
+  searchFilter: string;
+  setCurrentPage: (page: number) => void;
+};
+
+const KVMActionBar = ({
+  actions,
+  currentPage,
+  loading,
+  itemCount,
+  onSearchChange,
+  searchFilter,
+  setCurrentPage,
+}: Props): JSX.Element | null => {
+  return (
+    <div className="kvm-action-bar">
+      <div className="kvm-action-bar__actions">{actions}</div>
+      <div className="kvm-action-bar__search">
+        <SearchBox
+          className="u-no-margin--bottom"
+          externallyControlled
+          onChange={onSearchChange}
+          value={searchFilter}
+        />
+      </div>
+      <div className="kvm-action-bar__pagination">
+        <ArrowPagination
+          className="u-display-inline-block"
+          currentPage={currentPage}
+          itemCount={itemCount}
+          loading={loading}
+          pageSize={VMS_PER_PAGE}
+          setCurrentPage={setCurrentPage}
+          showPageBounds
+        />
+      </div>
+    </div>
+  );
+};
+
+export default KVMActionBar;

--- a/ui/src/app/kvm/components/KVMActionBar/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionBar/_index.scss
@@ -1,5 +1,5 @@
-@mixin VMsActionBar {
-  .vms-action-bar {
+@mixin KVMActionBar {
+  .kvm-action-bar {
     display: grid;
     grid-template-areas:
       "act"
@@ -9,16 +9,16 @@
     grid-template-rows: min-content min-content min-content;
     padding: $spv-inner--medium 0;
 
-    .vms-action-bar__actions {
+    .kvm-action-bar__actions {
       grid-area: act;
     }
 
-    .vms-action-bar__pagination {
+    .kvm-action-bar__pagination {
       grid-area: pag;
       margin-top: $spv-inner--small;
     }
 
-    .vms-action-bar__search {
+    .kvm-action-bar__search {
       grid-area: sea;
       margin-top: $spv-inner--medium;
     }
@@ -30,7 +30,7 @@
       grid-template-columns: auto auto;
       grid-template-rows: min-content min-content;
 
-      .vms-action-bar__pagination {
+      .kvm-action-bar__pagination {
         margin-top: 0;
         text-align: right;
       }
@@ -41,7 +41,7 @@
       grid-template-columns: max-content 1fr max-content;
       grid-template-rows: min-content;
 
-      .vms-action-bar__search {
+      .kvm-action-bar__search {
         margin: 0 $sph-inner;
         max-width: 50rem;
       }

--- a/ui/src/app/kvm/components/KVMActionBar/index.ts
+++ b/ui/src/app/kvm/components/KVMActionBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMActionBar";

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -1,9 +1,8 @@
-import { Button, Icon, SearchBox, Tooltip } from "@canonical/react-components";
+import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import { VMS_PER_PAGE } from "../LXDVMsTable";
+import KVMActionBar from "../../KVMActionBar";
 
-import ArrowPagination from "app/base/components/ArrowPagination";
 import type { SetSearchFilter } from "app/base/types";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import VmActionMenu from "app/machines/components/TakeActionMenu";
@@ -36,68 +35,57 @@ const VMsActionBar = ({
   const vmActionsDisabled = selectedIDs.length === 0;
 
   return (
-    <div className="vms-action-bar">
-      <div className="vms-action-bar__actions">
-        <VmActionMenu
-          appearance="vmTable"
-          data-test="vm-actions"
-          excludeActions={[NodeActions.DELETE]}
-          setHeaderContent={setHeaderContent}
-        />
-        <span className="u-nudge-right">
-          <Button
-            className="u-rotate-right"
-            appearance="base"
-            data-test="refresh-kvm"
-            hasIcon
-            onClick={onRefreshClick}
-            small
-          >
-            <Icon name="restart" />
-          </Button>
-        </span>
-        <Tooltip
-          className="u-nudge-right"
-          message={
-            vmActionsDisabled ? "Select VMs below to perform an action." : null
-          }
-        >
-          <Button
-            appearance="base"
-            data-test="delete-vm"
-            disabled={vmActionsDisabled}
-            hasIcon
-            onClick={() =>
-              setHeaderContent({ view: MachineHeaderViews.DELETE_MACHINE })
+    <KVMActionBar
+      actions={
+        <>
+          <VmActionMenu
+            appearance="vmTable"
+            data-test="vm-actions"
+            excludeActions={[NodeActions.DELETE]}
+            setHeaderContent={setHeaderContent}
+          />
+          <span className="u-nudge-right">
+            <Button
+              className="u-rotate-right"
+              appearance="base"
+              data-test="refresh-kvm"
+              hasIcon
+              onClick={onRefreshClick}
+              small
+            >
+              <Icon name="restart" />
+            </Button>
+          </span>
+          <Tooltip
+            className="u-nudge-right"
+            message={
+              vmActionsDisabled
+                ? "Select VMs below to perform an action."
+                : null
             }
-            small
           >
-            <Icon name="delete" />
-          </Button>
-        </Tooltip>
-      </div>
-      <div className="vms-action-bar__search">
-        <SearchBox
-          className="u-no-margin--bottom"
-          externallyControlled
-          onChange={(searchFilter: string) => {
-            setSearchFilter(searchFilter);
-          }}
-          value={searchFilter}
-        />
-      </div>
-      <div className="vms-action-bar__pagination">
-        <ArrowPagination
-          className="u-display-inline-block"
-          currentPage={currentPage}
-          itemCount={vms.length}
-          loading={loading}
-          pageSize={VMS_PER_PAGE}
-          setCurrentPage={setCurrentPage}
-          showPageBounds
-        />
-      </div>
-    </div>
+            <Button
+              appearance="base"
+              data-test="delete-vm"
+              disabled={vmActionsDisabled}
+              hasIcon
+              onClick={() =>
+                setHeaderContent({ view: MachineHeaderViews.DELETE_MACHINE })
+              }
+              small
+            >
+              <Icon name="delete" />
+            </Button>
+          </Tooltip>
+        </>
+      }
+      currentPage={currentPage}
+      itemCount={vms.length}
+      loading={loading}
+      onSearchChange={setSearchFilter}
+      searchFilter={searchFilter}
+      setCurrentPage={setCurrentPage}
+    />
   );
 };
 

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -119,6 +119,7 @@
 // kvm
 @import "~app/kvm/components/CoreResources";
 @import "~app/kvm/components/CPUColumn/CPUPopover";
+@import "~app/kvm/components/KVMActionBar";
 @import "~app/kvm/components/KVMDetailsHeader";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect";
@@ -130,7 +131,6 @@
 @import "~app/kvm/components/LXDHostVMs/NumaResources";
 @import "~app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard";
 @import "~app/kvm/components/LXDVMsSummaryCard";
-@import "~app/kvm/components/LXDVMsTable/VMsActionBar";
 @import "~app/kvm/components/LXDVMsTable/VMsTable";
 @import "~app/kvm/components/PodMeter";
 @import "~app/kvm/components/RAMColumn/RAMPopover";
@@ -148,6 +148,7 @@
 @import "~app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard";
 @include CoreResources;
 @include CPUPopover;
+@include KVMActionBar;
 @include KVMComposeInterfacesTable;
 @include KVMComposeStorageTable;
 @include KVMDetailsHeader;
@@ -173,7 +174,6 @@
 @include VirshTable;
 @include VmResources;
 @include SettingsBackLink;
-@include VMsActionBar;
 @include VMsTable;
 
 // Dashboard


### PR DESCRIPTION
## Done

- Split the action bar into a reusable component and a wrapping component for vms.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the list of vms for a cluster or single host and the action bar (refresh, search etc.) should appear and work as it did previously.

## Fixes

Fixes: canonical-web-and-design/app-squad#427.