### PR TITLE
feat(ui): update KVM storage cards to latest design

### DIFF
--- a/ui/src/app/kvm/components/StorageResources/StorageCards/StorageCards.tsx
+++ b/ui/src/app/kvm/components/StorageResources/StorageCards/StorageCards.tsx
@@ -6,14 +6,15 @@ import { useListener } from "@canonical/react-components/dist/hooks";
 import { COLOURS } from "app/base/constants";
 import StoragePopover from "app/kvm/components/StorageColumn/StoragePopover";
 import type { PodStoragePool } from "app/store/pod/types";
+import { formatBytes } from "app/utils";
 
 type Props = {
   pools: PodStoragePool[];
 };
 type CardSize = "small" | "medium" | "large";
 
-const MIN_ASPECT_RATIO = 0.85;
-const SMALL_CARD_HEIGHT = 35;
+const MIN_ASPECT_RATIO = 0.65;
+const SMALL_CARD_HEIGHT = 50;
 export const SMALL_MIN_WIDTH = Math.ceil(SMALL_CARD_HEIGHT * MIN_ASPECT_RATIO);
 export const MEDIUM_MIN_WIDTH = SMALL_MIN_WIDTH * 1.5;
 export const LARGE_MIN_WIDTH = SMALL_MIN_WIDTH * 3;
@@ -44,15 +45,47 @@ const StorageCards = ({ pools }: Props): JSX.Element | null => {
   useListener(window, onResize, "resize", true);
 
   return (
-    <div className={`storage-cards--${cardSize}`} ref={el}>
-      {pools.map((pool, i) => {
+    <div className={`storage-cards storage-cards--${cardSize}`} ref={el}>
+      {pools.map((pool) => {
         const allocatedWidth = (pool.used / pool.total) * 100;
+        const total = formatBytes(pool.total, "B");
+        const allocated = formatBytes(pool.used, "B", {
+          convertTo: total.unit,
+        });
+        const free = formatBytes(pool.total - pool.used, "B", {
+          convertTo: total.unit,
+        });
 
         return (
           <StoragePopover key={pool.id} pools={[pool]}>
             <div className="storage-card-container">
               <div className="storage-card">
-                <div className="storage-card__index u-align--right">#{i}</div>
+                <div className="storage-card__text-container">
+                  {cardSize === "large" ? (
+                    <>
+                      <div className="u-truncate">{pool.name}</div>
+                      <div className="p-text--x-small-capitalised u-text--muted u-no-margin--bottom">
+                        Free
+                      </div>
+                      <div className="u-align--right u-sv1">
+                        {free.value}
+                        {free.unit}
+                      </div>
+                      <hr />
+                      <div className="p-text--x-small-capitalised u-text--muted u-no-margin--bottom">
+                        Allocated
+                      </div>
+                      <div className="u-align--right">
+                        {allocated.value}
+                        {allocated.unit}
+                      </div>
+                    </>
+                  ) : (
+                    <div className="storage-card__small-text u-align--right u-nudge-right--x-small u-truncate">
+                      {pool.name}
+                    </div>
+                  )}
+                </div>
                 <div
                   className="storage-card__meter"
                   data-test="storage-card-meter"

--- a/ui/src/app/kvm/components/StorageResources/StorageCards/_index.scss
+++ b/ui/src/app/kvm/components/StorageResources/StorageCards/_index.scss
@@ -1,5 +1,5 @@
 @mixin storage-cards($height) {
-  $min-aspect-ratio: 0.85;
+  $min-aspect-ratio: 0.65;
   display: grid;
   grid-template-columns: repeat(
     auto-fill,
@@ -12,32 +12,58 @@
 }
 
 @mixin StorageCards {
-  $small-card-height: 35px;
+  $small-card-height: 50px;
+
+  .storage-cards {
+    // Max height is given to be 3 * the height of the small card, including the
+    // vertical space between card rows. This max-height is identical to 2 * the
+    // height of the medium card, and 1 * the height of the large card.
+    max-height: #{($small-card-height + 2) * 3};
+    overflow: auto;
+  }
 
   .storage-cards--small {
     @include storage-cards($small-card-height);
 
-    .storage-card__index {
+    .storage-card__text-container {
+      padding-right: $sp-xx-small;
+    }
+
+    .storage-card__small-text {
       font-size: 0.675rem;
       line-height: 1.5;
-      padding-right: $sp-xx-small;
+    }
+
+    .storage-card__meter {
+      height: 6px;
     }
   }
 
   .storage-cards--medium {
     @include storage-cards($small-card-height * 1.5);
 
-    .storage-card__index {
-      @extend %x-small-text;
+    .storage-card__text-container {
       padding-right: $sp-x-small;
+    }
+
+    .storage-card__small-text {
+      @extend %x-small-text;
+    }
+
+    .storage-card__meter {
+      height: 8px;
     }
   }
 
   .storage-cards--large {
     @include storage-cards($small-card-height * 3);
 
-    .storage-card__index {
-      padding: $spv-inner--small $sph-inner--small;
+    .storage-card__text-container {
+      padding: calc(#{$spv-inner--x-small} + 1px) $sph-inner--small $spv-inner--x-small;
+    }
+
+    .storage-card__meter {
+      height: 12px;
     }
   }
 
@@ -51,12 +77,15 @@
     flex-direction: column;
   }
 
-  .storage-card__index {
+  .storage-card__text-container {
     flex: 1;
   }
 
   .storage-card__meter {
-    height: 8%;
+    bottom: -1px;
+    left: -1px;
     min-height: math.div($sp-unit, 2);
+    position: relative;
+    width: calc(100% + 2px);
   }
 }

--- a/ui/src/app/kvm/components/StorageResources/StorageResources.test.tsx
+++ b/ui/src/app/kvm/components/StorageResources/StorageResources.test.tsx
@@ -22,9 +22,10 @@ describe("StorageResources", () => {
     );
     expect(wrapper.find("StorageMeter").exists()).toBe(true);
     expect(wrapper.find("StorageCards").exists()).toBe(false);
+    expect(wrapper.find("[data-test='storage-summary']").exists()).toBe(false);
   });
 
-  it("displays as cards if there is more than one pool", () => {
+  it("displays storage summary and pools as cards if there is more than one pool", () => {
     const storagePools = [
       storagePoolFactory({
         id: "0",
@@ -47,6 +48,7 @@ describe("StorageResources", () => {
       />
     );
     expect(wrapper.find("StorageCards").exists()).toBe(true);
+    expect(wrapper.find("[data-test='storage-summary']").exists()).toBe(true);
     expect(wrapper.find("StorageMeter").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/components/StorageResources/StorageResources.tsx
@@ -23,34 +23,37 @@ const StorageResources = ({ storage }: Props): JSX.Element | null => {
     <div
       className={classNames("storage-resources", { "single-pool": singlePool })}
     >
-      <h4 className="storage-resources__header p-heading--small u-sv1">
-        Storage
-      </h4>
+      <div className="storage-resources__header">
+        <h4 className="p-text--x-small-capitalised u-sv1">Storage</h4>
+        {!singlePool && (
+          <div data-test="storage-summary">
+            <div className="u-nudge-left">
+              <div className="p-text--x-small-capitalised u-text--muted u-no-margin--bottom">
+                Total
+              </div>
+              <div className="u-align--right u-nudge-right u-sv1">
+                {totalStorage.value}
+                {totalStorage.unit}
+              </div>
+              <hr />
+            </div>
+            <div className="u-nudge-left">
+              <div className="p-text--x-small-capitalised u-text--muted u-no-margin--bottom">
+                Free
+              </div>
+              <div className="u-align--right u-nudge-right">
+                {freeStorage.value}
+                {freeStorage.unit}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
       <div className="storage-resources__content">
         {singlePool ? (
           <StorageMeter pool={storage.pools[0]} />
         ) : (
-          <>
-            <div className="storage-resources__usage">
-              <div className="u-nudge-left">
-                <div className="p-heading--small u-text--muted">Total</div>
-                <div className="u-nudge-right u-sv1">
-                  {totalStorage.value}
-                  {totalStorage.unit}
-                </div>
-              </div>
-              <div className="u-nudge-left">
-                <div className="p-heading--small u-text--muted">Free</div>
-                <div className="u-nudge-right u-sv1">
-                  {freeStorage.value}
-                  {freeStorage.unit}
-                </div>
-              </div>
-            </div>
-            <div className="storage-resources__pools">
-              <StorageCards pools={storage.pools} />
-            </div>
-          </>
+          <StorageCards pools={storage.pools} />
         )}
       </div>
     </div>

--- a/ui/src/app/kvm/components/StorageResources/_index.scss
+++ b/ui/src/app/kvm/components/StorageResources/_index.scss
@@ -1,80 +1,52 @@
 @mixin StorageResources {
   .storage-resources {
+    display: flex;
+    flex-direction: row;
     padding: $spv-inner--medium $sph-inner;
+  }
+
+  .single-pool {
+    flex-direction: column;
   }
 
   .storage-resources__content {
     display: flex;
     flex-direction: column;
+    flex: 1;
   }
 
-  .storage-resources__usage {
-    border-bottom: $border;
-    display: flex;
-    margin-bottom: $spv-inner--medium;
-  }
-
-  .storage-resources__pools {
-    flex-grow: 1;
-    overflow: auto;
+  .storage-resources__header {
+    flex: 0;
+    margin-right: 0;
   }
 
   @media only screen and (min-width: $breakpoint-medium) {
+    .storage-resources {
+      flex-direction: row;
+    }
+
     .storage-resources__header {
+      flex: 1;
       margin-right: $sph-inner--large;
     }
 
     .storage-resources__content {
-      flex-direction: column;
+      flex: 3;
     }
   }
 
-  @media only screen and (min-width: $breakpoint-large) {
-    .storage-resources__content {
-      flex-direction: row;
-    }
-
-    .storage-resources__usage {
-      border-bottom: 0;
-      border-right: $border;
+  @media only screen and (min-width: $breakpoint-kvm-resources-card) {
+    .storage-resources.single-pool {
       flex-direction: column;
-      margin-bottom: 0;
-      margin-right: $sph-inner;
     }
-  }
-
-  .storage-resources.single-pool {
-    display: flex;
-    flex-direction: column;
 
     .storage-resources__header {
+      flex: 0;
       margin-right: 0;
     }
 
-    @media only screen and (min-width: $breakpoint-medium) {
-      flex-direction: row;
-
-      .storage-resources__header {
-        flex: 1;
-        margin-right: $sph-inner--large;
-      }
-
-      .storage-resources__content {
-        flex: 3;
-      }
-    }
-
-    @media only screen and (min-width: $breakpoint-kvm-resources-card) {
-      flex-direction: column;
-
-      .storage-resources__header {
-        flex: 0;
-        margin-right: 0;
-      }
-
-      .storage-resources__content {
-        flex: 0;
-      }
+    .storage-resources__content {
+      flex: 1;
     }
   }
 }


### PR DESCRIPTION
## Done

- Updated KVM storage cards to [latest design](https://www.figma.com/file/QNQ3ZsYLR0tamnFzCo8VP6/%5B21.10%5D-LXD-Clusters?node-id=340%3A8982). I have made some slight changes though:
  - Allocated shows the value instead of the percentage. I think the bar at bottom already provides a visual representation of the allocated ratio, so the actual byte value seems more useful here.
  - The bar does not sit butt up against the bottom of the summary card. I think that might have been a mistake in the design wireframe.
  - I've made the minimum aspect ratio of the cards higher than what's shown in the design, so you can only fit two cards in the space before it snaps to a smaller card size. Doing otherwise would mean a lot of the content would get truncated.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- Open `ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx` and edit line 88 so there are 2 pools
- Using bolla, navigate to the lxd-cluster details page and check that the card (mostly) matches the design
- Resize the screen and check that the cards are responsive
- Test again with ~6 pools and with ~18 pools

## Fixes

Fixes canonical-web-and-design/app-squad#482

## Screenshots
### Large cards
![Screenshot 2021-10-30 at 12-14-43 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/139517013-a9f7c480-15e0-4178-ab37-217d987464a7.png)

### Medium cards
![Screenshot 2021-10-30 at 12-14-33 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/139517019-cd8b639e-06e1-4989-82be-0d0da73f0ea3.png)

### Small cards
![Screenshot 2021-10-30 at 12-14-22 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/139517022-dae7b11a-b17e-4637-8b9d-e2e93c2e64fc.png)

