### PR TITLE
feat(ui): make the LXD toolbar responsive

### DIFF
--- a/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
@@ -173,35 +173,6 @@ describe("LXDHostToolbar", () => {
     expect(wrapper.find("[data-test='pod-tags']").exists()).toBe(true);
   });
 
-  it("does not shows tags in cluster view", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: kvmURLs.lxd.cluster.vms.host({
-                clusterId: 2,
-                hostId: 1,
-              }),
-              key: "testKey",
-            },
-          ]}
-        >
-          <LXDHostToolbar
-            clusterId={2}
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='pod-tags']").exists()).toBe(false);
-  });
-
   it("can open the compose VM form", () => {
     const setHeaderContent = jest.fn();
     const store = mockStore(state);

--- a/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
+++ b/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { useEffect } from "react";
 
 import { Button, Icon, Spinner } from "@canonical/react-components";
@@ -23,7 +22,7 @@ type Props = {
   setHeaderContent?: KVMSetHeaderContent;
   setViewByNuma?: (viewByNuma: boolean) => void;
   showBasic?: boolean;
-  title?: ReactNode;
+  title?: string;
   viewByNuma?: boolean;
 };
 
@@ -59,22 +58,27 @@ const LXDHostToolbar = ({
   // Safeguard in case local storage is set to true even though the pod has no
   // known NUMA nodes.
   const showNumaCards = viewByNuma && canViewByNuma;
-
+  const tags = pod.tags.join(", ");
+  const name = title ? title : pod.name;
   return (
     <div className="lxd-host-toolbar">
-      <div className="lxd-host-toolbar__title">
+      <div className="lxd-host-toolbar__title lxd-host-toolbar__block u-truncate">
         <h2
-          className="p-heading--4 u-no-margin--bottom u-no-padding--top"
+          className="p-heading--4 u-no-margin--bottom u-no-padding--top u-truncate"
           data-test="toolbar-title"
+          title={name}
         >
-          {title ? title : pod.name}
+          {name}
         </h2>
         {inClusterView && !showBasic && (
-          <div className="u-nudge-up--x-small">
+          <div className="u-nudge-up--x-small u-truncate">
             <Link
               data-test="settings-link"
               to={{
-                pathname: kvmURLs.lxd.cluster.host.edit({ clusterId, hostId }),
+                pathname: kvmURLs.lxd.cluster.host.edit({
+                  clusterId,
+                  hostId,
+                }),
                 state: { from: location.pathname },
               }}
             >
@@ -84,49 +88,52 @@ const LXDHostToolbar = ({
           </div>
         )}
       </div>
-      <div className="lxd-host-toolbar__blocks p-divider u-nudge-down--x-small">
-        <div className="p-divider__block" data-test="lxd-version">
-          <p className="u-text--muted u-no-margin u-no-padding">LXD version:</p>
-          <p className="u-no-margin u-no-padding">{pod.version}</p>
-        </div>
-        {setHeaderContent && !showBasic ? (
-          <>
-            <div className="p-divider__block">
-              <p className="u-text--muted u-no-margin u-no-padding">
-                Resource pool:
-              </p>
-              <p className="u-no-margin u-no-padding" data-test="pod-pool">
-                {pool?.name || <Spinner />}
-              </p>
-            </div>
-            {!inClusterView && (
-              <div className="p-divider__block">
-                <p className="u-text--muted u-no-margin u-no-padding">Tags:</p>
-                <p className="u-no-margin u-no-padding" data-test="pod-tags">
-                  {pod.tags.join(", ")}
-                </p>
-              </div>
-            )}
-            <div className="p-divider__block">
-              <Button
-                data-test="add-virtual-machine"
-                hasIcon
-                onClick={() =>
-                  setHeaderContent({
-                    view: KVMHeaderViews.COMPOSE_VM,
-                    extras: { hostId },
-                  })
-                }
-              >
-                <Icon name="plus" />
-                <span>Add virtual machine</span>
-              </Button>
-            </div>
-          </>
-        ) : null}
+      <div
+        className="lxd-host-toolbar__block no-divider u-nudge-down--x-small"
+        data-test="lxd-version"
+      >
+        <p className="u-text--muted u-no-margin u-no-padding">LXD version:</p>
+        <p className="u-no-margin u-no-padding">{pod.version}</p>
       </div>
+      {setHeaderContent && !showBasic ? (
+        <>
+          <div className="lxd-host-toolbar__block u-nudge-down--x-small">
+            <p className="u-text--muted u-no-margin u-no-padding">
+              Resource pool:
+            </p>
+            <p className="u-no-margin u-no-padding" data-test="pod-pool">
+              {pool?.name || <Spinner />}
+            </p>
+          </div>
+          <div className="lxd-host-toolbar__block u-nudge-down--x-small u-truncate">
+            <p className="u-text--muted u-no-margin u-no-padding">Tags:</p>
+            <p
+              className="u-no-margin u-no-padding u-truncate"
+              data-test="pod-tags"
+              title={tags}
+            >
+              {tags}
+            </p>
+          </div>
+          <div className="lxd-host-toolbar__block u-nudge-down--x-small">
+            <Button
+              data-test="add-virtual-machine"
+              hasIcon
+              onClick={() =>
+                setHeaderContent({
+                  view: KVMHeaderViews.COMPOSE_VM,
+                  extras: { hostId },
+                })
+              }
+            >
+              <Icon name="plus" />
+              <span>Add virtual machine</span>
+            </Button>
+          </div>
+        </>
+      ) : null}
       {canViewByNuma && setViewByNuma && !showBasic && (
-        <div className="lxd-host-toolbar__switch">
+        <div className="lxd-host-toolbar__switch lxd-host-toolbar__block">
           <Switch
             checked={showNumaCards}
             className="p-switch--inline-label"

--- a/ui/src/app/kvm/components/LXDHostToolbar/_index.scss
+++ b/ui/src/app/kvm/components/LXDHostToolbar/_index.scss
@@ -1,39 +1,81 @@
 @mixin LXDHostToolbar {
   .lxd-host-toolbar {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    // Add space between the toolbar and the content below it.
     padding-bottom: $spv-inner--medium;
-
-    .p-divider__block:not(:first-child)::before {
-      background-color: $color-mid-x-light;
-    }
   }
 
-  .lxd-host-toolbar__title {
-    flex-shrink: 0;
-    margin-right: $sph-outer;
-  }
-
-  .lxd-host-toolbar__blocks {
-    display: flex;
-    flex-direction: column;
-  }
-
-  @media only screen and (min-width: $breakpoint-medium) {
-    .lxd-host-toolbar__blocks {
-      flex-direction: row;
-    }
-  }
-
-  @media only screen and (min-width: $breakpoint-kvm-resources-card) {
+  @media only screen and (min-width: $breakpoint-small) {
     .lxd-host-toolbar {
-      flex-direction: row;
+      display: grid;
+      // The last column needs to take a minimum of the content width so that
+      // the numa label doesn't wrap and a max of auto so that it extends to the
+      // edge of the container.
+      grid-template-columns: repeat(3, minmax(auto, max-content)) minmax(
+          max-content,
+          auto
+        );
+      grid-template-rows: auto;
+      // The first row of content is given template areas, but the second row is
+      // not so that remaining elements appear as columns.
+      grid-template-areas: "title title title switch";
     }
 
-    .lxd-host-toolbar__switch {
-      flex-shrink: 0;
-      margin-left: $sph-outer;
+    .lxd-host-toolbar__block {
+      border-left: $border;
+      padding-left: $sph-inner--large;
+      margin-bottom: $spv-inner--medium;
+
+      &:not(:last-of-type) {
+        padding-right: $sph-inner--large;
+      }
+
+      &.no-divider {
+        border-left: 0;
+        padding-left: 0;
+      }
+
+      &.lxd-host-toolbar__title {
+        padding-left: 0;
+        padding-right: 0;
+        border-left: 0;
+        grid-area: title;
+      }
+
+      &.lxd-host-toolbar__switch {
+        border-left: 0;
+        // Position the content to the right of the given space.
+        justify-self: end;
+        padding-left: 0;
+        grid-area: switch;
+      }
+    }
+  }
+
+  @media only screen and (min-width: $breakpoint-large) {
+    .lxd-host-toolbar {
+      grid-template-columns: repeat(5, minmax(auto, max-content)) minmax(
+          max-content,
+          auto
+        );
+      // Remove the template from the small breakpoint.
+      grid-template-areas: none;
+    }
+
+    .lxd-host-toolbar__block {
+      &.no-divider {
+        border-left: 0;
+        padding-left: $sph-inner--large;
+      }
+
+      &.lxd-host-toolbar__title {
+        // Remove the template from the small breakpoint.
+        grid-area: unset;
+      }
+
+      &.lxd-host-toolbar__switch {
+        // Remove the template from the small breakpoint.
+        grid-area: unset;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Update the host toolbar to be responsive to the content and screen size.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /LXD.
- Click on a cluster.
- Click on a hostname in the table.
- Check that the toolbar (the "VMs on ..." row) looks OK at different screen sizes.

## Fixes

Fixes: canonical-web-and-design/app-squad#10.

## Screenshots

![dev local_8400_MAAS_r_kvm_lxd_61_vms (1)](https://user-images.githubusercontent.com/361637/139347362-3ff1c846-e7d8-4715-92fa-24289b3c8ca0.png)
![dev local_8400_MAAS_r_kvm_lxd_61_vms](https://user-images.githubusercontent.com/361637/139347369-5fbc078c-732b-435e-acd6-23113b21e761.png)
