### PR TITLE
feat(ui): handle cluster/pod 404s and redirects when deleting

### DIFF
--- a/ui/src/app/kvm/hooks.test.tsx
+++ b/ui/src/app/kvm/hooks.test.tsx
@@ -84,18 +84,6 @@ describe("kvm hooks", () => {
       expect(result.current).toBe(null);
     });
 
-    it("redirects to KVM list if pods have loaded but pod can't be found", () => {
-      const state = rootStateFactory({
-        pod: podStateFactory({ items: [], loaded: true }),
-      });
-      const store = mockStore(state);
-      const { result } = renderHook(() => useKVMDetailsRedirect(1), {
-        wrapper: generateWrapper(store),
-      });
-
-      expect(result.current).toBe(kvmURLs.kvm);
-    });
-
     it("can redirect to cluster host page", () => {
       const state = rootStateFactory({
         pod: podStateFactory({

--- a/ui/src/app/kvm/hooks.tsx
+++ b/ui/src/app/kvm/hooks.tsx
@@ -46,14 +46,8 @@ export const useKVMDetailsRedirect = (id: Pod["id"]): string | null => {
     dispatch(podActions.fetch());
   }, [dispatch, id]);
 
-  if (!podsLoaded) {
+  if (!podsLoaded || !pod) {
     return null;
-  }
-
-  if (!pod) {
-    // TODO: Show a "not found" message instead of redirecting.
-    // https://github.com/canonical-web-and-design/maas-ui/issues/3149
-    return kvmURLs.kvm;
   }
 
   const isLXDClusterHost = clusterId !== null && pod.type === PodType.LXD;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -14,7 +14,7 @@ import {
 const mockStore = configureStore();
 
 describe("LXDClusterDetails", () => {
-  it("redirects to KVM list if clusters have loaded but cluster is not in state", () => {
+  it("displays a message if the cluster does not exist", () => {
     const state = rootStateFactory({
       vmcluster: vmClusterStateFactory({
         items: [],
@@ -36,8 +36,7 @@ describe("LXDClusterDetails", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
-    expect(wrapper.find("Redirect").props().to).toBe(kvmURLs.kvm);
+    expect(wrapper.find("[data-test='not-found']").exists()).toBe(true);
   });
 
   it("sets the search filter from the URL", () => {

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -16,6 +16,31 @@ import {
 const mockStore = configureStore();
 
 describe("LXDSingleDetails", () => {
+  it("displays a message if the pod does not exist", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.single.vms({ id: 1 }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <LXDSingleDetails />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='not-found']").exists()).toBe(true);
+  });
+
   it("sets the search filter from the URL", () => {
     const state = rootStateFactory({
       pod: podStateFactory({

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 import {
+  Link,
   Redirect,
   Route,
   Switch,
@@ -16,6 +17,7 @@ import LXDSingleSettings from "./LXDSingleSettings";
 import LXDSingleVMs from "./LXDSingleVMs";
 
 import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
 import type { RouteParams, SetSearchFilter } from "app/base/types";
 import { useActivePod, useKVMDetailsRedirect } from "app/kvm/hooks";
 import type { KVMHeaderContent } from "app/kvm/types";
@@ -32,6 +34,7 @@ const LXDSingleDetails = (): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, id)
   );
+  const loaded = useSelector(podSelectors.loaded);
   // Search filter is determined by the URL and used to initialise state.
   const currentFilters = FilterMachines.queryStringToFilters(location.search);
   const [searchFilter, setFilter] = useState<string>(
@@ -51,6 +54,19 @@ const LXDSingleDetails = (): JSX.Element => {
 
   if (redirectURL) {
     return <Redirect to={redirectURL} />;
+  }
+  if (loaded && !pod) {
+    return (
+      <Section
+        header={<SectionHeader title="LXD host not found" />}
+        data-test="not-found"
+      >
+        <p>
+          Unable to find a LXD host with id "{id}".{" "}
+          <Link to={kvmURLs.kvm}>View all KVMs</Link>.
+        </p>
+      </Section>
+    );
   }
   return (
     <Section

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
@@ -2,13 +2,14 @@ import { useState } from "react";
 
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Link, Redirect, Route, Switch } from "react-router-dom";
 
 import VirshDetailsHeader from "./VirshDetailsHeader";
 import VirshResources from "./VirshResources";
 import VirshSettings from "./VirshSettings";
 
 import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
 import type { RouteParams } from "app/base/types";
 import { useActivePod, useKVMDetailsRedirect } from "app/kvm/hooks";
 import type { KVMHeaderContent } from "app/kvm/types";
@@ -22,6 +23,7 @@ const VirshDetails = (): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, id)
   );
+  const loaded = useSelector(podSelectors.loaded);
   const [headerContent, setHeaderContent] = useState<KVMHeaderContent | null>(
     null
   );
@@ -30,6 +32,19 @@ const VirshDetails = (): JSX.Element => {
 
   if (redirectURL) {
     return <Redirect to={redirectURL} />;
+  }
+  if (loaded && !pod) {
+    return (
+      <Section
+        header={<SectionHeader title="Virsh host not found" />}
+        data-test="not-found"
+      >
+        <p>
+          Unable to find a Virsh host with id "{id}".{" "}
+          <Link to={kvmURLs.kvm}>View all KVMs</Link>.
+        </p>
+      </Section>
+    );
   }
   return (
     <Section


### PR DESCRIPTION
## Done

- Update the cluster and pod detail views to display a not-found message if the id is invalid.
- Redirect from the delete form when the cluster/pod is deleted.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /MAAS/r/kvm/virsh/9999.
- You should see a not-found message.
- Visit /MAAS/r/kvm/lxd/9999.
- You should see a not-found message.
- Visit /MAAS/r/kvm/lxd/cluster/9999.
- You should see a not-found message.
- Go to the /KVM then to the Virsh tab and create a new virsh pod.
- Go to the new Virsh and use the take action menu to open the delete form.
- Click "Remove KVM" and you should get redirected back to the list and there should be a message the that KVM was removed.

## Fixes

Fixes: canonical-web-and-design/maas-ui#3149.

## Screenshots

![Uploading Screen Shot 2021-10-29 at 4.05.58 pm.png…]()
