### PR TITLE
fix(cypress): fix KVM list redirect location

### DIFF
--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -39,9 +39,9 @@ context("Header", () => {
     cy.get(".p-navigation__link.is-selected a").contains("Controllers");
   });
 
-  it("navigates to kvm", () => {
+  it("navigates to lxd kvm list", () => {
     cy.get(".p-navigation__link a:contains(KVM)").click();
-    cy.location("pathname").should("eq", generateNewURL("/kvm"));
+    cy.location("pathname").should("eq", generateNewURL("/kvm/lxd"));
     cy.get(".p-navigation__link.is-selected a").contains("KVM");
   });
 


### PR DESCRIPTION
## Done

- Update header Cypress test to point to LXD KVM list

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

 ### Fixes

Fixes #3203 