### PR TITLE
feat(ui): add authentication card to cluster settings

### DIFF
--- a/ui/src/app/kvm/hooks.test.tsx
+++ b/ui/src/app/kvm/hooks.test.tsx
@@ -69,6 +69,16 @@ describe("kvm hooks", () => {
       // the second instance.
       expect(setActiveActions[1]).toStrictEqual(expectedAction);
     });
+
+    it("does not dispatch actions if null id provided", () => {
+      const state = rootStateFactory();
+      const store = mockStore(state);
+      renderHook(() => useActivePod(null), {
+        wrapper: generateWrapper(store),
+      });
+
+      expect(store.getActions()).toStrictEqual([]);
+    });
   });
 
   describe("useKVMDetailsRedirect", () => {

--- a/ui/src/app/kvm/hooks.tsx
+++ b/ui/src/app/kvm/hooks.tsx
@@ -14,13 +14,15 @@ import type { RootState } from "app/store/root/types";
  * Handle setting a pod as active while a component is mounted.
  * @param id - The id of the pod to handle active state.
  */
-export const useActivePod = (id: Pod["id"]): void => {
+export const useActivePod = (id: Pod["id"] | null): void => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(podActions.get(id));
-    // Set pod as active to ensure all pod data is sent from the server.
-    dispatch(podActions.setActive(id));
+    if (id || id === 0) {
+      dispatch(podActions.get(id));
+      // Set pod as active to ensure all pod data is sent from the server.
+      dispatch(podActions.setActive(id));
+    }
 
     // Unset active pod on cleanup.
     return () => {

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.test.tsx
@@ -1,0 +1,47 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import LXDClusterSettings from "./LXDClusterSettings";
+
+import { actions as podActions } from "app/store/pod";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+  vmCluster as vmClusterFactory,
+  vmClusterState as vmClusterStateFactory,
+  vmHost as vmHostFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("LXDClusterSettings", () => {
+  it("sets the cluster's first host as active", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ id: 11 }), podFactory({ id: 22 })],
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [
+          vmClusterFactory({
+            id: 1,
+            hosts: [vmHostFactory({ id: 11 }), vmHostFactory({ id: 22 })],
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <LXDClusterSettings clusterId={1} setHeaderContent={jest.fn()} />
+      </Provider>
+    );
+
+    const expectedAction = podActions.setActive(11);
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
@@ -1,8 +1,12 @@
 import { Strip } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 
-import DangerZoneCard from "../../LXDSingleDetails/LXDSingleSettings/DangerZoneCard";
-
+import { useActivePod } from "app/kvm/hooks";
 import type { KVMSetHeaderContent } from "app/kvm/types";
+import AuthenticationCard from "app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard";
+import DangerZoneCard from "app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard";
+import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
@@ -14,8 +18,17 @@ const LXDClusterSettings = ({
   clusterId,
   setHeaderContent,
 }: Props): JSX.Element => {
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  useActivePod(cluster?.hosts[0]?.id || null);
+
   return (
-    <Strip className="u-no-padding--top" shallow>
+    <Strip shallow>
+      <AuthenticationCard
+        hostId={cluster?.hosts[0]?.id || null}
+        objectName={cluster?.name || null}
+      />
       <DangerZoneCard
         clusterId={clusterId}
         message={

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
@@ -10,7 +10,8 @@ import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   certificateMetadata as certificateFactory,
-  podDetails as podFactory,
+  pod as podFactory,
+  podDetails as podDetailsFactory,
   podPowerParameters as powerParametersFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
@@ -22,7 +23,7 @@ describe("AuthenticationCard", () => {
   let pod: PodDetails;
 
   beforeEach(() => {
-    pod = podFactory({
+    pod = podDetailsFactory({
       certificate: certificateFactory(),
       id: 1,
       power_parameters: powerParametersFactory({
@@ -36,6 +37,21 @@ describe("AuthenticationCard", () => {
     });
   });
 
+  it("shows a spinner if pod is not PodDetails type", () => {
+    state.pod.items[0] = podFactory({ id: 1 });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <AuthenticationCard hostId={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
   it("can open the update certificate form", () => {
     const store = mockStore(state);
     const wrapper = mount(
@@ -43,7 +59,7 @@ describe("AuthenticationCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <AuthenticationCard pod={pod} />
+          <AuthenticationCard hostId={pod.id} />
         </MemoryRouter>
       </Provider>
     );
@@ -65,7 +81,7 @@ describe("AuthenticationCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <AuthenticationCard pod={pod} />
+          <AuthenticationCard hostId={pod.id} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.tsx
@@ -1,41 +1,52 @@
+import type { ReactNode } from "react";
 import { useState } from "react";
 
-import { Button, Col, Icon, Row } from "@canonical/react-components";
+import { Button, Col, Icon, Row, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 
 import UpdateCertificate from "./UpdateCertificate";
 
 import CertificateDetails from "app/base/components/CertificateDetails";
 import FormCard from "app/base/components/FormCard";
-import type { PodDetails } from "app/store/pod/types";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import { isPodDetails } from "app/store/pod/utils";
+import type { RootState } from "app/store/root/types";
 
 type Props = {
-  pod: PodDetails;
+  hostId: Pod["id"] | null;
+  objectName?: string | null;
 };
 
-const AuthenticationCard = ({ pod }: Props): JSX.Element => {
-  const [showUpdateCertificate, setShowUpdateCertificate] = useState(false);
-  const { certificate: certificateMetadata, power_parameters } = pod;
-  const hasCertificateData = !!(
-    certificateMetadata &&
-    power_parameters.certificate &&
-    power_parameters.key
+const AuthenticationCard = ({ hostId, objectName }: Props): JSX.Element => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, hostId)
   );
+  const [showUpdateCertificate, setShowUpdateCertificate] = useState(false);
 
-  return (
-    <FormCard
-      className="authentication-card"
-      data-test="authentication-card"
-      highlighted={false}
-      sidebar={false}
-      title="Authentication"
-    >
-      {showUpdateCertificate || !hasCertificateData ? (
+  let content: ReactNode = (
+    <p>
+      <Spinner text="Loading" />
+    </p>
+  );
+  if (isPodDetails(pod)) {
+    const { certificate: certificateMetadata, power_parameters } = pod;
+    const hasCertificateData = !!(
+      certificateMetadata &&
+      power_parameters.certificate &&
+      power_parameters.key
+    );
+    if (showUpdateCertificate || !hasCertificateData) {
+      content = (
         <UpdateCertificate
           closeForm={() => setShowUpdateCertificate(false)}
           hasCertificateData={hasCertificateData}
+          objectName={objectName}
           pod={pod}
         />
-      ) : (
+      );
+    } else {
+      content = (
         <Row>
           <Col size={6}>
             <CertificateDetails
@@ -58,7 +69,19 @@ const AuthenticationCard = ({ pod }: Props): JSX.Element => {
             </Button>
           </div>
         </Row>
-      )}
+      );
+    }
+  }
+
+  return (
+    <FormCard
+      className="authentication-card"
+      data-test="authentication-card"
+      highlighted={false}
+      sidebar={false}
+      title="Authentication"
+    >
+      {content}
     </FormCard>
   );
 };

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
@@ -68,6 +68,35 @@ describe("UpdateCertificate", () => {
     ).toStrictEqual(expectedAction);
   });
 
+  it("can generate a certificate with a custom object name", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
+        >
+          <UpdateCertificate
+            closeForm={jest.fn()}
+            hasCertificateData
+            objectName="custom-name"
+            pod={pod}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Radio should be set to generate certificate by default.
+    submitFormikForm(wrapper);
+    wrapper.update();
+
+    const expectedAction = generalActions.generateCertificate({
+      object_name: "custom-name",
+    });
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+
   it("can dispatch an action to update pod with generated certificate and key", () => {
     const generatedCertificate = generatedCertificateFactory({
       certificate: "generated-certificate",

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.tsx
@@ -16,6 +16,7 @@ import type { PodDetails } from "app/store/pod/types";
 type Props = {
   closeForm: () => void;
   hasCertificateData: boolean;
+  objectName?: string | null;
   pod: PodDetails;
 };
 
@@ -28,6 +29,7 @@ export type UpdateCertificateValues = {
 const UpdateCertificate = ({
   closeForm,
   hasCertificateData,
+  objectName,
   pod,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -92,7 +94,9 @@ const UpdateCertificate = ({
           );
         } else if (shouldGenerateCert) {
           dispatch(
-            generalActions.generateCertificate({ object_name: pod.name })
+            generalActions.generateCertificate({
+              object_name: objectName || pod.name,
+            })
           );
         } else {
           dispatch(

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.tsx
@@ -53,7 +53,7 @@ const LXDSingleSettings = ({
     <Strip className="u-no-padding--top" shallow>
       <LXDHostToolbar hostId={id} showBasic />
       <KVMConfigurationCard pod={pod} />
-      <AuthenticationCard pod={pod} />
+      <AuthenticationCard hostId={id} objectName={pod.name} />
       <DangerZoneCard
         hostId={id}
         message={


### PR DESCRIPTION
## Done

- Added AuthenticationCard to LXDClusterSettings, using the cluster's first host as the canary

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, navigate to http://0.0.0.0:8400/MAAS/r/kvm/lxd/cluster/22/edit
- Check that an Authentication card shows
- Generate a new certificate and check that the change persists (the certificate data that is shown is for karura, the first host in lxd-cluster)
- Check that the certificate data for polong has also been updated

## Fixes

Fixes canonical-web-and-design/app-squad#384

## Screenshot

![Screenshot 2021-11-02 at 10-20-24 lxd-cluster VM hosts bolla MAAS](https://user-images.githubusercontent.com/25733845/139760388-13923d1d-14fa-48a8-9342-e7ed3c365496.png)

