### PR TITLE
feat(ui): include allocated_other for cluster rows in LXD KVM list

### DIFF
--- a/ui/src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
@@ -108,8 +108,9 @@ describe("CPUColumn", () => {
 
   it("can display correct cpu core information for vmclusters", () => {
     const resources = vmClusterResourceFactory({
+      allocated_other: 1,
+      allocated_tracked: 2,
       free: 3,
-      total: 5,
     });
     const store = mockStore(state);
     const wrapper = mount(
@@ -118,8 +119,8 @@ describe("CPUColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "2 of 5 allocated"
+      "2 of 6 allocated"
     );
-    expect(wrapper.find("Meter").prop("max")).toBe(5);
+    expect(wrapper.find("Meter").prop("max")).toBe(6);
   });
 });

--- a/ui/src/app/kvm/components/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/components/CPUColumn/CPUColumn.tsx
@@ -10,23 +10,10 @@ type Props = {
   overCommit?: number;
 };
 
-const CPUColumn = ({ cores, overCommit }: Props): JSX.Element | null => {
-  let total = 0;
-  let allocated = 0;
-  let other = 0;
-  let free = 0;
-  if (overCommit && "allocated_other" in cores) {
-    const resources = resourceWithOverCommit(cores, overCommit);
-    total =
-      resources.allocated_other + resources.allocated_tracked + resources.free;
-    allocated = resources.allocated_tracked;
-    other = resources.allocated_other;
-    free = resources.free;
-  } else if ("total" in cores) {
-    total = cores.total;
-    allocated = cores.total - cores.free;
-    free = cores.free;
-  }
+const CPUColumn = ({ cores, overCommit = 1 }: Props): JSX.Element | null => {
+  const resources = resourceWithOverCommit(cores, overCommit);
+  const { allocated_other, allocated_tracked, free } = resources;
+  const total = allocated_other + allocated_tracked + free;
   return (
     <CPUPopover cores={cores} overCommit={overCommit}>
       <Meter
@@ -34,11 +21,11 @@ const CPUColumn = ({ cores, overCommit }: Props): JSX.Element | null => {
         data={[
           {
             color: COLOURS.LINK,
-            value: allocated,
+            value: allocated_tracked,
           },
           {
             color: COLOURS.POSITIVE,
-            value: other,
+            value: allocated_other,
           },
           {
             color: COLOURS.LINK_FADED,
@@ -47,7 +34,7 @@ const CPUColumn = ({ cores, overCommit }: Props): JSX.Element | null => {
         ]}
         label={
           <small className="u-text--light">
-            {`${allocated} of ${total} allocated`}
+            {`${allocated_tracked} of ${total} allocated`}
           </small>
         }
         labelClassName="u-align--right"

--- a/ui/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
+++ b/ui/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
@@ -95,8 +95,9 @@ describe("CPUPopover", () => {
     const wrapper = mount(
       <CPUPopover
         cores={vmClusterResourceFactory({
+          allocated_other: 1,
+          allocated_tracked: 2,
           free: 3,
-          total: 5,
         })}
         overCommit={1}
       >
@@ -105,11 +106,11 @@ describe("CPUPopover", () => {
     );
     wrapper.find("Popover").simulate("focus");
     expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
-      "Allocated"
+      "Project"
     );
+    expect(wrapper.find("[data-test='other']").text()).toBe("1");
     expect(wrapper.find("[data-test='allocated']").text()).toBe("2");
     expect(wrapper.find("[data-test='free']").text()).toBe("3");
-    expect(wrapper.find("[data-test='total']").text()).toBe("5");
-    expect(wrapper.find("[data-test='other']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='total']").text()).toBe("6");
   });
 });

--- a/ui/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.tsx
+++ b/ui/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.tsx
@@ -10,31 +10,23 @@ type Props = {
   overCommit?: number;
 };
 
-const CPUPopover = ({ children, cores, overCommit }: Props): JSX.Element => {
-  let total = 0;
-  let allocated = 0;
-  let other = 0;
-  let free = 0;
-  let hostCores = 0;
-  let showOther = false;
-  let hasOverCommit = false;
-  if (overCommit && "allocated_other" in cores) {
-    const overCommitted = resourceWithOverCommit(cores, overCommit);
-    hostCores = cores.allocated_other + cores.allocated_tracked + cores.free;
-    total =
-      overCommitted.allocated_other +
-      overCommitted.allocated_tracked +
-      overCommitted.free;
-    showOther = cores.allocated_other > 0;
-    other = cores.allocated_other;
-    allocated = cores.allocated_tracked;
-    free = cores.free;
-    hasOverCommit = overCommit !== 1;
-  } else if ("total" in cores) {
-    total = cores.total;
-    allocated = cores.total - cores.free;
-    free = cores.free;
-  }
+const CPUPopover = ({
+  children,
+  cores,
+  overCommit = 1,
+}: Props): JSX.Element => {
+  const overCommitted = resourceWithOverCommit(cores, overCommit);
+  const hostCores =
+    cores.allocated_other + cores.allocated_tracked + cores.free;
+  const total =
+    overCommitted.allocated_other +
+    overCommitted.allocated_tracked +
+    overCommitted.free;
+  const showOther = cores.allocated_other > 0;
+  const other = cores.allocated_other;
+  const allocated = cores.allocated_tracked;
+  const free = cores.free;
+  const hasOverCommit = overCommit !== 1;
 
   return (
     <Popover

--- a/ui/src/app/kvm/components/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMColumn.test.tsx
@@ -137,12 +137,14 @@ describe("RAMColumn", () => {
   it("can display correct memory for a vmcluster", () => {
     const memory = vmClusterResourcesMemoryFactory({
       general: vmClusterResourceFactory({
-        free: 1,
-        total: 4,
+        allocated_other: 1,
+        allocated_tracked: 2,
+        free: 3,
       }),
       hugepages: vmClusterResourceFactory({
-        free: 3,
-        total: 5,
+        allocated_other: 4,
+        allocated_tracked: 5,
+        free: 6,
       }),
     });
     const store = mockStore(state);
@@ -152,8 +154,8 @@ describe("RAMColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "5 of 9B allocated"
+      "7 of 21B allocated"
     );
-    expect(wrapper.find("Meter").prop("max")).toBe(9);
+    expect(wrapper.find("Meter").prop("max")).toBe(21);
   });
 });

--- a/ui/src/app/kvm/components/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMColumn.tsx
@@ -14,32 +14,19 @@ export type Props = {
   overCommit?: number;
 };
 
-const RAMColumn = ({ memory, overCommit }: Props): JSX.Element | null => {
+const RAMColumn = ({ memory, overCommit = 1 }: Props): JSX.Element | null => {
   const { general, hugepages } = memory;
-  let total = 0;
-  let allocated = 0;
-  let other = 0;
-  let free = 0;
-  if (
-    overCommit &&
-    "allocated_other" in general &&
-    "allocated_other" in hugepages
-  ) {
-    const generalOver = resourceWithOverCommit(general, overCommit);
-    allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
-    other = generalOver.allocated_other + hugepages.allocated_other;
-    free = generalOver.free + hugepages.free;
-    total = allocated + other + free;
-  } else if ("total" in general && "total" in hugepages) {
-    free = general.free + hugepages.free;
-    total = general.total + hugepages.total;
-    allocated = total - free;
-  }
+  const generalOver = resourceWithOverCommit(general, overCommit);
+  const allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
+  const other = generalOver.allocated_other + hugepages.allocated_other;
+  const free = generalOver.free + hugepages.free;
+  const total = allocated + other + free;
   const formattedTotal = formatBytes(total, "B", { binary: true });
   const formattedAllocated = formatBytes(allocated, "B", {
     binary: true,
     convertTo: formattedTotal.unit,
   });
+
   return (
     <RAMPopover memory={memory} overCommit={overCommit}>
       <Meter

--- a/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.test.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.test.tsx
@@ -99,22 +99,24 @@ describe("RAMPopover", () => {
   it("displays memory for a vmcluster", () => {
     const memory = vmClusterResourcesMemoryFactory({
       general: vmClusterResourceFactory({
-        free: 1,
-        total: 4,
+        allocated_other: 1,
+        allocated_tracked: 2,
+        free: 3,
       }),
       hugepages: vmClusterResourceFactory({
-        free: 3,
-        total: 5,
+        allocated_other: 4,
+        allocated_tracked: 5,
+        free: 6,
       }),
     });
     const wrapper = mount(<RAMPopover memory={memory}>Child</RAMPopover>);
     wrapper.find("Popover").simulate("focus");
     expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
-      "Allocated"
+      "Project"
     );
-    expect(wrapper.find("[data-test='allocated']").text()).toBe("5B");
-    expect(wrapper.find("[data-test='free']").text()).toBe("4B");
-    expect(wrapper.find("[data-test='total']").text()).toBe("9B");
-    expect(wrapper.find("[data-test='other']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='other']").text()).toBe("5B");
+    expect(wrapper.find("[data-test='allocated']").text()).toBe("7B");
+    expect(wrapper.find("[data-test='free']").text()).toBe("9B");
+    expect(wrapper.find("[data-test='total']").text()).toBe("21B");
   });
 });

--- a/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.tsx
+++ b/ui/src/app/kvm/components/RAMColumn/RAMPopover/RAMPopover.tsx
@@ -14,37 +14,25 @@ type Props = {
   overCommit?: number;
 };
 
-const RAMPopover = ({ children, memory, overCommit }: Props): JSX.Element => {
+const RAMPopover = ({
+  children,
+  memory,
+  overCommit = 1,
+}: Props): JSX.Element => {
   const { general, hugepages } = memory;
-  let total = 0;
-  let allocated = 0;
-  let other = 0;
-  let free = 0;
-  let hostTotal = 0;
-  let showOther = false;
-  let hasOverCommit = false;
-  if (
-    overCommit &&
-    "allocated_other" in general &&
-    "allocated_other" in hugepages
-  ) {
-    const hostGeneral =
-      general.allocated_other + general.allocated_tracked + general.free;
-    const hostHugepages =
-      hugepages.allocated_other + hugepages.allocated_tracked + hugepages.free;
-    hostTotal = hostGeneral + hostHugepages;
-    const generalOver = resourceWithOverCommit(general, overCommit);
-    allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
-    other = generalOver.allocated_other + hugepages.allocated_other;
-    free = generalOver.free + hugepages.free;
-    total = allocated + other + free;
-    showOther = general.allocated_other > 0 || hugepages.allocated_other > 0;
-    hasOverCommit = overCommit !== 1;
-  } else if ("total" in general && "total" in hugepages) {
-    free = general.free + hugepages.free;
-    total = general.total + hugepages.total;
-    allocated = total - free;
-  }
+  const hostGeneral =
+    general.allocated_other + general.allocated_tracked + general.free;
+  const hostHugepages =
+    hugepages.allocated_other + hugepages.allocated_tracked + hugepages.free;
+  const hostTotal = hostGeneral + hostHugepages;
+  const generalOver = resourceWithOverCommit(general, overCommit);
+  const allocated = generalOver.allocated_tracked + hugepages.allocated_tracked;
+  const other = generalOver.allocated_other + hugepages.allocated_other;
+  const free = generalOver.free + hugepages.free;
+  const total = allocated + other + free;
+  const showOther =
+    general.allocated_other > 0 || hugepages.allocated_other > 0;
+  const hasOverCommit = overCommit !== 1;
 
   return (
     <Popover

--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.test.tsx
@@ -44,15 +44,16 @@ describe("StorageColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "0.1 of 1 TB allocated"
+      "0.1 of 1TB allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(1000000000000);
   });
 
   it("displays correct storage information for a vmcluster", () => {
     const resources = vmClusterResourceFactory({
-      free: 300000000000,
-      total: 500000000000,
+      allocated_other: 1,
+      allocated_tracked: 2,
+      free: 3,
     });
     const store = mockStore(rootStateFactory());
     const wrapper = mount(
@@ -61,8 +62,8 @@ describe("StorageColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "200 of 500 GB allocated"
+      "2 of 6B allocated"
     );
-    expect(wrapper.find("Meter").props().max).toBe(500000000000);
+    expect(wrapper.find("Meter").props().max).toBe(6);
   });
 });

--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import StoragePopover from "./StoragePopover";
 
 import Meter from "app/base/components/Meter";
+import { COLOURS } from "app/base/constants";
 import type { KVMResource } from "app/kvm/types";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod, PodMeta } from "app/store/pod/types";
@@ -30,21 +31,11 @@ const StorageColumn = ({
     podSelectors.getSortedPools(state, podId ?? null)
   );
   const pools = clusterId !== undefined ? sortedClusterPools : sortedPodPools;
-
-  let totalInBytes = 0;
-  let allocated = 0;
-  if ("allocated_other" in storage) {
-    totalInBytes =
-      storage.allocated_other + storage.allocated_tracked + storage.free;
-    allocated = storage.allocated_tracked;
-  } else if ("total" in storage) {
-    totalInBytes = storage.total;
-    allocated = totalInBytes - storage.free;
-  }
-
-  const totalStorage = formatBytes(totalInBytes, "B", { decimals: 1 });
-  const allocatedStorage = formatBytes(allocated, "B", {
-    convertTo: totalStorage.unit,
+  const total =
+    storage.allocated_other + storage.allocated_tracked + storage.free;
+  const formattedTotal = formatBytes(total, "B", { decimals: 1 });
+  const formattedAllocated = formatBytes(storage.allocated_tracked, "B", {
+    convertTo: formattedTotal.unit,
     decimals: 1,
   });
 
@@ -53,16 +44,25 @@ const StorageColumn = ({
       className="u-no-margin--bottom"
       data={[
         {
-          value: allocated,
+          color: COLOURS.LINK,
+          value: storage.allocated_tracked,
+        },
+        {
+          color: COLOURS.POSITIVE,
+          value: storage.allocated_other,
+        },
+        {
+          color: COLOURS.LINK_FADED,
+          value: storage.free,
         },
       ]}
       label={
         <small className="u-text--light">
-          {`${allocatedStorage.value} of ${totalStorage.value} ${totalStorage.unit} allocated`}
+          {`${formattedAllocated.value} of ${formattedTotal.value}${formattedTotal.unit} allocated`}
         </small>
       }
       labelClassName="u-align--right"
-      max={totalInBytes}
+      max={total}
       small
     />
   );

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
@@ -53,11 +53,6 @@ type Props = {
 
 type SortKey = "hostType" | "name" | "cpu" | "zone" | "ram" | "storage" | "vms";
 
-const calculateResources = (resource: KVMResource) =>
-  "allocated_tracked" in resource
-    ? resource.allocated_tracked
-    : resource.total - resource.free;
-
 const getSortValue = (
   sortKey: SortKey,
   row: LxdKVMHostTableRow,
@@ -68,14 +63,14 @@ const getSortValue = (
     case "zone":
       return zone?.name || "unknown";
     case "cpu":
-      return calculateResources(row.cpuCores);
+      return row.cpuCores.allocated_tracked;
     case "ram":
       return (
-        calculateResources(row.memory.general) +
-        calculateResources(row.memory.hugepages)
+        row.memory.general.allocated_tracked +
+        row.memory.hugepages.allocated_tracked
       );
     case "storage":
-      return calculateResources(row.storage);
+      return row.storage.allocated_tracked;
   }
   const value = row[sortKey];
   return isComparable(value) ? value : null;

--- a/ui/src/app/store/pod/utils.ts
+++ b/ui/src/app/store/pod/utils.ts
@@ -5,6 +5,7 @@ import type {
   PodNuma,
   PodResource,
 } from "app/store/pod/types";
+import type { VMClusterResource } from "app/store/vmcluster/types";
 
 export const formatHostType = (type: Pod["type"]): string => {
   switch (type) {
@@ -42,7 +43,7 @@ export const getCoreIndices = (
  * @returns the resource's usage with over-commit.
  */
 export const resourceWithOverCommit = (
-  resource: PodResource,
+  resource: PodResource | VMClusterResource,
   overCommit = 1
 ): PodResource => {
   if (overCommit === 1) {

--- a/ui/src/app/store/vmcluster/types/base.ts
+++ b/ui/src/app/store/vmcluster/types/base.ts
@@ -12,28 +12,36 @@ import type { GenericState } from "app/store/types/state";
 import type { Zone, ZoneMeta } from "app/store/zone/types";
 
 export type VMClusterResource = {
-  total: number;
+  allocated_other: number;
+  allocated_tracked: number;
   free: number;
+  total: number;
 };
+
 export type VMClusterResourcesMemory = {
   hugepages: VMClusterResource;
   general: VMClusterResource;
+};
+
+export type VMClusterPool = {
+  free: number;
+  total: number;
 };
 
 export type VMClusterResources = {
   cpu: VMClusterResource;
   memory: VMClusterResourcesMemory;
   storage: VMClusterResource;
-  storage_pools: Record<string, VMClusterResource>;
+  storage_pools: Record<string, VMClusterPool>;
   vm_count: number;
 };
 
 export type VMHost = Model & {
+  availability_zone: Zone["name"];
   name: Pod["name"];
   project: PodPowerParameters["project"];
-  tags: Pod["tags"];
   resource_pool: ResourcePool["name"];
-  availability_zone: Zone["name"];
+  tags: Pod["tags"];
 };
 
 export type VirtualMachine = {
@@ -46,14 +54,16 @@ export type VirtualMachine = {
 };
 
 export type VMCluster = Model & {
+  availability_zone: Zone[ZoneMeta.PK];
+  created_at: string;
+  hosts: VMHost[];
   name: string;
   project: string;
-  hosts: VMHost[];
-  total_resources: VMClusterResources;
-  virtual_machines: VirtualMachine[];
   resource_pool: ResourcePool[ResourcePoolMeta.PK] | "";
-  availability_zone: Zone[ZoneMeta.PK];
+  total_resources: VMClusterResources;
+  updated_at: string;
   version: string | "";
+  virtual_machines: VirtualMachine[];
 };
 
 export type VMClusterEventError = {

--- a/ui/src/app/store/vmcluster/types/index.ts
+++ b/ui/src/app/store/vmcluster/types/index.ts
@@ -4,6 +4,7 @@ export type {
   VirtualMachine,
   VMCluster,
   VMClusterEventError,
+  VMClusterPool,
   VMClusterResource,
   VMClusterResources,
   VMClusterResourcesMemory,

--- a/ui/src/testing/factories/vmcluster.ts
+++ b/ui/src/testing/factories/vmcluster.ts
@@ -7,6 +7,7 @@ import type {
   VirtualMachine,
   VMCluster,
   VMClusterEventError,
+  VMClusterPool,
   VMClusterResource,
   VMClusterResources,
   VMClusterResourcesMemory,
@@ -30,10 +31,18 @@ export const virtualMachine = define<VirtualMachine>({
   unpinned_cores: 0,
 });
 
-export const vmClusterResource = define<VMClusterResource>({
+export const vmClusterPool = define<VMClusterPool>({
   free: random,
   total: random,
 });
+
+export const vmClusterResource = define<VMClusterResource>({
+  allocated_other: random,
+  allocated_tracked: random,
+  free: random,
+  total: random,
+});
+
 export const vmClusterResourcesMemory = define<VMClusterResourcesMemory>({
   hugepages: vmClusterResource,
   general: vmClusterResource,
@@ -49,6 +58,7 @@ export const vmClusterResources = define<VMClusterResources>({
 
 export const vmCluster = extend<Model, VMCluster>(model, {
   availability_zone: random,
+  created_at: "Thu, 15 Aug. 2019 06:21:39",
   name: "clusterA",
   project: "my-project",
   hosts: () => [],
@@ -56,6 +66,7 @@ export const vmCluster = extend<Model, VMCluster>(model, {
   total_resources: vmClusterResources,
   version: "",
   virtual_machines: () => [],
+  updated_at: "Fri, 16 Aug. 2019 11:21:39",
 });
 
 export const vmClusterEventError = define<VMClusterEventError>({


### PR DESCRIPTION
## Done

- Updated vmcluster types to match latest shape
- Included `allocated_other` data for clusters in the LXD KVM list, which meant that a lot of type-checking could be removed from the column components
- Added `allocated_other` for storage, which was missing. There's currently a bug in the API where we only get back the total allocated_other across all pools, but not the allocated_other for each pool. https://bugs.launchpad.net/maas/+bug/1949418

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla, go to the LXD list and check that allocated_other is shown for storage.
- I'm not entirely sure how we would go about adding another project at `lxd-cluster`'s address. For now we can just see that `lxd-cluster` is unchanged, and that the logic in the tests makes sense.

## Fixes

Fixes canonical-web-and-design/app-squad#420

## Launchpad bug
[lp#1949418](https://bugs.launchpad.net/maas/+bug/1949418)

