### PR TITLE
feat(ui): change the title of the LXD host VMs toolbar to be generic

### DIFF
--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
@@ -67,7 +67,7 @@ const LXDHostVMs = ({
           hostId={hostId}
           setHeaderContent={setHeaderContent}
           setViewByNuma={setViewByNuma}
-          title={`VMs on ${pod.name}`}
+          title="VMs on this host"
           viewByNuma={viewByNuma}
         />
         {viewByNuma ? (


### PR DESCRIPTION
## Done

- Changed LXD host VMs title from "VMs on {pod.name}" to "VMs on this host"

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the VMs tab of a LXD host and check that the toolbar title is "VMs on this host"

## Fixes

Fixes canonical-web-and-design/app-squad#411
