### PR TITLE
fix(ui): set the window title for cluster settings

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
@@ -2,6 +2,7 @@ import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
 
+import { useWindowTitle } from "app/base/hooks";
 import KVMConfigurationCard from "app/kvm/components/KVMConfigurationCard";
 import LXDHostToolbar from "app/kvm/components/LXDHostToolbar";
 import SettingsBackLink from "app/kvm/components/SettingsBackLink";
@@ -10,6 +11,7 @@ import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import { isPodDetails } from "app/store/pod/utils";
 import type { RootState } from "app/store/root/types";
+import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
@@ -18,12 +20,18 @@ type Props = {
 };
 
 const LXDClusterHostSettings = ({ clusterId, hostId }: Props): JSX.Element => {
+  const cluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, hostId)
   );
   const loading = useSelector(podSelectors.loading);
   useActivePod(hostId);
   const redirectURL = useKVMDetailsRedirect(hostId);
+  useWindowTitle(
+    `${pod?.name || "Host"} in ${cluster?.name || "cluster"} settings`
+  );
 
   if (redirectURL) {
     return <Redirect to={redirectURL} />;

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
@@ -1,6 +1,7 @@
 import { Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import { useWindowTitle } from "app/base/hooks";
 import { useActivePod } from "app/kvm/hooks";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import AuthenticationCard from "app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard";
@@ -22,6 +23,7 @@ const LXDClusterSettings = ({
     vmClusterSelectors.getById(state, clusterId)
   );
   useActivePod(cluster?.hosts[0]?.id || null);
+  useWindowTitle(`${cluster?.name || "Cluster"} settings`);
 
   return (
     <Strip shallow>


### PR DESCRIPTION
## Done

- Set the window title when viewing the cluster settings or a cluster host's settings.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a cluster and click on the cluster settings tab.
- Check that the window title is something like "lxd-cluster settings".
- Go to the VM hosts tab and click on a VM host.
- Under the host's name click the settings link.
- Check that the window title is something like "karura in lxd-cluster settings".

## Fixes

Fixes: canonical-web-and-design/app-squad#489.