### PR TITLE
feat(ui): display hover titles for storage columns

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -149,8 +149,12 @@ const normaliseRowData = (
                 inputLabel={storageDevice.name}
               />
             }
+            primaryTitle={storageDevice.name}
             secondary={"serial" in storageDevice && storageDevice.serial}
             secondaryClassName="u-nudge--secondary-row"
+            secondaryTitle={
+              "serial" in storageDevice ? storageDevice.serial : null
+            }
           />
         ),
       },
@@ -158,9 +162,15 @@ const normaliseRowData = (
         content: (
           <DoubleRow
             primary={"model" in storageDevice ? storageDevice.model : "—"}
+            primaryTitle={"model" in storageDevice ? storageDevice.model : null}
             secondary={
               "firmware_version" in storageDevice &&
               storageDevice.firmware_version
+            }
+            secondaryTitle={
+              "firmware_version" in storageDevice
+                ? storageDevice.firmware_version
+                : null
             }
           />
         ),


### PR DESCRIPTION
## Done

- Add titles on hover for storage columns that get truncated.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab in machine details.
- Find the 'Available disks and partitions' table.
- Check that the name, serial, model and firmware data displays a title when hovered.

## Fixes

Fixes: #3180.