### PR TITLE
fix(ui): allow pinning to already pinned core when composing VM

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -342,7 +342,7 @@ describe("ComposeFormFields", () => {
     expect(wrapper.find("FormikField[name='cores']").exists()).toBe(false);
     expect(wrapper.find("FormikField[name='pinnedCores']").exists()).toBe(true);
     expect(wrapper.find("FormikField[name='pinnedCores']").prop("help")).toBe(
-      "2 cores available (free indices: 0-1)"
+      "2 cores available (unpinned indices: 0-1)"
     );
   });
 
@@ -479,7 +479,7 @@ describe("ComposeFormFields", () => {
     );
   });
 
-  it("can validate if the pinned cores are available", async () => {
+  it("shows a warning if some of the selected pinned cores are already pinned", async () => {
     const state = { ...initialState };
     state.pod.items[0].resources = podResourcesFactory({
       numa: [
@@ -517,13 +517,13 @@ describe("ComposeFormFields", () => {
     wrapper.find("input[name='pinnedCores']").simulate("change", {
       target: {
         name: "pinnedCores",
-        value: "1",
+        value: "1-3",
       },
     });
     wrapper.find("input[name='pinnedCores']").simulate("blur");
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find("Input[name='pinnedCores']").prop("error")).toBe(
-      "Some or all of the selected cores are unavailable."
+    expect(wrapper.find("Input[name='pinnedCores']").prop("caution")).toBe(
+      "The following cores have already been pinned: 1,3"
     );
 
     // Enter a core index that is available
@@ -534,8 +534,8 @@ describe("ComposeFormFields", () => {
       },
     });
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find("Input[name='pinnedCores']").prop("error")).toBe(
-      undefined
+    expect(wrapper.find("Input[name='pinnedCores']").prop("caution")).toBe(
+      null
     );
   });
 });

--- a/ui/src/app/utils/arrayFromRangesString.test.ts
+++ b/ui/src/app/utils/arrayFromRangesString.test.ts
@@ -15,8 +15,8 @@ describe("arrayFromRangesString", () => {
     expect(arrayFromRangesString("1, 2, 4, 5")).toStrictEqual([1, 2, 4, 5]);
     expect(arrayFromRangesString("0-2")).toStrictEqual([0, 1, 2]);
     expect(arrayFromRangesString("0-2, 6-7")).toStrictEqual([0, 1, 2, 6, 7]);
-    expect(arrayFromRangesString("0-2, 4, 6-7")).toStrictEqual([
-      0, 1, 2, 4, 6, 7,
+    expect(arrayFromRangesString("0-2, 4, 6-7, 9-11")).toStrictEqual([
+      0, 1, 2, 4, 6, 7, 9, 10, 11,
     ]);
   });
 });

--- a/ui/src/app/utils/arrayFromRangesString.ts
+++ b/ui/src/app/utils/arrayFromRangesString.ts
@@ -2,8 +2,10 @@ import { RANGE_REGEX } from "app/base/validation";
 
 // Convert a string of ranges into an array of numbers,
 // e.g "0-2,4,6-7" => [0, 1, 2, 4, 6, 7]
-export const arrayFromRangesString = (rangeString: string): number[] | null => {
-  if (!rangeString.match(RANGE_REGEX)) {
+export const arrayFromRangesString = (
+  rangeString?: string
+): number[] | null => {
+  if (!rangeString?.match(RANGE_REGEX)) {
     return null;
   }
   const rangeArray: number[] = [];
@@ -16,7 +18,7 @@ export const arrayFromRangesString = (rangeString: string): number[] | null => {
       const [start, end] = substring
         .split("-")
         .map((str) => Number(str))
-        .sort();
+        .sort((a, b) => (a > b ? 1 : -1));
       for (let i = start; i <= end; i++) {
         rangeArray.push(i);
       }


### PR DESCRIPTION
## Done

- Show a warning instead of an error when trying to pin to an already pinned core when composing a VM
- Fixed some bad sorting in `arrayFromRangesString` util which would put `10` before `2`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a LXD KVM and click "Add virtual machine"
- Choose to pin cores and enter "2-10" into the field and check that you don't get an error that says "No cores selected"
- Choose one or more valid core indices and compose a VM
- Try to compose another VM pinning to the same cores and check that a warning shows instead of an error, and you can still compose the VM successfully

## Fixes

Fixes #3156 

## Screenshot
![2021-11-05_16-01](https://user-images.githubusercontent.com/25733845/140465555-26dc3ec2-5485-4a0f-86ce-58276ab0c17e.png)
