### PR TITLE
fix(ui): surface global clone error returned from API

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
@@ -77,6 +77,9 @@ describe("CloneResults", () => {
     expect(wrapper.find("[data-test='results-string']").text()).toBe(
       `0 of 2 machines cloned successfully from ${machine.hostname}.`
     );
+    expect(wrapper.find("[data-test='error-description']").text()).toBe(
+      "Cloning was unsuccessful: it didn't work"
+    );
     expect(wrapper.find("Link[data-test='error-filter-link']").prop("to")).toBe(
       "/machines?system_id=def456%2Cghi789"
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
@@ -20,6 +20,7 @@ import type { Machine, MachineDetails } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
+import { formatErrors } from "app/utils";
 
 export const CloneErrorCodes = {
   IS_SOURCE: "is-source",
@@ -120,7 +121,7 @@ const formatCloneError = (
   return [
     {
       code: "global",
-      description: `Cloning was unsuccessful.`,
+      description: `Cloning was unsuccessful: ${formatErrors(error)}`,
       destinations,
     },
   ];
@@ -221,7 +222,10 @@ export const CloneResults = ({
                       <TableRow data-test="error-row" key={error.code}>
                         <TableCell className="error-col">
                           <Icon name="error" />
-                          <span className="u-nudge-right">
+                          <span
+                            className="u-nudge-right"
+                            data-test="error-description"
+                          >
                             {error.description}
                           </span>
                         </TableCell>


### PR DESCRIPTION
## Done

- Surface global clone errors returned from API

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Force a global clone error by malforming the websocket message
  - Open `ui/src/app/store/machine/slice.ts`, go to line 503 and replace the line with:
  ```
  destinations: 1,
  ```
- Go to the machine list, select a ready machine and choose "Clone from" from the action menu
- Try to clone the machine and check that the error returned from the API shows up in the table

## Fixes

Fixes #3231 

## Screenshot

