### PR TITLE
fix(cypress): fix duplicate data-test attr causing Cypress failures

### DIFF
--- a/integration/cypress/integration/preferences/base.spec.ts
+++ b/integration/cypress/integration/preferences/base.spec.ts
@@ -13,7 +13,7 @@ context("User preferences", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("h1.p-heading--four").contains("My preferences");
+    cy.get("[data-test='section-header-title']").contains("My preferences");
   });
 
   it("highlights the correct navigation link", () => {

--- a/integration/cypress/integration/settings/base.spec.ts
+++ b/integration/cypress/integration/settings/base.spec.ts
@@ -13,7 +13,7 @@ context("Settings", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("h1.p-heading--four").contains("Settings");
+    cy.get("[data-test='section-header-title']").contains("Settings");
   });
 
   it("highlights the correct navigation link", () => {

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -26,12 +26,12 @@ describe("SectionHeader", () => {
     const wrapper = shallow(
       <SectionHeader title="Title" subtitle="Subtitle" loading />
     );
-    expect(wrapper.find("[data-test='section-header-title']").text()).not.toBe(
-      "Title"
-    );
     expect(
-      wrapper.find("[data-test='section-header-title'] Spinner").exists()
+      wrapper.find("[data-test='section-header-title-spinner']").exists()
     ).toBe(true);
+    expect(wrapper.find("[data-test='section-header-title']").exists()).toBe(
+      false
+    );
   });
 
   it("shows a spinner instead of subtitle if subtitle loading", () => {

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -68,7 +68,7 @@ const SectionHeader = <P,>({
           {loading || !title ? (
             <h4
               className="section-header__title"
-              data-test="section-header-title"
+              data-test="section-header-title-spinner"
             >
               <Spinner text="Loading..." />
             </h4>


### PR DESCRIPTION
## Done

- Fixed a bug where two disparate DOM elements had the same `data-test` attribute, which caused Cypress to target the wrong element.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open `integration/cypress.json` and edit the login details for the MAAS you're connected to
- Run `yarn ui` in one window and `yarn cypress-open` in another
- Run the Cypress tests for preferences, settings and images and check that they pass. You can check other sections too, but all the failure types should be handled by these three test suites.

## Fixes

Fixes #3241 
Fixes #3242  

