### PR TITLE
fix(ui): fix possible null value being passed to KernelParametersForm

### DIFF
--- a/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -23,14 +23,14 @@ const KernelParametersForm = (): JSX.Element => {
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
 
-  const kernelParams = useSelector(configSelectors.kernelParams) as string;
+  const kernelParams = useSelector(configSelectors.kernelParams);
 
   return (
     <FormikForm<KernelParametersValues>
       buttonsAlign="left"
       buttonsBordered={false}
       initialValues={{
-        kernel_opts: kernelParams,
+        kernel_opts: kernelParams || "",
       }}
       onSaveAnalytics={{
         action: "Saved",


### PR DESCRIPTION
## Done

- Removed explicit type cast causing causing a Formik error in KernelParametersForm

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using a MAAS that has no global kernel parameters set, go to `/MAAS/r/settings/configuration/kernel-parameters` and check you don't get an error in the console

## Fixes

Fixes #3222 
