### PR TITLE
fix(ui): display the host title for single hosts

### DIFF
--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
+import LXDHostToolbar from "../LXDHostToolbar";
 import LXDVMsTable from "../LXDVMsTable";
 
 import LXDHostVMs from "./LXDHostVMs";
@@ -135,5 +136,56 @@ describe("LXDHostVMs", () => {
 
     expect(wrapper.find("LXDVMsSummaryCard").exists()).toBe(false);
     expect(wrapper.find("NumaResources").exists()).toBe(true);
+  });
+
+  it("displays the host name when in a cluster", async () => {
+    const pod = podFactory({ id: 1, name: "cluster host" });
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [pod],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <LXDHostVMs
+            clusterId={2}
+            hostId={1}
+            onRefreshClick={jest.fn()}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const title = wrapper.find(LXDHostToolbar).prop("title");
+    expect(title && title.includes(pod.name)).toBe(true);
+  });
+
+  it("does not display the host name when in a single host", async () => {
+    const pod = podFactory({ id: 1, name: "cluster host" });
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [pod],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <LXDHostVMs
+            hostId={1}
+            onRefreshClick={jest.fn()}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const title = wrapper.find(LXDHostToolbar).prop("title");
+    expect(title && title.includes(pod.name)).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
@@ -43,6 +43,7 @@ const LXDHostVMs = ({
     `viewPod${hostId}ByNuma`,
     false
   );
+  const isInCluster = !!clusterId || clusterId === 0;
 
   if (pod) {
     return (
@@ -52,7 +53,7 @@ const LXDHostVMs = ({
           hostId={hostId}
           setHeaderContent={setHeaderContent}
           setViewByNuma={setViewByNuma}
-          title="VMs on this host"
+          title={isInCluster ? `VMs on ${pod.name}` : "VMs on this host"}
           viewByNuma={viewByNuma}
         />
         {viewByNuma ? (


### PR DESCRIPTION
## Done

- Display the name of the host in the VM list when viewing a single LXD host.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /KVM and click on a single host.
- In the VMs tab the title should read "VMs on this host".
- Go back to the KVM list and click on a cluster.
- Click the name of a host.
- The title should now read "VMs on [host-name]".

## Fixes

Fixes: #3248.

## Screenshost

<img width="908" alt="Screen Shot 2021-11-09 at 12 18 38 pm" src="https://user-images.githubusercontent.com/361637/140844496-c5d11189-6937-49db-b262-0af46a594f5b.png">
<img width="935" alt="Screen Shot 2021-11-09 at 12 19 00 pm" src="https://user-images.githubusercontent.com/361637/140844506-dd9ddbbb-32ec-4db2-be33-d58aac2308d4.png">
