### PR TITLE
feat(ui): only warn if the boot disk is below 8GB

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
@@ -92,12 +92,13 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
           </thead>
           <tbody>
             {disks.map((disk, i) => {
+              const isBootDisk = disk.id === bootDisk;
               return (
                 <TableRow key={disk.id}>
                   <TableCell aria-label="Size">
                     <FormikField
                       caution={
-                        disk.size < 8
+                        isBootDisk && disk.size < 8
                           ? "Ubuntu typically requires 8GB minimum."
                           : undefined
                       }


### PR DESCRIPTION
## Done

- Updated the compose form to only show a warning if the boot disk is below 8GB.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a LXD cluster or single host and open the compose form.
- Scroll down to 'Storage configuration' and click 'Add disk'.
- Change the size on both disks to be less than 8GB.
- You should see size warning on the first disk but not the second.
- Change the boot radio button to the second disk.
- You should now see the size warning on the second disk but not the first.

## Fixes

Fixes: #3039.

## Screenshots

<img width="1324" alt="Screen Shot 2021-11-09 at 12 58 15 pm" src="https://user-images.githubusercontent.com/361637/140849960-f95a8d90-f34d-4a36-80de-f444fe20b5ea.png">
