### PR TITLE
fix(ui): re-add KVM storage pool sorting with resources endpoint

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -6,7 +6,7 @@ import type { ComposeFormValues, DiskField } from "../../ComposeForm";
 
 import Meter from "app/base/components/Meter";
 import { COLOURS } from "app/base/constants";
-import type { KVMStoragePoolResource } from "app/kvm/types";
+import { getSortedPoolsArray } from "app/kvm/utils";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod, PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
@@ -34,8 +34,9 @@ const generateDropdownContent = (
   requests: RequestMap,
   selectPool: SelectPool
 ): JSX.Element => {
-  const poolsArray = Object.entries<KVMStoragePoolResource>(
-    pod.resources.storage_pools
+  const sortedPools = getSortedPoolsArray(
+    pod.resources.storage_pools,
+    pod.default_storage_pool
   );
   return (
     <>
@@ -58,8 +59,9 @@ const generateDropdownContent = (
           </li>
         </ul>
       </div>
-      {poolsArray.map(([name, pool]) => {
+      {sortedPools.map(([name, pool]) => {
         const isSelected = name === disk.location;
+        const isDefault = "id" in pool && pool.id === pod.default_storage_pool;
 
         // Convert requests into bytes
         const requested = requests[name]
@@ -89,7 +91,9 @@ const generateDropdownContent = (
             <div className="kvm-pool-select__row">
               <div>{isSelected && <i className="p-icon--tick"></i>}</div>
               <div>
-                <strong>{name}</strong>
+                <strong data-test="pool-name">
+                  {isDefault ? `${name} (default)` : name}
+                </strong>
                 <br />
                 <span className="u-text--light">{pool.path}</span>
               </div>

--- a/ui/src/app/kvm/components/KVMStorageCards/KVMStorageCards.test.tsx
+++ b/ui/src/app/kvm/components/KVMStorageCards/KVMStorageCards.test.tsx
@@ -10,21 +10,59 @@ import * as hooks from "app/base/hooks";
 import {
   config as configFactory,
   configState as configStateFactory,
-  podStoragePool as podStoragePoolFactory,
+  podStoragePoolResource as podStoragePoolFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("KVMStorageCards", () => {
+  it("shows sort label as sorting by default then id if default pool id provided", () => {
+    const pools = {
+      a: podStoragePoolFactory(),
+    };
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <KVMStorageCards defaultPoolId="a" pools={pools} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='sort-label']").text()).toBe(
+      "(Sorted by id, default first)"
+    );
+  });
+
+  it("shows sort label as sorting by name if no default pool id provided", () => {
+    const pools = {
+      a: podStoragePoolFactory(),
+    };
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <KVMStorageCards pools={pools} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='sort-label']").text()).toBe(
+      "(Sorted by name)"
+    );
+  });
+
   it("can expand truncated pools if above truncation point", () => {
-    const pools = [
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-    ];
+    const pools = {
+      a: podStoragePoolFactory(),
+      b: podStoragePoolFactory(),
+      c: podStoragePoolFactory(),
+      d: podStoragePoolFactory(),
+      e: podStoragePoolFactory(),
+    };
     const state = rootStateFactory();
     const store = mockStore(state);
     const wrapper = mount(
@@ -48,17 +86,17 @@ describe("KVMStorageCards", () => {
     expect(
       wrapper.find("Button[data-test='show-more-pools'] span").text()
     ).toBe("Show less storage pools");
-    expect(wrapper.find("Card").length).toBe(pools.length);
+    expect(wrapper.find("Card").length).toBe(Object.keys(pools).length);
   });
 
   it("can send an analytics event when expanding pools if analytics enabled", () => {
-    const pools = [
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-    ];
+    const pools = {
+      a: podStoragePoolFactory(),
+      b: podStoragePoolFactory(),
+      c: podStoragePoolFactory(),
+      d: podStoragePoolFactory(),
+      e: podStoragePoolFactory(),
+    };
     const mockSendAnalytics = jest.fn();
     const mockUseSendAnalytics = jest
       .spyOn(hooks, "useSendAnalytics")

--- a/ui/src/app/kvm/components/LXDVMsSummaryCard/LXDVMsSummaryCard.tsx
+++ b/ui/src/app/kvm/components/LXDVMsSummaryCard/LXDVMsSummaryCard.tsx
@@ -25,6 +25,7 @@ const LXDVMsSummaryCard = ({ id }: Props): JSX.Element => {
 
   const {
     cpu_over_commit_ratio,
+    default_storage_pool,
     memory_over_commit_ratio,
     resources: {
       cores,
@@ -59,6 +60,7 @@ const LXDVMsSummaryCard = ({ id }: Props): JSX.Element => {
       />
       <StorageResources
         allocated={storage.allocated_tracked}
+        defaultPoolId={default_storage_pool}
         free={storage.free}
         other={storage.allocated_other}
         pools={storage_pools}

--- a/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StorageColumn.tsx
@@ -2,15 +2,21 @@ import StoragePopover from "./StoragePopover";
 
 import KVMResourceMeter from "app/kvm/components/KVMResourceMeter";
 import type { KVMResource, KVMStoragePoolResources } from "app/kvm/types";
+import type { Pod } from "app/store/pod/types";
 
 type Props = {
+  defaultPoolId?: Pod["default_storage_pool"];
   pools: KVMStoragePoolResources;
   storage: KVMResource;
 };
 
-const StorageColumn = ({ pools, storage }: Props): JSX.Element | null => {
+const StorageColumn = ({
+  defaultPoolId,
+  pools,
+  storage,
+}: Props): JSX.Element | null => {
   return (
-    <StoragePopover pools={pools}>
+    <StoragePopover defaultPoolId={defaultPoolId} pools={pools}>
       <KVMResourceMeter
         allocated={storage.allocated_tracked}
         free={storage.free}

--- a/ui/src/app/kvm/components/StorageColumn/StoragePopover/StoragePopover.test.tsx
+++ b/ui/src/app/kvm/components/StorageColumn/StoragePopover/StoragePopover.test.tsx
@@ -47,4 +47,19 @@ describe("StoragePopover", () => {
     expect(wrapper.find("[data-test='others-col']").exists()).toBe(false);
     expect(wrapper.find("[data-test='pool-others']").exists()).toBe(false);
   });
+
+  it("shows whether a pool is the default pool", () => {
+    const pools = {
+      poolio: podStoragePoolResourceFactory({ id: "abc123" }),
+    };
+    const wrapper = mount(
+      <StoragePopover defaultPoolId="abc123" pools={pools}>
+        Child
+      </StoragePopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='pool-name']").text()).toBe(
+      "poolio (default)"
+    );
+  });
 });

--- a/ui/src/app/kvm/components/StorageResources/StorageMeter/StorageMeter.tsx
+++ b/ui/src/app/kvm/components/StorageResources/StorageMeter/StorageMeter.tsx
@@ -1,25 +1,26 @@
 import KVMResourceMeter from "app/kvm/components/KVMResourceMeter";
 import StoragePopover from "app/kvm/components/StorageColumn/StoragePopover";
-import type {
-  KVMStoragePoolResource,
-  KVMStoragePoolResources,
-} from "app/kvm/types";
-import { calcFreePoolStorage } from "app/kvm/utils";
+import type { KVMStoragePoolResources } from "app/kvm/types";
+import { calcFreePoolStorage, getSortedPoolsArray } from "app/kvm/utils";
+import type { Pod } from "app/store/pod/types";
 
 type Props = {
+  defaultPoolId?: Pod["default_storage_pool"];
   pools: KVMStoragePoolResources;
 };
 
-const StorageMeter = ({ pools }: Props): JSX.Element | null => {
-  const poolsArray = Object.entries<KVMStoragePoolResource>(pools);
-  if (poolsArray.length !== 1) {
+const StorageMeter = ({ defaultPoolId, pools }: Props): JSX.Element | null => {
+  const sortedPools = getSortedPoolsArray(pools);
+  // This component is only meant to show the data for a single pool, so if
+  // there are any more return null.
+  if (sortedPools.length !== 1) {
     return null;
   }
-  const [, pool] = poolsArray[0];
+  const [, pool] = sortedPools[0];
 
   return (
     <div className="u-width--full">
-      <StoragePopover pools={pools}>
+      <StoragePopover defaultPoolId={defaultPoolId} pools={pools}>
         <KVMResourceMeter
           allocated={pool.allocated_tracked}
           detailed

--- a/ui/src/app/kvm/components/StorageResources/StorageMeter/__snapshots__/StorageMeter.test.tsx.snap
+++ b/ui/src/app/kvm/components/StorageResources/StorageMeter/__snapshots__/StorageMeter.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`StorageMeter renders 1`] = `
           "allocated_other": 1,
           "allocated_tracked": 2,
           "backend": "zfs",
+          "id": "abc123",
           "name": "pool-1",
           "path": "/path1",
           "total": 3,

--- a/ui/src/app/kvm/components/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/components/StorageResources/StorageResources.tsx
@@ -4,10 +4,12 @@ import StorageCards from "./StorageCards";
 import StorageMeter from "./StorageMeter";
 
 import type { KVMStoragePoolResources } from "app/kvm/types";
+import type { Pod } from "app/store/pod/types";
 import { formatBytes } from "app/utils";
 
 type Props = {
   allocated: number; // B
+  defaultPoolId?: Pod["default_storage_pool"];
   free: number; // B
   other?: number; // B
   pools: KVMStoragePoolResources;
@@ -15,6 +17,7 @@ type Props = {
 
 const StorageResources = ({
   allocated,
+  defaultPoolId,
   free,
   other = 0,
   pools,
@@ -55,9 +58,9 @@ const StorageResources = ({
       </div>
       <div className="storage-resources__content">
         {singlePool ? (
-          <StorageMeter pools={pools} />
+          <StorageMeter defaultPoolId={defaultPoolId} pools={pools} />
         ) : (
-          <StorageCards pools={pools} />
+          <StorageCards defaultPoolId={defaultPoolId} pools={pools} />
         )}
       </div>
     </div>

--- a/ui/src/app/kvm/utils.test.ts
+++ b/ui/src/app/kvm/utils.test.ts
@@ -1,4 +1,9 @@
-import { memoryWithUnit } from "./utils";
+import { getSortedPoolsArray, memoryWithUnit } from "./utils";
+
+import {
+  podStoragePoolResource as podPoolFactory,
+  vmClusterStoragePoolResource as vmPoolFactory,
+} from "testing/factories";
 
 describe("kvm utils", () => {
   describe("memoryWithUnit", () => {
@@ -7,6 +12,41 @@ describe("kvm utils", () => {
       expect(memoryWithUnit(1)).toBe("1B");
       expect(memoryWithUnit(1024)).toBe("1KiB");
       expect(memoryWithUnit(5000000000)).toBe("4.66GiB");
+    });
+  });
+
+  describe("getSortedPoolsArray", () => {
+    it("correctly returns a sorted array of pools in a pod", () => {
+      const poolA = podPoolFactory({ id: "a" });
+      const poolB = podPoolFactory({ id: "b" });
+      const poolC = podPoolFactory({ id: "c" });
+      const pools = {
+        poolC,
+        poolB,
+        poolA,
+      };
+      const defaultPoolId = "b";
+      expect(getSortedPoolsArray(pools, defaultPoolId)).toStrictEqual([
+        ["poolB", poolB],
+        ["poolA", poolA],
+        ["poolC", poolC],
+      ]);
+    });
+
+    it("correctly returns a sorted array of pools in a cluster", () => {
+      const poolA = vmPoolFactory();
+      const poolB = vmPoolFactory();
+      const poolC = vmPoolFactory();
+      const pools = {
+        poolC,
+        poolA,
+        poolB,
+      };
+      expect(getSortedPoolsArray(pools)).toStrictEqual([
+        ["poolA", poolA],
+        ["poolB", poolB],
+        ["poolC", poolC],
+      ]);
     });
   });
 });

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
@@ -137,7 +137,11 @@ const generateRows = (rows: LxdKVMHostTableRow[]) =>
         {
           className: "storage-col",
           content: (
-            <StorageColumn pools={row.storagePools} storage={row.storage} />
+            <StorageColumn
+              defaultPoolId={row.defaultPoolID}
+              pools={row.storagePools}
+              storage={row.storage}
+            />
           ),
         },
       ],

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleResources/LXDSingleResources.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleResources/LXDSingleResources.tsx
@@ -27,7 +27,10 @@ const LXDSingleResources = ({ id }: Props): JSX.Element => {
         <KVMResourcesCard id={pod.id} />
       </Strip>
       <Strip shallow>
-        <KVMStorageCards pools={pod.resources.storage_pools} />
+        <KVMStorageCards
+          defaultPoolId={pod.default_storage_pool}
+          pools={pod.resources.storage_pools}
+        />
       </Strip>
     </>
   );

--- a/ui/src/app/kvm/views/VirshDetails/VirshResources/VirshResources.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshResources/VirshResources.tsx
@@ -27,7 +27,10 @@ const VirshResources = ({ id }: Props): JSX.Element => {
         <KVMResourcesCard id={pod.id} />
       </Strip>
       <Strip shallow>
-        <KVMStorageCards pools={pod.resources.storage_pools} />
+        <KVMStorageCards
+          defaultPoolId={pod.default_storage_pool}
+          pools={pod.resources.storage_pools}
+        />
       </Strip>
     </>
   );

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -11,7 +11,6 @@ import {
   podProject as podProjectFactory,
   podResources as podResourcesFactory,
   podState as podStateFactory,
-  podStoragePool as storagePoolFactory,
   podVM as podVMFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -406,44 +405,6 @@ describe("pod selectors", () => {
       }),
     });
     expect(pod.getVmResource(state, 1, "abc123")).toEqual(thisVmResource);
-  });
-
-  it("can get a pod's storage pools, sorted by default first then id", () => {
-    const defaultPool = storagePoolFactory({ id: "c" });
-    const aPool = storagePoolFactory({ id: "a" });
-    const bPool = storagePoolFactory({ id: "b" });
-
-    const state = rootStateFactory({
-      pod: podStateFactory({
-        items: [
-          podFactory({
-            default_storage_pool: defaultPool.id,
-            id: 1,
-            storage_pools: [bPool, aPool, defaultPool],
-          }),
-        ],
-      }),
-    });
-    expect(pod.getSortedPools(state, 1)).toEqual([defaultPool, aPool, bPool]);
-  });
-
-  it("can handle default pools that are already at the start", () => {
-    const defaultPool = storagePoolFactory({ id: "c" });
-    const aPool = storagePoolFactory({ id: "a" });
-    const bPool = storagePoolFactory({ id: "b" });
-
-    const state = rootStateFactory({
-      pod: podStateFactory({
-        items: [
-          podFactory({
-            default_storage_pool: defaultPool.id,
-            id: 1,
-            storage_pools: [defaultPool, aPool, bPool],
-          }),
-        ],
-      }),
-    });
-    expect(pod.getSortedPools(state, 1)).toEqual([defaultPool, aPool, bPool]);
   });
 
   it("can get the LXD hosts that are in a given cluster", () => {

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -327,37 +327,6 @@ const getVmResource = createSelector(
   }
 );
 
-/**
- * Returns a pod's storage pools, sorted by default first then id.
- * @param state - The redux state.
- * @param podId - The id of the pod.
- * @returns A list of the pod's storage pools, sorted by default first then id.
- */
-const getSortedPools = createSelector(
-  [
-    (state: RootState, podId: Pod[PodMeta.PK] | null) =>
-      defaultSelectors.getById(state, podId),
-  ],
-  (pod) => {
-    if (!pod) {
-      return [];
-    }
-    const pools = pod.storage_pools || [];
-    return [...pools].sort((a, b) => {
-      if (
-        a.id === pod.default_storage_pool ||
-        (b.id !== pod.default_storage_pool && b.id > a.id)
-      ) {
-        return -1;
-      }
-      if (b.id === pod.default_storage_pool || a.id > b.id) {
-        return 1;
-      }
-      return 0;
-    });
-  }
-);
-
 const selectors = {
   ...defaultSelectors,
   active,
@@ -367,7 +336,6 @@ const selectors = {
   filteredVMs,
   getAllHosts,
   getHost,
-  getSortedPools,
   getVMs,
   getByLxdServer,
   getProjectsByLxdServer,

--- a/ui/src/app/store/pod/types/base.ts
+++ b/ui/src/app/store/pod/types/base.ts
@@ -78,6 +78,7 @@ export type PodStoragePoolResource = {
   allocated_other: number;
   allocated_tracked: number;
   backend: string;
+  id: string;
   name: string;
   path: string;
   total: number;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -403,6 +403,7 @@ export const podStoragePoolResource = define<PodStoragePoolResource>({
   allocated_other: random,
   allocated_tracked: random,
   backend: "zfs",
+  id: "abc123",
   name: "pool-name",
   path: "/path",
   total: random,


### PR DESCRIPTION
## Done

- Re-implemented KVM storage pool sorting using `pod.resources.storage_pools` as opposed to `pod.storage_pools` 
- Removed `pod.getSortedPools` selector as we want sorting to work across pods and clusters

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the LXD KVM list and hover over the storage column and check that single hosts show a "default" pool but clusters do not
- Go to the Resources tab of a LXD single host and check that the storage label says "Sorted by id, default first"
- Go to the Resources tab of a LXD cluster and check that the storage label says "Sorted by name"
- A proper QA will require you to set up a LXD host locally and adding multiple pools to it, otherwise you can use test factories in `KVMStorageCards`, `PoolSelect` and `StoragePopover` to check that the pools are sorting correctly.

## Fixes

Fixes #3232 
