### PR TITLE
feat(ui): add "custom" option to ChangeStorageLayout dropdown

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -21,11 +21,16 @@ type StorageLayoutOption = {
 
 type Props = { systemId: Machine["system_id"] };
 
+// TODO: Once the API returns a list of allowed storage layouts for a given
+// machine we should either filter this list, or add a boolean e.g. "allowable"
+// to each layout.
+// https://github.com/canonical-web-and-design/maas-ui/issues/3258
 const storageLayoutOptions: StorageLayoutOption[][] = [
   [
     { label: "Flat", sentenceLabel: "flat", value: StorageLayout.FLAT },
     { label: "LVM", sentenceLabel: "LVM", value: StorageLayout.LVM },
     { label: "bcache", sentenceLabel: "bcache", value: StorageLayout.BCACHE },
+    { label: "Custom", sentenceLabel: "custom", value: StorageLayout.CUSTOM },
   ],
   [
     {

--- a/ui/src/app/store/machine/types/enum.ts
+++ b/ui/src/app/store/machine/types/enum.ts
@@ -35,6 +35,7 @@ export enum PowerState {
 export enum StorageLayout {
   BCACHE = "bcache",
   BLANK = "blank",
+  CUSTOM = "custom",
   FLAT = "flat",
   LVM = "lvm",
   UNKNOWN = "unknown",


### PR DESCRIPTION
## Done

- Added "custom" option to ChangeStorageLayout dropdown

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Storage tab of a Ready machine
- Click "Change storage layout"
- Check that "Custom" is an option. Click it and submit the form.
- You should get an error. I've been trying to find out how to format a custom commissioning script to test this for real but it's not easy parsing information from the source code/discourse/docs. I think for now we can just test that the API is responding correctly and I'll follow up with the core team about testing a "real" custom storage layout machine.

## Fixes

Fixes #3219 

## Launchpad issue

[lp#1949455](https://bugs.launchpad.net/maas/+bug/1949455)
[lp#1950395](https://bugs.launchpad.net/maas/+bug/1950395)
