### PR TITLE
feat(ui): change "VM host" to "KVM host"

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
@@ -86,7 +86,7 @@ describe("AddLxd", () => {
   });
 
   it(`shows the authentication form if the user has generated a certificate for
-    the LXD VM host`, () => {
+    the LXD KVM host`, () => {
     const certificate = generatedCertificateFactory({
       CN: "my-favourite-kvm@host",
     });

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -73,7 +73,7 @@ export const AuthenticationForm = ({
   }, [setStep, shouldGoToProjectStep]);
 
   // The generated certificate is cleared as we only store one in state at a
-  // time. This will prepare the form for the next added VM host. We also make
+  // time. This will prepare the form for the next added KVM host. We also make
   // sure to stop polling the LXD server for projects.
   useEffect(() => {
     return () => {

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.tsx
@@ -126,7 +126,7 @@ export const SelectProjectForm = ({
       }}
       saved={saved}
       saving={saving}
-      submitLabel="Next"
+      submitLabel="Save LXD host"
       validationSchema={SelectProjectSchema}
     >
       <SelectProjectFormFields newPodValues={newPodValues} />

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.tsx
@@ -122,7 +122,7 @@ export const SelectProjectForm = ({
           zone: Number(newPodValues.zone),
         });
         dispatch(podActions.create(params));
-        setSavingPod(newPodValues.name || "LXD VM host");
+        setSavingPod(newPodValues.name || "LXD KVM host");
       }}
       saved={saved}
       saving={saving}

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.tsx
@@ -124,7 +124,7 @@ export const AddVirsh = ({ clearHeaderContent }: Props): JSX.Element => {
             ]),
           };
           dispatch(podActions.create(params));
-          setSavingPod(values.name || "virsh VM host");
+          setSavingPod(values.name || "virsh KVM host");
         }
       }}
       saving={podSaving}

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.tsx
@@ -130,7 +130,7 @@ export const AddVirsh = ({ clearHeaderContent }: Props): JSX.Element => {
       saving={podSaving}
       saved={podSaved}
       submitDisabled={!virshPowerType}
-      submitLabel="Save KVM"
+      submitLabel="Save Virsh host"
       validationSchema={AddVirshSchema}
     >
       {virshPowerType ? (

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -101,10 +101,10 @@ describe("InterfacesTable", () => {
     ).toBe(true);
     expect(
       wrapper.find("[data-test='define-interfaces']").prop("message")
-    ).toBe("There are no available networks seen by this VM host.");
+    ).toBe("There are no available networks seen by this KVM host.");
   });
 
-  it("disables add interface button with tooltip if VM host has no PXE-enabled networks", () => {
+  it("disables add interface button with tooltip if KVM host has no PXE-enabled networks", () => {
     const fabric = fabricFactory();
     const vlan = vlanFactory({ fabric: fabric.id });
     const subnet = subnetFactory({ vlan: vlan.id });
@@ -126,7 +126,7 @@ describe("InterfacesTable", () => {
     ).toBe(true);
     expect(
       wrapper.find("[data-test='define-interfaces']").prop("message")
-    ).toBe("There are no PXE-enabled networks seen by this VM host.");
+    ).toBe("There are no PXE-enabled networks seen by this KVM host.");
   });
 
   it("disables add interface button if pod is composing a machine", () => {

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -70,10 +70,10 @@ export const getPxeIconClass = (pod?: PodDetails, vlan?: VLAN): string => {
  */
 const getTooltipMessage = (hasSubnets: boolean, hasPxeSubnets: boolean) => {
   if (!hasSubnets) {
-    return "There are no available networks seen by this VM host.";
+    return "There are no available networks seen by this KVM host.";
   }
   if (!hasPxeSubnets) {
-    return "There are no PXE-enabled networks seen by this VM host.";
+    return "There are no PXE-enabled networks seen by this KVM host.";
   }
   return null;
 };

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -51,7 +51,7 @@ describe("DeleteForm", () => {
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
     expect(wrapper.find('[data-test="saving-label"]').text()).toBe(
-      "Removing KVM..."
+      "Removing KVM host..."
     );
   });
 

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -88,11 +88,11 @@ const DeleteForm = ({
       initialValues={{
         decompose: false,
       }}
-      modelName={pod ? "KVM" : "cluster"}
+      modelName={pod ? "KVM host" : "cluster"}
       onSaveAnalytics={{
         action: "Submit",
         category: "KVM details action form",
-        label: `Remove ${pod ? "KVM" : "cluster"}`,
+        label: `Remove ${pod ? "KVM host" : "cluster"}`,
       }}
       onSubmit={(values: DeleteFormValues) => {
         // Clean up so that previous errors are cleared.
@@ -116,7 +116,7 @@ const DeleteForm = ({
       onSuccess={() => {
         dispatch(
           messageActions.add(
-            `${pod ? "KVM" : "Cluster"} removed successfully`,
+            `${pod ? "KVM host" : "Cluster"} removed successfully`,
             NotificationSeverity.INFORMATION
           )
         );
@@ -133,8 +133,9 @@ const DeleteForm = ({
           <Col size={6}>
             <p>
               <Icon className="is-inline" name="warning" />
-              Once a {pod ? "KVM" : "cluster"} is removed, you can still access
-              all VMs in this {pod ? "project" : "cluster"} from the LXD server.
+              Once a {pod ? "KVM host" : "cluster"} is removed, you can still
+              access all VMs in this {pod ? "project" : "cluster"} from the LXD
+              server.
             </p>
             <FormikField
               label={

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.test.tsx
@@ -39,7 +39,7 @@ describe("RefreshForm", () => {
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
     expect(wrapper.find('[data-test="saving-label"]').text()).toBe(
-      "Refreshing KVM..."
+      "Refreshing KVM host..."
     );
   });
 

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 
+import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -29,7 +30,7 @@ const RefreshForm = ({
       clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{}}
-      modelName="KVM"
+      modelName={pluralize("KVM host", hostIds.length)}
       onSaveAnalytics={{
         action: "Submit",
         category: "KVM details action form",
@@ -44,9 +45,9 @@ const RefreshForm = ({
       selectedCount={hostIds.length}
     >
       <p>
-        Refreshing KVMs will cause MAAS to recalculate usage metrics, update
-        information about storage pools, and commission any machines present in
-        the KVMs that are not yet known to MAAS.
+        Refreshing KVM hosts will cause MAAS to recalculate usage metrics,
+        update information about storage pools, and commission any machines
+        present in the KVM hosts that are not yet known to MAAS.
       </p>
     </ActionForm>
   );

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
 
-import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -30,7 +29,7 @@ const RefreshForm = ({
       clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{}}
-      modelName={pluralize("KVM host", hostIds.length)}
+      modelName="KVM host"
       onSaveAnalytics={{
         action: "Submit",
         category: "KVM details action form",

--- a/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -12,6 +12,7 @@ import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
 
 type Props = {
+  displayForCluster?: boolean;
   getHostColumn?: GetHostColumn;
   getResources: GetResources;
   onRefreshClick: () => void;
@@ -24,6 +25,7 @@ type Props = {
 export const VMS_PER_PAGE = 10;
 
 const LXDVMsTable = ({
+  displayForCluster,
   getHostColumn,
   getResources,
   onRefreshClick,
@@ -57,6 +59,7 @@ const LXDVMsTable = ({
       />
       <VMsTable
         currentPage={currentPage}
+        displayForCluster={displayForCluster}
         getHostColumn={getHostColumn}
         getResources={getResources}
         searchFilter={searchFilter}

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -217,7 +217,7 @@ describe("VMsTable", () => {
     expect(wrapper.find("tbody tr").length).toBe(1);
   });
 
-  it("shows a message if no VMs match the search filter", () => {
+  it("shows a message if no VMs in a KVM host match the search filter", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [],
@@ -241,7 +241,36 @@ describe("VMsTable", () => {
 
     expect(wrapper.find("[data-test='no-vms']").exists()).toBe(true);
     expect(wrapper.find("[data-test='no-vms']").text()).toBe(
-      "No VMs in this VM host match the search criteria."
+      "No VMs in this KVM host match the search criteria."
+    );
+  });
+
+  it("shows a message if no VMs in a cluster match the search filter", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable
+            currentPage={1}
+            displayForCluster
+            getResources={getResources}
+            searchFilter="system_id:(=ghi789)"
+            vms={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='no-vms']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='no-vms']").text()).toBe(
+      "No VMs in this cluster match the search criteria."
     );
   });
 

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
@@ -31,6 +31,7 @@ export type GetResources = (vm: Machine) => {
 
 type Props = {
   currentPage: number;
+  displayForCluster?: boolean;
   getHostColumn?: GetHostColumn;
   getResources: GetResources;
   searchFilter: string;
@@ -128,6 +129,7 @@ const generateRows = (
 
 const VMsTable = ({
   currentPage,
+  displayForCluster,
   getHostColumn,
   getResources,
   searchFilter,
@@ -203,7 +205,7 @@ const VMsTable = ({
                 {
                   className: "host-col",
                   content: (
-                    <TableHeader data-test="host-column">VM host</TableHeader>
+                    <TableHeader data-test="host-column">KVM host</TableHeader>
                   ),
                 },
               ]
@@ -260,7 +262,8 @@ const VMsTable = ({
       {searchFilter && vms.length === 0 ? (
         <Strip shallow rowClassName="u-align--center">
           <span data-test="no-vms">
-            No VMs in this VM host match the search criteria.
+            No VMs in this {displayForCluster ? "cluster" : "KVM host"} match
+            the search criteria.
           </span>
         </Strip>
       ) : null}

--- a/ui/src/app/kvm/hooks.tsx
+++ b/ui/src/app/kvm/hooks.tsx
@@ -32,8 +32,8 @@ export const useActivePod = (id: Pod["id"] | null): void => {
 };
 
 /**
- * Handle redirects for the different types of VM host at certain URLs.
- * @param id - The id of the VM host to handle redirects for.
+ * Handle redirects for the different types of KVM host at certain URLs.
+ * @param id - The id of the KVM host to handle redirects for.
  */
 export const useKVMDetailsRedirect = (id: Pod["id"]): string | null => {
   const dispatch = useDispatch();

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -56,7 +56,7 @@ describe("KVMListHeader", () => {
       </Provider>
     );
     expect(wrapper.find('[data-test="section-header-subtitle"]').text()).toBe(
-      "2 VM hosts available"
+      "2 KVM hosts available"
     );
   });
 

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -60,7 +60,7 @@ const KVMListHeader = ({
           />
         ) : null
       }
-      subtitle={`${pluralize("VM host", kvms.length, true)} available`}
+      subtitle={`${pluralize("KVM host", kvms.length, true)} available`}
       subtitleLoading={!podsLoaded}
       tabLinks={[
         {

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.test.tsx
@@ -182,6 +182,8 @@ describe("LxdKVMHostTable", () => {
     );
     expect(wrapper.find("[data-test='host-type']").text()).toBe("Cluster");
     expect(wrapper.find("[data-test='hosts-count']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='hosts-count']").text()).toBe("2 VM hosts");
+    expect(wrapper.find("[data-test='hosts-count']").text()).toBe(
+      "2 KVM hosts"
+    );
   });
 });

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
@@ -1,4 +1,5 @@
 import { Col, Icon, MainTable, Row } from "@canonical/react-components";
+import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
@@ -101,7 +102,9 @@ const generateRows = (rows: LxdKVMHostTableRow[]) =>
               }
               secondary={
                 isCluster ? (
-                  <span data-test="hosts-count">{row.hostsCount} VM hosts</span>
+                  <span data-test="hosts-count">
+                    {pluralize("KVM host", row.hostsCount, true)}
+                  </span>
                 ) : null
               }
             />

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -65,7 +65,7 @@ const LXDClusterDetailsHeader = ({
             kvmURLs.lxd.cluster.hosts({ clusterId })
           ),
           component: Link,
-          label: "VM hosts",
+          label: "KVM hosts",
           to: kvmURLs.lxd.cluster.hosts({ clusterId }),
         },
         {

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -32,7 +32,7 @@ const LXDClusterHosts = ({
   const hosts = useSelector((state: RootState) =>
     podSelectors.searchInCluster(state, clusterId, searchFilter)
   );
-  useWindowTitle(`${cluster?.name || "LXD cluster"} VM hosts`);
+  useWindowTitle(`${cluster?.name || "LXD cluster"} KVM hosts`);
 
   return (
     <>

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterSettings/LXDClusterSettings.tsx
@@ -39,7 +39,7 @@ const LXDClusterSettings = ({
               <strong>Remove this LXD cluster</strong>
             </p>
             <p>
-              All VM hosts in this LXD cluster will be removed, you can still
+              All KVM hosts in this LXD cluster will be removed, you can still
               access this project from the LXD server.
             </p>
           </>

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -44,6 +44,7 @@ const LXDClusterVMs = ({
         <LXDClusterSummaryCard clusterId={clusterId} />
       </Strip>
       <LXDVMsTable
+        displayForCluster
         getHostColumn={(machine) => {
           if (machine.pod) {
             return (

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
@@ -78,7 +78,7 @@ const LXDSingleDetailsHeader = ({
         {
           active: location.pathname.endsWith(kvmURLs.lxd.single.edit({ id })),
           component: Link,
-          label: "VM host settings",
+          label: "KVM host settings",
           to: kvmURLs.lxd.single.edit({ id }),
         },
       ]}

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard/DangerZoneCard.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/DangerZoneCard/DangerZoneCard.tsx
@@ -37,7 +37,9 @@ const DangerZoneCard = ({
               })
             }
           >
-            Remove KVM
+            {!!clusterId || clusterId === 0
+              ? "Remove cluster"
+              : "Remove KVM host"}
           </Button>
         </Col>
       </Row>

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.tsx
@@ -59,10 +59,10 @@ const LXDSingleSettings = ({
         message={
           <>
             <p>
-              <strong>Remove this VM host</strong>
+              <strong>Remove this KVM host</strong>
             </p>
             <p>
-              Once a VM host is removed, you can still access this project from
+              Once a KVM host is removed, you can still access this project from
               the LXD server.
             </p>
           </>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -384,7 +384,7 @@ describe("DeployForm", () => {
     mockUseSendAnalytics.mockRestore();
   });
 
-  it("can register a LXD VM host", () => {
+  it("can register a LXD KVM host", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123"];
     const store = mockStore(state);

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -181,7 +181,7 @@ describe("DeployFormFields", () => {
     );
   });
 
-  it("disables VM host checkbox if not Ubuntu 18.04 or 20.04", async () => {
+  it("disables KVM host checkbox if not Ubuntu 18.04 or 20.04", async () => {
     const state = { ...initialState };
     if (state.general.osInfo.data) {
       state.general.osInfo.data.default_release = "xenial";
@@ -219,7 +219,7 @@ describe("DeployFormFields", () => {
     );
   });
 
-  it("enables VM host checkbox when switching to Ubuntu 18.04 from a different OS/Release", async () => {
+  it("enables KVM host checkbox when switching to Ubuntu 18.04 from a different OS/Release", async () => {
     const state = { ...initialState };
     if (state.general.osInfo.data) {
       state.general.osInfo.data.default_release = "bionic";
@@ -259,7 +259,7 @@ describe("DeployFormFields", () => {
     );
   });
 
-  it("shows VM host type options when the VM host checkbox is checked", async () => {
+  it("shows KVM host type options when the KVM host checkbox is checked", async () => {
     const state = { ...initialState };
     if (state.general.osInfo.data) {
       state.general.osInfo.data.default_release = "bionic";


### PR DESCRIPTION
## Done

- Update the host labels from "VM host" to "KVM host".

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- This could probably just have a code review, but you could have a poke around the LXD area to make sure everything says "KVM host" instead of "VM host".

## Fixes

Fixes: canonical-web-and-design/app-tribe#506.