### PR TITLE
fix(ui): display a 404 message when a KVM host is not found

### DIFF
--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -7,6 +7,8 @@ import LXDClusterDetails from "./LXDClusterDetails";
 
 import kvmURLs from "app/kvm/urls";
 import {
+  podState as podStateFactory,
+  vmCluster as vmClusterFactory,
   vmClusterState as vmClusterStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -32,11 +34,51 @@ describe("LXDClusterDetails", () => {
             },
           ]}
         >
-          <LXDClusterDetails />
+          <Route
+            exact
+            path={kvmURLs.lxd.cluster.index(null, true)}
+            component={() => <LXDClusterDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("[data-test='not-found']").exists()).toBe(true);
+  });
+
+  it("displays a message if a KVM host does not exist", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [],
+        loaded: true,
+      }),
+      vmcluster: vmClusterStateFactory({
+        items: [vmClusterFactory({ id: 1 })],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: kvmURLs.lxd.cluster.vms.host({
+                clusterId: 1,
+                hostId: 99,
+              }),
+              key: "testKey",
+            },
+          ]}
+        >
+          <Route
+            exact
+            path={kvmURLs.lxd.cluster.vms.host(null, true)}
+            component={() => <LXDClusterDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='host-not-found']").exists()).toBe(true);
   });
 
   it("sets the search filter from the URL", () => {

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -28,6 +28,7 @@ import type { KVMHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as vmClusterActions } from "app/store/vmcluster";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
@@ -47,7 +48,11 @@ const LXDClusterDetails = (): JSX.Element => {
   );
   const [fetched] = useCycled(getting);
   const loaded = clustersLoaded || fetched;
-  const hostId = params.hostId !== "" ? Number(params.hostId) : null;
+  const hostId = params.hostId ? Number(params.hostId) : null;
+  const host = useSelector((state: RootState) =>
+    podSelectors.getById(state, hostId)
+  );
+  const hostsLoaded = useSelector(podSelectors.loaded);
   const [headerContent, setHeaderContent] = useState<KVMHeaderContent | null>(
     null
   );
@@ -78,6 +83,22 @@ const LXDClusterDetails = (): JSX.Element => {
         <p>
           Unable to find a cluster with id "{clusterId}".{" "}
           <Link to={kvmURLs.kvm}>View all KVMs</Link>.
+        </p>
+      </Section>
+    );
+  }
+  if (hostId !== null && hostsLoaded && !host) {
+    return (
+      <Section
+        header={<SectionHeader title="KVM host not found" />}
+        data-test="host-not-found"
+      >
+        <p>
+          Unable to find a KVM host with id "{hostId}".{" "}
+          <Link to={kvmURLs.lxd.cluster.hosts({ clusterId })}>
+            View all KVM hosts
+          </Link>
+          .
         </p>
       </Section>
     );


### PR DESCRIPTION
## Done

- Display a 404 message when a KVM host is not found.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit a URL for a KVM host in a cluster that does not exist e.g. /MAAS/r/kvm/lxd/cluster/[valid-cluster-id]/vms/999
- You should see a "not found" message.

## Fixes

Fixes: #3265.