### PR TITLE
Fix login page a11y issues, add cypress-axe

### DIFF
--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -11,6 +11,13 @@ context("Login page", () => {
     clearCookies();
   });
 
+  it("has no detectable accessibility violations on load", () => {
+    cy.title().should("include", "Login");
+
+    cy.injectAxe();
+    cy.checkA11y();
+  });
+
   it("is disabled by default", () => {
     cy.get("button").should("have.attr", "disabled", "disabled");
   });

--- a/integration/cypress/support/index.js
+++ b/integration/cypress/support/index.js
@@ -12,6 +12,7 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+import "cypress-axe";
 
 // Import commands.js using ES2015 syntax:
 import "./commands";

--- a/integration/package.json
+++ b/integration/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/parser": "5.3.1",
     "concurrently": "6.2.1",
     "cypress": "7.7.0",
-    "cypress-axe": "^0.13.0",
+    "cypress-axe": "0.13.0",
     "dotenv-flow": "3.2.0",
     "eslint-plugin-cypress": "2.12.1",
     "eslint-plugin-import": "2.25.2",

--- a/integration/package.json
+++ b/integration/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/parser": "5.3.1",
     "concurrently": "6.2.1",
     "cypress": "7.7.0",
+    "cypress-axe": "^0.13.0",
     "dotenv-flow": "3.2.0",
     "eslint-plugin-cypress": "2.12.1",
     "eslint-plugin-import": "2.25.2",

--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -235,6 +235,7 @@ export const Header = ({
 
     return (
       <nav
+        aria-label="primary"
         className={classNames("p-navigation__nav", {
           "u-show": mobileMenuOpen,
         })}

--- a/shared/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/shared/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`Header renders 1`] = `
         </a>
       </div>
       <nav
+        aria-label="primary"
         className="p-navigation__nav"
       >
         <span

--- a/ui/src/app/base/components/Login/Login.tsx
+++ b/ui/src/app/base/components/Login/Login.tsx
@@ -46,7 +46,7 @@ export const Login = (): JSX.Element => {
   }, [dispatch, externalAuthURL]);
 
   return (
-    <Strip>
+    <Strip element="main">
       <Row>
         <Col size={6} emptyLarge={4}>
           {externalAuthURL && error && (
@@ -69,7 +69,8 @@ export const Login = (): JSX.Element => {
               </Button>
             </Card>
           ) : (
-            <Card title="Login">
+            <Card>
+              <h1 className="p-card__title p-heading--3">Login</h1>
               {externalAuthURL ? (
                 <Button
                   appearance="positive"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,7 +5690,7 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress-axe@^0.13.0:
+cypress-axe@0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.13.0.tgz#3234e1a79a27701f2451fcf2f333eb74204c7966"
   integrity sha512-fCIy7RiDCm7t30U3C99gGwQrUO307EYE1QqXNaf9ToK4DVqW8y5on+0a/kUHMrHdlls2rENF6TN9ZPpPpwLrnw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,6 +5690,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-axe@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.13.0.tgz#3234e1a79a27701f2451fcf2f333eb74204c7966"
+  integrity sha512-fCIy7RiDCm7t30U3C99gGwQrUO307EYE1QqXNaf9ToK4DVqW8y5on+0a/kUHMrHdlls2rENF6TN9ZPpPpwLrnw==
+
 cypress@7.7.0:
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.7.0.tgz#0839ae28e5520536f9667d6c9ae81496b3836e64"


### PR DESCRIPTION
## Done

- Add [cypress axe](https://github.com/component-driven/cypress-axe)
- improve login page accessibility
  - fix accessibility issues
  - add cypress-axe a11y violations test

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
