### PR TITLE
fix Users table email truncation

### DIFF
--- a/ui/src/app/settings/views/Users/UsersList/UsersList.tsx
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.tsx
@@ -52,7 +52,7 @@ const generateUserRows = (
           content: displayUsername ? user.username : fullName || <>&mdash;</>,
           role: "rowheader",
         },
-        { content: user.email },
+        { content: user.email, className: "u-break-word" },
         { content: user.machines_count, className: "u-align--right" },
         { content: user.is_local && "Local" },
         { content: last_login || "Never" },

--- a/ui/src/app/settings/views/Users/UsersList/_index.scss
+++ b/ui/src/app/settings/views/Users/UsersList/_index.scss
@@ -10,12 +10,12 @@
 
     // Email
     &:nth-child(2) {
-      flex: $grid-size * 6 0 0;
+      flex: $grid-size * 8 0 0;
     }
 
     // Machines
     &:nth-child(3) {
-      flex: $grid-size * 3 0 0;
+      flex: $grid-size * 2 0 0;
     }
 
     // Type
@@ -35,7 +35,9 @@
 
     // MAAS keys
     &:nth-child(7) {
-      flex: $grid-size * 3 0 0;
+      flex: $grid-size * 2 0 0;
+      white-space: nowrap;
+      text-overflow: clip;
     }
 
     // Actions


### PR DESCRIPTION
## Done

- fix Users table email truncation issue
  - enlarge table email column
  - add break-word to email

## Before
![image](https://user-images.githubusercontent.com/7452681/141778522-ac728623-2b95-4310-8e44-16d005da66b1.png)

## After
![image](https://user-images.githubusercontent.com/7452681/141778432-7bd77bad-be7d-4ed9-b245-0a8c88b48a91.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `MAAS/r/settings/users` and make sure emails wrap to multiple lines and are displayed in full

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
