### PR TITLE
fix(legacy): fix deleting a space when the edit form is open

### DIFF
--- a/legacy/src/app/factories/spaces.js
+++ b/legacy/src/app/factories/spaces.js
@@ -34,6 +34,9 @@ function SpacesManager(RegionConnection, Manager) {
 
   // Delete the space.
   SpacesManager.prototype.deleteSpace = function (space) {
+    if ("$maasForm" in space) {
+      delete space.$maasForm;
+    }
     return RegionConnection.callMethod("space.delete", space);
   };
 

--- a/legacy/src/app/factories/spaces.js
+++ b/legacy/src/app/factories/spaces.js
@@ -34,6 +34,8 @@ function SpacesManager(RegionConnection, Manager) {
 
   // Delete the space.
   SpacesManager.prototype.deleteSpace = function (space) {
+    // If there is a form in the in scope then it could be passed to the delete
+    // method, but we don't want to include it in the data to be sent with the request.
     if ("$maasForm" in space) {
       delete space.$maasForm;
     }

--- a/legacy/src/app/factories/tests/test_spaces.js
+++ b/legacy/src/app/factories/tests/test_spaces.js
@@ -45,5 +45,18 @@ describe("SpacesManager", function () {
         obj
       );
     });
+
+    it("does not include form values", function () {
+      var obj = {
+        $maasForm: {},
+        id: 1,
+      };
+      var result = {};
+      spyOn(RegionConnection, "callMethod").and.returnValue(result);
+      expect(SpacesManager.deleteSpace(obj)).toBe(result);
+      expect(RegionConnection.callMethod).toHaveBeenCalledWith("space.delete", {
+        id: 1,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Done

- Handle deleting a space when the space is in edit mode.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click 'Subnets' in the header.
- Change the grouping to 'Spaces'.
- Use the take action menu to add a space.
- Click on the space you created.
- In the space summary click 'Edit'.
- In the header click 'Delete space' and then confirm.
- You should be taken back to the subnets list and the space should have been deleted.

## Fixes

Fixes: #3288.