### PR TITLE
feat(ui): add util for determining whether device is BaseDevice or DeviceDetails type

### DIFF
--- a/ui/src/app/store/device/types/base.ts
+++ b/ui/src/app/store/device/types/base.ts
@@ -17,7 +17,7 @@ export type DeviceNetworkInterface = NetworkInterface & {
   ip_assignment: DeviceIpAssignment;
 };
 
-export type Device = SimpleNode & {
+export type BaseDevice = SimpleNode & {
   actions: DeviceActions[];
   extra_macs: string[];
   fabrics: string[];
@@ -32,7 +32,7 @@ export type Device = SimpleNode & {
   zone: ModelRef;
 };
 
-export type DeviceDetails = Device & {
+export type DeviceDetails = BaseDevice & {
   created: string;
   description: string;
   interfaces: DeviceNetworkInterface[];
@@ -43,5 +43,7 @@ export type DeviceDetails = Device & {
   swap_size: number | null;
   updated: string;
 };
+
+export type Device = BaseDevice | DeviceDetails;
 
 export type DeviceState = GenericState<Device, APIError>;

--- a/ui/src/app/store/device/types/index.ts
+++ b/ui/src/app/store/device/types/index.ts
@@ -5,6 +5,7 @@ export type {
 } from "./actions";
 
 export type {
+  BaseDevice,
   Device,
   DeviceActions,
   DeviceDetails,

--- a/ui/src/app/store/device/utils.test.ts
+++ b/ui/src/app/store/device/utils.test.ts
@@ -1,0 +1,28 @@
+import { isDeviceDetails } from "./utils";
+
+import {
+  device as deviceFactory,
+  deviceDetails as deviceDetailsFactory,
+} from "testing/factories";
+
+describe("device utils", () => {
+  describe("isDeviceDetails", () => {
+    it("identifies device details", () => {
+      const deviceDetails = deviceDetailsFactory();
+      expect(isDeviceDetails(deviceDetails)).toBe(true);
+    });
+
+    it("handles base device", () => {
+      const baseDevice = deviceFactory();
+      expect(isDeviceDetails(baseDevice)).toBe(false);
+    });
+
+    it("handles no device", () => {
+      expect(isDeviceDetails()).toBe(false);
+    });
+
+    it("handles null", () => {
+      expect(isDeviceDetails(null)).toBe(false);
+    });
+  });
+});

--- a/ui/src/app/store/device/utils.ts
+++ b/ui/src/app/store/device/utils.ts
@@ -1,0 +1,11 @@
+import type { Device, DeviceDetails } from "app/store/device/types";
+
+/**
+ * Returns whether a device is of type DeviceDetails.
+ * @param device - The device to check
+ * @returns Whether the device is of type DeviceDetails.
+ */
+export const isDeviceDetails = (
+  device?: Device | null
+  // Use "interfaces" as the canary as it only exists for DeviceDetails.
+): device is DeviceDetails => !!device && "interfaces" in device;

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -76,6 +76,8 @@ export { eventRecord, eventType } from "./event";
 export {
   controller,
   device,
+  deviceDetails,
+  deviceInterface,
   machine,
   machineDetails,
   machineDevice,
@@ -88,6 +90,7 @@ export {
   machineNumaNode,
   machinePartition,
   networkDiscoveredIP,
+  networkInterface,
   networkLink,
   pod,
   podDetails,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -3,7 +3,11 @@ import { define, extend, random, sequence } from "cooky-cutter";
 import { model, modelRef } from "./model";
 
 import type { Controller } from "app/store/controller/types";
-import type { Device } from "app/store/device/types";
+import type {
+  Device,
+  DeviceDetails,
+  DeviceNetworkInterface,
+} from "app/store/device/types";
 import { DeviceIpAssignment } from "app/store/device/types";
 import type {
   Disk,
@@ -47,7 +51,7 @@ import type {
   SimpleNode,
   TestStatus,
 } from "app/store/types/node";
-import { NodeStatus } from "app/store/types/node";
+import { NodeStatus, NodeType } from "app/store/types/node";
 
 export const testStatus = define<TestStatus>({
   status: 0,
@@ -88,6 +92,39 @@ const simpleNode = extend<Model, SimpleNode>(model, {
   tags,
 });
 
+export const networkLink = extend<Model, NetworkLink>(model, {
+  mode: NetworkLinkMode.AUTO,
+  subnet_id: random,
+});
+
+export const networkDiscoveredIP = define<DiscoveredIP>({
+  ip_address: "1.2.3.4",
+  subnet_id: random,
+});
+
+export const networkInterface = extend<Model, NetworkInterface>(model, {
+  children: () => [],
+  discovered: () => [],
+  enabled: true,
+  firmware_version: "1.0.0",
+  interface_speed: 10000,
+  is_boot: true,
+  link_connected: true,
+  link_speed: 10000,
+  links: () => [],
+  mac_address: (i: number) => `00.00.00.00.00.${i}`,
+  name: (i: number) => `eth${i}`,
+  numa_node: 0,
+  params: null,
+  parents: () => [],
+  product: "Product",
+  sriov_max_vf: 0,
+  tags: () => [],
+  type: NetworkInterfaceTypes.PHYSICAL,
+  vendor: "Vendor",
+  vlan_id: 5001,
+});
+
 export const device = extend<SimpleNode, Device>(simpleNode, {
   actions,
   extra_macs,
@@ -102,6 +139,26 @@ export const device = extend<SimpleNode, Device>(simpleNode, {
   spaces,
   subnets,
   zone: modelRef,
+});
+
+export const deviceInterface = extend<NetworkInterface, DeviceNetworkInterface>(
+  networkInterface,
+  {
+    ip_address: "192.168.1.100",
+    ip_assignment: DeviceIpAssignment.DYNAMIC,
+  }
+);
+
+export const deviceDetails = extend<Device, DeviceDetails>(device, {
+  created: "Thu, 15 Oct. 2020 07:25:10",
+  description: "Device description",
+  interfaces: () => [deviceInterface()],
+  locked: false,
+  node_type: NodeType.DEVICE,
+  on_network: false,
+  pool: null,
+  swap_size: null,
+  updated: "Thu, 15 Oct. 2020 07:25:10",
 });
 
 const node = extend<SimpleNode, BaseNode>(simpleNode, {
@@ -219,38 +276,7 @@ export const machineDisk = extend<Model, Disk>(model, {
   test_status: 0,
 });
 
-export const networkLink = extend<Model, NetworkLink>(model, {
-  mode: NetworkLinkMode.AUTO,
-  subnet_id: random,
-});
-
-export const networkDiscoveredIP = define<DiscoveredIP>({
-  ip_address: "1.2.3.4",
-  subnet_id: random,
-});
-
-export const machineInterface = extend<Model, NetworkInterface>(model, {
-  children: () => [],
-  discovered: () => [],
-  enabled: true,
-  firmware_version: "1.0.0",
-  interface_speed: 10000,
-  is_boot: true,
-  link_connected: true,
-  link_speed: 10000,
-  links: () => [],
-  mac_address: (i: number) => `00.00.00.00.00.${i}`,
-  name: (i: number) => `eth${i}`,
-  numa_node: 0,
-  params: null,
-  parents: () => [],
-  product: "Product",
-  sriov_max_vf: 0,
-  tags: () => [],
-  type: NetworkInterfaceTypes.PHYSICAL,
-  vendor: "Vendor",
-  vlan_id: 5001,
-});
+export const machineInterface = networkInterface;
 
 export const machineDevice = define<MachineDevice>({
   fqdn: "device.maas",


### PR DESCRIPTION
## Done

- Added a util for determining whether a device is `BaseDevice` or `DeviceDetails` type
- Added test factories for `DeviceDetails` and `DeviceNetworkInterface`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes canonical-web-and-design/app-tribe#515
