### PR TITLE
add common eslint config

### DIFF
--- a/eslint/common.js
+++ b/eslint/common.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ["no-only-tests"],
+  rules: {
+    "no-only-tests/no-only-tests": "error",
+  },
+};

--- a/integration/.eslintrc.js
+++ b/integration/.eslintrc.js
@@ -2,11 +2,11 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   extends: [
     "plugin:cypress/recommended",
+    "../eslint/common",
     "plugin:prettier/recommended", // Ensure this is last in the list.
   ],
   plugins: [
     "cypress",
-    "no-only-tests",
     "@typescript-eslint",
     "prettier",
     "eslint-plugin-import",
@@ -19,7 +19,6 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "no-only-tests/no-only-tests": "error",
     "cypress/no-force": "warn",
     "prettier/prettier": "error",
   },

--- a/root/.eslintrc
+++ b/root/.eslintrc
@@ -3,7 +3,7 @@
   "env": {
     "node": true
   },
-  "extends": ["eslint:recommended"],
+  "extends": ["eslint:recommended", "../eslint/common"],
   "globals": {
     "document": false,
     "window": false

--- a/shared/.eslintrc.json
+++ b/shared/.eslintrc.json
@@ -1,8 +1,7 @@
 {
-  "extends": ["react-app", "plugin:jsx-a11y/recommended"],
-  "plugins": ["jsx-a11y", "no-only-tests", "prettier"],
+  "extends": ["react-app", "plugin:jsx-a11y/recommended", "../eslint/common"],
+  "plugins": ["jsx-a11y", "prettier"],
   "rules": {
-    "no-only-tests/no-only-tests": "error",
     "no-unused-vars": "error",
     "prettier/prettier": "error"
   },

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   ],
   extends: [
     "react-app", // Use the recommended rules from CRA.
+    "../eslint/common",
     "plugin:prettier/recommended", // Ensure this is last in the list.
   ],
   parserOptions: {
@@ -36,6 +37,7 @@ module.exports = {
       plugins: ["react", "@typescript-eslint", "prettier"],
       extends: [
         "react-app", // Uses the recommended rules from CRA.
+        "../eslint/common",
         "plugin:@typescript-eslint/recommended", // Uses the recommended rules from @typescript-eslint/eslint-plugin
         "prettier",
         "plugin:import/errors",
@@ -83,7 +85,6 @@ module.exports = {
             },
           },
         ],
-        "no-only-tests/no-only-tests": "error",
       },
       settings: {
         "import/resolver": {


### PR DESCRIPTION
## Done

- create common eslint configuration files that can be shared across workspaces

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
