### PR TITLE
feat(ui): add placeholder device view components

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
@@ -1,0 +1,5 @@
+const DeviceConfiguration = (): JSX.Element => {
+  return <h2 className="p-heading--4">Device configuration</h2>;
+};
+
+export default DeviceConfiguration;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceConfiguration";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import { Link, Redirect, Route, Switch } from "react-router-dom";
+
+import DeviceConfiguration from "./DeviceConfiguration";
+import DeviceNetwork from "./DeviceNetwork";
+import DeviceSummary from "./DeviceSummary";
+
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import type { RouteParams } from "app/base/types";
+import deviceURLs from "app/devices/urls";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type { RootState } from "app/store/root/types";
+
+const DeviceDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const { id } = useParams<RouteParams>();
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, id)
+  );
+
+  useEffect(() => {
+    dispatch(deviceActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Section header={<SectionHeader loading={!device} title={device?.fqdn} />}>
+      {device && (
+        <>
+          <ul>
+            <li>
+              <Link to={deviceURLs.device.summary({ id: device.system_id })}>
+                Summary
+              </Link>
+            </li>
+            <li>
+              <Link to={deviceURLs.device.network({ id: device.system_id })}>
+                Network
+              </Link>
+            </li>
+            <li>
+              <Link
+                to={deviceURLs.device.configuration({ id: device.system_id })}
+              >
+                Configuration
+              </Link>
+            </li>
+          </ul>
+          <Switch>
+            <Route exact path={deviceURLs.device.summary(null, true)}>
+              <DeviceSummary />
+            </Route>
+            <Route exact path={deviceURLs.device.network(null, true)}>
+              <DeviceNetwork />
+            </Route>
+            <Route exact path={deviceURLs.device.configuration(null, true)}>
+              <DeviceConfiguration />
+            </Route>
+            <Redirect
+              from={deviceURLs.device.index(null, true)}
+              to={deviceURLs.device.summary(null, true)}
+            />
+          </Switch>
+        </>
+      )}
+    </Section>
+  );
+};
+
+export default DeviceDetails;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -1,0 +1,5 @@
+const DeviceNetwork = (): JSX.Element => {
+  return <h2 className="p-heading--4">Device network</h2>;
+};
+
+export default DeviceNetwork;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceNetwork";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceSummary.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceSummary.tsx
@@ -1,0 +1,5 @@
+const DeviceSummary = (): JSX.Element => {
+  return <h2 className="p-heading--4">Device summary</h2>;
+};
+
+export default DeviceSummary;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceSummary/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceSummary";

--- a/ui/src/app/devices/views/DeviceDetails/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceDetails";

--- a/ui/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import deviceURLs from "app/devices/urls";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+
+const DeviceList = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const devices = useSelector(deviceSelectors.all);
+  const loading = useSelector(deviceSelectors.loading);
+
+  useEffect(() => {
+    dispatch(deviceActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Section
+      header={<SectionHeader subtitleLoading={loading} title="Devices" />}
+    >
+      {!loading && (
+        <ul>
+          {devices.map((device) => (
+            <li key={device.system_id}>
+              <Link to={deviceURLs.device.index({ id: device.system_id })}>
+                {device.fqdn}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+};
+
+export default DeviceList;

--- a/ui/src/app/devices/views/DeviceList/index.ts
+++ b/ui/src/app/devices/views/DeviceList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceList";

--- a/ui/src/app/devices/views/Devices.tsx
+++ b/ui/src/app/devices/views/Devices.tsx
@@ -1,5 +1,8 @@
 import { Route, Switch } from "react-router-dom";
 
+import DeviceDetails from "./DeviceDetails";
+import DeviceList from "./DeviceList";
+
 import NotFound from "app/base/views/NotFound";
 import devicesURLs from "app/devices/urls";
 
@@ -7,7 +10,7 @@ const Devices = (): JSX.Element => {
   return (
     <Switch>
       <Route exact path={[devicesURLs.devices.index]}>
-        Devices
+        <DeviceList />
       </Route>
       <Route
         exact
@@ -18,7 +21,7 @@ const Devices = (): JSX.Element => {
           devicesURLs.device.summary(null, true),
         ]}
       >
-        Device
+        <DeviceDetails />
       </Route>
       <Route path="*">
         <NotFound />


### PR DESCRIPTION
## Done

- Added placeholder components for the device list and each device details tab

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to `/MAAS/r/devices` and check that a list of devices is fetched and shown
- Check that you can click on the device names and be taken to the correct urls

## Fixes

Fixes canonical-web-and-design/app-tribe#517
