### PR TITLE
feat(ui): build initial devices list header component

### DIFF
--- a/ui/src/app/base/components/ModelListSubtitle/ModelListSubtitle.test.tsx
+++ b/ui/src/app/base/components/ModelListSubtitle/ModelListSubtitle.test.tsx
@@ -1,0 +1,65 @@
+import { mount } from "enzyme";
+
+import ModelListSubtitle from "./ModelListSubtitle";
+
+describe("ModelListSubtitle", () => {
+  it("correctly displays when one model is available and none selected", () => {
+    const wrapper = mount(
+      <ModelListSubtitle available={1} modelName="machine" />
+    );
+    expect(wrapper.find('[data-test="subtitle-string"]').text()).toBe(
+      "1 machine available"
+    );
+  });
+
+  it("correctly displays when more than one model is available and none selected", () => {
+    const wrapper = mount(
+      <ModelListSubtitle available={2} modelName="machine" />
+    );
+    expect(wrapper.find('[data-test="subtitle-string"]').text()).toBe(
+      "2 machines available"
+    );
+  });
+
+  it("correctly displays when no models are available", () => {
+    const wrapper = mount(
+      <ModelListSubtitle available={0} modelName="machine" />
+    );
+    expect(wrapper.find('[data-test="subtitle-string"]').text()).toBe(
+      "No machines available"
+    );
+  });
+
+  it("correctly displays when all models are selected", () => {
+    const wrapper = mount(
+      <ModelListSubtitle available={2} modelName="machine" selected={2} />
+    );
+    expect(wrapper.find('[data-test="subtitle-string"]').text()).toBe(
+      "All machines selected"
+    );
+  });
+
+  it("correctly displays when some models are selected", () => {
+    const wrapper = mount(
+      <ModelListSubtitle available={2} modelName="machine" selected={1} />
+    );
+    expect(wrapper.find('[data-test="subtitle-string"]').text()).toBe(
+      "1 of 2 machines selected"
+    );
+  });
+
+  it("can render a filter button when some models are selected", () => {
+    const filterSelected = jest.fn();
+    const wrapper = mount(
+      <ModelListSubtitle
+        available={2}
+        filterSelected={filterSelected}
+        modelName="machine"
+        selected={1}
+      />
+    );
+    expect(wrapper.find('[data-test="subtitle-string"]').exists()).toBe(false);
+    wrapper.find("Button[data-test='filter-selected']").simulate("click");
+    expect(filterSelected).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/base/components/ModelListSubtitle/ModelListSubtitle.tsx
+++ b/ui/src/app/base/components/ModelListSubtitle/ModelListSubtitle.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@canonical/react-components";
+import pluralize from "pluralize";
+
+type Props = {
+  available: number;
+  filterSelected?: () => void;
+  modelName: string;
+  selected?: number;
+};
+
+const getSubtitleString = (
+  available: number,
+  modelName: string,
+  selected: number
+) => {
+  if (available === 0) {
+    return `No ${modelName}s available`;
+  } else if (selected === available) {
+    return `All ${modelName}s selected`;
+  } else {
+    const nodeCountString = pluralize(modelName, available, true);
+
+    if (selected) {
+      return `${selected} of ${nodeCountString} selected`;
+    } else {
+      return `${nodeCountString} available`;
+    }
+  }
+};
+
+export const ModelListSubtitle = ({
+  available,
+  filterSelected,
+  modelName,
+  selected = 0,
+}: Props): JSX.Element => {
+  const subtitleString = getSubtitleString(available, modelName, selected);
+  const showFilterButton = selected && selected !== available && filterSelected;
+
+  if (showFilterButton) {
+    return (
+      <Button
+        appearance="link"
+        data-test="filter-selected"
+        onClick={filterSelected}
+      >
+        {subtitleString}
+      </Button>
+    );
+  }
+  return (
+    <span className="u-text--muted" data-test="subtitle-string">
+      {subtitleString}
+    </span>
+  );
+};
+
+export default ModelListSubtitle;

--- a/ui/src/app/base/components/ModelListSubtitle/index.ts
+++ b/ui/src/app/base/components/ModelListSubtitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelListSubtitle";

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@canonical/react-components";
+
+import type { ClearHeaderContent } from "app/base/types";
+
+type Props = {
+  clearHeaderContent: ClearHeaderContent;
+};
+
+const AddDeviceForm = ({ clearHeaderContent }: Props): JSX.Element | null => {
+  // TODO: Build Add device form
+  // https://github.com/canonical-web-and-design/app-tribe/issues/523
+  return <Button onClick={clearHeaderContent}>Cancel</Button>;
+};
+
+export default AddDeviceForm;

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/index.ts
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddDeviceForm";

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.test.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.test.tsx
@@ -1,0 +1,18 @@
+import { mount } from "enzyme";
+
+import DeviceHeaderForms from "./DeviceHeaderForms";
+
+import { DeviceHeaderViews } from "app/devices/constants";
+
+describe("DeviceHeaderForms", () => {
+  it("can render the Add Device form", () => {
+    const wrapper = mount(
+      <DeviceHeaderForms
+        headerContent={{ view: DeviceHeaderViews.ADD_DEVICE }}
+        setHeaderContent={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find("AddDeviceForm").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.tsx
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+
+import AddDeviceForm from "./AddDeviceForm";
+
+import { DeviceHeaderViews } from "app/devices/constants";
+import type {
+  DeviceHeaderContent,
+  DeviceSetHeaderContent,
+} from "app/devices/types";
+
+type Props = {
+  headerContent: DeviceHeaderContent;
+  setHeaderContent: DeviceSetHeaderContent;
+};
+
+const DeviceHeaderForms = ({
+  headerContent,
+  setHeaderContent,
+}: Props): JSX.Element | null => {
+  const clearHeaderContent = useCallback(
+    () => setHeaderContent(null),
+    [setHeaderContent]
+  );
+
+  switch (headerContent.view) {
+    case DeviceHeaderViews.ADD_DEVICE:
+      return <AddDeviceForm clearHeaderContent={clearHeaderContent} />;
+    default:
+      // TODO: Make machine ActionFormWrapper work across different node types
+      // and use here.
+      // https://github.com/canonical-web-and-design/app-tribe/issues/525
+      return null;
+  }
+};
+
+export default DeviceHeaderForms;

--- a/ui/src/app/devices/components/DeviceHeaderForms/index.ts
+++ b/ui/src/app/devices/components/DeviceHeaderForms/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceHeaderForms";

--- a/ui/src/app/devices/constants.ts
+++ b/ui/src/app/devices/constants.ts
@@ -1,0 +1,15 @@
+import { NodeActions } from "app/store/types/node";
+
+export const DeviceActionHeaderViews = {
+  DELETE_DEVICE: ["deviceActionForm", NodeActions.DELETE],
+  SET_ZONE_DEVICE: ["deviceActionForm", NodeActions.SET_ZONE],
+} as const;
+
+export const DeviceNonActionHeaderViews = {
+  ADD_DEVICE: ["deviceNonActionForm", "addDevice"],
+} as const;
+
+export const DeviceHeaderViews = {
+  ...DeviceActionHeaderViews,
+  ...DeviceNonActionHeaderViews,
+} as const;

--- a/ui/src/app/devices/types.ts
+++ b/ui/src/app/devices/types.ts
@@ -1,0 +1,10 @@
+import type { ValueOf } from "@canonical/react-components";
+
+import type { HeaderContent, SetHeaderContent } from "app/base/types";
+import type { DeviceHeaderViews } from "app/devices/constants";
+
+export type DeviceHeaderContent = HeaderContent<
+  ValueOf<typeof DeviceHeaderViews>
+>;
+
+export type DeviceSetHeaderContent = SetHeaderContent<DeviceHeaderContent>;

--- a/ui/src/app/devices/utils.ts
+++ b/ui/src/app/devices/utils.ts
@@ -1,0 +1,26 @@
+import { DeviceHeaderViews } from "./constants";
+import type { DeviceHeaderContent } from "./types";
+
+import { getNodeActionTitle } from "app/store/utils/node";
+
+/**
+ * Get title depending on header content.
+ * @param defaultTitle - Title to show if no header content open.
+ * @param headerContentName - The name of the header content to check.
+ * @returns Header title string.
+ */
+export const getHeaderTitle = (
+  defaultTitle: string,
+  headerContent: DeviceHeaderContent | null
+): string => {
+  if (headerContent) {
+    const [, name] = headerContent.view;
+    switch (name) {
+      case DeviceHeaderViews.ADD_DEVICE[1]:
+        return "Add device";
+      default:
+        return getNodeActionTitle(name);
+    }
+  }
+  return defaultTitle;
+};

--- a/ui/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -1,10 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import DeviceListHeader from "./DeviceListHeader";
+
 import Section from "app/base/components/Section";
-import SectionHeader from "app/base/components/SectionHeader";
+import type { DeviceHeaderContent } from "app/devices/types";
 import deviceURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
@@ -13,6 +15,8 @@ const DeviceList = (): JSX.Element => {
   const dispatch = useDispatch();
   const devices = useSelector(deviceSelectors.all);
   const loading = useSelector(deviceSelectors.loading);
+  const [headerContent, setHeaderContent] =
+    useState<DeviceHeaderContent | null>(null);
 
   useEffect(() => {
     dispatch(deviceActions.fetch());
@@ -20,7 +24,12 @@ const DeviceList = (): JSX.Element => {
 
   return (
     <Section
-      header={<SectionHeader subtitleLoading={loading} title="Devices" />}
+      header={
+        <DeviceListHeader
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
+        />
+      }
     >
       {!loading && (
         <ul>

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
@@ -1,0 +1,81 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeviceListHeader from "./DeviceListHeader";
+
+import { DeviceHeaderViews } from "app/devices/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  device as deviceFactory,
+  deviceState as deviceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DeviceListHeader", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      device: deviceStateFactory({
+        loaded: true,
+        items: [
+          deviceFactory({ system_id: "abc123" }),
+          deviceFactory({ system_id: "def456" }),
+        ],
+      }),
+    });
+  });
+
+  it("displays a spinner in the header subtitle if devices have not loaded", () => {
+    state.device.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceListHeader headerContent={null} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='section-header-subtitle'] Spinner").exists()
+    ).toBe(true);
+  });
+
+  it("displays a devices count if devices have loaded", () => {
+    state.device.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceListHeader headerContent={null} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="section-header-subtitle"]').text()).toBe(
+      "2 devices available"
+    );
+  });
+
+  it("can open the add device form", () => {
+    const setHeaderContent = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceListHeader
+            headerContent={null}
+            setHeaderContent={setHeaderContent}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button[data-test='add-device-button']").simulate("click");
+    expect(setHeaderContent).toHaveBeenCalledWith({
+      view: DeviceHeaderViews.ADD_DEVICE,
+    });
+  });
+});

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
@@ -1,0 +1,65 @@
+import { Button, ContextualMenu } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import ModelListSubtitle from "app/base/components/ModelListSubtitle";
+import SectionHeader from "app/base/components/SectionHeader";
+import DeviceHeaderForms from "app/devices/components/DeviceHeaderForms";
+import { DeviceHeaderViews } from "app/devices/constants";
+import type {
+  DeviceHeaderContent,
+  DeviceSetHeaderContent,
+} from "app/devices/types";
+import { getHeaderTitle } from "app/devices/utils";
+import deviceSelectors from "app/store/device/selectors";
+
+type Props = {
+  headerContent: DeviceHeaderContent | null;
+  setHeaderContent: DeviceSetHeaderContent;
+};
+
+const DeviceListHeader = ({
+  headerContent,
+  setHeaderContent,
+}: Props): JSX.Element => {
+  const devices = useSelector(deviceSelectors.all);
+  const devicesLoaded = useSelector(deviceSelectors.loaded);
+
+  return (
+    <SectionHeader
+      buttons={[
+        <Button
+          appearance="neutral"
+          data-test="add-device-button"
+          onClick={() =>
+            setHeaderContent({ view: DeviceHeaderViews.ADD_DEVICE })
+          }
+        >
+          Add device
+        </Button>,
+        // TODO: Make machine TakeActionMenu generic and use here instead.
+        // https://github.com/canonical-web-and-design/app-tribe/issues/524
+        <ContextualMenu
+          hasToggleIcon
+          toggleAppearance="positive"
+          toggleDisabled
+          toggleLabel="Take action"
+        />,
+      ]}
+      headerContent={
+        headerContent && (
+          <DeviceHeaderForms
+            headerContent={headerContent}
+            setHeaderContent={setHeaderContent}
+          />
+        )
+      }
+      subtitle={
+        <ModelListSubtitle available={devices.length} modelName="device" />
+      }
+      subtitleLoading={!devicesLoaded}
+      title={getHeaderTitle("Devices", headerContent)}
+    />
+  );
+};
+
+export default DeviceListHeader;

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/index.ts
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceListHeader";

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
@@ -6,7 +6,6 @@ import ActionForm from "app/base/components/ActionForm";
 import type { ClearHeaderContent, EmptyObject } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import machineURLs from "app/machines/urls";
-import { getActionTitle } from "app/machines/utils";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type {
@@ -14,6 +13,7 @@ import type {
   MachineEventErrors,
 } from "app/store/machine/types/base";
 import { NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils/node";
 import { kebabToCamelCase } from "app/utils";
 
 // List of machine actions that do not require any extra parameters sent through
@@ -71,7 +71,7 @@ export const FieldlessForm = ({
       onSaveAnalytics={{
         action: "Submit",
         category: `Machine ${activeMachine ? "details" : "list"} action form`,
-        label: getActionTitle(action),
+        label: getNodeActionTitle(action),
       }}
       onSubmit={() => {
         if (fieldlessActions.includes(action)) {

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -5,11 +5,12 @@ import { useSelector } from "react-redux";
 import type { DataTestElement } from "app/base/types";
 import { MachineHeaderViews } from "app/machines/constants";
 import type { MachineSetHeaderContent } from "app/machines/types";
-import { canOpenActionForm, getActionTitle } from "app/machines/utils";
+import { canOpenActionForm } from "app/machines/utils";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils/node";
 
 type ActionGroup = {
   name: string;
@@ -89,7 +90,7 @@ const getTakeActionLinks = (
           groupLinks.push({
             children: (
               <div className="u-flex--between">
-                <span>{getActionTitle(action)}...</span>
+                <span>{getNodeActionTitle(action)}...</span>
                 {machines.length > 1 && (
                   <span
                     className="u-nudge-right--small"

--- a/ui/src/app/machines/utils.ts
+++ b/ui/src/app/machines/utils.ts
@@ -3,6 +3,7 @@ import type { MachineHeaderContent } from "./types";
 
 import type { Machine, MachineActions } from "app/store/machine/types";
 import { NodeActions, NodeStatus } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils/node";
 
 /**
  * Determine whether a machine can open an action form for a particular action.
@@ -30,58 +31,6 @@ export const canOpenActionForm = (
 };
 
 /**
- * Get action title from name.
- * @param actionName - The name of the action to check.
- * @returns Formatted action title.
- */
-export const getActionTitle = (actionName: MachineActions): string => {
-  switch (actionName) {
-    case NodeActions.ABORT:
-      return "Abort";
-    case NodeActions.ACQUIRE:
-      return "Acquire";
-    case NodeActions.CLONE:
-      return "Clone from";
-    case NodeActions.COMMISSION:
-      return "Commission";
-    case NodeActions.DELETE:
-      return "Delete";
-    case NodeActions.DEPLOY:
-      return "Deploy";
-    case NodeActions.EXIT_RESCUE_MODE:
-      return "Exit rescue mode";
-    case NodeActions.LOCK:
-      return "Lock";
-    case NodeActions.MARK_BROKEN:
-      return "Mark broken";
-    case NodeActions.MARK_FIXED:
-      return "Mark fixed";
-    case NodeActions.OFF:
-      return "Power off";
-    case NodeActions.ON:
-      return "Power on";
-    case NodeActions.OVERRIDE_FAILED_TESTING:
-      return "Override failed testing";
-    case NodeActions.RELEASE:
-      return "Release";
-    case NodeActions.RESCUE_MODE:
-      return "Enter rescue mode";
-    case NodeActions.SET_POOL:
-      return "Set pool";
-    case NodeActions.SET_ZONE:
-      return "Set zone";
-    case NodeActions.TAG:
-      return "Tag";
-    case NodeActions.TEST:
-      return "Test";
-    case NodeActions.UNLOCK:
-      return "Unlock";
-    default:
-      return "Action";
-  }
-};
-
-/**
  * Get title depending on header content.
  * @param defaultTitle - Title to show if no header content open.
  * @param headerContentName - The name of the header content to check.
@@ -99,7 +48,7 @@ export const getHeaderTitle = (
       case MachineHeaderViews.ADD_MACHINE[1]:
         return "Add machine";
       default:
-        return getActionTitle(name);
+        return getNodeActionTitle(name);
     }
   }
   return defaultTitle;

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -7,6 +7,7 @@ import { Link, useLocation } from "react-router-dom";
 
 import AddHardwareMenu from "./AddHardwareMenu";
 
+import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import SectionHeader from "app/base/components/SectionHeader";
 import type { SetSearchFilter } from "app/base/types";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
@@ -20,34 +21,8 @@ import { getHeaderTitle } from "app/machines/utils";
 import poolsURLs from "app/pools/urls";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
-
-const getMachineCount = (
-  machines: Machine[],
-  selectedMachines: Machine[],
-  setSearchFilter: SetSearchFilter
-) => {
-  const machineCountString = `${machines.length} ${pluralize(
-    "machine",
-    machines.length
-  )}`;
-  if (selectedMachines.length) {
-    if (machines.length === selectedMachines.length) {
-      return "All machines selected";
-    }
-    return (
-      <Button
-        className="p-button--link"
-        onClick={() => setSearchFilter("in:(Selected)")}
-      >
-        {`${selectedMachines.length} of ${machineCountString} selected`}
-      </Button>
-    );
-  }
-  return `${machineCountString} available`;
-};
 
 type Props = {
   headerContent: MachineHeaderContent | null;
@@ -114,7 +89,14 @@ export const MachineListHeader = ({
           />
         )
       }
-      subtitle={getMachineCount(machines, selectedMachines, setSearchFilter)}
+      subtitle={
+        <ModelListSubtitle
+          available={machines.length}
+          filterSelected={() => setSearchFilter("in:(Selected)")}
+          modelName="machine"
+          selected={selectedMachines.length}
+        />
+      }
       subtitleLoading={!machinesLoaded}
       tabLinks={[
         {

--- a/ui/src/app/store/utils/index.ts
+++ b/ui/src/app/store/utils/index.ts
@@ -1,4 +1,5 @@
 export { isMachine } from "./identifiers";
+export { getNodeActionTitle } from "./node";
 export { generateBaseSelectors } from "./selectors";
 export {
   generateCommonReducers,

--- a/ui/src/app/store/utils/node.ts
+++ b/ui/src/app/store/utils/node.ts
@@ -1,0 +1,53 @@
+import { NodeActions } from "app/store/types/node";
+
+/**
+ * Get title from node action name.
+ * @param actionName - The name of the node action to check.
+ * @returns Formatted node action title.
+ */
+export const getNodeActionTitle = (actionName: NodeActions): string => {
+  switch (actionName) {
+    case NodeActions.ABORT:
+      return "Abort";
+    case NodeActions.ACQUIRE:
+      return "Acquire";
+    case NodeActions.CLONE:
+      return "Clone from";
+    case NodeActions.COMMISSION:
+      return "Commission";
+    case NodeActions.DELETE:
+      return "Delete";
+    case NodeActions.DEPLOY:
+      return "Deploy";
+    case NodeActions.EXIT_RESCUE_MODE:
+      return "Exit rescue mode";
+    case NodeActions.LOCK:
+      return "Lock";
+    case NodeActions.MARK_BROKEN:
+      return "Mark broken";
+    case NodeActions.MARK_FIXED:
+      return "Mark fixed";
+    case NodeActions.OFF:
+      return "Power off";
+    case NodeActions.ON:
+      return "Power on";
+    case NodeActions.OVERRIDE_FAILED_TESTING:
+      return "Override failed testing";
+    case NodeActions.RELEASE:
+      return "Release";
+    case NodeActions.RESCUE_MODE:
+      return "Enter rescue mode";
+    case NodeActions.SET_POOL:
+      return "Set pool";
+    case NodeActions.SET_ZONE:
+      return "Set zone";
+    case NodeActions.TAG:
+      return "Tag";
+    case NodeActions.TEST:
+      return "Test";
+    case NodeActions.UNLOCK:
+      return "Unlock";
+    default:
+      return "Action";
+  }
+};


### PR DESCRIPTION
## Done

- Built initial devices list header component
  - Set up constants and types for the device header forms
  - Add placeholder Add device form
- Extracted machine list header subtitle into `ModelListSubtitle` component and reused in the device list header
- Moved `getActionTitle` machine util into a common node util folder and reused in device list header

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and check that there is an "Add devices" button and "Take action" menu
- Check that the header shows a spinner while devices are loading
- Check that once devices have loaded, the subtitle displays a count
- Click "Add device" and check that the title changes to "Add device", a placeholder form shows and the header buttons disappear
- Go to the machine list and check that the subtitle functions as before

## Fixes

Fixes canonical-web-and-design/app-tribe#522

## Screenshot

![Screenshot 2021-11-18 at 14-11-52 MAAS](https://user-images.githubusercontent.com/25733845/142350350-749f9481-b9f1-431b-b06a-11823a520088.png)
