### PR TITLE
feat(ui) build device list table

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -10,6 +10,7 @@ import LegacyLink from "app/base/components/LegacyLink";
 import baseURLs from "app/base/urls";
 import deviceSelectors from "app/store/device/selectors";
 import { DeviceIpAssignment, DeviceMeta } from "app/store/device/types";
+import { getIpAssignmentDisplay } from "app/store/device/utils";
 import type { Discovery } from "app/store/discovery/types";
 import domainSelectors from "app/store/domain/selectors";
 import machineSelectors from "app/store/machine/selectors";
@@ -129,11 +130,22 @@ const DiscoveryAddFormFields = ({ discovery }: Props): JSX.Element | null => {
             name="ip_assignment"
             options={[
               { label: "Select IP assignment", value: "", disabled: true },
-              { label: "Dynamic", value: DeviceIpAssignment.DYNAMIC },
+              {
+                label: getIpAssignmentDisplay(DeviceIpAssignment.DYNAMIC),
+                value: DeviceIpAssignment.DYNAMIC,
+              },
               ...(includeStatic
-                ? [{ label: "Static", value: DeviceIpAssignment.STATIC }]
+                ? [
+                    {
+                      label: getIpAssignmentDisplay(DeviceIpAssignment.STATIC),
+                      value: DeviceIpAssignment.STATIC,
+                    },
+                  ]
                 : []),
-              { label: "External", value: DeviceIpAssignment.EXTERNAL },
+              {
+                label: getIpAssignmentDisplay(DeviceIpAssignment.EXTERNAL),
+                value: DeviceIpAssignment.EXTERNAL,
+              },
             ]}
             required
           />

--- a/ui/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -1,22 +1,22 @@
 import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 
 import DeviceListHeader from "./DeviceListHeader";
+import DeviceListTable from "./DeviceListTable";
 
 import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
 import type { DeviceHeaderContent } from "app/devices/types";
-import deviceURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 
 const DeviceList = (): JSX.Element => {
   const dispatch = useDispatch();
   const devices = useSelector(deviceSelectors.all);
-  const loading = useSelector(deviceSelectors.loading);
   const [headerContent, setHeaderContent] =
     useState<DeviceHeaderContent | null>(null);
+  useWindowTitle("Devices");
 
   useEffect(() => {
     dispatch(deviceActions.fetch());
@@ -31,17 +31,7 @@ const DeviceList = (): JSX.Element => {
         />
       }
     >
-      {!loading && (
-        <ul>
-          {devices.map((device) => (
-            <li key={device.system_id}>
-              <Link to={deviceURLs.device.index({ id: device.system_id })}>
-                {device.fqdn}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+      <DeviceListTable devices={devices} />
     </Section>
   );
 };

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
@@ -1,0 +1,69 @@
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+
+import DeviceListTable from "./DeviceListTable";
+
+import deviceURLs from "app/devices/urls";
+import type { Device } from "app/store/device/types";
+import { DeviceIpAssignment } from "app/store/device/types";
+import zoneURLs from "app/zones/urls";
+import { device as deviceFactory } from "testing/factories";
+
+describe("DeviceListTable", () => {
+  let device: Device;
+
+  beforeEach(() => {
+    device = deviceFactory({
+      domain: { id: 1, name: "domain" },
+      fqdn: "device.domain",
+      hostname: "device",
+      ip_address: "192.168.1.1",
+      ip_assignment: DeviceIpAssignment.STATIC,
+      owner: "owner",
+      primary_mac: "11:22:33:44:55:66",
+      system_id: "abc123",
+      tags: ["tag1", "tag2"],
+      zone: { id: 2, name: "zone" },
+    });
+  });
+
+  it("links to a device's details page", () => {
+    device.system_id = "def456";
+    const wrapper = mount(
+      <MemoryRouter>
+        <DeviceListTable devices={[device]} />
+      </MemoryRouter>
+    );
+
+    expect(
+      wrapper.find("Link[data-test='device-details-link']").at(0).prop("to")
+    ).toBe(deviceURLs.device.index({ id: device.system_id }));
+  });
+
+  it("can show when a device has more than one mac address", () => {
+    device.primary_mac = "11:11:11:11:11:11";
+    device.extra_macs = ["22:22:22:22:22:22", "33:33:33:33:33:33"];
+    const wrapper = mount(
+      <MemoryRouter>
+        <DeviceListTable devices={[device]} />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find("[data-test='mac-display']").at(0).text()).toBe(
+      "11:11:11:11:11:11 (+2)"
+    );
+  });
+
+  it("links to a device's zone's details page", () => {
+    device.zone = { id: 101, name: "danger" };
+    const wrapper = mount(
+      <MemoryRouter>
+        <DeviceListTable devices={[device]} />
+      </MemoryRouter>
+    );
+
+    expect(
+      wrapper.find("Link[data-test='device-zone-link']").at(0).prop("to")
+    ).toBe(zoneURLs.details({ id: device.zone.id }));
+  });
+});

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -1,0 +1,137 @@
+import { MainTable } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import TableHeader from "app/base/components/TableHeader";
+import deviceURLs from "app/devices/urls";
+import type { Device } from "app/store/device/types";
+import { getIpAssignmentDisplay } from "app/store/device/utils";
+import zoneURLs from "app/zones/urls";
+
+type Props = {
+  devices: Device[];
+};
+
+const generateRows = (devices: Device[]) =>
+  devices.map((device) => {
+    const {
+      domain: { name: domainName },
+      extra_macs,
+      fqdn,
+      hostname,
+      ip_address,
+      ip_assignment,
+      owner,
+      primary_mac,
+      system_id,
+      tags,
+      zone: { id: zoneId, name: zoneName },
+    } = device;
+    const macDisplay = extra_macs.length
+      ? `${primary_mac} (+${extra_macs.length})`
+      : primary_mac;
+    const ipAssignment = getIpAssignmentDisplay(ip_assignment);
+    const tagsList = tags.join(", ");
+
+    return {
+      columns: [
+        {
+          className: "fqdn-col",
+          content: (
+            <DoubleRow
+              primary={
+                <Link
+                  data-test="device-details-link"
+                  to={deviceURLs.device.index({ id: system_id })}
+                >
+                  <strong>{hostname}</strong>
+                  <span>.{domainName}</span>
+                </Link>
+              }
+              primaryTitle={fqdn}
+              secondary={<span data-test="mac-display">{macDisplay}</span>}
+              secondaryTitle={[primary_mac, ...extra_macs].join(", ")}
+            />
+          ),
+        },
+        {
+          className: "ip-col",
+          content: (
+            <DoubleRow
+              primary={ipAssignment}
+              primaryTitle={ipAssignment}
+              secondary={ip_address}
+              secondaryTitle={ip_address}
+            />
+          ),
+        },
+        {
+          className: "zone-col",
+          content: (
+            <Link
+              className="p-link--soft"
+              data-test="device-zone-link"
+              to={zoneURLs.details({ id: zoneId })}
+            >
+              {zoneName}
+            </Link>
+          ),
+        },
+        {
+          className: "owner-col",
+          content: (
+            <DoubleRow
+              primary={owner}
+              primaryTitle={owner}
+              secondary={tagsList}
+              secondaryTitle={tagsList}
+            />
+          ),
+        },
+      ],
+    };
+  });
+
+const DeviceListTable = ({ devices }: Props): JSX.Element => {
+  return (
+    <MainTable
+      className="device-list-table"
+      headers={[
+        {
+          className: "fqdn-col",
+          content: (
+            <>
+              <TableHeader>FQDN</TableHeader>
+              <TableHeader>MAC address</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "ip-col",
+          content: (
+            <>
+              <TableHeader>IP assignment</TableHeader>
+              <TableHeader>IP address</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "zone-col",
+          content: <TableHeader>Zone</TableHeader>,
+        },
+        {
+          className: "owner-col",
+          content: (
+            <>
+              <TableHeader>Owner</TableHeader>
+              <TableHeader>Tags</TableHeader>
+            </>
+          ),
+        },
+      ]}
+      rows={generateRows(devices)}
+    />
+  );
+};
+
+export default DeviceListTable;

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/_index.scss
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/_index.scss
@@ -1,0 +1,19 @@
+@mixin DeviceListTable {
+  .device-list-table {
+    .fqdn-col {
+      @include breakpoint-widths(50%, 34%, 25%, 25%, 25%);
+    }
+
+    .ip-col {
+      @include breakpoint-widths(0, 33%, 25%, 25%, 25%);
+    }
+
+    .zone-col {
+      @include breakpoint-widths(0, 0, 25%, 25%, 25%);
+    }
+
+    .owner-col {
+      @include breakpoint-widths(50%, 33%, 25%, 25%, 25%);
+    }
+  }
+}

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/index.ts
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceListTable";

--- a/ui/src/app/store/device/utils.test.ts
+++ b/ui/src/app/store/device/utils.test.ts
@@ -1,4 +1,5 @@
-import { isDeviceDetails } from "./utils";
+import { DeviceIpAssignment } from "./types";
+import { isDeviceDetails, getIpAssignmentDisplay } from "./utils";
 
 import {
   device as deviceFactory,
@@ -23,6 +24,28 @@ describe("device utils", () => {
 
     it("handles null", () => {
       expect(isDeviceDetails(null)).toBe(false);
+    });
+  });
+
+  describe("getIpAssignmentDisplay", () => {
+    it("handles dynamic IP assignment", () => {
+      expect(getIpAssignmentDisplay(DeviceIpAssignment.DYNAMIC)).toBe(
+        "Dynamic"
+      );
+    });
+
+    it("handles external IP assignement", () => {
+      expect(getIpAssignmentDisplay(DeviceIpAssignment.EXTERNAL)).toBe(
+        "External"
+      );
+    });
+
+    it("handles static IP assignment", () => {
+      expect(getIpAssignmentDisplay(DeviceIpAssignment.STATIC)).toBe("Static");
+    });
+
+    it("handles unknown IP assignment", () => {
+      expect(getIpAssignmentDisplay()).toBe("Unknown");
     });
   });
 });

--- a/ui/src/app/store/device/utils.ts
+++ b/ui/src/app/store/device/utils.ts
@@ -1,4 +1,5 @@
 import type { Device, DeviceDetails } from "app/store/device/types";
+import { DeviceIpAssignment } from "app/store/device/types";
 
 /**
  * Returns whether a device is of type DeviceDetails.
@@ -9,3 +10,23 @@ export const isDeviceDetails = (
   device?: Device | null
   // Use "interfaces" as the canary as it only exists for DeviceDetails.
 ): device is DeviceDetails => !!device && "interfaces" in device;
+
+/**
+ * Returns the UI-friendly display for a device's IP assignment
+ * @param ipAssignment - The device's IP assignment to check
+ * @returns UI-friendly device IP assignment.
+ */
+export const getIpAssignmentDisplay = (
+  ipAssignment?: Device["ip_assignment"] | null
+): string => {
+  switch (ipAssignment) {
+    case DeviceIpAssignment.DYNAMIC:
+      return "Dynamic";
+    case DeviceIpAssignment.EXTERNAL:
+      return "External";
+    case DeviceIpAssignment.STATIC:
+      return "Static";
+    default:
+      return "Unknown";
+  }
+};

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -110,6 +110,10 @@
 @include TableMenu;
 @include TagSelector;
 
+// devices
+@import "~app/devices/views/DeviceList/DeviceListTable";
+@include DeviceListTable;
+
 // images
 @import "~app/images/components/ImagesTable";
 @include ImagesTable;


### PR DESCRIPTION
## Done

- Built device list table, without sorting or selected state
  - I've updated the design slightly from the legacy version so it's a bit more aligned with the machine list (used double rows, added tags and zone data)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices
- Check that a table of devices renders and the data is correct
- Check that you can click a device name to go to that device's details page
- Check that you can click the zone to go to that zone's details page

## Fixes

Fixes canonical-web-and-design/app-tribe#527

## Screenshot
![Screenshot 2021-11-18 at 16-47-00 Devices bolla MAAS](https://user-images.githubusercontent.com/25733845/142366535-f04aa16d-10c5-478d-81a3-1df7a1ec42a2.png)

