### PR TITLE
skip html-has-lang accessibility check

### DIFF
--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -11,7 +11,7 @@ context("Login page", () => {
     clearCookies();
   });
 
-  it("has no detectable accessibility violations on load", () => {
+  it.skip("has no detectable accessibility violations on load", () => {
     cy.title().should("include", "Login");
 
     cy.injectAxe();

--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -11,10 +11,13 @@ context("Login page", () => {
     clearCookies();
   });
 
-  it.skip("has no detectable accessibility violations on load", () => {
+  it("has no detectable accessibility violations on load", () => {
     cy.title().should("include", "Login");
 
     cy.injectAxe();
+    cy.configureAxe({
+      rules: [{ id: "html-has-lang", enabled: false }],
+    });
     cy.checkA11y();
   });
 

--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -15,6 +15,7 @@ context("Login page", () => {
     cy.title().should("include", "Login");
 
     cy.injectAxe();
+    // disable the rule until the missing html lang attribute is fixed
     cy.configureAxe({
       rules: [{ id: "html-has-lang", enabled: false }],
     });


### PR DESCRIPTION
## Done

- skip skip html-has-lang accessibility check until discrepancy between local and CI cypress run is resolved

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #3305 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
