### PR TITLE
add loading spinner for domain resources loading state

### DIFF
--- a/integration/cypress/tsconfig.json
+++ b/integration/cypress/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": "../node_modules",
     "target": "es6",
     "lib": ["es6", "dom"],
-    "types": ["cypress"],
+    "types": ["cypress", "cypress-axe"],
     "moduleResolution": "Node"
   },
   "include": ["**/*.ts"]

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.test.tsx
@@ -30,4 +30,22 @@ describe("ResourceRecords", () => {
       "Domain contains no records."
     );
   });
+
+  it("displays a loading spinner with text when loading", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [],
+        loading: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ResourceRecords id={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.text().trim()).toBe("Loading...");
+  });
 });

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
@@ -6,6 +6,7 @@ import {
   MainTable,
   Row,
   Strip,
+  Spinner,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
@@ -45,9 +46,17 @@ const ResourceRecords = ({ id }: Props): JSX.Element | null => {
   const domain = useSelector((state: RootState) =>
     domainsSelectors.getById(state, id)
   );
+  const loading = useSelector(domainsSelectors.loading);
   const isAdmin = useSelector(authSelectors.isAdmin);
   const [expanded, setExpanded] = useState<Expanded | null>(null);
 
+  if (loading) {
+    return (
+      <Strip>
+        <Spinner text="Loading..." />
+      </Strip>
+    );
+  }
   if (!isDomainDetails(domain)) {
     return null;
   }


### PR DESCRIPTION
## Done

- add spinner for domain resources loading state
- add cypress-axe types

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/142405242-cebc7d3b-0f10-448a-b92d-82a946943e4f.png)
![image](https://user-images.githubusercontent.com/7452681/142405313-86e435ef-c3ef-4954-ad16-d0c94ec7724a.png)



## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to `/MAAS/r/domains`
- select a domain from the list that contains some records
- verify the loading spinner has been shown

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
