### PR TITLE
remove redundant whitespace from tooltip

### DIFF
--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -97,6 +97,10 @@
     justify-content: flex-end;
   }
 
+  .p-tooltip__message .p-list::after {
+    white-space: normal;
+  }
+
   .u-nudge--checkbox {
     padding-left: $checkbox-offset;
   }


### PR DESCRIPTION
## Done

- remove redundant whitespace from tooltip
  - set whitespace to `normal` (tooltip white space setting was conflicting with p-list)
  - fix works on both Firefox and Chrome

## After
![image](https://user-images.githubusercontent.com/7452681/142449254-c0456e51-ca3c-4701-ab16-c7d03d0976d3.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
