### PR TITLE
fix loading title inconsistency

### DIFF
--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -48,13 +48,14 @@
           </div>
         </div>
       </nav>
-      <header class="p-strip is-shallow root-loading">
-        <div class="row">
+      <header class="root-loading" aria-label="loading">
+        <div class="row" aria-hidden="true">
           <div class="col-12">
-            <p class="u-no-margin--bottom">
-              <i class="p-icon--spinner u-animation--spin"></i>
-              <span style="margin-left: .25rem;">Loading...</span>
-            </p>
+            <h4>
+              <span class="p-text--default">
+                <i class="p-icon--spinner u-animation--spin"></i>&ensp;<span>Loading...</span>
+              </span>
+            </h4>
           </div>
         </div>
       </header>

--- a/root/src/scss/base.scss
+++ b/root/src/scss/base.scss
@@ -1,4 +1,4 @@
-@use 'sass:math';
+@use "sass:math";
 
 // Import settings
 @import "./settings";
@@ -14,4 +14,9 @@
 .root-loading {
   @extend %vf-has-box-shadow;
   background-color: $color-x-light;
+  padding-top: $spv-inner--medium;
+
+  h4 {
+    margin: 0 $sph-outer $spv-outer--medium 0;
+  }
 }

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -69,8 +69,9 @@ const SectionHeader = <P,>({
             <h4
               className="section-header__title"
               data-test="section-header-title-spinner"
+              aria-label="loading"
             >
-              <Spinner text="Loading..." />
+              <Spinner text="Loading..." aria-hidden="true" />
             </h4>
           ) : (
             <h1


### PR DESCRIPTION
## Done

fix loading title inconsistency
- add aria-label for improved accessibility (hiding multiple elements in the spinner that are irrelevant)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the login page
- Make sure there are no inconsistencies in the Loading component as described in https://github.com/canonical-web-and-design/maas-ui/issues/3274 throughout the loading period

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
