### PR TITLE
improve loading state for dhcp snippets

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.test.tsx
@@ -45,6 +45,23 @@ describe("DHCPTable", () => {
     });
   });
 
+  it("shows loading state for snippets", () => {
+    state.dhcpsnippet.loading = true;
+    state.dhcpsnippet.loaded = false;
+    state.dhcpsnippet.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DHCPTable systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("table caption").text().trim()).toEqual("Loading...");
+  });
+
   it("shows snippets for a machine", () => {
     state.machine.items = [
       machineDetailsFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.tsx
@@ -95,68 +95,70 @@ const DHCPTable = ({ systemId }: Props): JSX.Element | null => {
     dispatch(dhcpsnippetActions.fetch());
   }, [dispatch]);
 
-  if (!machine) {
-    return null;
-  }
-
-  if (dhcpsnippetLoading) {
-    return <Spinner />;
-  }
-
   return (
     <>
       <h2 className="p-heading--four">DHCP snippets</h2>
-      <MainTable
-        className="dhcp-snippets-table p-table-expanding--light"
-        defaultSort="name"
-        defaultSortDirection="descending"
-        emptyStateMsg="No DHCP snippets applied to this machine."
-        expanding
-        headers={[
-          {
-            content: "Name",
-            sortKey: "name",
-          },
-          {
-            content: "Type",
-            sortKey: "type",
-          },
-          {
-            content: "Applies to",
-            sortKey: "target",
-          },
-          {
-            content: "Enabled",
-            sortKey: "enabled",
-          },
-          {
-            content: "Description",
-            sortKey: "description",
-          },
-          {
-            content: "Actions",
-            className: "u-align--right",
-          },
-        ]}
-        rows={generateRows(dhcpsnippets, expanded, machine, setExpanded)}
-        sortable
-      />
-      <List
-        items={[
-          <Link to={settingsURLs.dhcp.index}>
-            All snippets: Settings &gt; DHCP snippets
-          </Link>,
-          <a
-            className="p-link--external"
-            href="https://maas.io/docs/dhcp"
-            rel="noreferrer"
-            target="_blank"
-          >
-            About DHCP snippets
-          </a>,
-        ]}
-        middot
-      />
+      {machine ? (
+        <>
+          <MainTable
+            className="dhcp-snippets-table p-table-expanding--light"
+            defaultSort="name"
+            defaultSortDirection="descending"
+            emptyStateMsg={
+              dhcpsnippetLoading ? (
+                <Spinner text="Loading..." />
+              ) : (
+                "No DHCP snippets applied to this machine."
+              )
+            }
+            expanding
+            headers={[
+              {
+                content: "Name",
+                sortKey: "name",
+              },
+              {
+                content: "Type",
+                sortKey: "type",
+              },
+              {
+                content: "Applies to",
+                sortKey: "target",
+              },
+              {
+                content: "Enabled",
+                sortKey: "enabled",
+              },
+              {
+                content: "Description",
+                sortKey: "description",
+              },
+              {
+                content: "Actions",
+                className: "u-align--right",
+              },
+            ]}
+            rows={generateRows(dhcpsnippets, expanded, machine, setExpanded)}
+            sortable
+          />
+          <List
+            items={[
+              <Link to={settingsURLs.dhcp.index}>
+                All snippets: Settings &gt; DHCP snippets
+              </Link>,
+              <a
+                className="p-link--external"
+                href="https://maas.io/docs/dhcp"
+                rel="noreferrer"
+                target="_blank"
+              >
+                About DHCP snippets
+              </a>,
+            ]}
+            middot
+          />
+        </>
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
## Done

- display loading spinner for dhcp snippets within the table

### Loading state with screen reader announcement working correctly
![image](https://user-images.githubusercontent.com/7452681/142864290-e3bc6248-4f75-44f8-ae6a-80c33e3e8668.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to Machines/Network, e.g. /MAAS/r/machine/7c7ya3/network 
- make sure the loading text and spinner are displayed within the table during loading

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
