### PR TITLE
set machines filter to disabled and display spinner within table on loading

### DIFF
--- a/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
+++ b/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
@@ -31,6 +31,7 @@ export type Props<I, PK extends keyof I> = {
   getValueDisplay?: (filter: FilterKey, value: FilterValue) => ReactNode;
   items: I[];
   onUpdateFilterString: (filterString: string) => void;
+  disabled?: boolean;
 };
 
 // An accordion section.
@@ -104,6 +105,7 @@ const FilterAccordion = <I, PK extends keyof I>({
   getValueDisplay,
   items,
   onUpdateFilterString,
+  disabled,
 }: Props<I, PK>): JSX.Element => {
   const currentFilters = filterItems.getCurrentFilters(filterString);
   const [expandedSection, setExpandedSection] = useState();
@@ -178,6 +180,7 @@ const FilterAccordion = <I, PK extends keyof I>({
       position="left"
       toggleClassName="filter-accordion__toggle"
       toggleLabel="Filters"
+      toggleDisabled={disabled}
     >
       <Accordion
         className="filter-accordion__dropdown"

--- a/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
+++ b/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
@@ -23,6 +23,7 @@ type FilterValues = Map<FilterValue, number>;
 type FilterSections = Map<FilterKey, FilterValues>;
 
 export type Props<I, PK extends keyof I> = {
+  disabled?: boolean;
   filterItems: FilterItems<I, PK>;
   filterNames: Map<FilterKey, string>;
   filterOrder: FilterKey[];
@@ -31,7 +32,6 @@ export type Props<I, PK extends keyof I> = {
   getValueDisplay?: (filter: FilterKey, value: FilterValue) => ReactNode;
   items: I[];
   onUpdateFilterString: (filterString: string) => void;
-  disabled?: boolean;
 };
 
 // An accordion section.
@@ -97,6 +97,7 @@ const sortByFilterKey = (
 };
 
 const FilterAccordion = <I, PK extends keyof I>({
+  disabled,
   filterItems,
   filterNames,
   filterOrder,
@@ -105,7 +106,6 @@ const FilterAccordion = <I, PK extends keyof I>({
   getValueDisplay,
   items,
   onUpdateFilterString,
-  disabled,
 }: Props<I, PK>): JSX.Element => {
   const currentFilters = filterItems.getCurrentFilters(filterString);
   const [expandedSection, setExpandedSection] = useState();

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
@@ -23,7 +23,7 @@ describe("DiscoveriesFilterAccordion", () => {
     });
   });
 
-  it("displays a spinner when loading discoveries", () => {
+  it("button is disabled when loading discoveries", () => {
     state.discovery.loaded = false;
     const store = mockStore(state);
     const wrapper = mount(
@@ -35,7 +35,9 @@ describe("DiscoveriesFilterAccordion", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(
+      wrapper.find("Button.p-contextual-menu__toggle").prop("disabled")
+    ).toBe(true);
   });
 
   it("displays a filter accordion", () => {

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.tsx
@@ -1,4 +1,3 @@
-import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import FilterAccordion from "app/base/components/FilterAccordion";
@@ -29,12 +28,9 @@ const DiscoveriesFilterAccordion = ({
   const discoveries = useSelector(discoverySelectors.all);
   const loaded = useSelector(discoverySelectors.loaded);
 
-  if (!loaded) {
-    return <Spinner />;
-  }
-
   return (
     <FilterAccordion
+      disabled={!loaded}
       filterItems={FilterDiscoveries}
       filterNames={filterNames}
       filterOrder={filterOrder}

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -49,7 +49,7 @@ describe("DiscoveriesList", () => {
     expect(wrapper.text().includes("another-test")).toBe(true);
   });
 
-  it("displays a spinner when loading", () => {
+  it("displays a spinner within table when loading", () => {
     state = rootStateFactory({
       discovery: discoveryStateFactory({
         loading: true,
@@ -65,8 +65,7 @@ describe("DiscoveriesList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
-    expect(wrapper.find("MainTable").exists()).toBe(false);
+    expect(wrapper.find("MainTable Spinner").exists()).toBe(true);
   });
 
   it("displays a message when there are no discoveries", () => {

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -187,10 +187,6 @@ const DiscoveriesList = (): JSX.Element => {
     dispatch(discoveryActions.fetch());
   }, [dispatch]);
 
-  if (loading) {
-    return <Spinner />;
-  }
-
   if (loaded && !searchString && discoveries.length === 0) {
     return <div data-test="no-discoveries">No new discoveries.</div>;
   }
@@ -256,7 +252,13 @@ const DiscoveriesList = (): JSX.Element => {
           dispatch
         )}
         sortable
-        emptyStateMsg="No discoveries match the search criteria."
+        emptyStateMsg={
+          loading ? (
+            <Spinner text="Loading..." />
+          ) : (
+            "No discoveries match the search criteria."
+          )
+        }
       />
     </>
   );

--- a/ui/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -399,7 +399,7 @@ describe("MachineList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Strip span").text()).toBe(
+    expect(wrapper.find("table caption").text()).toBe(
       "No machines match the search criteria."
     );
   });

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
@@ -40,7 +40,7 @@ describe("MachinesFilterAccordion", () => {
     });
   });
 
-  it("displays a spinner when loading machines", () => {
+  it("filter is disabled when loading machines", () => {
     state.machine.loaded = false;
     const store = mockStore(state);
     const wrapper = mount(
@@ -52,7 +52,9 @@ describe("MachinesFilterAccordion", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(
+      wrapper.find("Button.p-contextual-menu__toggle").prop("disabled")
+    ).toBe(true);
   });
 
   it("formats link speeds", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -1,4 +1,3 @@
-import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import FilterAccordion from "app/base/components/FilterAccordion";
@@ -65,12 +64,9 @@ const MachinesFilterAccordion = ({
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
 
-  if (!machinesLoaded) {
-    return <Spinner />;
-  }
-
   return (
     <FilterAccordion
+      disabled={!machinesLoaded}
       filterItems={FilterMachines}
       filterNames={filterNames}
       filterOrder={filterOrder}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -1,13 +1,13 @@
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 
-import { Button, MainTable, Strip } from "@canonical/react-components";
+import { Button, MainTable, Spinner } from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableRow,
 } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
@@ -29,6 +29,7 @@ import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
 import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
@@ -154,6 +155,7 @@ const generateRows = ({
 }: GenerateRowParams) => {
   const sortedMachines = sortRows(machines);
   const menuCallback = showActions ? onToggleMenu : undefined;
+
   return sortedMachines.map((row) => {
     const isActive = activeRow === row.system_id;
 
@@ -526,6 +528,7 @@ export const MachineListTable = ({
   showActions = true,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const machinesLoaded = useSelector(machineSelectors.loaded);
   const machineIDs = machines.map((machine) => machine.system_id);
   const { currentSort, sortRows, updateSort } = useTableSort<Machine, SortKey>(
     getSortValue,
@@ -835,12 +838,14 @@ export const MachineListTable = ({
           // allow null.
           rows ? rows : undefined
         }
+        emptyStateMsg={
+          !machinesLoaded ? (
+            <Spinner text="Loading..." />
+          ) : filter ? (
+            "No machines match the search criteria."
+          ) : null
+        }
       />
-      {filter && machines.length === 0 ? (
-        <Strip rowClassName="u-align--center">
-          <span>No machines match the search criteria.</span>
-        </Strip>
-      ) : null}
     </>
   );
 };


### PR DESCRIPTION
## Done

- set machines filter to disabled on loading
- display loading spinner within machines and discovery lists

![image](https://user-images.githubusercontent.com/7452681/142875763-9c982bb9-2bce-463e-a16f-51985e1f7ce7.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to machines list and verify that filters button is disabled and loading text displayed when loading

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
