### PR TITLE
feat(ui): build device details header component

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -1,16 +1,17 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { Link, Redirect, Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch } from "react-router-dom";
 
 import DeviceConfiguration from "./DeviceConfiguration";
+import DeviceDetailsHeader from "./DeviceDetailsHeader";
 import DeviceNetwork from "./DeviceNetwork";
 import DeviceSummary from "./DeviceSummary";
 
 import Section from "app/base/components/Section";
-import SectionHeader from "app/base/components/SectionHeader";
 import type { RouteParams } from "app/base/types";
+import type { DeviceHeaderContent } from "app/devices/types";
 import deviceURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
@@ -22,50 +23,41 @@ const DeviceDetails = (): JSX.Element => {
   const device = useSelector((state: RootState) =>
     deviceSelectors.getById(state, id)
   );
+  const [headerContent, setHeaderContent] =
+    useState<DeviceHeaderContent | null>(null);
 
+  // TODO: Replace with "get" method when implemented
+  // https://github.com/canonical-web-and-design/app-tribe/issues/520
   useEffect(() => {
     dispatch(deviceActions.fetch());
   }, [dispatch]);
 
   return (
-    <Section header={<SectionHeader loading={!device} title={device?.fqdn} />}>
+    <Section
+      header={
+        <DeviceDetailsHeader
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
+          systemId={id}
+        />
+      }
+    >
       {device && (
-        <>
-          <ul>
-            <li>
-              <Link to={deviceURLs.device.summary({ id: device.system_id })}>
-                Summary
-              </Link>
-            </li>
-            <li>
-              <Link to={deviceURLs.device.network({ id: device.system_id })}>
-                Network
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={deviceURLs.device.configuration({ id: device.system_id })}
-              >
-                Configuration
-              </Link>
-            </li>
-          </ul>
-          <Switch>
-            <Route exact path={deviceURLs.device.summary(null, true)}>
-              <DeviceSummary />
-            </Route>
-            <Route exact path={deviceURLs.device.network(null, true)}>
-              <DeviceNetwork />
-            </Route>
-            <Route exact path={deviceURLs.device.configuration(null, true)}>
-              <DeviceConfiguration />
-            </Route>
-            <Redirect
-              from={deviceURLs.device.index(null, true)}
-              to={deviceURLs.device.summary(null, true)}
-            />
-          </Switch>
-        </>
+        <Switch>
+          <Route exact path={deviceURLs.device.summary(null, true)}>
+            <DeviceSummary />
+          </Route>
+          <Route exact path={deviceURLs.device.network(null, true)}>
+            <DeviceNetwork />
+          </Route>
+          <Route exact path={deviceURLs.device.configuration(null, true)}>
+            <DeviceConfiguration />
+          </Route>
+          <Redirect
+            from={deviceURLs.device.index(null, true)}
+            to={deviceURLs.device.summary(null, true)}
+          />
+        </Switch>
       )}
     </Section>
   );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
@@ -1,0 +1,108 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeviceDetailsHeader from "./DeviceDetailsHeader";
+
+import { DeviceHeaderViews } from "app/devices/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  device as deviceFactory,
+  deviceDetails as deviceDetailsFactory,
+  deviceState as deviceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DeviceDetailsHeader", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [deviceDetailsFactory({ system_id: "abc123" })],
+      }),
+    });
+  });
+
+  it("displays a spinner as the title if device has not loaded yet", () => {
+    state.device.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceDetailsHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("SectionHeader").prop("loading")).toBe(true);
+    expect(wrapper.find("SectionHeader").prop("subtitleLoading")).not.toBe(
+      true
+    );
+  });
+
+  it("displays a spinner as the subtitle if loaded device is not the detailed type", () => {
+    state.device.items = [deviceFactory({ system_id: "abc123" })];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceDetailsHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("SectionHeader").prop("subtitleLoading")).toBe(true);
+    expect(wrapper.find("SectionHeader").prop("loading")).not.toBe(true);
+  });
+
+  it("displays the device's FQDN once loaded", () => {
+    state.device.items = [
+      deviceDetailsFactory({ fqdn: "plot-device", system_id: "abc123" }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceDetailsHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='section-header-title']").text()).toBe(
+      "plot-device"
+    );
+  });
+
+  it("displays action title if an action is selected", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceDetailsHeader
+            headerContent={{ view: DeviceHeaderViews.DELETE_DEVICE }}
+            setHeaderContent={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='section-header-title']").text()).toBe(
+      "Delete"
+    );
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -1,0 +1,98 @@
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router";
+import { Link } from "react-router-dom";
+
+import NodeActionMenu from "app/base/components/NodeActionMenu";
+import SectionHeader from "app/base/components/SectionHeader";
+import DeviceHeaderForms from "app/devices/components/DeviceHeaderForms";
+import { DeviceHeaderViews } from "app/devices/constants";
+import type {
+  DeviceHeaderContent,
+  DeviceSetHeaderContent,
+} from "app/devices/types";
+import deviceURLs from "app/devices/urls";
+import { getHeaderTitle } from "app/devices/utils";
+import deviceSelectors from "app/store/device/selectors";
+import type { Device } from "app/store/device/types";
+import { isDeviceDetails } from "app/store/device/utils";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  headerContent: DeviceHeaderContent | null;
+  setHeaderContent: DeviceSetHeaderContent;
+  systemId: Device["system_id"];
+};
+
+const DeviceDetailsHeader = ({
+  headerContent,
+  setHeaderContent,
+  systemId,
+}: Props): JSX.Element => {
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, systemId)
+  );
+  const { pathname } = useLocation();
+
+  if (!device) {
+    return <SectionHeader loading />;
+  }
+
+  return (
+    <SectionHeader
+      buttons={[
+        <NodeActionMenu
+          nodes={[device]}
+          nodeDisplay="device"
+          onActionClick={(action) => {
+            const view = Object.values(DeviceHeaderViews).find(
+              ([, actionName]) => actionName === action
+            );
+            if (view) {
+              setHeaderContent({ view });
+            }
+          }}
+        />,
+      ]}
+      headerContent={
+        headerContent && (
+          <DeviceHeaderForms
+            headerContent={headerContent}
+            setHeaderContent={setHeaderContent}
+          />
+        )
+      }
+      subtitleLoading={!isDeviceDetails(device)}
+      tabLinks={[
+        {
+          active: pathname.startsWith(
+            deviceURLs.device.summary({ id: systemId })
+          ),
+          component: Link,
+          label: "Summary",
+          to: deviceURLs.device.summary({ id: systemId }),
+        },
+        {
+          active: pathname.startsWith(
+            deviceURLs.device.network({ id: systemId })
+          ),
+          component: Link,
+          label: "Network",
+          to: deviceURLs.device.network({ id: systemId }),
+        },
+        {
+          active: pathname.startsWith(
+            deviceURLs.device.configuration({ id: systemId })
+          ),
+          component: Link,
+          label: "Configuration",
+          to: deviceURLs.device.configuration({ id: systemId }),
+        },
+      ]}
+      // TODO: Make MachineName component generic and use here instead
+      // https://github.com/canonical-web-and-design/app-tribe/issues/553
+      title={getHeaderTitle(device.fqdn || "", headerContent)}
+    />
+  );
+};
+
+export default DeviceDetailsHeader;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceDetailsHeader";


### PR DESCRIPTION
## Done

- Built initial `DeviceDetailsHeader` component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and click on device name
- Check that you are taken to the device details page and you can navigate between the tabs properly.
- Note that the subtitle will always show a spinner as we don't currently have the `device.get` action implemented, so devices in state can never be the "details" version

## Fixes

Fixes canonical-web-and-design/app-tribe#532

## Screenshot
![Screenshot 2021-11-23 at 13-52-37 MAAS](https://user-images.githubusercontent.com/25733845/142968999-d1359a7d-d86a-4bea-b5cf-b378efc34e65.png)
