### PR TITLE
feat(ui): build "Add device" form

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -142,6 +142,9 @@ const DiscoveryAddFormFields = ({
         </Col>
         <Col size={6}>
           <FormikField
+            // TODO: Convert to common component as an almost identical verison
+            // is used in AddDeviceForm.
+            // https://github.com/canonical-web-and-design/app-tribe/issues/554
             component={Select}
             label="IP assignment"
             name="ip_assignment"

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -1,0 +1,162 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddDeviceForm from "./AddDeviceForm";
+
+import { actions as deviceActions } from "app/store/device";
+import { DeviceIpAssignment } from "app/store/device/types";
+import { actions as domainActions } from "app/store/domain";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import { actions as zoneActions } from "app/store/zone";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import { submitFormikForm } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("AddDeviceForm", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ id: 0, name: "maas" })],
+        loaded: true,
+      }),
+      subnet: subnetStateFactory({
+        items: [subnetFactory({ id: 0, name: "subnet" })],
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory({ id: 0, name: "default" })],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("fetches the necessary data on load", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AddDeviceForm clearHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const expectedActions = [
+      domainActions.fetch(),
+      subnetActions.fetch(),
+      zoneActions.fetch(),
+    ];
+    const actualActions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        actualActions.find(
+          (actualAction) => actualAction.type === expectedAction.type
+        )
+      ).toStrictEqual(expectedAction);
+    });
+  });
+
+  it("displays a spinner if data has not loaded", () => {
+    state.zone.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AddDeviceForm clearHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("can handle saving a device", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AddDeviceForm clearHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    submitFormikForm(wrapper, {
+      domain: "maas",
+      hostname: "plot-device",
+      interfaces: [
+        {
+          id: 0,
+          ip_address: "192.168.1.1",
+          ip_assignment: DeviceIpAssignment.STATIC,
+          mac: "11:11:11:11:11:11",
+          name: "eth0",
+          subnet: 0,
+        },
+        {
+          id: 1,
+          ip_address: "192.168.1.2",
+          ip_assignment: DeviceIpAssignment.EXTERNAL,
+          mac: "22:22:22:22:22:22",
+          name: "eth1",
+          subnet: "",
+        },
+        {
+          id: 2,
+          ip_address: "",
+          ip_assignment: DeviceIpAssignment.DYNAMIC,
+          mac: "33:33:33:33:33:33",
+          name: "eth2",
+          subnet: "",
+        },
+      ],
+      zone: "default",
+    });
+
+    const expectedAction = deviceActions.create({
+      domain: { name: "maas" },
+      extra_macs: ["22:22:22:22:22:22", "33:33:33:33:33:33"],
+      hostname: "plot-device",
+      interfaces: [
+        {
+          ip_address: "192.168.1.1",
+          ip_assignment: DeviceIpAssignment.STATIC,
+          mac: "11:11:11:11:11:11",
+          name: "eth0",
+          subnet: 0,
+        },
+        {
+          ip_address: "192.168.1.2",
+          ip_assignment: DeviceIpAssignment.EXTERNAL,
+          mac: "22:22:22:22:22:22",
+          name: "eth1",
+          subnet: null,
+        },
+        {
+          ip_address: null,
+          ip_assignment: DeviceIpAssignment.DYNAMIC,
+          mac: "33:33:33:33:33:33",
+          name: "eth2",
+          subnet: null,
+        },
+      ],
+      primary_mac: "11:11:11:11:11:11",
+      zone: { name: "default" },
+    });
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
@@ -1,15 +1,195 @@
-import { Button } from "@canonical/react-components";
+import { useEffect, useState } from "react";
 
+import { Col, Row, Spinner, Strip } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import AddDeviceInterfaces from "./AddDeviceInterfaces";
+import type { AddDeviceValues } from "./types";
+
+import DomainSelect from "app/base/components/DomainSelect";
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import ZoneSelect from "app/base/components/ZoneSelect";
+import { useAddMessage } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
+import { MAC_ADDRESS_REGEX } from "app/base/validation";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import { DeviceIpAssignment } from "app/store/device/types";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import { actions as zoneActions } from "app/store/zone";
+import zoneSelectors from "app/store/zone/selectors";
 
 type Props = {
   clearHeaderContent: ClearHeaderContent;
 };
 
-const AddDeviceForm = ({ clearHeaderContent }: Props): JSX.Element | null => {
-  // TODO: Build Add device form
-  // https://github.com/canonical-web-and-design/app-tribe/issues/523
-  return <Button onClick={clearHeaderContent}>Cancel</Button>;
+const AddDeviceSchema = Yup.object().shape({
+  domain: Yup.string().required("Domain required"),
+  hostname: Yup.string(),
+  interfaces: Yup.array()
+    .of(
+      Yup.object().shape({
+        mac: Yup.string()
+          .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
+          .required("MAC address is required"),
+        ip_assignment: Yup.string().required("IP assignment is required"),
+        ip_address: Yup.string().when("ip_assignment", {
+          is: (ipAssignment: DeviceIpAssignment) =>
+            ipAssignment === DeviceIpAssignment.STATIC ||
+            ipAssignment === DeviceIpAssignment.EXTERNAL,
+          then: Yup.string().required("IP address is required"),
+        }),
+        subnet: Yup.number().when("ip_assignment", {
+          is: (ipAssignment: DeviceIpAssignment) =>
+            ipAssignment === DeviceIpAssignment.STATIC,
+          then: Yup.number().required("Subnet is required"),
+        }),
+      })
+    )
+    .min(1, "At least one interface must be defined"),
+  zone: Yup.string().required("Zone required"),
+});
+
+export const AddDeviceForm = ({ clearHeaderContent }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const devicesSaved = useSelector(deviceSelectors.saved);
+  const devicesSaving = useSelector(deviceSelectors.saving);
+  const devicesErrors = useSelector(deviceSelectors.errors);
+  const domains = useSelector(domainSelectors.all);
+  const domainsLoaded = useSelector(domainSelectors.loaded);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+  const zones = useSelector(zoneSelectors.all);
+  const zonesLoaded = useSelector(zoneSelectors.loaded);
+
+  const [secondarySubmit, setSecondarySubmit] = useState(false);
+  const [savingDevice, setSavingDevice] = useState<string | null>(null);
+
+  // Fetch all data required for the form.
+  useEffect(() => {
+    dispatch(domainActions.fetch());
+    dispatch(subnetActions.fetch());
+    dispatch(zoneActions.fetch());
+  }, [dispatch]);
+
+  useAddMessage(
+    devicesSaved,
+    deviceActions.cleanup,
+    `${savingDevice} added successfully.`,
+    () => setSavingDevice(null)
+  );
+
+  const loaded = domainsLoaded && subnetsLoaded && zonesLoaded;
+
+  if (!loaded) {
+    return (
+      <Strip>
+        <Spinner text="Loading" />
+      </Strip>
+    );
+  }
+
+  return (
+    <FormikForm<AddDeviceValues>
+      cleanup={deviceActions.cleanup}
+      errors={devicesErrors}
+      initialValues={{
+        domain: (domains.length && domains[0].name) || "",
+        hostname: "",
+        interfaces: [
+          {
+            id: 0,
+            ip_address: "",
+            ip_assignment: DeviceIpAssignment.DYNAMIC,
+            mac: "",
+            name: "eth0",
+            subnet: "",
+          },
+        ],
+        zone: (zones.length && zones[0].name) || "",
+      }}
+      onCancel={clearHeaderContent}
+      onSaveAnalytics={{
+        action: "Add device",
+        category: "Device list",
+        label: secondarySubmit ? "Save and add another" : "Save device",
+      }}
+      onSubmit={(values) => {
+        const { domain, hostname, interfaces, zone } = values;
+        const normalisedInterfaces = interfaces.map((iface) => ({
+          ip_address: iface.ip_address || null,
+          ip_assignment: iface.ip_assignment,
+          mac: iface.mac,
+          name: iface.name,
+          subnet: iface.subnet || iface.subnet === 0 ? iface.subnet : null,
+        }));
+        // We determine the MAC addresses of the device based on the defined
+        // interfaces.
+        const { primary_mac, extra_macs } = normalisedInterfaces.reduce<{
+          primary_mac: string;
+          extra_macs: string[];
+        }>(
+          (split, iface, i) => {
+            if (i === 0) {
+              split.primary_mac = iface.mac;
+            } else {
+              split.extra_macs.push(iface.mac);
+            }
+            return split;
+          },
+          { primary_mac: "", extra_macs: [] }
+        );
+        const params = {
+          domain: { name: domain },
+          extra_macs,
+          hostname,
+          interfaces: normalisedInterfaces,
+          primary_mac,
+          zone: { name: zone },
+        };
+        dispatch(deviceActions.create(params));
+        setSavingDevice(values.hostname || "Device");
+      }}
+      onSuccess={() => {
+        if (!secondarySubmit) {
+          clearHeaderContent();
+        }
+        setSecondarySubmit(false);
+      }}
+      resetOnSave
+      saving={devicesSaving}
+      saved={devicesSaved}
+      secondarySubmit={(_, { submitForm }) => {
+        setSecondarySubmit(true);
+        submitForm();
+      }}
+      secondarySubmitLabel="Save and add another"
+      submitLabel="Save device"
+      validationSchema={AddDeviceSchema}
+    >
+      <Row>
+        <Col size={5}>
+          <FormikField
+            label="Device name"
+            name="hostname"
+            placeholder="Device name (optional)"
+            type="text"
+          />
+          <DomainSelect name="domain" required />
+          <ZoneSelect name="zone" required />
+        </Col>
+      </Row>
+      <Row>
+        <Col size={12}>
+          <AddDeviceInterfaces />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
 };
 
 export default AddDeviceForm;

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
@@ -1,0 +1,133 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddDeviceInterfaces from "../AddDeviceInterfaces";
+import type { AddDeviceInterface } from "../types";
+
+import { DeviceIpAssignment } from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+import {
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("AddDeviceInterfaces", () => {
+  let interfaces: AddDeviceInterface[];
+  let state: RootState;
+
+  beforeEach(() => {
+    interfaces = [
+      {
+        id: 0,
+        ip_address: "",
+        ip_assignment: DeviceIpAssignment.DYNAMIC,
+        mac: "",
+        name: "eth0",
+        subnet: "",
+      },
+    ];
+    state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnetFactory({ id: 0, name: "default" })],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("does not show subnet or IP address fields for dynamic IP assignment", () => {
+    interfaces[0].ip_assignment = DeviceIpAssignment.DYNAMIC;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Formik initialValues={{ interfaces }} onSubmit={jest.fn()}>
+            <AddDeviceInterfaces />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='subnet-field']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='ip-address-field']").exists()).toBe(false);
+  });
+
+  it("shows the IP address field for external IP assignment", () => {
+    interfaces[0].ip_assignment = DeviceIpAssignment.EXTERNAL;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Formik initialValues={{ interfaces }} onSubmit={jest.fn()}>
+            <AddDeviceInterfaces />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='subnet-field']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='ip-address-field']").exists()).toBe(true);
+  });
+
+  it("shows both the subnet and IP address fields for static IP assignment", () => {
+    interfaces[0].ip_assignment = DeviceIpAssignment.STATIC;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Formik initialValues={{ interfaces }} onSubmit={jest.fn()}>
+            <AddDeviceInterfaces />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='subnet-field']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='ip-address-field']").exists()).toBe(true);
+  });
+
+  it("can add and remove interfaces", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Formik initialValues={{ interfaces }} onSubmit={jest.fn()}>
+            <AddDeviceInterfaces />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const getRowCount = () =>
+      wrapper.find("tr[data-test='interface-row']").length;
+    const getAddButton = () =>
+      wrapper.find("button[data-test='add-interface']");
+    const getRemoveButton = () =>
+      wrapper.find("button[data-test='table-actions-delete']").at(0);
+
+    // There is only one interface by default. Since at least one interface must
+    // be defined, the remove button should be disabled.
+    expect(getRowCount()).toBe(1);
+    expect(getRemoveButton().prop("disabled")).toBe(true);
+
+    // Add an interface.
+    getAddButton().simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    expect(getRowCount()).toBe(2);
+    expect(getRemoveButton().prop("disabled")).toBe(false);
+
+    // Remove an interface.
+    getRemoveButton().simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    expect(getRowCount()).toBe(1);
+    expect(getRemoveButton().prop("disabled")).toBe(true);
+  });
+});

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -1,0 +1,179 @@
+import type { ChangeEvent } from "react";
+import { useRef } from "react";
+
+import { Button, Icon, MainTable, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { AddDeviceValues } from "../types";
+
+import FormikField from "app/base/components/FormikField";
+import MacAddressField from "app/base/components/MacAddressField";
+import SubnetSelect from "app/base/components/SubnetSelect";
+import TableActions from "app/base/components/TableActions";
+import { DeviceIpAssignment } from "app/store/device/types";
+import { getIpAssignmentDisplay } from "app/store/device/utils";
+import { getNextName } from "app/utils";
+
+export const AddDeviceInterfaces = (): JSX.Element => {
+  const currentId = useRef<number>(0);
+  const {
+    handleChange,
+    setFieldValue,
+    values: { interfaces },
+  } = useFormikContext<AddDeviceValues>();
+
+  const addInterface = () => {
+    currentId.current += 1;
+    setFieldValue("interfaces", [
+      ...interfaces,
+      {
+        id: currentId.current,
+        ip_address: "",
+        ip_assignment: DeviceIpAssignment.DYNAMIC,
+        mac: "",
+        name: getNextName(
+          interfaces.map((iface) => iface.name),
+          "eth"
+        ),
+        subnet: "",
+      },
+    ]);
+  };
+
+  const removeInterface = (id: number) => {
+    setFieldValue(
+      "interfaces",
+      interfaces.filter((iface) => iface.id !== id)
+    );
+  };
+
+  return (
+    <>
+      <MainTable
+        className="p-form--table"
+        headers={[
+          { className: "u-no-padding--left", content: "Name" },
+          { content: "* MAC address" },
+          { content: "* IP assignment" },
+          { content: "Subnet" },
+          { content: "IP address" },
+          {
+            className: "u-align--right u-no-padding--right",
+            content: "Actions",
+          },
+        ]}
+        rows={interfaces.map((iface, i) => {
+          const showSubnetField =
+            iface.ip_assignment === DeviceIpAssignment.STATIC;
+          const showIpAddressField =
+            iface.ip_assignment === DeviceIpAssignment.STATIC ||
+            iface.ip_assignment === DeviceIpAssignment.EXTERNAL;
+          const deleteDisabled = interfaces.length <= 1;
+
+          return {
+            columns: [
+              {
+                className: "u-no-padding--left",
+                content: (
+                  <FormikField name={`interfaces[${i}].name`} type="text" />
+                ),
+              },
+              {
+                content: (
+                  <MacAddressField name={`interfaces[${i}].mac`} required />
+                ),
+              },
+              {
+                content: (
+                  <FormikField
+                    // TODO: Convert to common component as an almost
+                    // identical version is used in DiscoveryAddForm.
+                    // https://github.com/canonical-web-and-design/app-tribe/issues/554
+                    component={Select}
+                    name={`interfaces[${i}].ip_assignment`}
+                    onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+                      handleChange(e);
+                      setFieldValue(`interfaces[${i}].subnet`, "");
+                      setFieldValue(`interfaces[${i}].ip_address`, "");
+                    }}
+                    options={[
+                      {
+                        label: "Select IP assignment",
+                        value: "",
+                        disabled: true,
+                      },
+                      {
+                        label: getIpAssignmentDisplay(
+                          DeviceIpAssignment.DYNAMIC
+                        ),
+                        value: DeviceIpAssignment.DYNAMIC,
+                      },
+                      {
+                        label: getIpAssignmentDisplay(
+                          DeviceIpAssignment.STATIC
+                        ),
+                        value: DeviceIpAssignment.STATIC,
+                      },
+                      {
+                        label: getIpAssignmentDisplay(
+                          DeviceIpAssignment.EXTERNAL
+                        ),
+                        value: DeviceIpAssignment.EXTERNAL,
+                      },
+                    ]}
+                    required
+                  />
+                ),
+              },
+              {
+                content: showSubnetField ? (
+                  <SubnetSelect
+                    data-test="subnet-field"
+                    labelClassName="u-hide"
+                    name={`interfaces[${i}].subnet`}
+                  />
+                ) : null,
+              },
+              {
+                content: showIpAddressField ? (
+                  <FormikField
+                    data-test="ip-address-field"
+                    name={`interfaces[${i}].ip_address`}
+                    type="text"
+                  />
+                ) : null,
+              },
+              {
+                className:
+                  "u-align--right u-align-non-field u-no-padding--right",
+                content: (
+                  <TableActions
+                    deleteDisabled={deleteDisabled}
+                    deleteTooltip={
+                      deleteDisabled
+                        ? "At least one interface must be defined"
+                        : null
+                    }
+                    onDelete={() => removeInterface(iface.id)}
+                  />
+                ),
+              },
+            ],
+            "data-test": "interface-row",
+          };
+        })}
+      />
+      <Button
+        data-test="add-interface"
+        hasIcon
+        onClick={() => addInterface()}
+        type="button"
+      >
+        <Icon name="plus" />
+        <span>Add interface</span>
+      </Button>
+    </>
+  );
+};
+
+export default AddDeviceInterfaces;

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/index.ts
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddDeviceInterfaces";

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/types.ts
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/types.ts
@@ -1,0 +1,25 @@
+import type {
+  CreateParams,
+  Device,
+  DeviceIpAssignment,
+} from "app/store/device/types";
+import type { Domain } from "app/store/domain/types";
+import type { Zone } from "app/store/zone/types";
+
+type CreateParamsInterface = CreateParams["interfaces"][0];
+
+export type AddDeviceInterface = {
+  id: number;
+  ip_address: NonNullable<CreateParamsInterface["ip_address"]>;
+  ip_assignment: DeviceIpAssignment;
+  mac: CreateParamsInterface["mac"];
+  name: NonNullable<CreateParamsInterface["name"]>;
+  subnet: NonNullable<CreateParamsInterface["subnet"]> | "";
+};
+
+export type AddDeviceValues = {
+  domain: Domain["name"];
+  hostname: Device["hostname"];
+  interfaces: AddDeviceInterface[];
+  zone: Zone["name"];
+};

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.test.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.test.tsx
@@ -1,16 +1,28 @@
 import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import DeviceHeaderForms from "./DeviceHeaderForms";
 
 import { DeviceHeaderViews } from "app/devices/constants";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
 
 describe("DeviceHeaderForms", () => {
   it("can render the Add Device form", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
     const wrapper = mount(
-      <DeviceHeaderForms
-        headerContent={{ view: DeviceHeaderViews.ADD_DEVICE }}
-        setHeaderContent={jest.fn()}
-      />
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceHeaderForms
+            headerContent={{ view: DeviceHeaderViews.ADD_DEVICE }}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     expect(wrapper.find("AddDeviceForm").exists()).toBe(true);

--- a/ui/src/app/store/device/types/actions.ts
+++ b/ui/src/app/store/device/types/actions.ts
@@ -16,13 +16,14 @@ export type CreateParams = {
   extra_macs?: Device["extra_macs"];
   hostname?: Device["hostname"];
   interfaces: {
-    ip_address: DeviceNetworkInterface["ip_address"];
+    ip_address?: DeviceNetworkInterface["ip_address"];
     ip_assignment: DeviceIpAssignment;
     mac: DeviceNetworkInterface["mac_address"];
-    subnet: Subnet[SubnetMeta.PK];
+    name?: DeviceNetworkInterface["name"];
+    subnet?: Subnet[SubnetMeta.PK] | null;
   }[];
   parent?: Controller[ControllerMeta.PK] | Machine[MachineMeta.PK];
-  primary_mac?: Device["primary_mac"];
+  primary_mac: Device["primary_mac"];
   swap_size?: DeviceDetails["swap_size"];
   zone?: {
     name: Zone["name"];


### PR DESCRIPTION
## Done

- Built "Add device" form in the device list header
  - It's a little different from the legacy version - I've added a zone select and a name field for each interface. There's more fields we *could* add, but those two stood out as being particularly weird to be omitted. 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and click "Add device"
- Check that you can add a device using different interface configurations, and the validation works as expected, i.e. you must define one interface, every interface must have a MAC address, etc

## Fixes

Fixes canonical-web-and-design/app-tribe#523

## Screenshot

![Screenshot 2021-11-24 at 18-04-29 Devices bolla MAAS](https://user-images.githubusercontent.com/25733845/143199296-08015860-2491-4f00-b30b-d59df63c7107.png)

