### PR TITLE
fix(ui): fix flashing error messages on login/logout

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -170,7 +170,6 @@ export const App = (): JSX.Element => {
         )}
         location={location}
         logout={() => {
-          dispatch(statusActions.websocketDisconnect());
           dispatch(statusActions.logout());
           if (window.legacyWS) {
             window.legacyWS.close();

--- a/ui/src/app/base/sagas/http.test.ts
+++ b/ui/src/app/base/sagas/http.test.ts
@@ -74,6 +74,7 @@ describe("http sagas", () => {
           .provide([[matchers.call.fn(api.auth.login), payload]])
           .put({ type: "status/loginStart" })
           .put({ type: "status/loginSuccess" })
+          .put({ type: "status/websocketConnect" })
           .run();
       });
 
@@ -115,6 +116,7 @@ describe("http sagas", () => {
           .provide([[matchers.call.fn(api.auth.externalLogin), null]])
           .put({ type: "status/externalLoginStart" })
           .put({ type: "status/externalLoginSuccess" })
+          .put({ type: "status/websocketConnect" })
           .run();
       });
 

--- a/ui/src/app/base/sagas/http.ts
+++ b/ui/src/app/base/sagas/http.ts
@@ -297,6 +297,9 @@ export function* loginSaga(
     yield* put({
       type: "status/loginSuccess",
     });
+    yield* put({
+      type: "status/websocketConnect",
+    });
   } catch (error) {
     yield* put({
       error: true,

--- a/ui/src/app/base/sagas/http.ts
+++ b/ui/src/app/base/sagas/http.ts
@@ -339,6 +339,9 @@ export function* externalLoginSaga(): SagaGenerator<void> {
     yield* put({
       type: "status/externalLoginSuccess",
     });
+    yield* put({
+      type: "status/websocketConnect",
+    });
   } catch (error) {
     yield* put({
       error: true,


### PR DESCRIPTION
## Done

- display loading consistently until user data has fully loaded
  - dispatch `status/websocketConnect` from `loginSaga` and `externalLoginSaga`
- display loading consistently until logout has finished
  - do not dispatch `status/websocketDisconnect` separately from the component - it already happens in the `logoutSaga` https://github.com/canonical-web-and-design/maas-ui/blob/c8c0b3f596e2e9fe4bf2dca9ce38e466c5e9da90/ui/src/app/base/sagas/http.ts#L312-L325


### Why was this happening 
The loading process consists of multiple actions (REST API, WebSocket) which are dispatched from react components which re-render before dispatching the next action. This makes the UI flash between Login/Error components when the App is in the intermediary state (authenticated, but not yet connected).

![image](https://user-images.githubusercontent.com/7452681/143479617-de804f44-3045-4610-8756-489d6c28a8bd.png)
*User is authenticated, but `websocketConnect` action hasn’t been dispatched yet.*

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- open developer tools and slow down the network
- log in and log out multiple times to ensure there's no flash of connection error before full page is displayed

## Fixes

Fixes: #3255 #3275 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
