### PR TITLE
feat(ui): make add device interfaces table responsive

### DIFF
--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
@@ -183,11 +183,9 @@ export const AddDeviceForm = ({ clearHeaderContent }: Props): JSX.Element => {
           <ZoneSelect name="zone" required />
         </Col>
       </Row>
-      <Row>
-        <Col size={12}>
-          <AddDeviceInterfaces />
-        </Col>
-      </Row>
+      <Strip shallow>
+        <AddDeviceInterfaces />
+      </Strip>
     </FormikForm>
   );
 };

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent } from "react";
 import { useRef } from "react";
 
 import { Button, Icon, MainTable, Select } from "@canonical/react-components";
+import classNames from "classnames";
 import { useFormikContext } from "formik";
 
 import type { AddDeviceValues } from "../types";
@@ -49,19 +50,21 @@ export const AddDeviceInterfaces = (): JSX.Element => {
 
   return (
     <>
+      <h4>Interfaces</h4>
       <MainTable
-        className="p-form--table"
+        className="add-device-interfaces p-form--table"
         headers={[
-          { className: "u-no-padding--left", content: "Name" },
-          { content: "* MAC address" },
-          { content: "* IP assignment" },
-          { content: "Subnet" },
-          { content: "IP address" },
+          { className: "name-col u-no-padding--left", content: "Name" },
+          { className: "mac-col", content: "* MAC address" },
+          { className: "ip-assignment-col", content: "* IP assignment" },
+          { className: "subnet-col", content: "Subnet" },
+          { className: "ip-address-col", content: "IP address" },
           {
-            className: "u-align--right u-no-padding--right",
+            className: "actions-col u-align--right u-no-padding--right",
             content: "Actions",
           },
         ]}
+        responsive
         rows={interfaces.map((iface, i) => {
           const showSubnetField =
             iface.ip_assignment === DeviceIpAssignment.STATIC;
@@ -73,17 +76,22 @@ export const AddDeviceInterfaces = (): JSX.Element => {
           return {
             columns: [
               {
-                className: "u-no-padding--left",
+                "aria-label": "Name",
+                className: "name-col u-no-padding--left",
                 content: (
                   <FormikField name={`interfaces[${i}].name`} type="text" />
                 ),
               },
               {
+                "aria-label": "* MAC address",
+                className: "mac-col",
                 content: (
                   <MacAddressField name={`interfaces[${i}].mac`} required />
                 ),
               },
               {
+                "aria-label": "* IP assignment",
+                className: "ip-assignment-col",
                 content: (
                   <FormikField
                     // TODO: Convert to common component as an almost
@@ -126,26 +134,39 @@ export const AddDeviceInterfaces = (): JSX.Element => {
                 ),
               },
               {
+                "aria-label": "Subnet",
+                className: classNames("subnet-col", {
+                  "u-align-non-field": !showSubnetField,
+                }),
                 content: showSubnetField ? (
                   <SubnetSelect
                     data-test="subnet-field"
                     labelClassName="u-hide"
                     name={`interfaces[${i}].subnet`}
                   />
-                ) : null,
+                ) : (
+                  <span>N/A</span>
+                ),
               },
               {
+                "aria-label": "IP address",
+                className: classNames("ip-address-col", {
+                  "u-align-non-field": !showIpAddressField,
+                }),
                 content: showIpAddressField ? (
                   <FormikField
                     data-test="ip-address-field"
                     name={`interfaces[${i}].ip_address`}
                     type="text"
                   />
-                ) : null,
+                ) : (
+                  <span>N/A</span>
+                ),
               },
               {
+                "aria-label": "Actions",
                 className:
-                  "u-align--right u-align-non-field u-no-padding--right",
+                  "actions-col u-align--right u-align-non-field u-no-padding--right",
                 content: (
                   <TableActions
                     deleteDisabled={deleteDisabled}

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/_index.scss
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/_index.scss
@@ -1,0 +1,35 @@
+@mixin AddDeviceInterfaces {
+  .add-device-interfaces {
+    .name-col {
+      width: 26%;
+    }
+
+    .mac-col {
+      width: 12rem;
+    }
+
+    .ip-assignment-col {
+      width: 10rem;
+    }
+
+    .subnet-col {
+      width: 37%;
+    }
+
+    .ip-address-col {
+      width: 37%;
+    }
+
+    .actions-col {
+      width: 4.5rem;
+    }
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      .mac-col,
+      .ip-assignment-col,
+      .actions-col {
+        width: auto;
+      }
+    }
+  }
+}

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -52,6 +52,10 @@
     td {
       padding-bottom: $spv-inner--small;
       padding-top: $spv-inner--small;
+
+      &[aria-label]::before {
+        margin-bottom: $spv-inner--x-small;
+      }
     }
 
     .p-form-validation__message {
@@ -62,29 +66,10 @@
       top: initial;
     }
 
-    // Align non-form fields with form fields
-    .u-align-non-field {
-      padding-top: $sp-unit * 1.75;
-    }
-
-    @media screen and (max-width: $breakpoint-medium) {
-      tr {
-        padding: $spv-inner--small $sph-inner;
-        width: 100%;
-      }
-
-      td {
-        align-items: center;
-        padding-left: calc(33% + #{$sph-inner--small});
-
-        .p-form__group {
-          flex: 1;
-        }
-
-        &[aria-label="Actions"] > * {
-          left: calc(-#{$sph-inner--small} - 1px);
-          position: relative;
-        }
+    @media only screen and (min-width: $breakpoint-medium) {
+      // Align non-form fields with form fields on larger viewports
+      .u-align-non-field {
+        padding-top: $sp-unit * 1.75;
       }
     }
   }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -111,7 +111,9 @@
 @include TagSelector;
 
 // devices
+@import "~app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces";
 @import "~app/devices/views/DeviceList/DeviceListTable";
+@include AddDeviceInterfaces;
 @include DeviceListTable;
 
 // images


### PR DESCRIPTION
## Done

- Made "Add device" interfaces table responsive

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and click "Add device"
- Add some interfaces and resize the viewport to be smaller
- Check that the table looks alright for different viewport sizes and number of interfaces

## Fixes

Fixes canonical-web-and-design/app-tribe#555

## Screenshot

![Screenshot 2021-11-25 at 10-52-48 Devices bolla MAAS](https://user-images.githubusercontent.com/25733845/143333353-cf92cc97-e6e7-4dee-95b1-e8a9b01c0a12.png)

