### PR TITLE
feat(ui): add checkboxes to device list

### DIFF
--- a/ui/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -14,6 +14,7 @@ import deviceSelectors from "app/store/device/selectors";
 const DeviceList = (): JSX.Element => {
   const dispatch = useDispatch();
   const devices = useSelector(deviceSelectors.all);
+  const selectedIDs = useSelector(deviceSelectors.selectedIDs);
   const [headerContent, setHeaderContent] =
     useState<DeviceHeaderContent | null>(null);
   useWindowTitle("Devices");
@@ -31,7 +32,13 @@ const DeviceList = (): JSX.Element => {
         />
       }
     >
-      <DeviceListTable devices={devices} />
+      <DeviceListTable
+        devices={devices}
+        onSelectedChange={(deviceIDs) => {
+          dispatch(deviceActions.setSelected(deviceIDs));
+        }}
+        selectedIDs={selectedIDs}
+      />
     </Section>
   );
 };

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
@@ -60,6 +60,21 @@ describe("DeviceListHeader", () => {
     );
   });
 
+  it("disables the add device button if any devices are selected", () => {
+    state.device.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceListHeader headerContent={null} setHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('button[data-test="add-device-button"]').prop("disabled")
+    ).toBe(true);
+  });
+
   it("can open the add device form", () => {
     const setHeaderContent = jest.fn();
     const store = mockStore(state);

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
@@ -24,6 +24,7 @@ const DeviceListHeader = ({
 }: Props): JSX.Element => {
   const devices = useSelector(deviceSelectors.all);
   const devicesLoaded = useSelector(deviceSelectors.loaded);
+  const selectedDevices = useSelector(deviceSelectors.selected);
 
   return (
     <SectionHeader
@@ -31,6 +32,7 @@ const DeviceListHeader = ({
         <Button
           appearance="neutral"
           data-test="add-device-button"
+          disabled={selectedDevices.length > 0}
           onClick={() =>
             setHeaderContent({ view: DeviceHeaderViews.ADD_DEVICE })
           }
@@ -38,7 +40,7 @@ const DeviceListHeader = ({
           Add device
         </Button>,
         <NodeActionMenu
-          nodes={[]}
+          nodes={selectedDevices}
           nodeDisplay="device"
           onActionClick={(action) => {
             const view = Object.values(DeviceHeaderViews).find(
@@ -59,7 +61,11 @@ const DeviceListHeader = ({
         )
       }
       subtitle={
-        <ModelListSubtitle available={devices.length} modelName="device" />
+        <ModelListSubtitle
+          available={devices.length}
+          modelName="device"
+          selected={selectedDevices.length}
+        />
       }
       subtitleLoading={!devicesLoaded}
       title={getHeaderTitle("Devices", headerContent)}

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
@@ -32,7 +32,11 @@ describe("DeviceListTable", () => {
     device.system_id = "def456";
     const wrapper = mount(
       <MemoryRouter>
-        <DeviceListTable devices={[device]} />
+        <DeviceListTable
+          devices={[device]}
+          onSelectedChange={jest.fn()}
+          selectedIDs={[]}
+        />
       </MemoryRouter>
     );
 
@@ -46,7 +50,11 @@ describe("DeviceListTable", () => {
     device.extra_macs = ["22:22:22:22:22:22", "33:33:33:33:33:33"];
     const wrapper = mount(
       <MemoryRouter>
-        <DeviceListTable devices={[device]} />
+        <DeviceListTable
+          devices={[device]}
+          onSelectedChange={jest.fn()}
+          selectedIDs={[]}
+        />
       </MemoryRouter>
     );
 
@@ -59,7 +67,11 @@ describe("DeviceListTable", () => {
     device.zone = { id: 101, name: "danger" };
     const wrapper = mount(
       <MemoryRouter>
-        <DeviceListTable devices={[device]} />
+        <DeviceListTable
+          devices={[device]}
+          onSelectedChange={jest.fn()}
+          selectedIDs={[]}
+        />
       </MemoryRouter>
     );
 
@@ -80,7 +92,11 @@ describe("DeviceListTable", () => {
       ];
       const wrapper = mount(
         <MemoryRouter>
-          <DeviceListTable devices={devices} />
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={jest.fn()}
+            selectedIDs={[]}
+          />
         </MemoryRouter>
       );
 
@@ -113,7 +129,11 @@ describe("DeviceListTable", () => {
       ];
       const wrapper = mount(
         <MemoryRouter>
-          <DeviceListTable devices={devices} />
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={jest.fn()}
+            selectedIDs={[]}
+          />
         </MemoryRouter>
       );
 
@@ -138,7 +158,11 @@ describe("DeviceListTable", () => {
       ];
       const wrapper = mount(
         <MemoryRouter>
-          <DeviceListTable devices={devices} />
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={jest.fn()}
+            selectedIDs={[]}
+          />
         </MemoryRouter>
       );
 
@@ -163,7 +187,11 @@ describe("DeviceListTable", () => {
       ];
       const wrapper = mount(
         <MemoryRouter>
-          <DeviceListTable devices={devices} />
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={jest.fn()}
+            selectedIDs={[]}
+          />
         </MemoryRouter>
       );
 
@@ -178,6 +206,96 @@ describe("DeviceListTable", () => {
       expect(getRowTestId(wrapper, 0)).toBe("device-c");
       expect(getRowTestId(wrapper, 1)).toBe("device-b");
       expect(getRowTestId(wrapper, 2)).toBe("device-a");
+    });
+  });
+
+  describe("device selection", () => {
+    it("handles selecting a single device", () => {
+      const devices = [deviceFactory({ system_id: "abc123" })];
+      const onSelectedChange = jest.fn();
+      const wrapper = mount(
+        <MemoryRouter>
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={onSelectedChange}
+            selectedIDs={[]}
+          />
+        </MemoryRouter>
+      );
+
+      wrapper
+        .find("[data-test='device-checkbox'] input")
+        .at(0)
+        .simulate("change");
+
+      expect(onSelectedChange).toHaveBeenCalledWith(["abc123"]);
+    });
+
+    it("handles unselecting a single device", () => {
+      const devices = [deviceFactory({ system_id: "abc123" })];
+      const onSelectedChange = jest.fn();
+      const wrapper = mount(
+        <MemoryRouter>
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={onSelectedChange}
+            selectedIDs={["abc123"]}
+          />
+        </MemoryRouter>
+      );
+
+      wrapper
+        .find("[data-test='device-checkbox'] input")
+        .at(0)
+        .simulate("change");
+
+      expect(onSelectedChange).toHaveBeenCalledWith([]);
+    });
+
+    it("handles selecting all devices", () => {
+      const devices = [
+        deviceFactory({ system_id: "abc123" }),
+        deviceFactory({ system_id: "def456" }),
+      ];
+      const onSelectedChange = jest.fn();
+      const wrapper = mount(
+        <MemoryRouter>
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={onSelectedChange}
+            selectedIDs={[]}
+          />
+        </MemoryRouter>
+      );
+
+      wrapper
+        .find("[data-test='all-devices-checkbox'] input")
+        .simulate("change");
+
+      expect(onSelectedChange).toHaveBeenCalledWith(["abc123", "def456"]);
+    });
+
+    it("handles unselecting all devices", () => {
+      const devices = [
+        deviceFactory({ system_id: "abc123" }),
+        deviceFactory({ system_id: "def456" }),
+      ];
+      const onSelectedChange = jest.fn();
+      const wrapper = mount(
+        <MemoryRouter>
+          <DeviceListTable
+            devices={devices}
+            onSelectedChange={onSelectedChange}
+            selectedIDs={["abc123", "def456"]}
+          />
+        </MemoryRouter>
+      );
+
+      wrapper
+        .find("[data-test='all-devices-checkbox'] input")
+        .simulate("change");
+
+      expect(onSelectedChange).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -2,17 +2,22 @@ import { MainTable } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import GroupCheckbox from "app/base/components/GroupCheckbox";
+import RowCheckbox from "app/base/components/RowCheckbox";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import deviceURLs from "app/devices/urls";
-import type { Device } from "app/store/device/types";
+import type { Device, DeviceMeta } from "app/store/device/types";
 import { getIpAssignmentDisplay } from "app/store/device/utils";
-import { isComparable } from "app/utils";
+import { generateCheckboxHandlers, isComparable } from "app/utils";
+import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 import zoneURLs from "app/zones/urls";
 
 type Props = {
   devices: Device[];
+  onSelectedChange: (newSelectedIDs: Device[DeviceMeta.PK][]) => void;
+  selectedIDs: Device[DeviceMeta.PK][];
 };
 
 type SortKey = keyof Device;
@@ -28,7 +33,13 @@ const getSortValue = (sortKey: SortKey, device: Device) => {
   return isComparable(value) ? value : null;
 };
 
-const generateRows = (devices: Device[]) =>
+const generateRows = (
+  devices: Device[],
+  selectedIDs: Device[DeviceMeta.PK][],
+  handleRowCheckbox: CheckboxHandlers<
+    Device[DeviceMeta.PK]
+  >["handleRowCheckbox"]
+) =>
   devices.map((device) => {
     const {
       domain: { name: domainName },
@@ -56,16 +67,25 @@ const generateRows = (devices: Device[]) =>
           content: (
             <DoubleRow
               primary={
-                <Link
-                  data-test="device-details-link"
-                  to={deviceURLs.device.index({ id: system_id })}
-                >
-                  <strong>{hostname}</strong>
-                  <span>.{domainName}</span>
-                </Link>
+                <RowCheckbox
+                  data-test="device-checkbox"
+                  handleRowCheckbox={handleRowCheckbox}
+                  inputLabel={
+                    <Link
+                      data-test="device-details-link"
+                      to={deviceURLs.device.index({ id: system_id })}
+                    >
+                      <strong>{hostname}</strong>
+                      <span>.{domainName}</span>
+                    </Link>
+                  }
+                  item={device.system_id}
+                  items={selectedIDs}
+                />
               }
               primaryTitle={fqdn}
               secondary={<span data-test="mac-display">{macDisplay}</span>}
+              secondaryClassName="u-nudge--secondary-row"
               secondaryTitle={[primary_mac, ...extra_macs].join(", ")}
             />
           ),
@@ -109,7 +129,11 @@ const generateRows = (devices: Device[]) =>
     };
   });
 
-const DeviceListTable = ({ devices }: Props): JSX.Element => {
+const DeviceListTable = ({
+  devices,
+  onSelectedChange,
+  selectedIDs,
+}: Props): JSX.Element => {
   const { currentSort, sortRows, updateSort } = useTableSort<Device, SortKey>(
     getSortValue,
     {
@@ -118,6 +142,9 @@ const DeviceListTable = ({ devices }: Props): JSX.Element => {
     }
   );
   const sortedDevices = sortRows(devices);
+  const { handleGroupCheckbox, handleRowCheckbox } =
+    generateCheckboxHandlers<Device[DeviceMeta.PK]>(onSelectedChange);
+  const deviceIDs = devices.map((device) => device.system_id);
 
   return (
     <MainTable
@@ -126,17 +153,25 @@ const DeviceListTable = ({ devices }: Props): JSX.Element => {
         {
           className: "fqdn-col",
           content: (
-            <>
-              <TableHeader
-                currentSort={currentSort}
-                data-test="fqdn-header"
-                onClick={() => updateSort("fqdn")}
-                sortKey="fqdn"
-              >
-                FQDN
-              </TableHeader>
-              <TableHeader>MAC address</TableHeader>
-            </>
+            <div className="u-flex">
+              <GroupCheckbox
+                data-test="all-devices-checkbox"
+                handleGroupCheckbox={handleGroupCheckbox}
+                items={deviceIDs}
+                selectedItems={selectedIDs}
+              />
+              <div>
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="fqdn-header"
+                  onClick={() => updateSort("fqdn")}
+                  sortKey="fqdn"
+                >
+                  FQDN
+                </TableHeader>
+                <TableHeader>MAC address</TableHeader>
+              </div>
+            </div>
           ),
         },
         {
@@ -185,7 +220,7 @@ const DeviceListTable = ({ devices }: Props): JSX.Element => {
           ),
         },
       ]}
-      rows={generateRows(sortedDevices)}
+      rows={generateRows(sortedDevices, selectedIDs, handleRowCheckbox)}
     />
   );
 };

--- a/ui/src/app/store/device/actions.test.ts
+++ b/ui/src/app/store/device/actions.test.ts
@@ -293,4 +293,11 @@ describe("device actions", () => {
       },
     });
   });
+
+  it("can handle setting selected devices", () => {
+    expect(actions.setSelected(["abc123", "def456"])).toEqual({
+      type: "device/setSelected",
+      payload: ["abc123", "def456"],
+    });
+  });
 });

--- a/ui/src/app/store/device/slice.ts
+++ b/ui/src/app/store/device/slice.ts
@@ -284,6 +284,12 @@ const deviceSlice = createSlice({
     ) => {
       state.active = action.payload?.system_id || null;
     },
+    setSelected: (
+      state: DeviceState,
+      action: PayloadAction<Device[DeviceMeta.PK][]>
+    ) => {
+      state.selected = action.payload;
+    },
     setZone: {
       prepare: (params: SetZoneParams) => ({
         meta: {


### PR DESCRIPTION
## Done

- Added `setSelected` action to device slice
- Added checkboxes to device list

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and check that the "Add device" button is enabled and the "Take action" button is disabled
- Check some checkboxes
- Check that the header subtitle updates with the selected count, the "Add device" button becomes disabled and the "Take action" button is enabled

## Fixes

Fixes canonical-web-and-design/app-tribe#526

## Screenshot
![Screenshot 2021-11-25 at 15-56-23 Devices bolla MAAS](https://user-images.githubusercontent.com/25733845/143387591-efad9424-2231-492e-a16d-2b0f22c11c59.png)


