### PR TITLE
feat(ui): build devices searchbox

### DIFF
--- a/ui/src/app/base/components/DebounceSearchBox/DebounceSearchBox.test.tsx
+++ b/ui/src/app/base/components/DebounceSearchBox/DebounceSearchBox.test.tsx
@@ -1,0 +1,86 @@
+import type { ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+
+import DebounceSearchBox, {
+  DEFAULT_DEBOUNCE_INTERVAL,
+} from "./DebounceSearchBox";
+
+jest.useFakeTimers("modern");
+
+describe("DebounceSearchBox", () => {
+  const updateSearch = (wrapper: ReactWrapper, text: string) => {
+    act(() => {
+      wrapper.find("input[name='search']").simulate("change", {
+        target: { name: "search", value: text },
+      });
+    });
+    wrapper.update();
+  };
+
+  const advanceDebounceTimer = (wrapper: ReactWrapper) => {
+    act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+    });
+    wrapper.update();
+  };
+
+  it(`runs onDebounced fn when the search text changes via the input, after the
+      debounce interval`, () => {
+    const onDebounced = jest.fn();
+    const wrapper = mount(
+      <DebounceSearchBox
+        onDebounced={onDebounced}
+        searchText="old-value"
+        setSearchText={jest.fn()}
+      />
+    );
+
+    updateSearch(wrapper, "new-value");
+    expect(onDebounced).not.toHaveBeenCalled();
+
+    advanceDebounceTimer(wrapper);
+    expect(onDebounced).toHaveBeenCalledWith("new-value");
+  });
+
+  it(`does not run onDebounced fn when the search text changes via props, even
+      after the debounce interval`, () => {
+    const onDebounced = jest.fn();
+    const Proxy = ({ searchText }: { searchText: string }) => (
+      <DebounceSearchBox
+        onDebounced={onDebounced}
+        searchText={searchText}
+        setSearchText={jest.fn()}
+      />
+    );
+    const wrapper = mount(<Proxy searchText="old-value" />);
+
+    wrapper.setProps({
+      searchText: "new-value",
+    });
+    wrapper.update();
+    expect(onDebounced).not.toHaveBeenCalled();
+
+    advanceDebounceTimer(wrapper);
+    expect(onDebounced).not.toHaveBeenCalled();
+  });
+
+  it("displays a spinner while debouncing search box input", () => {
+    const wrapper = mount(
+      <DebounceSearchBox
+        onDebounced={jest.fn()}
+        searchText="old-value"
+        setSearchText={jest.fn()}
+      />
+    );
+    const spinnerExists = () =>
+      wrapper.find("[data-test='debouncing-spinner']").exists();
+    expect(spinnerExists()).toBe(false);
+
+    updateSearch(wrapper, "new-value");
+    expect(spinnerExists()).toBe(true);
+
+    advanceDebounceTimer(wrapper);
+    expect(spinnerExists()).toBe(false);
+  });
+});

--- a/ui/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
+++ b/ui/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { SearchBoxProps } from "@canonical/react-components";
+import { Icon, SearchBox } from "@canonical/react-components";
+import classNames from "classnames";
+
+type Props = {
+  debounceInterval?: number;
+  onDebounced: (debouncedText: string) => void;
+  searchText: string;
+  setSearchText: (searchText: string) => void;
+} & Omit<SearchBoxProps, "externallyControlled" | "onChange" | "value">;
+
+export const DEFAULT_DEBOUNCE_INTERVAL = 500;
+
+const DebounceSearchBox = ({
+  debounceInterval = DEFAULT_DEBOUNCE_INTERVAL,
+  onDebounced,
+  searchText,
+  setSearchText,
+}: Props): JSX.Element => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [debouncing, setDebouncing] = useState(false);
+
+  // Clear the timeout when the component is unmounted.
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearTimeout(intervalRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="debounce-search-box">
+      <SearchBox
+        externallyControlled
+        onChange={(text: string) => {
+          setDebouncing(true);
+          setSearchText(text);
+          // Clear the previous timeout.
+          if (intervalRef.current) {
+            clearTimeout(intervalRef.current);
+          }
+          intervalRef.current = setTimeout(() => {
+            onDebounced(text);
+            setDebouncing(false);
+          }, debounceInterval);
+        }}
+        value={searchText}
+      />
+      {debouncing && (
+        <div
+          className={classNames(
+            "debounce-search-box__spinner-container u-vertically-center",
+            { "nudge-left": !!searchText }
+          )}
+          data-test="debouncing-spinner"
+        >
+          <Icon className="u-animation--spin" name="spinner" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DebounceSearchBox;

--- a/ui/src/app/base/components/DebounceSearchBox/_index.scss
+++ b/ui/src/app/base/components/DebounceSearchBox/_index.scss
@@ -1,0 +1,20 @@
+@mixin DebounceSearchBox {
+  .debounce-search-box {
+    position: relative;
+  }
+
+  .debounce-search-box__spinner-container {
+    // Use Vanilla's calculation for the the height of the search box
+    height: calc(
+      #{2 * $spv-nudge + map-get($line-heights, default-text)} - #{2 * $bar-thickness}
+    );
+    margin: $bar-thickness 0;
+    position: absolute;
+    right: 3rem;
+    top: 0;
+
+    &.nudge-left {
+      right: 5rem;
+    }
+  }
+}

--- a/ui/src/app/base/components/DebounceSearchBox/index.ts
+++ b/ui/src/app/base/components/DebounceSearchBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DebounceSearchBox";

--- a/ui/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -30,6 +30,7 @@ const DeviceList = (): JSX.Element => {
   const filteredDevices = useSelector((state: RootState) =>
     deviceSelectors.search(state, searchFilter || null, selectedIDs)
   );
+  const devicesLoading = useSelector(deviceSelectors.loading);
   useWindowTitle("Devices");
 
   useEffect(() => {
@@ -52,12 +53,15 @@ const DeviceList = (): JSX.Element => {
         <DeviceListHeader
           headerContent={headerContent}
           setHeaderContent={setHeaderContent}
+          setSearchFilter={setSearchFilter}
         />
       }
     >
       <DeviceListControls filter={searchFilter} setFilter={setSearchFilter} />
       <DeviceListTable
         devices={filteredDevices}
+        hasFilter={!!searchFilter}
+        loading={devicesLoading}
         onSelectedChange={(deviceIDs) => {
           dispatch(deviceActions.setSelected(deviceIDs));
         }}

--- a/ui/src/app/devices/views/DeviceList/DeviceListControls/DeviceListControls.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListControls/DeviceListControls.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
 
-import { Col, Row, SearchBox } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 
 import DeviceFilterAccordion from "./DeviceFilterAccordion";
 
+import DebounceSearchBox from "app/base/components/DebounceSearchBox";
+import type { SetSearchFilter } from "app/base/types";
+
 type Props = {
   filter: string;
-  setFilter: (filter: string) => void;
+  setFilter: SetSearchFilter;
 };
 
 const DeviceListControls = ({ filter, setFilter }: Props): JSX.Element => {
@@ -26,14 +29,10 @@ const DeviceListControls = ({ filter, setFilter }: Props): JSX.Element => {
         />
       </Col>
       <Col size={9}>
-        {/*
-          TODO: Build device search box.
-          https://github.com/canonical-web-and-design/app-tribe/issues/529
-        */}
-        <SearchBox
-          externallyControlled
-          onChange={() => null}
-          value={searchText}
+        <DebounceSearchBox
+          searchText={searchText}
+          onDebounced={(debouncedText) => setFilter(debouncedText)}
+          setSearchText={setSearchText}
         />
       </Col>
     </Row>

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
@@ -36,7 +36,11 @@ describe("DeviceListHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <DeviceListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -51,7 +55,11 @@ describe("DeviceListHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <DeviceListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -66,7 +74,11 @@ describe("DeviceListHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <DeviceListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -84,6 +96,7 @@ describe("DeviceListHeader", () => {
           <DeviceListHeader
             headerContent={null}
             setHeaderContent={setHeaderContent}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
+import type { SetSearchFilter } from "app/base/types";
 import DeviceHeaderForms from "app/devices/components/DeviceHeaderForms";
 import { DeviceHeaderViews } from "app/devices/constants";
 import type {
@@ -16,11 +17,13 @@ import deviceSelectors from "app/store/device/selectors";
 type Props = {
   headerContent: DeviceHeaderContent | null;
   setHeaderContent: DeviceSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
 };
 
 const DeviceListHeader = ({
   headerContent,
   setHeaderContent,
+  setSearchFilter,
 }: Props): JSX.Element => {
   const devices = useSelector(deviceSelectors.all);
   const devicesLoaded = useSelector(deviceSelectors.loaded);
@@ -63,6 +66,7 @@ const DeviceListHeader = ({
       subtitle={
         <ModelListSubtitle
           available={devices.length}
+          filterSelected={() => setSearchFilter("in:(Selected)")}
           modelName="device"
           selected={selectedDevices.length}
         />

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -1,4 +1,4 @@
-import { MainTable } from "@canonical/react-components";
+import { MainTable, Spinner } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
@@ -16,6 +16,8 @@ import zoneURLs from "app/zones/urls";
 
 type Props = {
   devices: Device[];
+  hasFilter?: boolean;
+  loading?: boolean;
   onSelectedChange: (newSelectedIDs: Device[DeviceMeta.PK][]) => void;
   selectedIDs: Device[DeviceMeta.PK][];
 };
@@ -131,6 +133,8 @@ const generateRows = (
 
 const DeviceListTable = ({
   devices,
+  hasFilter = false,
+  loading = false,
   onSelectedChange,
   selectedIDs,
 }: Props): JSX.Element => {
@@ -149,6 +153,13 @@ const DeviceListTable = ({
   return (
     <MainTable
       className="device-list-table"
+      emptyStateMsg={
+        loading ? (
+          <Spinner text="Loading..." />
+        ) : hasFilter ? (
+          "No devices match the search criteria."
+        ) : null
+      }
       headers={[
         {
           className: "fqdn-col",

--- a/ui/src/app/machines/views/MachineList/MachineList.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.tsx
@@ -16,7 +16,7 @@ import { formatErrors } from "app/utils";
 
 type Props = {
   headerFormOpen?: boolean;
-  searchFilter?: string;
+  searchFilter: string;
   setSearchFilter: SetSearchFilter;
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import MachineListControls, { DEBOUNCE_INTERVAL } from "./MachineListControls";
+import MachineListControls from "./MachineListControls";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import type { RootState } from "app/store/root/types";
@@ -23,38 +23,6 @@ describe("MachineListControls", () => {
 
   afterEach(() => {
     localStorage.clear();
-  });
-
-  it("changes the filter when the search text changes, after the debounce interval", () => {
-    const store = mockStore(initialState);
-    const setFilter = jest.fn();
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
-          ]}
-        >
-          <MachineListControls
-            filter=""
-            grouping="none"
-            setFilter={setFilter}
-            setGrouping={jest.fn()}
-            setHiddenGroups={jest.fn()}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    act(() => {
-      wrapper.find("SearchBox input[name='search']").simulate("change", {
-        target: { name: "search", value: "status:new" },
-      });
-    });
-    expect(setFilter).not.toHaveBeenCalled();
-    act(() => {
-      jest.advanceTimersByTime(DEBOUNCE_INTERVAL);
-    });
-    expect(setFilter).toHaveBeenCalledWith("status:new");
   });
 
   it("changes the filter when the filter accordion changes", () => {
@@ -81,60 +49,5 @@ describe("MachineListControls", () => {
       wrapper.find(MachinesFilterAccordion).props().setSearchText("status:new");
     });
     expect(setFilter).toHaveBeenCalledWith("status:new");
-  });
-
-  it("displays a spinner while debouncing search box input", () => {
-    const store = mockStore(initialState);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <MachineListControls
-            filter=""
-            grouping="none"
-            setFilter={jest.fn()}
-            setGrouping={jest.fn()}
-            setHiddenGroups={jest.fn()}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    act(() => {
-      wrapper.find("SearchBox input[name='search']").simulate("change", {
-        target: { name: "search", value: "filtering" },
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find("[data-test='search-spinner']").exists()).toBe(true);
-    act(() => {
-      jest.advanceTimersByTime(DEBOUNCE_INTERVAL);
-    });
-    wrapper.update();
-    expect(wrapper.find("[data-test='search-spinner']").exists()).toBe(false);
-  });
-
-  it("does not debounce when using filter dropdown", () => {
-    const store = mockStore(initialState);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <MachineListControls
-            filter=""
-            grouping="none"
-            setFilter={jest.fn()}
-            setGrouping={jest.fn()}
-            setHiddenGroups={jest.fn()}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    act(() => {
-      wrapper.find(MachinesFilterAccordion).props().setSearchText("filtering");
-    });
-    wrapper.update();
-    expect(wrapper.find("[data-test='search-spinner']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -1,19 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { Col, Row, SearchBox } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 
 import GroupSelect from "./GroupSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
+import DebounceSearchBox from "app/base/components/DebounceSearchBox";
+
 type Props = {
-  filter?: string;
+  filter: string;
   grouping: string;
   setFilter: (filter: string) => void;
   setGrouping: (group: string) => void;
   setHiddenGroups: (groups: string[]) => void;
 };
-
-export const DEBOUNCE_INTERVAL = 500;
 
 const MachineListControls = ({
   filter,
@@ -22,25 +22,12 @@ const MachineListControls = ({
   setGrouping,
   setHiddenGroups,
 }: Props): JSX.Element => {
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-
   const [searchText, setSearchText] = useState(filter);
-  const [debouncing, setDebouncing] = useState(false);
 
   useEffect(() => {
     // If the filters change then update the search input text.
     setSearchText(filter);
   }, [filter]);
-
-  // Clear the timeout when the component is unmounted.
-  useEffect(
-    () => () => {
-      if (intervalRef.current) {
-        clearTimeout(intervalRef.current);
-      }
-    },
-    []
-  );
 
   return (
     <Row>
@@ -52,36 +39,12 @@ const MachineListControls = ({
           }}
         />
       </Col>
-      <Col size={6} style={{ position: "relative" }}>
-        <SearchBox
-          externallyControlled
-          onChange={(searchText: string) => {
-            setDebouncing(true);
-            setSearchText(searchText);
-            // Clear the previous timeout.
-            if (intervalRef.current) {
-              clearTimeout(intervalRef.current);
-            }
-            intervalRef.current = setTimeout(() => {
-              setFilter(searchText);
-              setDebouncing(false);
-            }, DEBOUNCE_INTERVAL);
-          }}
-          value={searchText}
+      <Col size={6}>
+        <DebounceSearchBox
+          onDebounced={(debouncedText) => setFilter(debouncedText)}
+          searchText={searchText}
+          setSearchText={setSearchText}
         />
-        {/* TODO Caleb 23/04/2020 - Update SearchBox to allow spinner
-            https://github.com/canonical-web-and-design/react-components/issues/112 */}
-        {debouncing && (
-          <i
-            className="p-icon--spinner u-animation--spin"
-            data-test="search-spinner"
-            style={{
-              position: "absolute",
-              top: ".675rem",
-              right: searchText ? "5rem" : "3rem",
-            }}
-          ></i>
-        )}
       </Col>
       <Col size={3}>
         <GroupSelect

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -74,6 +74,7 @@
 @import "~app/base/components/CertificateDownload";
 @import "~app/base/components/CertificateMetadata";
 @import "~app/base/components/ColumnToggle";
+@import "~app/base/components/DebounceSearchBox";
 @import "~app/base/components/DoughnutChart";
 @import "~app/base/components/FilterAccordion";
 @import "~app/base/components/FormCard";
@@ -93,6 +94,7 @@
 @include CertificateDownload;
 @include CertificateMetadata;
 @include ColumnToggle;
+@include DebounceSearchBox;
 @include DoughnutChart;
 @include FilterAccordion;
 @include FormCard;


### PR DESCRIPTION
## Done

- Create `DebounceSearchBox` component for use in the node list pages (or anywhere that needs a searchbox that runs a function after a bit of time)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and type into the search box
- Check that the devices get filtered after a second
- Select a device and check that the subtitle turns into a link that filters to only the selected devices
- Add search text that doesn't match any devices and check that a message shows

## Fixes

Fixes canonical-web-and-design/app-tribe#529

## Screenshot

![Screenshot 2021-11-26 at 12-37-35 Devices bolla MAAS](https://user-images.githubusercontent.com/25733845/143518337-3f66d3e7-176f-46d3-ba0b-67973adbbbf9.png)
