### PR TITLE
feat(ui): make the machine name form reusable

### DIFF
--- a/ui/src/app/base/components/DomainSelect/DomainSelect.tsx
+++ b/ui/src/app/base/components/DomainSelect/DomainSelect.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
-import type { HTMLProps } from "react";
 
 import { Select } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
+import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 
@@ -13,7 +13,7 @@ type Props = {
   label?: string;
   name: string;
   valueKey?: "name" | "id";
-} & HTMLProps<HTMLSelectElement>;
+} & FormikFieldProps;
 
 export const DomainSelect = ({
   disabled = false,

--- a/ui/src/app/base/components/NodeName/NodeName.test.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.test.tsx
@@ -1,0 +1,180 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NodeName from "./NodeName";
+import type { Props as NodeNameProps } from "./NodeName";
+
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  generalState as generalStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NodeName", () => {
+  let state: RootState;
+  let machine: Machine;
+
+  beforeEach(() => {
+    const domain = domainFactory({ id: 99 });
+    machine = machineDetailsFactory({
+      domain,
+      locked: false,
+      permissions: ["edit"],
+      system_id: "abc123",
+    });
+    state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domain],
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+        }),
+      }),
+      machine: machineStateFactory({
+        loaded: true,
+        items: [machine],
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName
+            editingName={false}
+            node={null}
+            onSubmit={jest.fn()}
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays just the name when not editable", () => {
+    state.machine.items[0].locked = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName
+            editingName={false}
+            node={machine}
+            onSubmit={jest.fn()}
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".node-name").exists()).toBe(true);
+  });
+
+  it("displays name in a button", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName
+            editingName={false}
+            node={machine}
+            onSubmit={jest.fn()}
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button.node-name--editable").exists()).toBe(true);
+  });
+
+  it("changes the form state when clicking the name", () => {
+    const setEditingName = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName
+            editingName={false}
+            node={machine}
+            onSubmit={jest.fn()}
+            setEditingName={setEditingName}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button.node-name--editable").simulate("click");
+    expect(setEditingName).toHaveBeenCalled();
+  });
+
+  it("can display the form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName
+            editingName={true}
+            node={machine}
+            onSubmit={jest.fn()}
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm")).toMatchSnapshot();
+  });
+
+  it("closes the form when it saves", () => {
+    state.machine.saving = true;
+    const setEditingName = jest.fn();
+    const store = mockStore(state);
+    const ProxyNodeName = (props: NodeNameProps) => (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName {...props} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const wrapper = mount(
+      <ProxyNodeName
+        editingName={true}
+        node={machine}
+        onSubmit={jest.fn()}
+        setEditingName={setEditingName}
+        saved={false}
+        saving={true}
+      />
+    );
+    wrapper.setProps({
+      saved: true,
+      saving: false,
+    });
+    expect(setEditingName).toHaveBeenCalledWith(false);
+  });
+});

--- a/ui/src/app/base/components/NodeName/NodeName.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.tsx
@@ -1,0 +1,109 @@
+import { useEffect } from "react";
+
+import { Button, Spinner } from "@canonical/react-components";
+import { usePrevious } from "@canonical/react-components/dist/hooks";
+import * as Yup from "yup";
+
+import NodeNameFields from "./NodeNameFields";
+
+import FormikForm from "app/base/components/FormikForm";
+import { useCanEdit } from "app/base/hooks";
+import type { Device } from "app/store/device/types";
+import type { Domain, DomainMeta } from "app/store/domain/types";
+import type { Machine } from "app/store/machine/types";
+import type { SimpleNode } from "app/store/types/node";
+
+export type Props = {
+  editingName: boolean;
+  // Machines and devices can edit their name, but no controllers.
+  node: Machine | Device | null;
+  onSubmit: (
+    hostname: SimpleNode["hostname"],
+    domain: Domain[DomainMeta.PK]
+  ) => void;
+  setEditingName: (editingName: boolean) => void;
+  saved?: boolean;
+  saving?: boolean;
+};
+
+export type FormValues = {
+  hostname: string;
+  domain: string;
+};
+
+const hostnamePattern = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
+
+const Schema = Yup.object().shape({
+  hostname: Yup.string()
+    .max(63, "Hostname must be 63 characters or less.")
+    .matches(
+      hostnamePattern,
+      "Hostname must only contain letters, numbers and hyphens."
+    )
+    .required(),
+  domain: Yup.string(),
+});
+
+const NodeName = ({
+  editingName,
+  node,
+  onSubmit,
+  setEditingName,
+  saved,
+  saving,
+}: Props): JSX.Element => {
+  const canEdit = useCanEdit(node);
+  const previousSaving = usePrevious(saving);
+
+  useEffect(() => {
+    // The node has transitioned from saving to saved so close the form.
+    if (saved && !saving && previousSaving) {
+      setEditingName(false);
+    }
+  }, [previousSaving, saved, saving, setEditingName]);
+
+  if (!node) {
+    return <Spinner />;
+  }
+  if (!canEdit) {
+    return <span className="node-name">{node.fqdn}</span>;
+  }
+  if (!editingName) {
+    return (
+      <Button
+        appearance="base"
+        className="node-name--editable"
+        onClick={() => setEditingName(true)}
+      >
+        {node.fqdn}
+      </Button>
+    );
+  }
+  return (
+    <FormikForm<FormValues>
+      buttonsAlign="right"
+      buttonsBordered={false}
+      initialValues={{
+        domain: String(node.domain.id),
+        hostname: node.hostname,
+      }}
+      inline
+      onCancel={() => setEditingName(false)}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Node details header",
+        label: "name",
+      }}
+      onSubmit={({ hostname, domain }) => {
+        onSubmit(hostname, parseInt(domain, 10));
+      }}
+      saving={saving}
+      saved={saved}
+      validationSchema={Schema}
+    >
+      <NodeNameFields saving={saving} />
+    </FormikForm>
+  );
+};
+
+export default NodeName;

--- a/ui/src/app/base/components/NodeName/NodeName.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.tsx
@@ -83,6 +83,7 @@ const NodeName = ({
     <FormikForm<FormValues>
       buttonsAlign="right"
       buttonsBordered={false}
+      className="node-name"
       initialValues={{
         domain: String(node.domain.id),
         hostname: node.hostname,
@@ -95,7 +96,7 @@ const NodeName = ({
         label: "name",
       }}
       onSubmit={({ hostname, domain }) => {
-        onSubmit(hostname, parseInt(domain, 10));
+        onSubmit(hostname, Number(domain));
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.test.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import MachineNameFields from "./MachineNameFields";
+import NodeNameFields from "./NodeNameFields";
 
 import FormikForm from "app/base/components/FormikForm";
 import type { RootState } from "app/store/root/types";
@@ -16,7 +16,7 @@ import {
 
 const mockStore = configureStore();
 
-describe("MachineNameFields", () => {
+describe("NodeNameFields", () => {
   let state: RootState;
   beforeEach(() => {
     state = rootStateFactory({
@@ -51,7 +51,7 @@ describe("MachineNameFields", () => {
             }}
             onSubmit={jest.fn()}
           >
-            <MachineNameFields />
+            <NodeNameFields />
           </FormikForm>
         </MemoryRouter>
       </Provider>
@@ -73,12 +73,12 @@ describe("MachineNameFields", () => {
             }}
             onSubmit={jest.fn()}
           >
-            <MachineNameFields />
+            <NodeNameFields />
           </FormikForm>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("MachineNameFields")).toMatchSnapshot();
+    expect(wrapper.find("NodeNameFields")).toMatchSnapshot();
   });
 
   it("disables fields when saving", () => {
@@ -95,7 +95,7 @@ describe("MachineNameFields", () => {
             }}
             onSubmit={jest.fn()}
           >
-            <MachineNameFields saving />
+            <NodeNameFields saving />
           </FormikForm>
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -1,18 +1,19 @@
-import { Select, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import type { FormValues } from "../NodeName";
 
+import DomainSelect from "app/base/components/DomainSelect";
 import FormikField from "app/base/components/FormikField";
 import domainSelectors from "app/store/domain/selectors";
+import { DomainMeta } from "app/store/domain/types";
 
 type Props = {
   saving?: boolean;
 };
 
 export const NodeNameFields = ({ saving }: Props): JSX.Element => {
-  const domains = useSelector(domainSelectors.all);
   const domainsLoaded = useSelector(domainSelectors.loaded);
   const { values } = useFormikContext<FormValues>();
 
@@ -30,16 +31,12 @@ export const NodeNameFields = ({ saving }: Props): JSX.Element => {
       />
       <span className="u-nudge-left--small u-no-margin--right">.</span>
       {domainsLoaded ? (
-        <FormikField
+        <DomainSelect
           className="u-no-margin--bottom"
-          component={Select}
           disabled={saving}
           name="domain"
-          options={domains.map((domain) => ({
-            label: domain.name,
-            value: domain.id,
-          }))}
           required
+          valueKey={DomainMeta.PK}
           wrapperClassName="u-nudge-left u-no-margin--right"
         />
       ) : (

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -2,7 +2,7 @@ import { Select, Spinner } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
-import type { FormValues } from "../MachineName/MachineName";
+import type { FormValues } from "../NodeName";
 
 import FormikField from "app/base/components/FormikField";
 import domainSelectors from "app/store/domain/selectors";
@@ -11,7 +11,7 @@ type Props = {
   saving?: boolean;
 };
 
-export const MachineNameFields = ({ saving }: Props): JSX.Element => {
+export const NodeNameFields = ({ saving }: Props): JSX.Element => {
   const domains = useSelector(domainSelectors.all);
   const domainsLoaded = useSelector(domainSelectors.loaded);
   const { values } = useFormikContext<FormValues>();
@@ -20,7 +20,7 @@ export const MachineNameFields = ({ saving }: Props): JSX.Element => {
     <>
       <FormikField
         type="text"
-        className="machine-name__hostname"
+        className="node-name__hostname"
         disabled={saving}
         name="hostname"
         required={true}
@@ -49,4 +49,4 @@ export const MachineNameFields = ({ saving }: Props): JSX.Element => {
   );
 };
 
-export default MachineNameFields;
+export default NodeNameFields;

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -67,52 +67,99 @@ exports[`NodeNameFields displays the fields 1`] = `
   >
     .
   </span>
-  <FormikField
+  <DomainSelect
     className="u-no-margin--bottom"
-    component={[Function]}
     name="domain"
-    options={Array []}
     required={true}
+    valueKey="id"
     wrapperClassName="u-nudge-left u-no-margin--right"
   >
-    <Select
+    <FormikField
       className="u-no-margin--bottom"
-      error={null}
+      component={[Function]}
+      disabled={false}
+      label="Domain"
       name="domain"
-      onBlur={[Function]}
-      onChange={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "disabled": true,
+            "label": "Select domain",
+            "value": "",
+          },
+        ]
+      }
       required={true}
-      value=""
       wrapperClassName="u-nudge-left u-no-margin--right"
     >
-      <Field
-        className="u-nudge-left u-no-margin--right"
+      <Select
+        className="u-no-margin--bottom"
+        disabled={false}
         error={null}
-        isSelect={true}
+        label="Domain"
+        name="domain"
+        onBlur={[Function]}
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "disabled": true,
+              "label": "Select domain",
+              "value": "",
+            },
+          ]
+        }
         required={true}
+        value=""
+        wrapperClassName="u-nudge-left u-no-margin--right"
       >
-        <div
-          className="p-form__group p-form-validation u-nudge-left u-no-margin--right"
+        <Field
+          className="u-nudge-left u-no-margin--right"
+          error={null}
+          isSelect={true}
+          label="Domain"
+          required={true}
         >
           <div
-            className="p-form__control u-clearfix"
+            className="p-form__group p-form-validation u-nudge-left u-no-margin--right"
           >
-            <div
-              className="p-form-validation__select-wrapper"
+            <Label
+              required={true}
             >
-              <select
-                className="p-form-validation__input u-no-margin--bottom"
-                name="domain"
-                onBlur={[Function]}
-                onChange={[Function]}
-                value=""
-              />
+              <label
+                className="p-form__label is-required"
+              >
+                Domain
+              </label>
+            </Label>
+            <div
+              className="p-form__control u-clearfix"
+            >
+              <div
+                className="p-form-validation__select-wrapper"
+              >
+                <select
+                  className="p-form-validation__input u-no-margin--bottom"
+                  disabled={false}
+                  name="domain"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  value=""
+                >
+                  <option
+                    disabled={true}
+                    key="Select domain"
+                    value=""
+                  >
+                    Select domain
+                  </option>
+                </select>
+              </div>
             </div>
           </div>
-        </div>
-      </Field>
-    </Select>
-  </FormikField>
+        </Field>
+      </Select>
+    </FormikField>
+  </DomainSelect>
 </NodeNameFields>
 `;

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MachineNameFields displays the fields 1`] = `
-<MachineNameFields>
+exports[`NodeNameFields displays the fields 1`] = `
+<NodeNameFields>
   <FormikField
-    className="machine-name__hostname"
+    className="node-name__hostname"
     name="hostname"
     required={true}
     style={
@@ -16,7 +16,7 @@ exports[`MachineNameFields displays the fields 1`] = `
     wrapperClassName="u-nudge-left--small u-no-margin--right"
   >
     <Input
-      className="machine-name__hostname"
+      className="node-name__hostname"
       error={null}
       name="hostname"
       onBlur={[Function]}
@@ -45,7 +45,7 @@ exports[`MachineNameFields displays the fields 1`] = `
             className="p-form__control u-clearfix"
           >
             <input
-              className="p-form-validation__input machine-name__hostname"
+              className="p-form-validation__input node-name__hostname"
               name="hostname"
               onBlur={[Function]}
               onChange={[Function]}
@@ -114,5 +114,5 @@ exports[`MachineNameFields displays the fields 1`] = `
       </Field>
     </Select>
   </FormikField>
-</MachineNameFields>
+</NodeNameFields>
 `;

--- a/ui/src/app/base/components/NodeName/NodeNameFields/index.ts
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeNameFields";

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MachineName can display the form 1`] = `
+exports[`NodeName can display the form 1`] = `
 <FormikForm
   buttonsAlign="right"
   buttonsBordered={false}
@@ -15,13 +15,11 @@ exports[`MachineName can display the form 1`] = `
   onSaveAnalytics={
     Object {
       "action": "Saved",
-      "category": "Machine details header",
+      "category": "Node details header",
       "label": "name",
     }
   }
   onSubmit={[Function]}
-  saved={false}
-  saving={false}
   validationSchema={
     ObjectSchema {
       "_blacklist": ReferenceSet {
@@ -250,12 +248,10 @@ exports[`MachineName can display the form 1`] = `
       onSaveAnalytics={
         Object {
           "action": "Saved",
-          "category": "Machine details header",
+          "category": "Node details header",
           "label": "name",
         }
       }
-      saved={false}
-      saving={false}
     >
       <Form
         inline={true}
@@ -265,12 +261,9 @@ exports[`MachineName can display the form 1`] = `
           className="p-form p-form--inline"
           onSubmit={[Function]}
         >
-          <MachineNameFields
-            saving={false}
-          >
+          <NodeNameFields>
             <FormikField
-              className="machine-name__hostname"
-              disabled={false}
+              className="node-name__hostname"
               name="hostname"
               required={true}
               style={
@@ -283,8 +276,7 @@ exports[`MachineName can display the form 1`] = `
               wrapperClassName="u-nudge-left--small u-no-margin--right"
             >
               <Input
-                className="machine-name__hostname"
-                disabled={false}
+                className="node-name__hostname"
                 error={null}
                 name="hostname"
                 onBlur={[Function]}
@@ -313,8 +305,7 @@ exports[`MachineName can display the form 1`] = `
                       className="p-form__control u-clearfix"
                     >
                       <input
-                        className="p-form-validation__input machine-name__hostname"
-                        disabled={false}
+                        className="p-form-validation__input node-name__hostname"
                         name="hostname"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -347,15 +338,13 @@ exports[`MachineName can display the form 1`] = `
                 />
               </span>
             </Spinner>
-          </MachineNameFields>
+          </NodeNameFields>
           <FormikFormButtons
             buttonsAlign="right"
             buttonsBordered={false}
-            cancelDisabled={false}
             inline={true}
             onCancel={[Function]}
             saved={false}
-            saving={false}
             submitDisabled={true}
           >
             <div
@@ -369,14 +358,12 @@ exports[`MachineName can display the form 1`] = `
                   appearance="base"
                   className="formik-form-buttons__button"
                   data-test="cancel-action"
-                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
                   <button
                     className="p-button--base formik-form-buttons__button"
                     data-test="cancel-action"
-                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >
@@ -387,7 +374,6 @@ exports[`MachineName can display the form 1`] = `
                   appearance="positive"
                   className="formik-form-buttons__button"
                   disabled={true}
-                  loading={false}
                   success={false}
                   type="submit"
                 >

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`NodeName can display the form 1`] = `
 <FormikForm
   buttonsAlign="right"
   buttonsBordered={false}
+  className="node-name"
   initialValues={
     Object {
       "domain": "99",
@@ -243,6 +244,7 @@ exports[`NodeName can display the form 1`] = `
     <FormikFormContent
       buttonsAlign="right"
       buttonsBordered={false}
+      className="node-name"
       inline={true}
       onCancel={[Function]}
       onSaveAnalytics={
@@ -254,11 +256,12 @@ exports[`NodeName can display the form 1`] = `
       }
     >
       <Form
+        className="node-name"
         inline={true}
         onSubmit={[Function]}
       >
         <form
-          className="p-form p-form--inline"
+          className="node-name p-form p-form--inline"
           onSubmit={[Function]}
         >
           <NodeNameFields>

--- a/ui/src/app/base/components/NodeName/_index.scss
+++ b/ui/src/app/base/components/NodeName/_index.scss
@@ -22,4 +22,9 @@
     padding: calc(#{$sp-xx-small} - 2px) $spv-inner--large
       calc(#{$sp-xx-small} + 1px);
   }
+
+  // Hide the required asterisk in the field labels.
+  .node-name label.is-required:before {
+    display: none;
+  }
 }

--- a/ui/src/app/base/components/NodeName/_index.scss
+++ b/ui/src/app/base/components/NodeName/_index.scss
@@ -1,5 +1,5 @@
-@mixin MachineName {
-  button.machine-name--editable {
+@mixin NodeName {
+  button.node-name--editable {
     @extend %vf-heading-4;
     margin-bottom: 0;
     padding: 0 $spv-inner--large;
@@ -13,7 +13,7 @@
     }
   }
 
-  [type="text"].machine-name__hostname {
+  [type="text"].node-name__hostname {
     @extend %vf-heading-4;
     box-sizing: content-box;
     margin-bottom: -1px;

--- a/ui/src/app/base/components/NodeName/index.ts
+++ b/ui/src/app/base/components/NodeName/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeName";

--- a/ui/src/app/base/hooks.test.tsx
+++ b/ui/src/app/base/hooks.test.tsx
@@ -1,20 +1,36 @@
+import type { ReactNode } from "react";
+
 import { renderHook } from "@testing-library/react-hooks";
 import { Provider } from "react-redux";
 import TestRenderer from "react-test-renderer";
+import type { MockStoreEnhanced } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
 import {
+  useCanEdit,
   useCompletedIntro,
   useCompletedUserIntro,
   useCycled,
+  useIsRackControllerConnected,
   useScrollOnRender,
 } from "./hooks";
 
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import { getCookie } from "app/utils";
 import {
+  architecturesState as architecturesStateFactory,
   authState as authStateFactory,
   config as configFactory,
   configState as configStateFactory,
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineEvent as machineEventFactory,
+  machineState as machineStateFactory,
+  osInfo as osInfoFactory,
+  osInfoState as osInfoStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
   user as userFactory,
   userState as userStateFactory,
@@ -28,6 +44,11 @@ jest.mock("app/utils", () => ({
   ...jest.requireActual("app/utils"),
   getCookie: jest.fn(),
 }));
+
+const generateWrapper =
+  (store: MockStoreEnhanced<unknown>) =>
+  ({ children }: { children: ReactNode }) =>
+    <Provider store={store}>{children}</Provider>;
 
 describe("hooks", () => {
   describe("useScrollOnRender", () => {
@@ -259,6 +280,121 @@ describe("hooks", () => {
       });
       expect(result.current).toBe(true);
       getCookieMock.mockReset();
+    });
+  });
+
+  describe("useIsRackControllerConnected", () => {
+    let state: RootState;
+
+    beforeEach(() => {
+      state = rootStateFactory({
+        general: generalStateFactory({
+          architectures: architecturesStateFactory({
+            data: ["amd64"],
+          }),
+          osInfo: osInfoStateFactory({
+            data: osInfoFactory(),
+          }),
+          powerTypes: powerTypesStateFactory({
+            data: [powerTypeFactory()],
+          }),
+        }),
+      });
+    });
+
+    it("handles a connected state", () => {
+      state.general.powerTypes = powerTypesStateFactory({
+        data: [powerTypeFactory()],
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useIsRackControllerConnected(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("handles a disconnected state", () => {
+      state.general.powerTypes.data = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useIsRackControllerConnected(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("useCanEdit", () => {
+    let state: RootState;
+    let machine: Machine | null;
+
+    beforeEach(() => {
+      machine = machineFactory({
+        architecture: "amd64",
+        events: [machineEventFactory()],
+        locked: false,
+        permissions: ["edit"],
+        system_id: "abc123",
+      });
+      state = rootStateFactory({
+        general: generalStateFactory({
+          architectures: architecturesStateFactory({
+            data: ["amd64"],
+          }),
+          osInfo: osInfoStateFactory({
+            data: osInfoFactory(),
+          }),
+          powerTypes: powerTypesStateFactory({
+            data: [powerTypeFactory()],
+          }),
+        }),
+        machine: machineStateFactory({
+          items: [machine],
+        }),
+      });
+    });
+
+    it("handles an editable machine", () => {
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("handles incorrect permissions", () => {
+      state.machine.items[0].permissions = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("handles a locked machine", () => {
+      state.machine.items[0].locked = true;
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("handles a disconnected rack controller", () => {
+      state.general.powerTypes.data = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("can ignore the rack controller state", () => {
+      state.general.powerTypes.data = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine, true), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
     });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
@@ -9,10 +9,11 @@ import * as Yup from "yup";
 import MachineFormFields from "./MachineFormFields";
 
 import FormikForm from "app/base/components/FormikForm";
+import { useCanEdit } from "app/base/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
-import { isMachineDetails, useCanEdit } from "app/store/machine/utils";
+import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
@@ -9,6 +9,7 @@ import * as Yup from "yup";
 import PowerFormFields from "./PowerFormFields";
 
 import FormikForm from "app/base/components/FormikForm";
+import { useCanEdit } from "app/base/hooks";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import type { PowerType } from "app/store/general/types";
 import { PowerFieldScope } from "app/store/general/types";
@@ -20,7 +21,7 @@ import {
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, PowerParameters } from "app/store/machine/types";
-import { isMachineDetails, useCanEdit } from "app/store/machine/utils";
+import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 export type PowerFormValues = {

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
@@ -5,11 +5,11 @@ import { useSelector } from "react-redux";
 import type { PowerFormValues } from "../PowerForm";
 
 import PowerTypeFields from "app/base/components/PowerTypeFields";
+import { useIsRackControllerConnected } from "app/base/hooks";
 import { PowerTypeNames } from "app/store/general/constants";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import { PowerFieldScope } from "app/store/general/types";
 import type { MachineDetails } from "app/store/machine/types";
-import { useIsRackControllerConnected } from "app/store/machine/utils";
 
 type Props = {
   editing: boolean;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -293,7 +293,7 @@ describe("MachineHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    wrapper.find("Button.machine-name--editable").simulate("click");
+    wrapper.find("Button.node-name--editable").simulate("click");
     expect(wrapper.find("SectionHeader").prop("subtitle")).toBe(null);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
@@ -1,19 +1,13 @@
 import { useEffect } from "react";
 
-import { Button, Spinner } from "@canonical/react-components";
-import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 
-import MachineNameFields from "../MachineNameFields";
-
-import FormikForm from "app/base/components/FormikForm";
+import NodeName from "app/base/components/NodeName";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
-import { useCanEdit } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -21,24 +15,6 @@ type Props = {
   id: Machine["system_id"];
   setEditingName: (editingName: boolean) => void;
 };
-
-export type FormValues = {
-  hostname: string;
-  domain: string;
-};
-
-const hostnamePattern = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
-
-const Schema = Yup.object().shape({
-  hostname: Yup.string()
-    .max(63, "Hostname must be 63 characters or less.")
-    .matches(
-      hostnamePattern,
-      "Hostname must only contain letters, numbers and hyphens."
-    )
-    .required(),
-  domain: Yup.string(),
-});
 
 const MachineName = ({
   editingName,
@@ -52,69 +28,32 @@ const MachineName = ({
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const domains = useSelector(domainSelectors.all);
-  const canEdit = useCanEdit(machine);
-  const previousSaving = usePrevious(saving);
-
-  useEffect(() => {
-    // The machine has transitioned from saving to saved so close the form.
-    if (saved && !saving && previousSaving) {
-      setEditingName(false);
-    }
-  }, [previousSaving, saved, saving, setEditingName]);
 
   useEffect(() => {
     dispatch(domainActions.fetch());
   }, [dispatch]);
 
-  if (!machine) {
-    return <Spinner />;
-  }
-  if (!canEdit) {
-    return <span className="machine-name">{machine.fqdn}</span>;
-  }
-  if (!editingName) {
-    return (
-      <Button
-        appearance="base"
-        className="machine-name--editable"
-        onClick={() => setEditingName(true)}
-      >
-        {machine.fqdn}
-      </Button>
-    );
-  }
   return (
-    <FormikForm<FormValues>
-      buttonsAlign="right"
-      buttonsBordered={false}
-      initialValues={{
-        domain: String(machine.domain.id),
-        hostname: machine.hostname,
+    <NodeName
+      editingName={editingName}
+      node={machine}
+      onSubmit={(hostname, domain) => {
+        if (machine) {
+          dispatch(
+            machineActions.update({
+              domain: domains.find(({ id }) => id === domain),
+              extra_macs: machine.extra_macs,
+              hostname,
+              pxe_mac: machine.pxe_mac,
+              system_id: machine.system_id,
+            })
+          );
+        }
       }}
-      inline
-      onCancel={() => setEditingName(false)}
-      onSaveAnalytics={{
-        action: "Saved",
-        category: "Machine details header",
-        label: "name",
-      }}
-      onSubmit={({ hostname, domain }) => {
-        dispatch(
-          machineActions.update({
-            domain: domains.find(({ id }) => id === parseInt(domain, 10)),
-            extra_macs: machine.extra_macs,
-            hostname,
-            pxe_mac: machine.pxe_mac,
-            system_id: machine.system_id,
-          })
-        );
-      }}
-      saving={saving}
       saved={saved}
-      validationSchema={Schema}
-    >
-      <MachineNameFields saving={saving} />
-    </FormikForm>
+      saving={saving}
+      setEditingName={setEditingName}
+    />
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./MachineNameFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
@@ -1,6 +1,7 @@
 import { NotificationSeverity } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import { useCanEdit } from "app/base/hooks";
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
@@ -9,7 +10,6 @@ import {
   canOsSupportStorageConfig,
   isMachineDetails,
   isMachineStorageConfigurable,
-  useCanEdit,
 } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -4,13 +4,12 @@ import { extractPowerType } from "@maas-ui/maas-ui-shared";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { useSendAnalytics } from "app/base/hooks";
+import { useCanEdit, useSendAnalytics } from "app/base/hooks";
 import kvmURLs from "app/kvm/urls";
 import { actions as generalActions } from "app/store/general";
 import { PowerTypeNames } from "app/store/general/constants";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import type { MachineDetails } from "app/store/machine/types";
-import { useCanEdit } from "app/store/machine/utils";
 
 type Props = {
   machine: MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import LegacyLink from "app/base/components/LegacyLink";
+import { useCanEdit, useIsRackControllerConnected } from "app/base/hooks";
 import baseURLs from "app/base/urls";
 import machineURLs from "app/machines/urls";
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
@@ -14,9 +15,7 @@ import type { MachineEvent, Machine } from "app/store/machine/types";
 import { PowerState } from "app/store/machine/types";
 import {
   isMachineDetails,
-  useCanEdit,
   useHasInvalidArchitecture,
-  useIsRackControllerConnected,
 } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/store/machine/utils/hooks.test.tsx
+++ b/ui/src/app/store/machine/utils/hooks.test.tsx
@@ -7,13 +7,11 @@ import type { MockStoreEnhanced } from "redux-mock-store";
 
 import {
   useCanAddVLAN,
-  useCanEdit,
   useCanEditStorage,
   useFormattedOS,
   useHasInvalidArchitecture,
   useIsAllNetworkingDisabled,
   useIsLimitedEditingAllowed,
-  useIsRackControllerConnected,
 } from "./hooks";
 
 import type { Machine } from "app/store/machine/types";
@@ -70,52 +68,6 @@ describe("machine hook utils", () => {
       machine: machineStateFactory({
         items: [machine],
       }),
-    });
-  });
-
-  describe("useCanEdit", () => {
-    it("handles an editable machine", () => {
-      const store = mockStore(state);
-      const { result } = renderHook(() => useCanEdit(machine), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(true);
-    });
-
-    it("handles incorrect permissions", () => {
-      state.machine.items[0].permissions = [];
-      const store = mockStore(state);
-      const { result } = renderHook(() => useCanEdit(machine), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(false);
-    });
-
-    it("handles a locked machine", () => {
-      state.machine.items[0].locked = true;
-      const store = mockStore(state);
-      const { result } = renderHook(() => useCanEdit(machine), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(false);
-    });
-
-    it("handles a disconnected rack controller", () => {
-      state.general.powerTypes.data = [];
-      const store = mockStore(state);
-      const { result } = renderHook(() => useCanEdit(machine), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(false);
-    });
-
-    it("can ignore the rack controller state", () => {
-      state.general.powerTypes.data = [];
-      const store = mockStore(state);
-      const { result } = renderHook(() => useCanEdit(machine, true), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(true);
     });
   });
 
@@ -280,28 +232,6 @@ describe("machine hook utils", () => {
     it("can be not disabled", () => {
       const store = mockStore(state);
       const { result } = renderHook(() => useIsAllNetworkingDisabled(machine), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(false);
-    });
-  });
-
-  describe("useIsRackControllerConnected", () => {
-    it("handles a connected state", () => {
-      state.general.powerTypes = powerTypesStateFactory({
-        data: [powerTypeFactory()],
-      });
-      const store = mockStore(state);
-      const { result } = renderHook(() => useIsRackControllerConnected(), {
-        wrapper: generateWrapper(store),
-      });
-      expect(result.current).toBe(true);
-    });
-
-    it("handles a disconnected state", () => {
-      state.general.powerTypes.data = [];
-      const store = mockStore(state);
-      const { result } = renderHook(() => useIsRackControllerConnected(), {
         wrapper: generateWrapper(store),
       });
       expect(result.current).toBe(false);

--- a/ui/src/app/store/machine/utils/hooks.ts
+++ b/ui/src/app/store/machine/utils/hooks.ts
@@ -4,11 +4,11 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { isMachineStorageConfigurable } from "./storage";
 
+import { useCanEdit } from "app/base/hooks";
 import { actions as generalActions } from "app/store/general";
 import {
   architectures as architecturesSelectors,
   osInfo as osInfoSelectors,
-  powerTypes as powerTypesSelectors,
 } from "app/store/general/selectors";
 import type { Machine } from "app/store/machine/types";
 import { getLinkInterface, hasInterfaceType } from "app/store/machine/utils";
@@ -18,29 +18,6 @@ import type { Host } from "app/store/types/host";
 import type { NetworkInterface, NetworkLink } from "app/store/types/node";
 import { NodeStatus } from "app/store/types/node";
 import vlanSelectors from "app/store/vlan/selectors";
-
-/**
- * Check if a machine can be edited.
- * @param machine - A machine object.
- * @param ignoreRackControllerConnection - Whether the editable check should
- *                                         include whether the rack controller
- *                                          is connected.
- * @returns Whether the machine can be edited.
- */
-export const useCanEdit = (
-  machine?: Machine | null,
-  ignoreRackControllerConnection = false
-): boolean => {
-  const isRackControllerConnected = useIsRackControllerConnected();
-  if (!machine) {
-    return false;
-  }
-  return (
-    machine.permissions.includes("edit") &&
-    !machine.locked &&
-    (ignoreRackControllerConnection || isRackControllerConnected)
-  );
-};
 
 /**
  * Check whether a machine's storage can be edited based on permissions and the
@@ -132,22 +109,6 @@ export const useIsAllNetworkingDisabled = (
       NodeStatus.BROKEN,
     ].includes(machine.status)
   );
-};
-
-/**
- * Check if the rack controller is connected.
- * @returns Whether the rack controller is connected.
- */
-export const useIsRackControllerConnected = (): boolean => {
-  const dispatch = useDispatch();
-  const powerTypes = useSelector(powerTypesSelectors.get);
-
-  useEffect(() => {
-    dispatch(generalActions.fetchPowerTypes());
-  }, [dispatch]);
-
-  // If power types exist then a rack controller is connected.
-  return powerTypes.length > 0;
 };
 
 /**

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -2,13 +2,11 @@ export { isMachineDetails } from "./common";
 
 export {
   useCanAddVLAN,
-  useCanEdit,
   useCanEditStorage,
   useFormattedOS,
   useHasInvalidArchitecture,
   useIsAllNetworkingDisabled,
   useIsLimitedEditingAllowed,
-  useIsRackControllerConnected,
 } from "./hooks";
 
 export {

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -81,6 +81,7 @@
 @import "~app/base/components/LabelledList";
 @import "~app/base/components/Login";
 @import "~app/base/components/Meter";
+@import "~app/base/components/NodeName";
 @import "~app/base/components/NotificationGroup";
 @import "~app/base/components/Placeholder";
 @import "~app/base/components/Popover";
@@ -100,6 +101,7 @@
 @include LabelledList;
 @include Login;
 @include Meter;
+@include NodeName;
 @include NotificationGroup;
 @include Placeholder;
 @include Popover;
@@ -189,7 +191,6 @@
 @import "~app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect";
 @import "~app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults";
 @import "~app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
-@import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
 @import "~app/machines/views/MachineDetails/MachineLogs/DownloadMenu";
 @import "~app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/DHCPTable";
@@ -207,7 +208,6 @@
 @include EventLogsTable;
 @include MachineDHCPTable;
 @include MachineList;
-@include MachineName;
 @include MachineNetworkTable;
 @include MachineSummary;
 @include MachineTestsTable;


### PR DESCRIPTION
## Done

- Update the machine name for to be reusable by devices.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page for a machine.
- Click on the name in the header.
- Enter a new name and domain and submit the form.
- The form should close and the machine's name and domain should update.

## Fixes

Fixes: canonical-web-and-design/app-tribe#553.