### PR TITLE
feat(ui): build IP assignment select component

### DIFF
--- a/ui/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.test.tsx
+++ b/ui/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.test.tsx
@@ -1,0 +1,39 @@
+import { Select } from "@canonical/react-components";
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import IpAssignmentSelect from "./IpAssignmentSelect";
+
+import { DeviceIpAssignment } from "app/store/device/types";
+
+describe("IpAssignmentSelect", () => {
+  it("includes static IP assignment as an option by default", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <IpAssignmentSelect name="ipAssignment" />
+      </Formik>
+    );
+
+    expect(
+      wrapper
+        .find(Select)
+        .prop("options")
+        ?.some((option) => option.value === DeviceIpAssignment.STATIC)
+    ).toBe(true);
+  });
+
+  it("can omit static IP assignment as an option", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <IpAssignmentSelect includeStatic={false} name="ipAssignment" />
+      </Formik>
+    );
+
+    expect(
+      wrapper
+        .find(Select)
+        .prop("options")
+        ?.some((option) => option.value === DeviceIpAssignment.STATIC)
+    ).toBe(false);
+  });
+});

--- a/ui/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.tsx
+++ b/ui/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.tsx
@@ -1,0 +1,45 @@
+import { Select } from "@canonical/react-components";
+
+import FormikField from "app/base/components/FormikField";
+import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
+import { DeviceIpAssignment } from "app/store/device/types";
+import { getIpAssignmentDisplay } from "app/store/device/utils";
+
+type Props = {
+  includeStatic?: boolean;
+} & Omit<FormikFieldProps<typeof Select>, "component" | "options">;
+
+export const IpAssignmentSelect = ({
+  includeStatic = true,
+  label = "IP assignment",
+  ...props
+}: Props): JSX.Element => {
+  return (
+    <FormikField
+      component={Select}
+      label={label}
+      options={[
+        { label: "Select IP assignment", value: "", disabled: true },
+        {
+          label: getIpAssignmentDisplay(DeviceIpAssignment.DYNAMIC),
+          value: DeviceIpAssignment.DYNAMIC,
+        },
+        ...(includeStatic
+          ? [
+              {
+                label: getIpAssignmentDisplay(DeviceIpAssignment.STATIC),
+                value: DeviceIpAssignment.STATIC,
+              },
+            ]
+          : []),
+        {
+          label: getIpAssignmentDisplay(DeviceIpAssignment.EXTERNAL),
+          value: DeviceIpAssignment.EXTERNAL,
+        },
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default IpAssignmentSelect;

--- a/ui/src/app/base/components/IpAssignmentSelect/index.ts
+++ b/ui/src/app/base/components/IpAssignmentSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IpAssignmentSelect";

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -6,12 +6,12 @@ import type { DiscoveryAddValues } from "../types";
 import { DeviceType } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
 import LegacyLink from "app/base/components/LegacyLink";
 import baseURLs from "app/base/urls";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
-import { DeviceIpAssignment, DeviceMeta } from "app/store/device/types";
-import { getIpAssignmentDisplay } from "app/store/device/utils";
+import { DeviceMeta } from "app/store/device/types";
 import type { Discovery } from "app/store/discovery/types";
 import domainSelectors from "app/store/domain/selectors";
 import machineSelectors from "app/store/machine/selectors";
@@ -48,7 +48,7 @@ const DiscoveryAddFormFields = ({
   const isDevice = values.type === DeviceType.DEVICE;
   const isInterface = values.type === DeviceType.INTERFACE;
   // Only include static when the discovery has a subnet.
-  const includeStatic = discovery.subnet || discovery.subnet === 0;
+  const includeStatic = !!discovery.subnet || discovery.subnet === 0;
   const subnetDisplay = getSubnetDisplay(subnet);
   const vlanDisplay = getVLANDisplay(vlan);
 
@@ -141,32 +141,9 @@ const DiscoveryAddFormFields = ({
           )}
         </Col>
         <Col size={6}>
-          <FormikField
-            // TODO: Convert to common component as an almost identical verison
-            // is used in AddDeviceForm.
-            // https://github.com/canonical-web-and-design/app-tribe/issues/554
-            component={Select}
-            label="IP assignment"
+          <IpAssignmentSelect
+            includeStatic={includeStatic}
             name="ip_assignment"
-            options={[
-              { label: "Select IP assignment", value: "", disabled: true },
-              {
-                label: getIpAssignmentDisplay(DeviceIpAssignment.DYNAMIC),
-                value: DeviceIpAssignment.DYNAMIC,
-              },
-              ...(includeStatic
-                ? [
-                    {
-                      label: getIpAssignmentDisplay(DeviceIpAssignment.STATIC),
-                      value: DeviceIpAssignment.STATIC,
-                    },
-                  ]
-                : []),
-              {
-                label: getIpAssignmentDisplay(DeviceIpAssignment.EXTERNAL),
-                value: DeviceIpAssignment.EXTERNAL,
-              },
-            ]}
             required
           />
           <div className="">

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -1,18 +1,18 @@
 import type { ChangeEvent } from "react";
 import { useRef } from "react";
 
-import { Button, Icon, MainTable, Select } from "@canonical/react-components";
+import { Button, Icon, MainTable } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 
 import type { AddDeviceValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
 import MacAddressField from "app/base/components/MacAddressField";
 import SubnetSelect from "app/base/components/SubnetSelect";
 import TableActions from "app/base/components/TableActions";
 import { DeviceIpAssignment } from "app/store/device/types";
-import { getIpAssignmentDisplay } from "app/store/device/utils";
 import { getNextName } from "app/utils";
 
 export const AddDeviceInterfaces = (): JSX.Element => {
@@ -93,42 +93,13 @@ export const AddDeviceInterfaces = (): JSX.Element => {
                 "aria-label": "* IP assignment",
                 className: "ip-assignment-col",
                 content: (
-                  <FormikField
-                    // TODO: Convert to common component as an almost
-                    // identical version is used in DiscoveryAddForm.
-                    // https://github.com/canonical-web-and-design/app-tribe/issues/554
-                    component={Select}
+                  <IpAssignmentSelect
                     name={`interfaces[${i}].ip_assignment`}
                     onChange={(e: ChangeEvent<HTMLSelectElement>) => {
                       handleChange(e);
                       setFieldValue(`interfaces[${i}].subnet`, "");
                       setFieldValue(`interfaces[${i}].ip_address`, "");
                     }}
-                    options={[
-                      {
-                        label: "Select IP assignment",
-                        value: "",
-                        disabled: true,
-                      },
-                      {
-                        label: getIpAssignmentDisplay(
-                          DeviceIpAssignment.DYNAMIC
-                        ),
-                        value: DeviceIpAssignment.DYNAMIC,
-                      },
-                      {
-                        label: getIpAssignmentDisplay(
-                          DeviceIpAssignment.STATIC
-                        ),
-                        value: DeviceIpAssignment.STATIC,
-                      },
-                      {
-                        label: getIpAssignmentDisplay(
-                          DeviceIpAssignment.EXTERNAL
-                        ),
-                        value: DeviceIpAssignment.EXTERNAL,
-                      },
-                    ]}
                     required
                   />
                 ),


### PR DESCRIPTION
## Done

- Created `IpAssignmentSelect` component and used in the add discovery and device forms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that you can still add a discovery and device as before, using the IP assignment select

## Fixes

Fixes canonical-web-and-design/app-tribe#554
