### PR TITLE
feat(ui): add the device name form

### DIFF
--- a/ui/src/app/base/components/DomainSelect/DomainSelect.tsx
+++ b/ui/src/app/base/components/DomainSelect/DomainSelect.tsx
@@ -10,7 +10,7 @@ import domainSelectors from "app/store/domain/selectors";
 
 type Props = {
   disabled?: boolean;
-  label?: string;
+  label?: string | null;
   name: string;
   valueKey?: "name" | "id";
 } & FormikFieldProps;

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -34,6 +34,7 @@ export const NodeNameFields = ({ saving }: Props): JSX.Element => {
         <DomainSelect
           className="u-no-margin--bottom"
           disabled={saving}
+          label={null}
           name="domain"
           required
           valueKey={DomainMeta.PK}

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`NodeNameFields displays the fields 1`] = `
   </span>
   <DomainSelect
     className="u-no-margin--bottom"
+    label={null}
     name="domain"
     required={true}
     valueKey="id"
@@ -78,7 +79,7 @@ exports[`NodeNameFields displays the fields 1`] = `
       className="u-no-margin--bottom"
       component={[Function]}
       disabled={false}
-      label="Domain"
+      label={null}
       name="domain"
       options={
         Array [
@@ -96,7 +97,7 @@ exports[`NodeNameFields displays the fields 1`] = `
         className="u-no-margin--bottom"
         disabled={false}
         error={null}
-        label="Domain"
+        label={null}
         name="domain"
         onBlur={[Function]}
         onChange={[Function]}
@@ -117,21 +118,12 @@ exports[`NodeNameFields displays the fields 1`] = `
           className="u-nudge-left u-no-margin--right"
           error={null}
           isSelect={true}
-          label="Domain"
+          label={null}
           required={true}
         >
           <div
             className="p-form__group p-form-validation u-nudge-left u-no-margin--right"
           >
-            <Label
-              required={true}
-            >
-              <label
-                className="p-form__label is-required"
-              >
-                Domain
-              </label>
-            </Label>
             <div
               className="p-form__control u-clearfix"
             >

--- a/ui/src/app/base/components/NodeName/_index.scss
+++ b/ui/src/app/base/components/NodeName/_index.scss
@@ -22,9 +22,4 @@
     padding: calc(#{$sp-xx-small} - 2px) $spv-inner--large
       calc(#{$sp-xx-small} + 1px);
   }
-
-  // Hide the required asterisk in the field labels.
-  .node-name label.is-required:before {
-    display: none;
-  }
 }

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
@@ -105,4 +105,20 @@ describe("DeviceDetailsHeader", () => {
       "Delete"
     );
   });
+
+  it("displays the device name if an action is not selected", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeviceDetailsHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("DeviceName").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
@@ -119,6 +119,6 @@ describe("DeviceDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("DeviceName").exists()).toBe(true);
+    expect(wrapper.find("data-testid=['DeviceName']").exists()).toBe(true);
   });
 });

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
@@ -119,6 +119,6 @@ describe("DeviceDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("data-testid=['DeviceName']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='DeviceName']").exists()).toBe(true);
   });
 });

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -1,6 +1,10 @@
+import { useState } from "react";
+
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
+
+import DeviceName from "./DeviceName";
 
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
@@ -28,6 +32,7 @@ const DeviceDetailsHeader = ({
   setHeaderContent,
   systemId,
 }: Props): JSX.Element => {
+  const [editingName, setEditingName] = useState(false);
   const device = useSelector((state: RootState) =>
     deviceSelectors.getById(state, systemId)
   );
@@ -90,7 +95,17 @@ const DeviceDetailsHeader = ({
       ]}
       // TODO: Make MachineName component generic and use here instead
       // https://github.com/canonical-web-and-design/app-tribe/issues/553
-      title={getHeaderTitle(device.fqdn || "", headerContent)}
+      title={
+        headerContent ? (
+          getHeaderTitle(device.fqdn || "", headerContent)
+        ) : (
+          <DeviceName
+            editingName={editingName}
+            id={systemId}
+            setEditingName={setEditingName}
+          />
+        )
+      }
     />
   );
 };

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -93,13 +93,12 @@ const DeviceDetailsHeader = ({
           to: deviceURLs.device.configuration({ id: systemId }),
         },
       ]}
-      // TODO: Make MachineName component generic and use here instead
-      // https://github.com/canonical-web-and-design/app-tribe/issues/553
       title={
         headerContent ? (
           getHeaderTitle(device.fqdn || "", headerContent)
         ) : (
           <DeviceName
+            data-testid="DeviceName"
             editingName={editingName}
             id={systemId}
             setEditingName={setEditingName}

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
@@ -1,0 +1,89 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeviceName from "./DeviceName";
+
+import type { RootState } from "app/store/root/types";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  generalState as generalStateFactory,
+  deviceDetails as deviceDetailsFactory,
+  deviceState as deviceStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { submitFormikForm } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("DeviceName", () => {
+  let state: RootState;
+  const domain = domainFactory({ id: 99 });
+  beforeEach(() => {
+    state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domain],
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+        }),
+      }),
+      device: deviceStateFactory({
+        loaded: true,
+        items: [
+          deviceDetailsFactory({
+            domain,
+            locked: false,
+            permissions: ["edit"],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("can update a device with the new name and domain", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/device/abc123", key: "testKey" }]}
+        >
+          <DeviceName
+            editingName={true}
+            id="abc123"
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      submitFormikForm(wrapper, {
+        hostname: "new-lease",
+        domain: "99",
+      })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "device/update")
+    ).toStrictEqual({
+      type: "device/update",
+      payload: {
+        params: {
+          domain: domain,
+          hostname: "new-lease",
+          system_id: "abc123",
+        },
+      },
+      meta: {
+        model: "device",
+        method: "update",
+      },
+    });
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import NodeName from "app/base/components/NodeName";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type { Device } from "app/store/device/types";
+import { DeviceMeta } from "app/store/device/types";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  editingName: boolean;
+  id: Device["system_id"];
+  setEditingName: (editingName: boolean) => void;
+};
+
+const DeviceName = ({
+  editingName,
+  id,
+  setEditingName,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, id)
+  );
+  const saved = useSelector(deviceSelectors.saved);
+  const saving = useSelector(deviceSelectors.saving);
+  const domains = useSelector(domainSelectors.all);
+
+  useEffect(() => {
+    dispatch(domainActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <NodeName
+      editingName={editingName}
+      node={device}
+      onSubmit={(hostname, domain) => {
+        if (device) {
+          dispatch(
+            deviceActions.update({
+              domain: domains.find(({ id }) => id === domain),
+              hostname,
+              [DeviceMeta.PK]: device[DeviceMeta.PK],
+            })
+          );
+        }
+      }}
+      saved={saved}
+      saving={saving}
+      setEditingName={setEditingName}
+    />
+  );
+};
+
+export default DeviceName;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceName";


### PR DESCRIPTION
## Done

- Add the device name form to the device details header.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to details page for a device.
- Click the device name in the header and the form should appear.
- Change the name and domain and submit.
- The device name should update.

## Fixes

Fixes: canonical-web-and-design/app-tribe#557.