### PR TITLE
fix(ui): handle machine null status_message

### DIFF
--- a/ui/src/app/utils/breakLines.test.ts
+++ b/ui/src/app/utils/breakLines.test.ts
@@ -1,6 +1,10 @@
 import breakLines from "./breakLines";
 
 describe("breakLines", () => {
+  it("handles null text value", () => {
+    expect(breakLines(null, true, 15)).toBe("");
+  });
+
   it("handles lines that are the exact expected length", () => {
     expect(
       breakLines("Lorem ipsum dolor sit amet, consectetur adipiscinges")

--- a/ui/src/app/utils/breakLines.ts
+++ b/ui/src/app/utils/breakLines.ts
@@ -3,12 +3,13 @@
  * that is inserted into a <pre> block.
  */
 export const breakLines = (
-  text: string | null,
+  text?: string | null,
   breakAtSpaces = true,
   lineLength = 52
 ): string => {
   let chunks = [];
 
+  // Check if text is `null` or `undefined`
   if (text == null) {
     return "";
   }

--- a/ui/src/app/utils/breakLines.ts
+++ b/ui/src/app/utils/breakLines.ts
@@ -8,9 +8,13 @@ export const breakLines = (
   lineLength = 52
 ): string => {
   let chunks = [];
+
+  if (text == null) {
+    return "";
+  }
   // Check that the text includes whitespace, otherwise we'll treat it as if we
   // are not breaking at spaces.
-  if (breakAtSpaces && text?.includes(" ")) {
+  if (breakAtSpaces && text.includes(" ")) {
     let remainingText = text.trim();
     while (remainingText.length) {
       // Get the next chunk.
@@ -35,7 +39,7 @@ export const breakLines = (
     }
   } else {
     // Split the text into chunks of the provided size.
-    chunks = text?.match(new RegExp(`.{1,${lineLength}}`, "g")) || [];
+    chunks = text.match(new RegExp(`.{1,${lineLength}}`, "g")) || [];
   }
   // Trim any wrapping whitespace from the chunks and add the newlines.
   return chunks.map((chunk) => chunk.trim()).join(" \n");

--- a/ui/src/app/utils/breakLines.ts
+++ b/ui/src/app/utils/breakLines.ts
@@ -3,14 +3,14 @@
  * that is inserted into a <pre> block.
  */
 export const breakLines = (
-  text: string,
+  text: string | null,
   breakAtSpaces = true,
   lineLength = 52
 ): string => {
   let chunks = [];
   // Check that the text includes whitespace, otherwise we'll treat it as if we
   // are not breaking at spaces.
-  if (breakAtSpaces && text.includes(" ")) {
+  if (breakAtSpaces && text?.includes(" ")) {
     let remainingText = text.trim();
     while (remainingText.length) {
       // Get the next chunk.
@@ -35,7 +35,7 @@ export const breakLines = (
     }
   } else {
     // Split the text into chunks of the provided size.
-    chunks = text.match(new RegExp(`.{1,${lineLength}}`, "g")) || [];
+    chunks = text?.match(new RegExp(`.{1,${lineLength}}`, "g")) || [];
   }
   // Trim any wrapping whitespace from the chunks and add the newlines.
   return chunks.map((chunk) => chunk.trim()).join(" \n");


### PR DESCRIPTION
## Done
- fix Uncaught Type error for null machine `status_message` 
  - fix breakLines behaviour for null text value

## Before
https://pastebin.canonical.com/p/9XMPk5xQkP/
![image](https://user-images.githubusercontent.com/7452681/143879446-64f7d0d9-b858-46e2-94c9-11d79c44e2e9.png)

https://pastebin.canonical.com/p/tmF4SwWdbc/
![image](https://user-images.githubusercontent.com/7452681/143879488-f2d8878b-92da-49d7-8bc6-fc20fd13554a.png)

## After
![image](https://user-images.githubusercontent.com/7452681/143879590-9001038b-9e6d-47bc-a70c-18ae545d1a44.png)


## QA
- if the machine on http://bolla.internal:5240/MAAS/r/ is still in the same state state that causes the UI to break - verify that the error no longer occurs
- otherwise, manually add/update a machine with the state below (`"status_message": null,`) to verify there's no runtime error

[Example machine that's causing the runtime error (text is null)](https://pastebin.canonical.com/p/GH56Vpk2jq/)
  