### PR TITLE
fix(ui): update base node status_message type

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -29,7 +29,7 @@ const hideFailedTestWarningStatuses = [
 ];
 
 const getProgressText = (machine: Machine) => {
-  if (isTransientStatus(machine.status_code)) {
+  if (isTransientStatus(machine.status_code) && machine.status_message) {
     return machine.status_message;
   }
   return "";
@@ -97,6 +97,8 @@ export const StatusColumn = ({
   ];
 
   if (machine) {
+    const progressText = getProgressText(machine);
+
     return (
       <DoubleRow
         icon={getStatusIcon(machine)}
@@ -111,8 +113,8 @@ export const StatusColumn = ({
         }
         secondary={
           <>
-            <span data-testid="progress-text" title={getProgressText(machine)}>
-              {getProgressText(machine)}
+            <span data-testid="progress-text" title={progressText}>
+              {progressText}
             </span>
             <span data-testid="error-text">
               {machine.error_description &&

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -156,7 +156,6 @@ export type BaseMachine = BaseNode & {
   pxe_mac?: string;
   spaces: string[];
   sriov_support: boolean;
-  status_message: string;
   storage_tags: string[];
   storage: number;
   subnets: string[];

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -187,7 +187,7 @@ export type BaseNode = SimpleNode & {
   other_test_status: TestStatus;
   pool?: ModelRef;
   status: NodeStatus;
-  status_message: string;
+  status_message: string | null;
   status_code: NodeStatusCode;
   storage_test_status: TestStatus;
 };


### PR DESCRIPTION
## Done

- Updated `BaseNode` type to include the possibility of `status_message: null`
- Fixed machine status column using the updated type

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes #3365 

