### PR TITLE
feat(ui): set active device when viewing details

### DIFF
--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -94,6 +94,7 @@ export const AddDeviceInterfaces = (): JSX.Element => {
                 className: "ip-assignment-col",
                 content: (
                   <IpAssignmentSelect
+                    label={null}
                     name={`interfaces[${i}].ip_assignment`}
                     onChange={(e: ChangeEvent<HTMLSelectElement>) => {
                       handleChange(e);

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
@@ -1,0 +1,123 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeviceDetails from "./DeviceDetails";
+
+import deviceURLs from "app/devices/urls";
+import { actions as deviceActions } from "app/store/device";
+import type { RootState } from "app/store/root/types";
+import {
+  device as deviceFactory,
+  deviceState as deviceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DeviceDetails", () => {
+  const device = deviceFactory({ system_id: "abc123" });
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [device],
+        loaded: true,
+        loading: false,
+      }),
+    });
+  });
+
+  it("gets and sets the device as active", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: deviceURLs.device.index({ id: device.system_id }) },
+          ]}
+        >
+          <Route
+            exact
+            path={deviceURLs.device.index(null, true)}
+            component={() => <DeviceDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const expectedActions = [
+      deviceActions.get(device.system_id),
+      deviceActions.setActive(device.system_id),
+    ];
+    const actualActions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        actualActions.find(
+          (actualAction) => actualAction.type === expectedAction.type
+        )
+      ).toStrictEqual(expectedAction);
+    });
+  });
+
+  it("unsets active device and cleans up when unmounting", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: deviceURLs.device.index({ id: device.system_id }) },
+          ]}
+        >
+          <Route
+            exact
+            path={deviceURLs.device.index(null, true)}
+            component={() => <DeviceDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.unmount();
+
+    const expectedActions = [
+      deviceActions.setActive(null),
+      deviceActions.cleanup(),
+    ];
+    const actualActions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        actualActions.find(
+          (actualAction) =>
+            actualAction.type === expectedAction.type &&
+            // Check payload to differentiate "set" and "unset" active actions
+            actualAction.payload?.params === expectedAction.payload?.params
+        )
+      ).toStrictEqual(expectedAction);
+    });
+  });
+
+  it("displays a message if the device does not exist", () => {
+    state.device.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: deviceURLs.device.index({ id: device.system_id }) },
+          ]}
+        >
+          <Route
+            exact
+            path={deviceURLs.device.index(null, true)}
+            component={() => <DeviceDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-testid='not-found']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -28,11 +28,18 @@ const DeviceDetails = (): JSX.Element => {
   const [headerContent, setHeaderContent] =
     useState<DeviceHeaderContent | null>(null);
 
-  // TODO: Replace with "get" method when implemented
-  // https://github.com/canonical-web-and-design/app-tribe/issues/520
   useEffect(() => {
-    dispatch(deviceActions.fetch());
-  }, [dispatch]);
+    // Set active device on load to ensure all device details are sent through
+    // the websocket.
+    dispatch(deviceActions.get(id));
+    dispatch(deviceActions.setActive(id));
+
+    // Unset active device and cleanup state on unmount.
+    return () => {
+      dispatch(deviceActions.setActive(null));
+      dispatch(deviceActions.cleanup());
+    };
+  }, [dispatch, id]);
 
   if (!devicesLoading && !device) {
     return (


### PR DESCRIPTION
## Done

- Set active device when viewing device details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices
- Click on a device, and check that a loading spinner shows in the header initially before disappearing
- Check in Redux DevTools that the device was successfully set as active

## Fixes

Fixes canonical-web-and-design/app-tribe#558

