### PR TITLE
fix(ui): fix machine storage tables on small screens

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -157,6 +157,7 @@ const normaliseRowData = (
             }
           />
         ),
+        "aria-label": "Name & Serial",
       },
       {
         content: (
@@ -174,6 +175,7 @@ const normaliseRowData = (
             }
           />
         ),
+        "aria-label": "Model & Firmware",
       },
       {
         content: (
@@ -188,6 +190,7 @@ const normaliseRowData = (
             primaryClassName="u-align--center"
           />
         ),
+        "aria-label": "Boot",
       },
       {
         content: (
@@ -199,6 +202,7 @@ const normaliseRowData = (
             }
           />
         ),
+        "aria-label": "Size",
       },
       {
         content: (
@@ -212,6 +216,7 @@ const normaliseRowData = (
             }
           />
         ),
+        "aria-label": "Type & NUMA node",
       },
       {
         content: (
@@ -228,6 +233,7 @@ const normaliseRowData = (
             }
           />
         ),
+        "aria-label": "Health & Tags",
       },
       {
         className: "u-align--right",
@@ -241,6 +247,7 @@ const normaliseRowData = (
             systemId={systemId}
           />
         ),
+        "aria-label": "Actions",
       },
     ],
     expanded: isExpanded,
@@ -560,6 +567,7 @@ const AvailableStorageTable = ({
       <>
         <MainTable
           className="p-table-expanding--light"
+          responsive
           expanding
           headers={[
             {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -136,6 +136,7 @@ const normaliseRowData = (
     className: isExpanded ? "p-table__row is-active" : null,
     columns: [
       {
+        "aria-label": "Name & Serial",
         content: (
           <DoubleRow
             primary={
@@ -157,9 +158,9 @@ const normaliseRowData = (
             }
           />
         ),
-        "aria-label": "Name & Serial",
       },
       {
+        "aria-label": "Model & Firmware",
         content: (
           <DoubleRow
             primary={"model" in storageDevice ? storageDevice.model : "—"}
@@ -175,9 +176,9 @@ const normaliseRowData = (
             }
           />
         ),
-        "aria-label": "Model & Firmware",
       },
       {
+        "aria-label": "Boot",
         content: (
           <DoubleRow
             primary={
@@ -189,9 +190,9 @@ const normaliseRowData = (
             }
           />
         ),
-        "aria-label": "Boot",
       },
       {
+        "aria-label": "Size",
         content: (
           <DoubleRow
             primary={formatSize(storageDevice.size)}
@@ -201,9 +202,9 @@ const normaliseRowData = (
             }
           />
         ),
-        "aria-label": "Size",
       },
       {
+        "aria-label": "Type & NUMA node",
         content: (
           <DoubleRow
             primary={formatType(storageDevice)}
@@ -215,9 +216,9 @@ const normaliseRowData = (
             }
           />
         ),
-        "aria-label": "Type & NUMA node",
       },
       {
+        "aria-label": "Health & Tags",
         content: (
           <DoubleRow
             primary={
@@ -232,9 +233,10 @@ const normaliseRowData = (
             }
           />
         ),
-        "aria-label": "Health & Tags",
       },
       {
+        "aria-label": "Actions",
+        className: "u-align--right",
         content: (
           <StorageDeviceActions
             disabled={actionsDisabled}
@@ -245,7 +247,6 @@ const normaliseRowData = (
             systemId={systemId}
           />
         ),
-        "aria-label": "Actions",
       },
     ],
     expanded: isExpanded,
@@ -616,6 +617,7 @@ const AvailableStorageTable = ({
               ),
             },
             {
+              className: "u-align--right",
               content: <div>Actions</div>,
             },
           ]}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -187,7 +187,6 @@ const normaliseRowData = (
                 "—"
               )
             }
-            primaryClassName="u-align--center"
           />
         ),
         "aria-label": "Boot",
@@ -236,7 +235,6 @@ const normaliseRowData = (
         "aria-label": "Health & Tags",
       },
       {
-        className: "u-align--right",
         content: (
           <StorageDeviceActions
             disabled={actionsDisabled}
@@ -596,7 +594,6 @@ const AvailableStorageTable = ({
               ),
             },
             {
-              className: "u-align--center",
               content: <div>Boot</div>,
             },
             {
@@ -619,7 +616,6 @@ const AvailableStorageTable = ({
               ),
             },
             {
-              className: "u-align--right",
               content: <div>Actions</div>,
             },
           ]}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -124,6 +124,7 @@ const CacheSetsTable = ({
       <MainTable
         className="p-table-expanding--light"
         expanding
+        responsive
         headers={headers}
         rows={rows}
       />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -63,7 +63,7 @@ const CacheSetsTable = ({
           columns: [
             { content: disk.name },
             { content: formatSize(disk.size) },
-            { content: disk.used_for },
+            { className: "u-break-spaces", content: disk.used_for },
             {
               className: "u-align--right",
               content: (

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -42,6 +42,16 @@ const CacheSetsTable = ({
   const [expanded, setExpanded] = useState<Expanded | null>(null);
   const closeExpanded = () => setExpanded(null);
 
+  const headers = [
+    { content: "Name" },
+    { content: "Size" },
+    { content: "Used for" },
+    {
+      className: "u-align--right",
+      content: "Actions",
+    },
+  ];
+
   if (isMachineDetails(machine)) {
     const rows = machine.disks.reduce<MainTableRow[]>((rows, disk) => {
       if (isCacheSet(disk)) {
@@ -71,7 +81,10 @@ const CacheSetsTable = ({
                 />
               ),
             },
-          ],
+          ].map((column, i) => ({
+            ...column,
+            "aria-label": headers[i].content,
+          })),
           expanded: isExpanded,
           expandedContent: (
             <div className="u-flex--grow">
@@ -111,15 +124,7 @@ const CacheSetsTable = ({
       <MainTable
         className="p-table-expanding--light"
         expanding
-        headers={[
-          { content: "Name" },
-          { content: "Size" },
-          { content: "Used for" },
-          {
-            className: "u-align--right",
-            content: "Actions",
-          },
-        ]}
+        headers={headers}
         rows={rows}
       />
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -43,6 +43,17 @@ const DatastoresTable = ({
 
   const closeExpanded = () => setExpanded(null);
 
+  const headers = [
+    { content: "Name" },
+    { content: "Filesystem" },
+    { content: "Size" },
+    { content: "Mount point" },
+    {
+      content: "Actions",
+      className: "u-align--right",
+    },
+  ];
+
   if (isMachineDetails(machine)) {
     const rows = machine.disks.reduce<MainTableRow[]>((rows, disk) => {
       if (disk.filesystem && isDatastore(disk.filesystem)) {
@@ -73,7 +84,10 @@ const DatastoresTable = ({
               ),
               className: "u-align--right",
             },
-          ],
+          ].map((column, i) => ({
+            ...column,
+            "aria-label": headers[i].content,
+          })),
           expanded: isExpanded,
           expandedContent: (
             <div className="u-flex--grow">
@@ -114,16 +128,8 @@ const DatastoresTable = ({
         <MainTable
           className="p-table-expanding--light"
           expanding
-          headers={[
-            { content: "Name" },
-            { content: "Filesystem" },
-            { content: "Size" },
-            { content: "Mount point" },
-            {
-              content: "Actions",
-              className: "u-align--right",
-            },
-          ]}
+          responsive
+          headers={headers}
           rows={rows}
         />
         {rows.length === 0 && (

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -40,6 +40,32 @@ type Props = {
   systemId: Machine["system_id"];
 };
 
+const headers = [
+  {
+    content: "Name",
+    sortKey: "name",
+  },
+  {
+    content: "Size",
+    sortKey: "size",
+  },
+  {
+    content: "Filesystem",
+    sortKey: "fstype",
+  },
+  {
+    content: "Mount point",
+    sortKey: "mountPoint",
+  },
+  {
+    content: "Mount options",
+  },
+  {
+    content: "Actions",
+    className: "u-align--right",
+  },
+];
+
 /**
  * Normalise rendered row data so that both disk and partition filesystems can
  * be displayed.
@@ -90,7 +116,7 @@ const normaliseRowData = (
           />
         ),
       },
-    ],
+    ].map((column, i) => ({ ...column, "aria-label": headers[i].content })),
     expanded: isExpanded,
     key: rowId,
   };
@@ -312,31 +338,8 @@ const FilesystemsTable = ({
           defaultSort="name"
           defaultSortDirection="ascending"
           expanding
-          headers={[
-            {
-              content: "Name",
-              sortKey: "name",
-            },
-            {
-              content: "Size",
-              sortKey: "size",
-            },
-            {
-              content: "Filesystem",
-              sortKey: "fstype",
-            },
-            {
-              content: "Mount point",
-              sortKey: "mountPoint",
-            },
-            {
-              content: "Mount options",
-            },
-            {
-              content: "Actions",
-              className: "u-align--right",
-            },
-          ]}
+          responsive
+          headers={headers}
           rows={rows}
         />
         {rows.length === 0 && (

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -43,31 +43,35 @@ const MachineStorage = (): JSX.Element => {
         <Strip shallow>
           {showDatastores ? (
             <>
-              <h4>Datastores</h4>
+              <h4 className="machine-storage__subtitle">Datastores</h4>
               <DatastoresTable canEditStorage={canEditStorage} systemId={id} />
             </>
           ) : (
             <>
-              <h4>Filesystems</h4>
+              <h4 className="machine-storage__subtitle">Filesystems</h4>
               <FilesystemsTable canEditStorage={canEditStorage} systemId={id} />
             </>
           )}
         </Strip>
         {showCacheSets && (
           <Strip shallow>
-            <h4>Available cache sets</h4>
+            <h4 className="machine-storage__subtitle">Available cache sets</h4>
             <CacheSetsTable canEditStorage={canEditStorage} systemId={id} />
           </Strip>
         )}
         <Strip shallow>
-          <h4>Available disks and partitions</h4>
+          <h4 className="machine-storage__subtitle">
+            Available disks and partitions
+          </h4>
           <AvailableStorageTable
             canEditStorage={canEditStorage}
             systemId={id}
           />
         </Strip>
         <Strip shallow>
-          <h4>Used disks and partitions</h4>
+          <h4 className="machine-storage__subtitle">
+            Used disks and partitions
+          </h4>
           <UsedStorageTable systemId={id} />
         </Strip>
         <Strip shallow>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -95,9 +95,9 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
       "aria-label": "Health & Tags",
     },
     {
-      content: storageDevice.used_for,
       "aria-label": "Used for",
       className: "u-break-spaces",
+      content: storageDevice.used_for,
     },
   ];
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -30,6 +30,7 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
           secondary={"serial" in storageDevice && storageDevice.serial}
         />
       ),
+      "aria-label": "Name & serial",
     },
     {
       content: (
@@ -41,6 +42,7 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
           }
         />
       ),
+      "aria-label": "Model & firmware",
     },
     {
       content: (
@@ -55,9 +57,11 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
           primaryClassName="u-align--center"
         />
       ),
+      "aria-label": "Boot",
     },
     {
       content: <DoubleRow primary={formatSize(storageDevice.size)} />,
+      "aria-label": "Size",
     },
     {
       content: (
@@ -71,6 +75,7 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
           }
         />
       ),
+      "aria-label": "Type & NUMA node",
     },
     {
       content: (
@@ -88,8 +93,9 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
           }
         />
       ),
+      "aria-label": "Health & Tags",
     },
-    { content: storageDevice.used_for },
+    { content: storageDevice.used_for, "aria-label": "Used for" },
   ];
 };
 
@@ -127,6 +133,7 @@ const UsedStorageTable = ({ systemId }: Props): JSX.Element | null => {
       <>
         <MainTable
           className="p-table-expanding--light"
+          responsive
           headers={[
             {
               content: (

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -54,7 +54,6 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
               "—"
             )
           }
-          primaryClassName="u-align--center"
         />
       ),
       "aria-label": "Boot",
@@ -95,7 +94,11 @@ const normaliseColumns = (storageDevice: Disk | Partition) => {
       ),
       "aria-label": "Health & Tags",
     },
-    { content: storageDevice.used_for, "aria-label": "Used for" },
+    {
+      content: storageDevice.used_for,
+      "aria-label": "Used for",
+      className: "u-break-spaces",
+    },
   ];
 };
 
@@ -152,7 +155,6 @@ const UsedStorageTable = ({ systemId }: Props): JSX.Element | null => {
               ),
             },
             {
-              className: "u-align--center",
               content: <div>Boot</div>,
             },
             { content: <div>Size</div> },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/_index.scss
@@ -1,0 +1,5 @@
+@mixin MachineStorage {
+  .machine-storage__subtitle {
+    margin-bottom: $sph-outer;
+  }
+}

--- a/ui/src/scss/_patterns_tables.scss
+++ b/ui/src/scss/_patterns_tables.scss
@@ -45,13 +45,4 @@
   .p-table__row--muted {
     background-color: $color-light;
   }
-
-  .p-table--mobile-card td,
-  .p-table--mobile-card tbody th {
-    white-space: normal;
-
-    &[aria-label]::before {
-      margin-bottom: 0.25rem;
-    }
-  }
 }

--- a/ui/src/scss/_patterns_tables.scss
+++ b/ui/src/scss/_patterns_tables.scss
@@ -45,4 +45,13 @@
   .p-table__row--muted {
     background-color: $color-light;
   }
+
+  .p-table--mobile-card td,
+  .p-table--mobile-card tbody th {
+    white-space: normal;
+
+    &[aria-label]::before {
+      margin-bottom: 0.25rem;
+    }
+  }
 }

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -8,6 +8,10 @@
     word-break: break-word !important;
   }
 
+  .u-break-spaces {
+    white-space: break-spaces !important;
+  }
+
   .u-default-text {
     color: $color-dark !important;
     font-size: 1rem !important;

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -48,12 +48,17 @@ input[type="radio"] {
 }
 
 @media screen and (max-width: $breakpoint-medium) {
+  // 30-11-2021 Peter: workaround p-table--mobile-card mobile margin
+  // being overwritten by p-table--expanding
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/4163
   .p-table--mobile-card tr + tr {
     margin-bottom: $sph-outer;
   }
 
   .p-table--mobile-card td {
+    // 30-11-2021 Peter: margin bottom has negative value when $multi = 1
     // set margin-bottom to 0.25rem to match the default spacing
+    // https://github.com/canonical-web-and-design/vanilla-framework/issues/4162
     &[aria-label]::before {
       margin-bottom: $sph-inner--x-small;
     }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -46,3 +46,16 @@ input[type="radio"] {
     margin: 0;
   }
 }
+
+@media screen and (max-width: $breakpoint-medium) {
+  .p-table--mobile-card tr + tr {
+    margin-bottom: $sph-outer;
+  }
+
+  .p-table--mobile-card td {
+    // set margin-bottom to 0.25rem to match the default spacing
+    &[aria-label]::before {
+      margin-bottom: $sph-inner--x-small;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -197,6 +197,7 @@
 @import "~app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/DHCPTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/NetworkTable";
+@import "~app/machines/views/MachineDetails/MachineStorage";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
@@ -210,6 +211,7 @@
 @include EventLogsTable;
 @include MachineDHCPTable;
 @include MachineList;
+@include MachineStorage;
 @include MachineNetworkTable;
 @include MachineSummary;
 @include MachineTestsTable;


### PR DESCRIPTION
## Done

- use the [responsive table pattern](https://vanillaframework.io/docs/base/tables#responsive) (`.p-table--mobile-card`) for tables in the Machine Storage section
  - remove unsupported `u-align--center` (only `u-align--right` works by default in mobile card pattern, otherwise there are alignement issues on mobile)
  - add vanilla overrides for p-table--mobile-card to accomodate for negative margin that's caused by our altered defaults in `_settings.scss` (`$multi: 1`)
  - add extra margin to machine-storage__subtitle for better spacing
  - add `.u-break-spaces` utility class to allow wrapping text in tables to the next line where needed
  - opened issues on Vanilla framework related to workarounds I had to use:
    - https://github.com/canonical-web-and-design/vanilla-framework/issues/4162
    - https://github.com/canonical-web-and-design/vanilla-framework/issues/4163

### before
![image](https://user-images.githubusercontent.com/7452681/144073265-d08e686d-8af5-4bb8-881f-0cf8972abe43.png)

### after
![image](https://user-images.githubusercontent.com/7452681/144200267-5e6608bf-e417-48fb-a169-31ff1e58e6fa.png)


### before
![image](https://user-images.githubusercontent.com/7452681/144073347-6b9f0ea9-b396-44da-99a4-82363f70fa98.png)

### after
![image](https://user-images.githubusercontent.com/7452681/144072204-c7e4b943-3706-49e4-a92e-7de3278e0661.png)


### before
![image](https://user-images.githubusercontent.com/7452681/144073087-102f0907-e47c-4c3a-aa67-dc32aba2eb50.png)
### after
![image](https://user-images.githubusercontent.com/7452681/144072071-8ef78506-b3b3-4cc0-9fbe-cc77c6f3739b.png)

### before
![image](https://user-images.githubusercontent.com/7452681/144074223-e54ad00e-9369-4f7d-81a8-6406952cca48.png)


### after
![image](https://user-images.githubusercontent.com/7452681/144072097-5ebe20b8-2439-48e8-a11a-d000369082cc.png)


## After







## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #3279 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
