### PR TITLE
refactor(ui): remove useMachineActionForm hook and actionSelected selectors

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -56,6 +56,7 @@ describe("CloneForm", () => {
           <CloneForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -101,6 +102,7 @@ describe("CloneForm", () => {
           <CloneForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -144,6 +146,7 @@ describe("CloneForm", () => {
           <CloneForm
             clearHeaderContent={jest.fn()}
             machines={[machines[0], machines[1]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -1,26 +1,22 @@
 import { useEffect, useState } from "react";
 
 import { Link } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 
 import CloneFormFields from "./CloneFormFields";
 import CloneResults from "./CloneResults";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearHeaderContent, SetSearchFilter } from "app/base/types";
+import type { SetSearchFilter } from "app/base/types";
+import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineDetails } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
 
 type Props = {
-  actionDisabled?: boolean;
-  clearHeaderContent: ClearHeaderContent;
-  machines: Machine[];
   setSearchFilter?: SetSearchFilter;
-  viewingDetails: boolean;
-};
+} & MachineActionFormProps;
 
 export type CloneFormValues = {
   interfaces: boolean;
@@ -53,6 +49,7 @@ export const CloneForm = ({
   actionDisabled,
   clearHeaderContent,
   machines,
+  processingCount,
   setSearchFilter,
   viewingDetails,
 }: Props): JSX.Element => {
@@ -61,8 +58,7 @@ export const CloneForm = ({
     null
   );
   const [showResults, setShowResults] = useState(false);
-  const processingCount = useSelector(machineSelectors.cloning).length;
-  const destinations = machines.map(({ system_id }) => system_id);
+  const destinations = machines.map((machine) => machine.system_id);
 
   // Run cleanup function here rather than in the ActionForm otherwise errors
   // get cleared before the results are shown.
@@ -100,13 +96,13 @@ export const CloneForm = ({
           </Link>
         </p>
       }
-      clearHeaderContent={clearHeaderContent}
       initialValues={{
         interfaces: false,
         source: "",
         storage: false,
       }}
       modelName="machine"
+      onCancel={clearHeaderContent}
       onSaveAnalytics={{
         action: "Submit",
         category: `Machine ${viewingDetails ? "details" : "list"} action form`,

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -73,6 +73,7 @@ describe("CommissionForm", () => {
           <CommissionForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -94,6 +95,7 @@ describe("CommissionForm", () => {
           <CommissionForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 
-import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -8,10 +7,9 @@ import CommissionFormFields from "./CommissionFormFields";
 import type { CommissionFormValues, FormattedScript } from "./types";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearHeaderContent } from "app/base/types";
-import { useMachineActionForm } from "app/machines/hooks";
+import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import type { Machine, MachineEventErrors } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types";
 import { actions as scriptActions } from "app/store/script";
 import scriptSelectors from "app/store/script/selectors";
 import type { Script } from "app/store/script/types";
@@ -47,17 +45,14 @@ type ScriptInput = {
   [x: string]: { url: string };
 };
 
-type Props = {
-  actionDisabled?: boolean;
-  clearHeaderContent: ClearHeaderContent;
-  machines: Machine[];
-  viewingDetails: boolean;
-};
+type Props = MachineActionFormProps;
 
 export const CommissionForm = ({
   actionDisabled,
   clearHeaderContent,
+  errors,
   machines,
+  processingCount,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -71,9 +66,6 @@ export const CommissionForm = ({
   );
   const urlScripts = useSelector(scriptSelectors.testingWithUrl);
   const testingScripts = useSelector(scriptSelectors.testing);
-  const { errors, processingCount } = useMachineActionForm(
-    NodeActions.COMMISSION
-  );
 
   const testingScript = testingScripts.find(
     (script) => script.name === "smartctl-validate"
@@ -106,7 +98,6 @@ export const CommissionForm = ({
       actionName={NodeActions.COMMISSION}
       allowUnchanged
       cleanup={machineActions.cleanup}
-      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         enableSSH: false,
@@ -121,12 +112,14 @@ export const CommissionForm = ({
       }}
       loaded={scriptsLoaded}
       modelName="machine"
+      onCancel={clearHeaderContent}
       onSaveAnalytics={{
         action: "Submit",
         category: `Machine ${viewingDetails ? "details" : "list"} action form`,
         label: "Commission",
       }}
       onSubmit={(values) => {
+        dispatch(machineActions.cleanup());
         const {
           enableSSH,
           skipBMCConfig,
@@ -155,6 +148,7 @@ export const CommissionForm = ({
           );
         });
       }}
+      onSuccess={clearHeaderContent}
       processingCount={processingCount}
       selectedCount={machines.length}
       validationSchema={CommissionFormSchema}
@@ -167,10 +161,6 @@ export const CommissionForm = ({
       />
     </ActionForm>
   );
-};
-
-CommissionForm.propTypes = {
-  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default CommissionForm;

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
@@ -77,6 +77,7 @@ describe("CommissionForm", () => {
           <CommissionForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -111,6 +111,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -138,6 +139,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -204,6 +206,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -254,6 +257,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -307,6 +311,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -343,6 +348,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -373,6 +379,7 @@ describe("DeployForm", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -140,6 +140,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -161,6 +162,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -180,6 +182,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -203,6 +206,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -244,6 +248,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -287,6 +292,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -314,6 +320,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -337,6 +344,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -367,6 +375,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -395,6 +404,7 @@ describe("DeployFormFields", () => {
           <DeployForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/FieldlessForm/FieldlessForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/FieldlessForm/FieldlessForm.test.tsx
@@ -63,6 +63,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.ON}
             clearHeaderContent={clearHeaderContent}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -84,6 +85,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.ABORT}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -122,6 +124,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.ACQUIRE}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -160,6 +163,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.EXIT_RESCUE_MODE}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -198,6 +202,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.LOCK}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -236,6 +241,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.MARK_FIXED}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -274,6 +280,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.OFF}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -312,6 +319,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.ON}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -350,6 +358,7 @@ describe("FieldlessForm", () => {
             action={NodeActions.UNLOCK}
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -389,6 +398,7 @@ describe("FieldlessForm", () => {
               action={NodeActions.DELETE}
               clearHeaderContent={jest.fn()}
               machines={[state.machine.items[0]]}
+              processingCount={0}
               viewingDetails={false}
             />
           </MemoryRouter>
@@ -408,6 +418,7 @@ describe("FieldlessForm", () => {
               action={NodeActions.DELETE}
               clearHeaderContent={jest.fn()}
               machines={[state.machine.items[0]]}
+              processingCount={0}
               viewingDetails={false}
             />
           </MemoryRouter>
@@ -450,6 +461,7 @@ describe("FieldlessForm", () => {
               action={NodeActions.DELETE}
               clearHeaderContent={jest.fn()}
               machines={[state.machine.items[0]]}
+              processingCount={0}
               viewingDetails
             />
           </MemoryRouter>
@@ -459,15 +471,11 @@ describe("FieldlessForm", () => {
     });
 
     it("does not redirect if there are errors", () => {
-      state.machine.selected = ["abc123"];
-      state.machine.statuses.abc123.deleting = false;
-      state.machine.eventErrors = [
-        machineEventErrorFactory({
-          id: "abc123",
-          event: "delete",
-          error: "uh oh",
-        }),
-      ];
+      const errors = machineEventErrorFactory({
+        id: "abc123",
+        event: "delete",
+        error: "uh oh",
+      }).error;
       jest
         .spyOn(reactComponentHooks, "usePrevious")
         .mockImplementation(() => true);
@@ -480,7 +488,9 @@ describe("FieldlessForm", () => {
             <FieldlessForm
               action={NodeActions.DELETE}
               clearHeaderContent={jest.fn()}
+              errors={errors}
               machines={[state.machine.items[0]]}
+              processingCount={0}
               viewingDetails={false}
             />
           </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -46,6 +46,7 @@ describe("MarkBrokenForm", () => {
           <MarkBrokenForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -108,6 +109,7 @@ describe("MarkBrokenForm", () => {
           <MarkBrokenForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -1,16 +1,14 @@
 import { useEffect } from "react";
 
-import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 
 import MarkBrokenFormFields from "./MarkBrokenFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearHeaderContent } from "app/base/types";
-import { useMachineActionForm } from "app/machines/hooks";
+import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import type { Machine, MachineEventErrors } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
 
 const MarkBrokenSchema = Yup.object().shape({
@@ -21,23 +19,17 @@ type MarkBrokenFormValues = {
   comment: string;
 };
 
-type Props = {
-  actionDisabled?: boolean;
-  clearHeaderContent: ClearHeaderContent;
-  machines: Machine[];
-  viewingDetails: boolean;
-};
+type Props = MachineActionFormProps;
 
 export const MarkBrokenForm = ({
   actionDisabled,
   clearHeaderContent,
+  errors,
   machines,
+  processingCount,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const { errors, processingCount } = useMachineActionForm(
-    NodeActions.MARK_BROKEN
-  );
 
   useEffect(
     () => () => {
@@ -52,18 +44,19 @@ export const MarkBrokenForm = ({
       actionName={NodeActions.MARK_BROKEN}
       allowAllEmpty
       cleanup={machineActions.cleanup}
-      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         comment: "",
       }}
       modelName="machine"
+      onCancel={clearHeaderContent}
       onSaveAnalytics={{
         action: "Submit",
         category: `Machine ${viewingDetails ? "details" : "list"} action form`,
         label: "Mark broken",
       }}
       onSubmit={(values) => {
+        dispatch(machineActions.cleanup());
         machines.forEach((machine) => {
           dispatch(
             machineActions.markBroken({
@@ -73,6 +66,7 @@ export const MarkBrokenForm = ({
           );
         });
       }}
+      onSuccess={clearHeaderContent}
       processingCount={processingCount}
       selectedCount={machines.length}
       validationSchema={MarkBrokenSchema}
@@ -80,10 +74,6 @@ export const MarkBrokenForm = ({
       <MarkBrokenFormFields selectedCount={machines.length} />
     </ActionForm>
   );
-};
-
-MarkBrokenForm.propTypes = {
-  clearHeaderContent: PropTypes.func.isRequired,
 };
 
 export default MarkBrokenForm;

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -86,6 +86,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -114,6 +115,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -140,6 +142,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={[state.machine.items[0]]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -164,6 +167,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -185,6 +189,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -244,6 +249,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -268,6 +274,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -300,6 +307,7 @@ describe("OverrideTestForm", () => {
           <OverrideTestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
@@ -64,6 +64,7 @@ describe("ReleaseForm", () => {
           <ReleaseForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -86,6 +87,7 @@ describe("ReleaseForm", () => {
           <ReleaseForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
@@ -63,6 +63,7 @@ describe("SetPoolForm", () => {
           <SetPoolForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -84,6 +85,7 @@ describe("SetPoolForm", () => {
           <SetPoolForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -145,6 +147,7 @@ describe("SetPoolForm", () => {
           <SetPoolForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
@@ -54,6 +54,7 @@ describe("SetPoolFormFields", () => {
           <SetPoolForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -78,6 +79,7 @@ describe("SetPoolFormFields", () => {
           <SetPoolForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetZoneForm/SetZoneForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetZoneForm/SetZoneForm.test.tsx
@@ -62,6 +62,7 @@ describe("SetZoneForm", () => {
           <SetZoneForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
@@ -6,21 +6,15 @@ import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
 import ZoneSelect from "app/base/components/ZoneSelect";
-import type { ClearHeaderContent } from "app/base/types";
-import { useMachineActionForm } from "app/machines/hooks";
+import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import type { Machine, MachineEventErrors } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import type { Zone } from "app/store/zone/types";
 
-type Props = {
-  actionDisabled?: boolean;
-  clearHeaderContent: ClearHeaderContent;
-  machines: Machine[];
-  viewingDetails: boolean;
-};
+type Props = MachineActionFormProps;
 
 export type SetZoneFormValues = {
   zone: Zone["name"];
@@ -33,15 +27,14 @@ const SetZoneSchema = Yup.object().shape({
 export const SetZoneForm = ({
   actionDisabled,
   clearHeaderContent,
+  errors,
   machines,
+  processingCount,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const zones = useSelector(zoneSelectors.all);
   const zonesLoaded = useSelector(zoneSelectors.loaded);
-  const { errors, processingCount } = useMachineActionForm(
-    NodeActions.SET_ZONE
-  );
 
   useEffect(() => {
     dispatch(zoneActions.fetch());
@@ -52,17 +45,18 @@ export const SetZoneForm = ({
       actionDisabled={actionDisabled}
       actionName={NodeActions.SET_ZONE}
       cleanup={machineActions.cleanup}
-      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{ zone: "" }}
       loaded={zonesLoaded}
       modelName="machine"
+      onCancel={clearHeaderContent}
       onSaveAnalytics={{
         action: "Submit",
         category: `Machine ${viewingDetails ? "details" : "list"} action form`,
         label: "Set zone",
       }}
       onSubmit={(values) => {
+        dispatch(machineActions.cleanup());
         const zone = zones.find((zone) => zone.name === values.zone);
         if (zone) {
           machines.forEach((machine) => {
@@ -75,6 +69,7 @@ export const SetZoneForm = ({
           });
         }
       }}
+      onSuccess={clearHeaderContent}
       processingCount={processingCount}
       selectedCount={machines.length}
       validationSchema={SetZoneSchema}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -38,6 +38,7 @@ describe("TagForm", () => {
           <TagForm
             clearHeaderContent={jest.fn()}
             machines={[]}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -63,6 +64,7 @@ describe("TagForm", () => {
           <TagForm
             clearHeaderContent={jest.fn()}
             machines={machines}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -81,6 +81,7 @@ describe("TestForm", () => {
           <TestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -175,6 +176,7 @@ describe("TestForm", () => {
             clearHeaderContent={jest.fn()}
             hardwareType={HardwareType.Network}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -219,6 +221,7 @@ describe("TestForm", () => {
             applyConfiguredNetworking={true}
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -77,6 +77,7 @@ describe("TestForm", () => {
           <TestForm
             clearHeaderContent={jest.fn()}
             machines={state.machine.items}
+            processingCount={0}
             viewingDetails={false}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/hooks.test.tsx
+++ b/ui/src/app/machines/hooks.test.tsx
@@ -6,10 +6,9 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import type { MockStoreEnhanced } from "redux-mock-store";
 
-import { useMachineActionForm, useMachineDetailsForm } from "./hooks";
+import { useMachineDetailsForm } from "./hooks";
 
 import type { RootState } from "app/store/root/types";
-import { NodeActions } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineEventError as machineEventErrorFactory,
@@ -66,32 +65,6 @@ describe("machine utils", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  describe("useMachineActionForm", () => {
-    it("can return errors for an active machine", () => {
-      state.machine.active = "abc123";
-      const store = mockStore(state);
-      const { result } = renderHook(
-        () => useMachineActionForm(NodeActions.MARK_FIXED),
-        {
-          wrapper: generateWrapper(store),
-        }
-      );
-      expect(result.current.errors).toBe("uh oh");
-    });
-
-    it("can return errors for selected machines", () => {
-      state.machine.selected = ["abc123", "def456"];
-      const store = mockStore(state);
-      const { result } = renderHook(
-        () => useMachineActionForm(NodeActions.MARK_FIXED),
-        {
-          wrapper: generateWrapper(store),
-        }
-      );
-      expect(result.current.errors).toStrictEqual("uh oh");
-    });
   });
 
   describe("useMachineDetailsForm", () => {

--- a/ui/src/app/machines/types.ts
+++ b/ui/src/app/machines/types.ts
@@ -3,7 +3,13 @@ import type { ValueOf } from "@canonical/react-components";
 import type { MachineHeaderViews } from "./constants";
 
 import type { HardwareType } from "app/base/enum";
-import type { HeaderContent, SetHeaderContent } from "app/base/types";
+import type {
+  APIError,
+  ClearHeaderContent,
+  HeaderContent,
+  SetHeaderContent,
+} from "app/base/types";
+import type { Machine, MachineEventErrors } from "app/store/machine/types";
 import type { Script } from "app/store/script/types";
 
 export type MachineHeaderContent = HeaderContent<
@@ -15,3 +21,12 @@ export type MachineHeaderContent = HeaderContent<
 >;
 
 export type MachineSetHeaderContent = SetHeaderContent<MachineHeaderContent>;
+
+export type MachineActionFormProps = {
+  actionDisabled?: boolean;
+  clearHeaderContent: ClearHeaderContent;
+  errors?: APIError<MachineEventErrors>;
+  machines: Machine[];
+  processingCount: number;
+  viewingDetails: boolean;
+};

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -184,20 +184,6 @@ describe("machine selectors", () => {
     expect(machine.processing(state)).toStrictEqual(["abc123"]);
   });
 
-  it("can get selected machines that are processing", () => {
-    const statuses = machineStatusesFactory({
-      abc123: machineStatusFactory({ testing: true }),
-      def456: machineStatusFactory({ testing: true }),
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        selected: ["abc123"],
-        statuses,
-      }),
-    });
-    expect(machine.selectedProcessing(state)).toStrictEqual(["abc123"]);
-  });
-
   it("can get machines that are saving pools", () => {
     const items = [
       machineFactory({ system_id: "808" }),
@@ -214,27 +200,6 @@ describe("machine selectors", () => {
       }),
     });
     expect(machine.settingPool(state)).toStrictEqual([items[1]]);
-  });
-
-  it("can get machines that are both selected and saving pools", () => {
-    const items = [
-      machineFactory({ system_id: "707" }),
-      machineFactory({ system_id: "808" }),
-      machineFactory({ system_id: "909" }),
-    ];
-    const statuses = machineStatusesFactory({
-      "707": machineStatusFactory({ settingPool: true }),
-      "808": machineStatusFactory(),
-      "909": machineStatusFactory({ settingPool: true }),
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items,
-        selected: ["909"],
-        statuses,
-      }),
-    });
-    expect(machine.settingPoolSelected(state)).toStrictEqual([items[2]]);
   });
 
   it("can get machines that are deleting interfaces", () => {
@@ -255,27 +220,6 @@ describe("machine selectors", () => {
     expect(machine.deletingInterface(state)).toStrictEqual([items[1]]);
   });
 
-  it("can get selected machines that are deleting interfaces", () => {
-    const items = [
-      machineFactory({ system_id: "707" }),
-      machineFactory({ system_id: "808" }),
-      machineFactory({ system_id: "909" }),
-    ];
-    const statuses = machineStatusesFactory({
-      "707": machineStatusFactory({ deletingInterface: true }),
-      "808": machineStatusFactory(),
-      "909": machineStatusFactory({ deletingInterface: true }),
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items,
-        selected: ["909"],
-        statuses,
-      }),
-    });
-    expect(machine.deletingInterfaceSelected(state)).toStrictEqual([items[2]]);
-  });
-
   it("can get machines that are linking subnets", () => {
     const items = [
       machineFactory({ system_id: "808" }),
@@ -292,27 +236,6 @@ describe("machine selectors", () => {
       }),
     });
     expect(machine.linkingSubnet(state)).toStrictEqual([items[1]]);
-  });
-
-  it("can get selected machines that are linking subnets", () => {
-    const items = [
-      machineFactory({ system_id: "707" }),
-      machineFactory({ system_id: "808" }),
-      machineFactory({ system_id: "909" }),
-    ];
-    const statuses = machineStatusesFactory({
-      "707": machineStatusFactory({ linkingSubnet: true }),
-      "808": machineStatusFactory(),
-      "909": machineStatusFactory({ linkingSubnet: true }),
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items,
-        selected: ["909"],
-        statuses,
-      }),
-    });
-    expect(machine.linkingSubnetSelected(state)).toStrictEqual([items[2]]);
   });
 
   it("can get machines that are unlinking subnets", () => {
@@ -333,27 +256,6 @@ describe("machine selectors", () => {
     expect(machine.unlinkingSubnet(state)).toStrictEqual([items[1]]);
   });
 
-  it("can get selected machines that are unlinking subnets", () => {
-    const items = [
-      machineFactory({ system_id: "707" }),
-      machineFactory({ system_id: "808" }),
-      machineFactory({ system_id: "909" }),
-    ];
-    const statuses = machineStatusesFactory({
-      "707": machineStatusFactory({ unlinkingSubnet: true }),
-      "808": machineStatusFactory(),
-      "909": machineStatusFactory({ unlinkingSubnet: true }),
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items,
-        selected: ["909"],
-        statuses,
-      }),
-    });
-    expect(machine.unlinkingSubnetSelected(state)).toStrictEqual([items[2]]);
-  });
-
   it("can get machines that are creating physical interfaces", () => {
     const items = [
       machineFactory({ system_id: "808" }),
@@ -370,27 +272,6 @@ describe("machine selectors", () => {
       }),
     });
     expect(machine.creatingPhysical(state)).toStrictEqual([items[1]]);
-  });
-
-  it("can get selected machines that are creating physical interfaces", () => {
-    const items = [
-      machineFactory({ system_id: "707" }),
-      machineFactory({ system_id: "808" }),
-      machineFactory({ system_id: "909" }),
-    ];
-    const statuses = machineStatusesFactory({
-      "707": machineStatusFactory({ creatingPhysical: true }),
-      "808": machineStatusFactory(),
-      "909": machineStatusFactory({ creatingPhysical: true }),
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items,
-        selected: ["909"],
-        statuses,
-      }),
-    });
-    expect(machine.creatingPhysicalSelected(state)).toStrictEqual([items[2]]);
   });
 
   it("can get all event errors", () => {

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -61,19 +61,6 @@ const processing = (state: RootState): Machine[MachineMeta.PK][] =>
     )
   );
 
-/**
- * Returns IDs of machines that are both selected and currently being processed.
- * @param {RootState} state - The redux state.
- * @returns {Machine["system_id"][]} List of selected machines being processed.
- */
-const selectedProcessing = createSelector(
-  [selectedIDs, processing],
-  (
-    selectedIDs: Machine[MachineMeta.PK][],
-    processing: Machine[MachineMeta.PK][]
-  ) => processing.filter((id) => selectedIDs.includes(id))
-);
-
 export const statusSelectors: { [x: string]: Selector<RootState, Machine[]> } =
   {};
 
@@ -85,15 +72,6 @@ ACTIONS.forEach(({ status }) => {
       machines.filter(
         ({ system_id }) => statuses[system_id][status as keyof MachineStatus]
       )
-  );
-});
-
-// Create a selector for selected machines in each machine status.
-ACTIONS.forEach(({ status }) => {
-  statusSelectors[`${status}Selected`] = createSelector(
-    [statusSelectors[status], selectedIDs],
-    (machines: Machine[], selectedIDs) =>
-      machines.filter(({ system_id }) => selectedIDs.includes(system_id))
   );
 });
 
@@ -293,72 +271,44 @@ const getByStatusCode = createSelector(
 const selectors = {
   ...defaultSelectors,
   aborting: statusSelectors["aborting"],
-  abortingSelected: statusSelectors["abortingSelected"],
   acquiring: statusSelectors["acquiring"],
-  acquiringSelected: statusSelectors["acquiringSelected"],
   active,
   activeID,
   checkingPower: statusSelectors["checkingPower"],
-  checkingPowerSelected: statusSelectors["checkingPowerSelected"],
   cloning: statusSelectors["cloning"],
-  cloningSelected: statusSelectors["cloningSelected"],
   commissioning: statusSelectors["commissioning"],
-  commissioningSelected: statusSelectors["commissioningSelected"],
   creatingPhysical: statusSelectors["creatingPhysical"],
-  creatingPhysicalSelected: statusSelectors["creatingPhysicalSelected"],
   creatingVlan: statusSelectors["creatingVlan"],
-  creatingVlanSelected: statusSelectors["creatingVlanSelected"],
   deleting: statusSelectors["deleting"],
-  deletingSelected: statusSelectors["deletingSelected"],
   deletingInterface: statusSelectors["deletingInterface"],
-  deletingInterfaceSelected: statusSelectors["deletingInterfaceSelected"],
   deploying: statusSelectors["deploying"],
-  deployingSelected: statusSelectors["deployingSelected"],
   enteringRescueMode: statusSelectors["enteringRescueMode"],
-  enteringRescueModeSelected: statusSelectors["enteringRescueModeSelected"],
   eventErrors,
   eventErrorsForIds,
   exitingRescueMode: statusSelectors["exitingRescueMode"],
-  exitingRescueModeSelected: statusSelectors["exitingRescueModeSelected"],
   getByStatusCode,
   getInterfaceById,
   getStatuses,
   getStatusForMachine,
   linkingSubnet: statusSelectors["linkingSubnet"],
-  linkingSubnetSelected: statusSelectors["linkingSubnetSelected"],
   locking: statusSelectors["locking"],
-  lockingSelected: statusSelectors["lockingSelected"],
   markingBroken: statusSelectors["markingBroken"],
-  markingBrokenSelected: statusSelectors["markingBrokenSelected"],
   markingFixed: statusSelectors["markingFixed"],
-  markingFixedSelected: statusSelectors["markingFixedSelected"],
   overridingFailedTesting: statusSelectors["overridingFailedTesting"],
-  overridingFailedTestingSelected:
-    statusSelectors["overridingFailedTestingSelected"],
   processing,
   releasing: statusSelectors["releasing"],
-  releasingSelected: statusSelectors["releasingSelected"],
   search,
   selected,
   selectedIDs,
-  selectedProcessing,
   settingPool: statusSelectors["settingPool"],
-  settingPoolSelected: statusSelectors["settingPoolSelected"],
   settingZone: statusSelectors["settingZone"],
-  settingZoneSelected: statusSelectors["settingZoneSelected"],
   statuses,
   tagging: statusSelectors["tagging"],
-  taggingSelected: statusSelectors["taggingSelected"],
   testing: statusSelectors["testing"],
-  testingSelected: statusSelectors["testingSelected"],
   turningOff: statusSelectors["turningOff"],
-  turningOffSelected: statusSelectors["turningOffSelected"],
   turningOn: statusSelectors["turningOn"],
-  turningOnSelected: statusSelectors["turningOnSelected"],
   unlocking: statusSelectors["unlocking"],
-  unlockingSelected: statusSelectors["unlockingSelected"],
   unlinkingSubnet: statusSelectors["unlinkingSubnet"],
-  unlinkingSubnetSelected: statusSelectors["unlinkingSubnetSelected"],
   unselected,
 };
 


### PR DESCRIPTION
## Done

- Determine machine action form errors and processing count in `ActionFormWrapper`
- Removed `useMachineActionForm` hook, which fully decouples the machine action forms from machines in the store, so it should now be possible to make the forms work across node types
- Removed all `actionSelected` machine selectors since we no longer use machine state to determine what's selected

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that you can still perform actions from the machine list and machine details pages.

## Fixes

Fixes canonical-web-and-design/app-tribe#525