### PR TITLE
feat: add the DHCP table to the devices network tab

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -67,7 +67,7 @@ const DeviceDetails = (): JSX.Element => {
             <DeviceSummary systemId={id} />
           </Route>
           <Route exact path={deviceURLs.device.network(null, true)}>
-            <DeviceNetwork />
+            <DeviceNetwork systemId={id} />
           </Route>
           <Route exact path={deviceURLs.device.configuration(null, true)}>
             <DeviceConfiguration systemId={id} />

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
@@ -1,0 +1,57 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeviceNetwork from "./DeviceNetwork";
+
+import {
+  deviceDetails as deviceDetailsFactory,
+  deviceState as deviceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DeviceNetwork", () => {
+  it("displays a spinner if device is loading", () => {
+    const state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/device/abc123", key: "testKey" }]}
+        >
+          <DeviceNetwork systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.find("NodeNetworkTab").exists()).toBe(false);
+  });
+
+  it("displays the network tab when loaded", () => {
+    const state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [deviceDetailsFactory({ system_id: "abc123" })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/device/abc123", key: "testKey" }]}
+        >
+          <DeviceNetwork systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("NodeNetworkTab").exists()).toBe(true);
+    expect(wrapper.find("DHCPTable").exists()).toBe(true);
+    expect(wrapper.find("Spinner").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -1,5 +1,42 @@
-const DeviceNetwork = (): JSX.Element => {
-  return <h2 className="p-heading--4">Device network</h2>;
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import DHCPTable from "app/base/components/DHCPTable";
+import NodeNetworkTab from "app/base/components/NodeNetworkTab";
+import { useWindowTitle } from "app/base/hooks";
+import deviceSelectors from "app/store/device/selectors";
+import { DeviceMeta } from "app/store/device/types";
+import type { Device } from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Device[DeviceMeta.PK];
+};
+
+const DeviceNetwork = ({ systemId }: Props): JSX.Element => {
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, systemId)
+  );
+
+  useWindowTitle(`${device?.fqdn ? `${device?.fqdn} ` : "Device"} network`);
+
+  if (!device) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return (
+    <>
+      <NodeNetworkTab
+        actions={() => null}
+        addInterface={() => null}
+        dhcpTable={() => (
+          <DHCPTable node={device} nodeType={DeviceMeta.MODEL} />
+        )}
+        expandedForm={() => null}
+        interfaceTable={() => null}
+      />
+    </>
+  );
 };
 
 export default DeviceNetwork;


### PR DESCRIPTION




## Done

- Add the DHCP table
- Setup the network state.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the /r/devices and click on a device.
- In the network tab you should see a DHCP table with no snippets.
- Go to the DHCP settings and add a snippet to the device you visited.
- Go back to the network tab for the device and you should see the snippet in the table.

## Fixes

Fixes: canonical-web-and-design/app-tribe#564.
Fixes: canonical-web-and-design/app-tribe#569.