### PR TITLE
refactor(ui): improve action form composability

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -4,7 +4,6 @@ import configureStore from "redux-mock-store";
 
 import ActionForm from "./ActionForm";
 
-import type { APIError } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
 import { submitFormikForm, waitForComponentToPaint } from "testing/utils";
@@ -22,10 +21,13 @@ describe("ActionForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <ActionForm
+          actionName="action"
           initialValues={{}}
           loaded={false}
           modelName="machine"
           onSubmit={jest.fn()}
+          processingCount={0}
+          selectedCount={1}
         />
       </Provider>
     );
@@ -38,9 +40,12 @@ describe("ActionForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <ActionForm
+          actionName="action"
           initialValues={{}}
           modelName="machine"
           onSubmit={jest.fn()}
+          processingCount={0}
+          selectedCount={1}
         />
       </Provider>
     );
@@ -53,6 +58,7 @@ describe("ActionForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <ActionForm
+          actionName="action"
           initialValues={{}}
           modelName="machine"
           onSubmit={jest.fn()}
@@ -71,95 +77,12 @@ describe("ActionForm", () => {
     expect(wrapper.find("ActionButton").prop("disabled")).toBe(true);
   });
 
-  it("runs clearHeaderContent function when processing complete", () => {
-    const store = mockStore(state);
-    const clearHeaderContent = jest.fn();
-    const Proxy = ({ processingCount }: { processingCount: number }) => (
-      <Provider store={store}>
-        <ActionForm
-          clearHeaderContent={clearHeaderContent}
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={processingCount}
-          selectedCount={2}
-        />
-      </Provider>
-    );
-    const wrapper = mount(<Proxy processingCount={1} />);
-
-    submitFormikForm(wrapper);
-    wrapper.setProps({ processingCount: 0 });
-    wrapper.update();
-
-    expect(clearHeaderContent).toHaveBeenCalled();
-  });
-
-  it("runs onSuccess function if processing is successful", () => {
-    const store = mockStore(state);
-    const onSuccess = jest.fn();
-    const Proxy = ({ processingCount }: { processingCount: number }) => (
-      <Provider store={store}>
-        <ActionForm
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          onSuccess={onSuccess}
-          processingCount={processingCount}
-          selectedCount={2}
-        />
-      </Provider>
-    );
-    const wrapper = mount(<Proxy processingCount={1} />);
-
-    submitFormikForm(wrapper);
-    wrapper.setProps({ processingCount: 0 });
-    wrapper.update();
-
-    expect(onSuccess).toHaveBeenCalled();
-  });
-
-  it("does not run clearHeaderContent function if errors occur while processing", () => {
-    const store = mockStore(state);
-    const clearHeaderContent = jest.fn();
-    const Proxy = ({
-      errors,
-      processingCount,
-    }: {
-      errors: APIError;
-      processingCount: number;
-    }) => (
-      <Provider store={store}>
-        <ActionForm
-          clearHeaderContent={clearHeaderContent}
-          errors={errors}
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={processingCount}
-          selectedCount={2}
-        />
-      </Provider>
-    );
-    const wrapper = mount(<Proxy errors={{}} processingCount={1} />);
-
-    submitFormikForm(wrapper);
-    wrapper.setProps({
-      errors: { name: "Name already exists" },
-      processingCount: 0,
-    });
-    wrapper.update();
-
-    expect(clearHeaderContent).not.toHaveBeenCalled();
-  });
-
   it("shows correct saving label if selectedCount changes after submit", async () => {
     const store = mockStore(state);
-    const clearHeaderContent = jest.fn();
     const Proxy = ({ selectedCount }: { selectedCount: number }) => (
       <Provider store={store}>
         <ActionForm
-          clearHeaderContent={clearHeaderContent}
+          actionName="action"
           initialValues={{}}
           modelName="machine"
           onSubmit={jest.fn()}

--- a/ui/src/app/base/hooks/base.ts
+++ b/ui/src/app/base/hooks/base.ts
@@ -87,32 +87,38 @@ export const useCycled = (
  * @param onComplete - The function to call when all the items have been processed.
  * @param hasErrors - Whether there are any item errors in state.
  * @param onError - The function to call when an error occurs.
+ * @returns Whether the list of items has been processed successfully.
  */
-export const useProcessing = (
-  processingCount: number,
-  onComplete: () => void,
+export const useProcessing = ({
   hasErrors = false,
-  onError: () => void
-): void => {
-  const processingStarted = useRef(false);
-  if (processingStarted.current === false && processingCount > 0) {
-    processingStarted.current = true;
-  }
+  onComplete,
+  onError,
+  processingCount,
+}: {
+  hasErrors?: boolean;
+  onComplete?: () => void;
+  onError?: () => void;
+  processingCount: number;
+}): boolean => {
+  const [processingStarted] = useCycled(processingCount !== 0);
+  const [processingComplete, setProcessingComplete] = useState(false);
 
   // If all the items have finished processing and there are no errors, run the
   // onComplete function.
   useCycled(processingCount === 0, () => {
     if (!hasErrors) {
-      onComplete();
+      setProcessingComplete(true);
+      onComplete && onComplete();
     }
   });
 
-  // If the items are processing and errors occur, run the onError function.
-  useCycled(hasErrors, () => {
-    if (processingStarted) {
-      onError();
-    }
+  // If processing has started and an error occurs, run the onError function.
+  useCycled(hasErrors && processingStarted, () => {
+    setProcessingComplete(false);
+    onError && onError();
   });
+
+  return processingComplete;
 };
 
 /**

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
@@ -430,7 +430,6 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
         actionName="compose"
         allowUnchanged
         cleanup={cleanup}
-        clearHeaderContent={clearHeaderContent}
         errors={errors}
         initialTouched={{
           architecture: true,
@@ -485,15 +484,17 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
           setMachineName(values.hostname || "Machine");
           dispatch(podActions.compose(params));
         }}
-        onSuccess={() =>
+        onSuccess={() => {
           dispatch(
             messageActions.add(
               `${machineName} composed successfully.`,
               NotificationSeverity.INFORMATION
             )
-          )
-        }
+          );
+          clearHeaderContent();
+        }}
         processingCount={composingPods.length}
+        selectedCount={1}
         validationSchema={ComposeFormSchema}
         validateOnMount
       >

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -5,7 +5,7 @@ import configureStore from "redux-mock-store";
 
 import DeleteForm from "./DeleteForm";
 
-import ActionForm from "app/base/components/ActionForm";
+import FormikForm from "app/base/components/FormikForm";
 import { PodType } from "app/store/pod/constants";
 import podSelectors from "app/store/pod/selectors";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
@@ -242,20 +242,20 @@ describe("DeleteForm", () => {
       </Provider>
     );
     const wrapper = mount(<Proxy />);
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     const status = jest.spyOn(vmClusterSelectors, "status");
     // Update the component to the state where the cluster is being deleted.
     status.mockReturnValue(true);
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     // Update the component to the state where the cluster has finished being deleted.
     status.mockReturnValue(false);
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(true);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(true);
   });
 
   it("sets the form to saved when a pod has been deleted", async () => {
@@ -277,20 +277,20 @@ describe("DeleteForm", () => {
       </Provider>
     );
     const wrapper = mount(<Proxy />);
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     // Update the component to the state where the pod is being deleted.
     const podsDeleting = jest.spyOn(podSelectors, "deleting");
     podsDeleting.mockReturnValue([pod]);
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     // Update the component to the state where the pod has finished being deleted.
     podsDeleting.mockReturnValue([]);
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(true);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(true);
   });
 
   it("clusters do not get marked as deleted if there is an error", async () => {
@@ -312,7 +312,7 @@ describe("DeleteForm", () => {
       </Provider>
     );
     const wrapper = mount(<Proxy />);
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     const status = jest.spyOn(vmClusterSelectors, "status");
     const eventError = jest.spyOn(vmClusterSelectors, "eventError");
     // Update the component to the state where the cluster is being deleted.
@@ -320,7 +320,7 @@ describe("DeleteForm", () => {
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     // Update the component to the state where the cluster has finished being deleted.
     status.mockReturnValue(false);
     eventError.mockReturnValue([
@@ -332,7 +332,7 @@ describe("DeleteForm", () => {
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
   });
 
   it("pods do not get marked as deleted if there is an error", async () => {
@@ -354,7 +354,7 @@ describe("DeleteForm", () => {
       </Provider>
     );
     const wrapper = mount(<Proxy />);
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     // Update the component to the state where the pod is being deleted.
     const podsDeleting = jest.spyOn(podSelectors, "deleting");
     const errors = jest.spyOn(podSelectors, "errors");
@@ -362,13 +362,13 @@ describe("DeleteForm", () => {
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
     // Update the component to the state where the pod has finished being deleted.
     podsDeleting.mockReturnValue([]);
     errors.mockReturnValue("Uh oh");
     // Make the component rerender with the new value.
     store.dispatch({ type: "" });
     wrapper.setProps({ clearHeaderContent: jest.fn() });
-    expect(wrapper.find(ActionForm).prop("saved")).toBe(false);
+    expect(wrapper.find(FormikForm).prop("saved")).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -12,7 +12,6 @@ import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
-import { useCycled } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
 import kvmURLs from "app/kvm/urls";
 import { actions as messageActions } from "app/store/message";
@@ -71,7 +70,6 @@ const DeleteForm = ({
   const showRemoveMessage = (pod && pod.type === PodType.LXD) || cluster;
   const clusterDeletingCount = clusterDeleting ? 1 : 0;
   const deletingCount = pod ? podsDeleting.length : clusterDeletingCount;
-  const [deleted] = useCycled(deletingCount === 0 && !errors);
 
   if (!pod && !cluster) {
     return null;
@@ -83,7 +81,6 @@ const DeleteForm = ({
       allowAllEmpty
       allowUnchanged
       cleanup={cleanup}
-      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{
         decompose: false,
@@ -121,9 +118,9 @@ const DeleteForm = ({
           )
         );
         history.push({ pathname: kvmURLs.kvm });
+        clearHeaderContent();
       }}
       processingCount={deletingCount}
-      saved={deleted}
       selectedCount={deletingCount}
       submitAppearance="negative"
       validationSchema={DeleteFormSchema}

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
@@ -26,7 +26,6 @@ const RefreshForm = ({
     <ActionForm<EmptyObject>
       actionName="refresh"
       cleanup={cleanup}
-      clearHeaderContent={clearHeaderContent}
       errors={errors}
       initialValues={{}}
       modelName="KVM host"
@@ -40,6 +39,7 @@ const RefreshForm = ({
           dispatch(podActions.refresh(id));
         });
       }}
+      onSuccess={clearHeaderContent}
       processingCount={refreshing.length}
       selectedCount={hostIds.length}
     >

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -46,7 +46,6 @@ const CloneFormSchema = Yup.object()
   .defined();
 
 export const CloneForm = ({
-  actionDisabled,
   clearHeaderContent,
   machines,
   processingCount,
@@ -78,7 +77,6 @@ export const CloneForm = ({
     />
   ) : (
     <ActionForm<CloneFormValues>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.CLONE}
       buttonsBordered
       buttonsHelp={

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -48,7 +48,6 @@ type ScriptInput = {
 type Props = MachineActionFormProps;
 
 export const CommissionForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -94,7 +93,6 @@ export const CommissionForm = ({
 
   return (
     <ActionForm<CommissionFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.COMMISSION}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -38,7 +38,6 @@ export type DeployFormValues = {
 type Props = MachineActionFormProps;
 
 export const DeployForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -80,7 +79,6 @@ export const DeployForm = ({
 
   return (
     <ActionForm<DeployFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.DEPLOY}
       allowUnchanged={osystems?.length !== 0 && releases?.length !== 0}
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
@@ -36,7 +36,6 @@ type Props = { action: MachineActions } & MachineActionFormProps;
 
 export const FieldlessForm = ({
   action,
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -56,7 +55,6 @@ export const FieldlessForm = ({
 
   return (
     <ActionForm<EmptyObject, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={action}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -22,7 +22,6 @@ type MarkBrokenFormValues = {
 type Props = MachineActionFormProps;
 
 export const MarkBrokenForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -40,7 +39,6 @@ export const MarkBrokenForm = ({
 
   return (
     <ActionForm<MarkBrokenFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.MARK_BROKEN}
       allowAllEmpty
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -75,7 +75,6 @@ const OverrideTestFormSchema = Yup.object().shape({
 });
 
 export const OverrideTestForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -122,7 +121,6 @@ export const OverrideTestForm = ({
 
   return (
     <ActionForm<OverrideTestFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.OVERRIDE_FAILED_TESTING}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -29,7 +29,6 @@ const ReleaseSchema = Yup.object().shape({
 type Props = MachineActionFormProps;
 
 export const ReleaseForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -52,7 +51,6 @@ export const ReleaseForm = ({
 
   return configLoaded ? (
     <ActionForm<ReleaseFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.RELEASE}
       allowAllEmpty
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -23,7 +23,6 @@ const SetPoolSchema = Yup.object().shape({
 });
 
 export const SetPoolForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -56,7 +55,6 @@ export const SetPoolForm = ({
 
   return (
     <ActionForm<SetPoolFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.SET_POOL}
       cleanup={machineActions.cleanup}
       errors={errorsToShow}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
@@ -25,7 +25,6 @@ const SetZoneSchema = Yup.object().shape({
 });
 
 export const SetZoneForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -42,7 +41,6 @@ export const SetZoneForm = ({
 
   return (
     <ActionForm<SetZoneFormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.SET_ZONE}
       cleanup={machineActions.cleanup}
       errors={errors}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -26,7 +26,6 @@ const TagFormSchema = Yup.object().shape({
 });
 
 export const TagForm = ({
-  actionDisabled,
   clearHeaderContent,
   errors,
   machines,
@@ -54,7 +53,6 @@ export const TagForm = ({
 
   return (
     <ActionForm<TagFormValues>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.TAG}
       cleanup={machineActions.cleanup}
       errors={formErrors}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TestForm/TestForm.tsx
@@ -45,7 +45,6 @@ type Props = {
 } & MachineActionFormProps;
 
 export const TestForm = ({
-  actionDisabled,
   applyConfiguredNetworking,
   clearHeaderContent,
   errors,
@@ -112,7 +111,6 @@ export const TestForm = ({
 
   return (
     <ActionForm<FormValues, MachineEventErrors>
-      actionDisabled={actionDisabled}
       actionName={NodeActions.TEST}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/types.ts
+++ b/ui/src/app/machines/types.ts
@@ -23,7 +23,6 @@ export type MachineHeaderContent = HeaderContent<
 export type MachineSetHeaderContent = SetHeaderContent<MachineHeaderContent>;
 
 export type MachineActionFormProps = {
-  actionDisabled?: boolean;
   clearHeaderContent: ClearHeaderContent;
   errors?: APIError<MachineEventErrors>;
   machines: Machine[];


### PR DESCRIPTION
## Done

- Removed some workarounds in `ActionForm` to get the machine batched actions to work. Now the form remains rendered if an action has started as opposed to being 100% locked to the processing machines in state. This change could also lead us to better handle errors returned from the API, like with the clone form that has a results page that lists the different errors for the different machines.
- Updated `useProcessing` hook to return completed state and added tests. Note we don't actually use the `onComplete` or `onError` functions in the hook anymore, but it could still be useful so I've kept them in.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- I've set up a bunch of Manual machines in bolla so it might be easier to use bolla here
- Go to the machine list, select all the machines then select an action that can't be performed by all of them
- Check that a warning shows and you can filter the machines to only those that can perform the action
- Unselect the machines and select a bunch of "New" machines
- Commission them and check that the warning doesn't show up at any point
- With the same machines selected, mark them broken while they're commissioning
- Now, try and mark them fixed
- Check that an error shows and the form does not close

## Fixes

Fixes canonical-web-and-design/app-tribe#582

