### PR TITLE
feat(ui): add the device network actions row

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -2,6 +2,7 @@ import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DHCPTable from "app/base/components/DHCPTable";
+import NetworkActionRow from "app/base/components/NetworkActionRow";
 import NodeNetworkTab from "app/base/components/NodeNetworkTab";
 import { useWindowTitle } from "app/base/hooks";
 import deviceSelectors from "app/store/device/selectors";
@@ -27,8 +28,14 @@ const DeviceNetwork = ({ systemId }: Props): JSX.Element => {
   return (
     <>
       <NodeNetworkTab
-        actions={() => null}
-        addInterface={() => null}
+        actions={(expanded, setExpanded) => (
+          <NetworkActionRow
+            expanded={expanded}
+            node={device}
+            setExpanded={setExpanded}
+          />
+        )}
+        addInterface={() => "Add interface"}
         dhcpTable={() => (
           <DHCPTable node={device} nodeType={DeviceMeta.MODEL} />
         )}


### PR DESCRIPTION
## Done

- Add the actions row to the device network tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab for a device.
- You should see a button to add an interface.
- Clicking the button should show some placeholder text.

## Fixes

Fixes: canonical-web-and-design/app-tribe#567.