### PR TITLE
refactor(ui): make ActionFormWrapper reusable across node types

### DIFF
--- a/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
+++ b/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
@@ -1,0 +1,146 @@
+import { mount } from "enzyme";
+
+import NodeActionFormWrapper from "./NodeActionFormWrapper";
+
+import * as baseHooks from "app/base/hooks/base";
+import type { Node } from "app/store/types/node";
+import { NodeActions } from "app/store/types/node";
+import { machine as machineFactory } from "testing/factories";
+
+describe("NodeActionFormWrapper", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders children if all selected nodes can perform selected action", () => {
+    const nodes = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
+      machineFactory({ system_id: "def456", actions: [NodeActions.ABORT] }),
+    ];
+    const wrapper = mount(
+      <NodeActionFormWrapper
+        action={NodeActions.ABORT}
+        clearHeaderContent={jest.fn()}
+        nodes={nodes}
+        nodeType="node"
+        onUpdateSelected={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      >
+        <span data-testid="children">Children</span>
+      </NodeActionFormWrapper>
+    );
+
+    expect(wrapper.find("[data-testid='children']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='node-action-warning']").exists()).toBe(
+      false
+    );
+  });
+
+  it("displays a warning if not all selected nodes can perform selected action", () => {
+    const nodes = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
+      machineFactory({ system_id: "def456", actions: [] }),
+    ];
+    const wrapper = mount(
+      <NodeActionFormWrapper
+        action={NodeActions.ABORT}
+        clearHeaderContent={jest.fn()}
+        nodes={nodes}
+        nodeType="node"
+        onUpdateSelected={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      >
+        <span data-testid="children">Children</span>
+      </NodeActionFormWrapper>
+    );
+
+    expect(wrapper.find("[data-testid='node-action-warning']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("[data-testid='children']").exists()).toBe(false);
+  });
+
+  it(`does not display a warning when action has started even if not all
+      selected nodes can perform selected action`, async () => {
+    // Mock that action has started.
+    jest
+      .spyOn(baseHooks, "useCycled")
+      .mockImplementation(() => [true, () => null]);
+    const nodes = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
+      machineFactory({ system_id: "def456", actions: [] }),
+    ];
+    const wrapper = mount(
+      <NodeActionFormWrapper
+        action={NodeActions.ABORT}
+        clearHeaderContent={jest.fn()}
+        nodes={nodes}
+        nodeType="node"
+        onUpdateSelected={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      >
+        <span data-testid="children">Children</span>
+      </NodeActionFormWrapper>
+    );
+
+    expect(wrapper.find("[data-testid='children']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='node-action-warning']").exists()).toBe(
+      false
+    );
+  });
+
+  it("can run a function on actionable nodes if warning is shown", () => {
+    const onUpdateSelected = jest.fn();
+    const nodes = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
+      machineFactory({ system_id: "def456", actions: [] }),
+    ];
+    const wrapper = mount(
+      <NodeActionFormWrapper
+        action={NodeActions.ABORT}
+        clearHeaderContent={jest.fn()}
+        nodes={nodes}
+        nodeType="node"
+        onUpdateSelected={onUpdateSelected}
+        processingCount={0}
+        viewingDetails={false}
+      >
+        Children
+      </NodeActionFormWrapper>
+    );
+
+    wrapper.find("button[data-testid='on-update-selected']").simulate("click");
+
+    expect(onUpdateSelected).toHaveBeenCalledWith(["abc123"]);
+  });
+
+  it("clears header content if no nodes are provided", () => {
+    const clearHeaderContent = jest.fn();
+    const Proxy = ({ nodes }: { nodes: Node[] }) => (
+      <NodeActionFormWrapper
+        action={NodeActions.ABORT}
+        clearHeaderContent={clearHeaderContent}
+        nodes={nodes}
+        nodeType="node"
+        onUpdateSelected={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      >
+        Children
+      </NodeActionFormWrapper>
+    );
+    // Mount with one node selected.
+    const wrapper = mount(<Proxy nodes={[machineFactory()]} />);
+
+    expect(clearHeaderContent).not.toHaveBeenCalled();
+
+    // Update with no nodes selected - clear header content should be called.
+    wrapper.setProps({ nodes: [] });
+    wrapper.update();
+
+    expect(clearHeaderContent).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
+++ b/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { Button } from "@canonical/react-components";
+
+import { useCycled, useScrollOnRender } from "app/base/hooks";
+import type { ClearHeaderContent } from "app/base/types";
+import type { Node } from "app/store/types/node";
+import { NodeActions } from "app/store/types/node";
+import { canOpenActionForm } from "app/store/utils/node";
+
+const getErrorSentence = (
+  action: NodeActions,
+  nodeType: string,
+  count: number
+) => {
+  const nodeString = `${count} ${nodeType}${count === 1 ? "" : "s"}`;
+
+  switch (action) {
+    case NodeActions.ABORT:
+      return `${nodeString} cannot abort action`;
+    case NodeActions.ACQUIRE:
+      return `${nodeString} cannot be acquired`;
+    case NodeActions.CLONE:
+      return `${nodeString} cannot be cloned to`;
+    case NodeActions.COMMISSION:
+      return `${nodeString} cannot be commissioned`;
+    case NodeActions.DELETE:
+      return `${nodeString} cannot be deleted`;
+    case NodeActions.DEPLOY:
+      return `${nodeString} cannot be deployed`;
+    case NodeActions.EXIT_RESCUE_MODE:
+      return `${nodeString} cannot exit rescue mode`;
+    case NodeActions.IMPORT_IMAGES:
+      return `${nodeString} cannot import images`;
+    case NodeActions.LOCK:
+      return `${nodeString} cannot be locked`;
+    case NodeActions.MARK_BROKEN:
+      return `${nodeString} cannot be marked broken`;
+    case NodeActions.MARK_FIXED:
+      return `${nodeString} cannot be marked fixed`;
+    case NodeActions.OFF:
+      return `${nodeString} cannot be powered off`;
+    case NodeActions.ON:
+      return `${nodeString} cannot be powered on`;
+    case NodeActions.OVERRIDE_FAILED_TESTING:
+      return `Cannot override failed tests on ${nodeString}`;
+    case NodeActions.RELEASE:
+      return `${nodeString} cannot be released`;
+    case NodeActions.RESCUE_MODE:
+      return `${nodeString} cannot be put in rescue mode`;
+    case NodeActions.SET_POOL:
+      return `Cannot set pool of ${nodeString}`;
+    case NodeActions.SET_ZONE:
+      return `Cannot set zone of ${nodeString}`;
+    case NodeActions.TAG:
+      return `${nodeString} cannot be tagged`;
+    case NodeActions.TEST:
+      return `${nodeString} cannot be tested`;
+    case NodeActions.UNLOCK:
+      return `${nodeString} cannot be unlocked`;
+    default:
+      return `${nodeString} cannot perform action`;
+  }
+};
+
+type Props = {
+  action: NodeActions;
+  children: ReactNode;
+  clearHeaderContent: ClearHeaderContent;
+  nodes: Node[];
+  nodeType: string;
+  processingCount: number;
+  onUpdateSelected: (nodeIDs: Node["system_id"][]) => void;
+  viewingDetails: boolean;
+};
+
+export const NodeActionFormWrapper = ({
+  action,
+  children,
+  clearHeaderContent,
+  nodes,
+  nodeType,
+  onUpdateSelected,
+  processingCount,
+  viewingDetails,
+}: Props): JSX.Element => {
+  const onRenderRef = useScrollOnRender<HTMLDivElement>();
+  const [actionStarted] = useCycled(processingCount !== 0);
+  const actionableNodeIDs = nodes.reduce<Node["system_id"][]>(
+    (nodeIDs, node) =>
+      canOpenActionForm(node, action) ? [...nodeIDs, node.system_id] : nodeIDs,
+    []
+  );
+  // Show a warning if not all the selected nodes can perform the selected
+  // action, unless an action has already been started in which case we want to
+  // maintain the form being rendered.
+  const showWarning =
+    !viewingDetails &&
+    !actionStarted &&
+    actionableNodeIDs.length !== nodes.length;
+
+  useEffect(() => {
+    if (nodes.length === 0) {
+      // All the nodes were deselected so close the form.
+      clearHeaderContent();
+    }
+  }, [clearHeaderContent, nodes.length]);
+
+  return (
+    <div ref={onRenderRef}>
+      {showWarning ? (
+        <p data-testid="node-action-warning">
+          <i className="p-icon--warning" />
+          <span className="u-nudge-right--small">
+            {getErrorSentence(
+              action,
+              nodeType,
+              nodes.length - actionableNodeIDs.length
+            )}
+            . To proceed,{" "}
+            <Button
+              appearance="link"
+              data-testid="on-update-selected"
+              inline
+              onClick={() => onUpdateSelected(actionableNodeIDs)}
+            >
+              update your selection
+            </Button>
+            .
+          </span>
+        </p>
+      ) : (
+        children
+      )}
+    </div>
+  );
+};
+
+export default NodeActionFormWrapper;

--- a/ui/src/app/base/components/node/NodeActionFormWrapper/index.ts
+++ b/ui/src/app/base/components/node/NodeActionFormWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeActionFormWrapper";

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.test.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.test.tsx
@@ -3,34 +3,34 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import ActionFormWrapper from "./ActionFormWrapper";
+import DeviceActionFormWrapper from "./DeviceActionFormWrapper";
 
-import { actions as machineActions } from "app/store/machine";
+import { actions as deviceActions } from "app/store/device";
 import { NodeActions } from "app/store/types/node";
 import {
-  machine as machineFactory,
+  device as deviceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
-describe("ActionFormWrapper", () => {
-  it("can set selected machines to those that can perform action", () => {
+describe("DeviceActionFormWrapper", () => {
+  it("can set selected devices to those that can perform action", () => {
     const state = rootStateFactory();
-    const machines = [
-      machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
-      machineFactory({ system_id: "def456", actions: [] }),
+    const devices = [
+      deviceFactory({ system_id: "abc123", actions: [NodeActions.DELETE] }),
+      deviceFactory({ system_id: "def456", actions: [] }),
     ];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          initialEntries={[{ pathname: "/devices", key: "testKey" }]}
         >
-          <ActionFormWrapper
-            action={NodeActions.ABORT}
+          <DeviceActionFormWrapper
+            action={NodeActions.DELETE}
             clearHeaderContent={jest.fn()}
-            machines={machines}
+            devices={devices}
             viewingDetails={false}
           />
         </MemoryRouter>
@@ -39,7 +39,7 @@ describe("ActionFormWrapper", () => {
 
     wrapper.find('button[data-testid="on-update-selected"]').simulate("click");
 
-    const expectedAction = machineActions.setSelected(["abc123"]);
+    const expectedAction = deviceActions.setSelected(["abc123"]);
     const actualActions = store.getActions();
     expect(
       actualActions.find((action) => action.type === expectedAction.type)

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.tsx
@@ -1,0 +1,46 @@
+import { useDispatch, useSelector } from "react-redux";
+
+import NodeActionFormWrapper from "app/base/components/node/NodeActionFormWrapper";
+import type { ClearHeaderContent } from "app/base/types";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type { Device, DeviceActions } from "app/store/device/types";
+import { NodeActions } from "app/store/types/node";
+
+type Props = {
+  action: DeviceActions;
+  clearHeaderContent: ClearHeaderContent;
+  devices: Device[];
+  viewingDetails: boolean;
+};
+
+export const ActionFormWrapper = ({
+  action,
+  clearHeaderContent,
+  devices,
+  viewingDetails,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const deleting = useSelector(deviceSelectors.deleting);
+  const settingZone = useSelector(deviceSelectors.settingZone);
+  const processingCount =
+    action === NodeActions.DELETE ? deleting.length : settingZone.length;
+
+  return (
+    <NodeActionFormWrapper
+      action={action}
+      clearHeaderContent={clearHeaderContent}
+      nodes={devices}
+      nodeType="device"
+      processingCount={processingCount}
+      onUpdateSelected={(deviceIDs) =>
+        dispatch(deviceActions.setSelected(deviceIDs))
+      }
+      viewingDetails={viewingDetails}
+    >
+      {action}
+    </NodeActionFormWrapper>
+  );
+};
+
+export default ActionFormWrapper;

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/index.ts
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceActionFormWrapper";

--- a/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.tsx
@@ -1,21 +1,30 @@
 import { useCallback } from "react";
 
-import AddDeviceForm from "./AddDeviceForm";
+import type { ValueOf } from "@canonical/react-components";
 
+import AddDeviceForm from "./AddDeviceForm";
+import DeviceActionFormWrapper from "./DeviceActionFormWrapper";
+
+import type { DeviceActionHeaderViews } from "app/devices/constants";
 import { DeviceHeaderViews } from "app/devices/constants";
 import type {
   DeviceHeaderContent,
   DeviceSetHeaderContent,
 } from "app/devices/types";
+import type { Device } from "app/store/device/types";
 
 type Props = {
+  devices: Device[];
   headerContent: DeviceHeaderContent;
   setHeaderContent: DeviceSetHeaderContent;
+  viewingDetails?: boolean;
 };
 
 const DeviceHeaderForms = ({
+  devices,
   headerContent,
   setHeaderContent,
+  viewingDetails = false,
 }: Props): JSX.Element | null => {
   const clearHeaderContent = useCallback(
     () => setHeaderContent(null),
@@ -26,10 +35,22 @@ const DeviceHeaderForms = ({
     case DeviceHeaderViews.ADD_DEVICE:
       return <AddDeviceForm clearHeaderContent={clearHeaderContent} />;
     default:
-      // TODO: Make machine ActionFormWrapper work across different node types
-      // and use here.
-      // https://github.com/canonical-web-and-design/app-tribe/issues/525
-      return <button onClick={clearHeaderContent}>Cancel</button>;
+      // We need to explicitly cast headerContent.view here - TypeScript doesn't
+      // seem to be able to infer remaining object tuple values as with string
+      // values.
+      // https://github.com/canonical-web-and-design/maas-ui/issues/3040
+      const { view } = headerContent as {
+        view: ValueOf<typeof DeviceActionHeaderViews>;
+      };
+      const [, action] = view;
+      return (
+        <DeviceActionFormWrapper
+          action={action}
+          clearHeaderContent={clearHeaderContent}
+          devices={devices}
+          viewingDetails={viewingDetails}
+        />
+      );
   }
 };
 

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -61,8 +61,10 @@ const DeviceDetailsHeader = ({
       headerContent={
         headerContent && (
           <DeviceHeaderForms
+            devices={[device]}
             headerContent={headerContent}
             setHeaderContent={setHeaderContent}
+            viewingDetails
           />
         )
       }

--- a/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
@@ -58,6 +58,7 @@ const DeviceListHeader = ({
       headerContent={
         headerContent && (
           <DeviceHeaderForms
+            devices={selectedDevices}
             headerContent={headerContent}
             setHeaderContent={setHeaderContent}
           />

--- a/ui/src/app/store/device/selectors.ts
+++ b/ui/src/app/store/device/selectors.ts
@@ -53,6 +53,28 @@ const getStatusForDevice = createSelector(
 );
 
 /**
+ * Returns the devices which are being deleted.
+ * @param state - The redux state.
+ * @returns Devices being deleted.
+ */
+const deleting = createSelector(
+  [defaultSelectors.all, statuses],
+  (devices, statuses) =>
+    devices.filter((device) => statuses[device.system_id]?.deleting || false)
+);
+
+/**
+ * Returns the devices which are having their zone set.
+ * @param state - The redux state.
+ * @returns Devices having their zone set.
+ */
+const settingZone = createSelector(
+  [defaultSelectors.all, statuses],
+  (devices, statuses) =>
+    devices.filter((device) => statuses[device.system_id]?.settingZone || false)
+);
+
+/**
  * Select the event errors for all devices.
  * @param state - The redux state.
  * @returns The event errors.
@@ -182,11 +204,13 @@ const selectors = {
   ...defaultSelectors,
   active,
   activeID,
+  deleting,
   eventErrorsForDevices,
   getStatusForDevice,
   search,
   selected,
   selectedIDs,
+  settingZone,
 };
 
 export default selectors;


### PR DESCRIPTION
## Done

- Refactored machine `ActionFormWrapper` to be able to be used across node types and implemented for devices

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the machine action forms still work as before 
  - A warning shows if not all machines can perform the action
  - The form shows if they can
  - Unselecting all machines closes the form
- Check that the device action forms work like with machines
  - Select some devices and open a form - placeholder form content should show
  - Since I don't think it's possible to be able to see a device *and* only be able to perform a subset of actions on it, we can only test that unselecting all devices closes the form

## Fixes

Fixes canonical-web-and-design/app-tribe#583