### PR TITLE
fix(ui): correctly handle device create/delete notify actions

### DIFF
--- a/ui/src/app/store/device/reducers.test.ts
+++ b/ui/src/app/store/device/reducers.test.ts
@@ -58,6 +58,85 @@ describe("device reducers", () => {
     );
   });
 
+  it("reduces createNotify", () => {
+    const initialState = deviceStateFactory({
+      items: [deviceFactory({ system_id: "abc123" })],
+      statuses: { abc123: deviceStatusFactory() },
+    });
+    const newDevice = deviceFactory({ system_id: "def456" });
+
+    expect(reducers(initialState, actions.createNotify(newDevice))).toEqual(
+      deviceStateFactory({
+        items: [...initialState.items, newDevice],
+        statuses: {
+          abc123: deviceStatusFactory(),
+          def456: deviceStatusFactory(),
+        },
+      })
+    );
+  });
+
+  it("should update if device exists on createNotify", () => {
+    const initialState = deviceStateFactory({
+      items: [deviceFactory({ hostname: "device1", system_id: "abc123" })],
+      statuses: { abc123: deviceStatusFactory() },
+    });
+    const updatedDevice = deviceFactory({
+      hostname: "device1-newname",
+      system_id: "abc123",
+    });
+
+    expect(reducers(initialState, actions.createNotify(updatedDevice))).toEqual(
+      deviceStateFactory({
+        items: [updatedDevice],
+        statuses: {
+          abc123: deviceStatusFactory(),
+        },
+      })
+    );
+  });
+
+  it("reduces updateNotify", () => {
+    const initialState = deviceStateFactory({
+      items: [
+        deviceFactory({ system_id: "abc123", hostname: "device1" }),
+        deviceFactory({ system_id: "def456", hostname: "device2" }),
+      ],
+    });
+    const updatedDevice = deviceFactory({
+      system_id: "abc123",
+      hostname: "device1-new",
+    });
+
+    expect(reducers(initialState, actions.updateNotify(updatedDevice))).toEqual(
+      deviceStateFactory({
+        items: [updatedDevice, initialState.items[1]],
+      })
+    );
+  });
+
+  it("reduces deleteNotify", () => {
+    const initialState = deviceStateFactory({
+      items: [
+        deviceFactory({ system_id: "abc123" }),
+        deviceFactory({ system_id: "def456" }),
+      ],
+      selected: ["abc123"],
+      statuses: {
+        abc123: deviceStatusFactory(),
+        def456: deviceStatusFactory(),
+      },
+    });
+
+    expect(reducers(initialState, actions.deleteNotify("abc123"))).toEqual(
+      deviceStateFactory({
+        items: [initialState.items[1]],
+        selected: [],
+        statuses: { def456: deviceStatusFactory() },
+      })
+    );
+  });
+
   it("reduces createInterfaceStart", () => {
     expect(
       reducers(


### PR DESCRIPTION
## Done

- Updated the device slice to handle creating/deleting statuses

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/devices and create a couple of devices
- Check that the Redux store is updated with a status key for each of them
- Select the newly created devices and open the Delete form
- Delete the devices and check that processing message counts down and eventually the form closes
- Check that the devices have been removed from `items`, `selected` and `statuses` in device state

## Fixes

Fixes canonical-web-and-design/app-tribe#587

