### PR TITLE
remove redundant clearCookies in afterEach hook

### DIFF
--- a/integration/cypress/integration/base/footer.spec.ts
+++ b/integration/cypress/integration/base/footer.spec.ts
@@ -1,6 +1,6 @@
 import { generateLegacyURL, generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 declare global {
   interface Window {
@@ -13,10 +13,6 @@ context("Footer", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("navigates to the local documentation", () => {

--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -1,6 +1,6 @@
 import { generateLegacyURL, generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Header", () => {
   beforeEach(() => {
@@ -9,10 +9,6 @@ context("Header", () => {
     // the hardware menu.
     cy.viewport("macbook-13");
     cy.visit(generateNewURL("/"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("navigates to the machine list when clicking on the logo as a non admin", () => {

--- a/integration/cypress/integration/dashboard/dashboard.spec.ts
+++ b/integration/cypress/integration/dashboard/dashboard.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Dashboard", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/dashboard"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/domains/list.spec.ts
+++ b/integration/cypress/integration/domains/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("DNS", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/domains"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/images/list.spec.ts
+++ b/integration/cypress/integration/images/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Images list", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/images"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/kvm/list.spec.ts
+++ b/integration/cypress/integration/kvm/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("KVM listing", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/kvm"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/legacy/controllers.spec.ts
+++ b/integration/cypress/integration/legacy/controllers.spec.ts
@@ -1,15 +1,11 @@
 import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Controller listing", () => {
   beforeEach(() => {
     login();
     cy.visit(generateLegacyURL("/controllers"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/legacy/devices.spec.ts
+++ b/integration/cypress/integration/legacy/devices.spec.ts
@@ -1,15 +1,11 @@
 import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Device listing", () => {
   beforeEach(() => {
     login();
     cy.visit(generateLegacyURL("/devices"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/legacy/subnets.spec.ts
+++ b/integration/cypress/integration/legacy/subnets.spec.ts
@@ -1,15 +1,11 @@
 import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Subnets", () => {
   beforeEach(() => {
     login();
     cy.visit(generateLegacyURL("/networks?by=fabric"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -7,10 +7,6 @@ context("Login page", () => {
     cy.visit(generateNewURL("/"));
   });
 
-  afterEach(() => {
-    clearCookies();
-  });
-
   it("has no detectable accessibility violations on load", () => {
     cy.title().should("include", "Login");
 

--- a/integration/cypress/integration/machines/add.spec.ts
+++ b/integration/cypress/integration/machines/add.spec.ts
@@ -1,7 +1,7 @@
 import { customAlphabet } from "nanoid";
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, generateMac, login } from "../utils";
+import { generateMac, login } from "../utils";
 
 const nanoid = customAlphabet("1234567890abcdefghi", 10);
 
@@ -11,10 +11,6 @@ context("Machine add", () => {
     cy.visit(generateNewURL("/machines"));
     cy.get("[data-testid='add-hardware-dropdown'] button").click();
     cy.get(".p-contextual-menu__link").contains("Machine").click();
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("can add a machine", () => {

--- a/integration/cypress/integration/machines/list.spec.ts
+++ b/integration/cypress/integration/machines/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Machine listing", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/machines"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/pools/list.spec.ts
+++ b/integration/cypress/integration/pools/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Pools list", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/pools"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders a heading", () => {

--- a/integration/cypress/integration/preferences/base.spec.ts
+++ b/integration/cypress/integration/preferences/base.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("User preferences", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/account/prefs"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/settings/base.spec.ts
+++ b/integration/cypress/integration/settings/base.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Settings", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/settings"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {

--- a/integration/cypress/integration/settings/users/add.spec.ts
+++ b/integration/cypress/integration/settings/users/add.spec.ts
@@ -1,7 +1,7 @@
 import { customAlphabet } from "nanoid";
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, generateEmail, login } from "../../utils";
+import { generateEmail, login } from "../../utils";
 
 const nanoid = customAlphabet("1234567890abcdefghi", 10);
 
@@ -9,10 +9,6 @@ context("Settings - User add", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/settings/users/add"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("can add a user", () => {

--- a/integration/cypress/integration/settings/users/list.spec.ts
+++ b/integration/cypress/integration/settings/users/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../../utils";
+import { login } from "../../utils";
 
 context("Settings - User list", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/settings/users"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("the side nav highlights correctly", () => {

--- a/integration/cypress/integration/zones/list.spec.ts
+++ b/integration/cypress/integration/zones/list.spec.ts
@@ -1,15 +1,11 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-import { clearCookies, login } from "../utils";
+import { login } from "../utils";
 
 context("Zones", () => {
   beforeEach(() => {
     login();
     cy.visit(generateNewURL("/zones"));
-  });
-
-  afterEach(() => {
-    clearCookies();
   });
 
   it("renders the correct heading", () => {


### PR DESCRIPTION
## Done

- remove redundant `clearCookies` in `afterEach` hook
  - initally I planned to move state reset from `afterEach` to `beforeEach` hook to follow best practices:
    **[Resetting the state in afterEach hook is an anti-pattern](https://docs.cypress.io/guides/references/best-practices#Using-after-or-afterEach-hooks)**
  - [cypress clears cookies automatically before each test](https://docs.cypress.io/api/commands/clearcookies) - so there's no need to do this manually
