### PR TITLE
feat(ui): display the device interfaces

### DIFF
--- a/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
+++ b/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
@@ -15,7 +15,6 @@ import {
   getInterfaceFabric,
   getInterfaceSubnet,
   getLinkInterface,
-  nodeIsDevice,
 } from "app/store/utils";
 import vlanSelectors from "app/store/vlan/selectors";
 
@@ -52,8 +51,7 @@ const SubnetColumn = ({ link, nic, node }: Props): JSX.Element | null => {
   );
   const discovered = getInterfaceDiscovered(node, nic, link);
   const discoveredSubnetId = discovered?.subnet_id || null;
-  const showLinkSubnet =
-    (nodeIsDevice(node) && !!subnet) || (!!fabric && !discoveredSubnetId);
+  const showLinkSubnet = !!fabric && !discoveredSubnetId;
   const showDiscoveredSubnet = isAllNetworkingDisabled && discoveredSubnetId;
   const subnetDisplay = getSubnetDisplay(subnet, showLinkSubnet);
   let primary: ReactNode = null;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -1,6 +1,8 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import DeviceNetworkTable from "./DeviceNetworkTable";
+
 import DHCPTable from "app/base/components/DHCPTable";
 import NetworkActionRow from "app/base/components/NetworkActionRow";
 import NodeNetworkTab from "app/base/components/NodeNetworkTab";
@@ -40,7 +42,13 @@ const DeviceNetwork = ({ systemId }: Props): JSX.Element => {
           <DHCPTable node={device} nodeType={DeviceMeta.MODEL} />
         )}
         expandedForm={() => null}
-        interfaceTable={() => null}
+        interfaceTable={(expanded, setExpanded) => (
+          <DeviceNetworkTable
+            expanded={expanded}
+            setExpanded={setExpanded}
+            systemId={systemId}
+          />
+        )}
       />
     </>
   );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -1,0 +1,221 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DeviceNetworkTable from "./DeviceNetworkTable";
+
+import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
+import type { RootState } from "app/store/root/types";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import {
+  deviceDetails as deviceDetailsFactory,
+  deviceInterface as deviceInterfaceFactory,
+  deviceState as deviceStateFactory,
+  deviceStatus as deviceStatusFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  networkLink as networkLinkFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DeviceNetworkTable", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        loaded: true,
+      }),
+      device: deviceStateFactory({
+        items: [deviceDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+        statuses: {
+          abc123: deviceStatusFactory(),
+        },
+      }),
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.device.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeviceNetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a table when loaded", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeviceNetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+
+  it("can display an interface that has no links", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    state.vlan.items = [vlan];
+    const subnets = [
+      subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" }),
+      subnetFactory({ cidr: "subnet2-cidr", name: "subnet2-name" }),
+    ];
+    state.subnet.items = subnets;
+    state.device.items = [
+      deviceDetailsFactory({
+        interfaces: [
+          deviceInterfaceFactory({
+            discovered: null,
+            links: [],
+            type: NetworkInterfaceTypes.BOND,
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeviceNetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
+      "Unconfigured"
+    );
+    expect(wrapper.find("[data-testid='ip-address']").text()).toBe(
+      "Unconfigured"
+    );
+  });
+
+  it("can display an interface that has a link", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    state.vlan.items = [vlan];
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    state.subnet.items = [subnet];
+    state.device.items = [
+      deviceDetailsFactory({
+        interfaces: [
+          deviceInterfaceFactory({
+            discovered: null,
+            links: [
+              networkLinkFactory({
+                subnet_id: subnet.id,
+                ip_address: "1.2.3.99",
+              }),
+            ],
+            type: NetworkInterfaceTypes.BOND,
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeviceNetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("SubnetColumn LegacyLink").at(0).text()).toBe(
+      "subnet-cidr"
+    );
+    expect(wrapper.find("[data-testid='ip-address']").text()).toBe("1.2.3.99");
+  });
+
+  it("expands a row when a matching link is found", () => {
+    state.device.items = [
+      deviceDetailsFactory({
+        interfaces: [
+          deviceInterfaceFactory({
+            discovered: null,
+            links: [networkLinkFactory(), networkLinkFactory({ id: 2 })],
+            name: "alias",
+            type: NetworkInterfaceTypes.ALIAS,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeviceNetworkTable
+          expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    const row = wrapper.findWhere(
+      (n) => n.name() === "TableRow" && n.key() === "alias:1"
+    );
+    expect(row.hasClass("is-active")).toBe(true);
+  });
+
+  it("expands a row when a matching nic is found", () => {
+    state.device.items = [
+      deviceDetailsFactory({
+        interfaces: [
+          deviceInterfaceFactory({
+            id: 2,
+            discovered: null,
+            links: [],
+            name: "eth0",
+            type: NetworkInterfaceTypes.PHYSICAL,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeviceNetworkTable
+          expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    const row = wrapper.findWhere(
+      (n) => n.name() === "TableRow" && n.key() === "eth0"
+    );
+    expect(row.hasClass("is-active")).toBe(true);
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/_index.scss
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/_index.scss
@@ -1,0 +1,23 @@
+@mixin DeviceNetworkTable {
+  .device-network-table {
+    @include truncated-border(
+      $width: #{2 * map-get($icon-sizes, default) + $sph-inner--small}
+    );
+
+    th,
+    td {
+      &:nth-child(1) {
+        @include breakpoint-widths(0.3);
+      }
+      &:nth-child(2) {
+        @include breakpoint-widths(0.3);
+      }
+      &:nth-child(3) {
+        @include breakpoint-widths(0.3);
+      }
+      &:nth-child(4) {
+        @include breakpoint-widths(10);
+      }
+    }
+  }
+}

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceNetworkTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
@@ -1,6 +1,5 @@
-import type { ReactNode } from "react";
-
 import { MainTable, Spinner } from "@canonical/react-components";
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import { useSelector } from "react-redux";
 
 import IPColumn from "../NetworkTable/IPColumn";
@@ -31,14 +30,6 @@ import {
 import { generateCheckboxHandlers, simpleSortByKey } from "app/utils";
 import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
-// TODO: This should eventually extend the react-components table row type
-// when it has been migrated to TypeScript.
-type NetworkRow = {
-  className: string | null;
-  columns: { className?: string; content: ReactNode }[];
-  key: NetworkInterface["name"];
-};
-
 export type InterfaceRow = {
   linkId?: NetworkLink["id"] | null;
   nicId?: NetworkInterface["id"] | null;
@@ -51,7 +42,7 @@ const generateRow = (
   handleRowCheckbox?: CheckboxHandlers<Selected>["handleRowCheckbox"] | null,
   checkSelected?: CheckboxHandlers<Selected>["checkSelected"] | null,
   selectedEditable?: boolean
-): NetworkRow => {
+): MainTableRow => {
   const { linkId, nicId } = interfaceRow;
   const nic = getInterfaceById(machine, nicId, linkId);
   const link = getLinkFromNic(nic, linkId);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -1,7 +1,7 @@
-import type { ReactNode } from "react";
 import { useEffect } from "react";
 
 import { MainTable, Spinner } from "@canonical/react-components";
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -73,14 +73,7 @@ type NetworkRowSortData = {
   type: string | null;
 };
 
-// TODO: This should eventually extend the react-components table row type
-// when it has been migrated to TypeScript.
-type NetworkRow = {
-  className: string | null;
-  columns: { className?: string; content: ReactNode }[];
-  expanded: boolean;
-  expandedContent: ReactNode | null;
-  key: NetworkInterface["name"];
+type NetworkRow = Omit<MainTableRow, "sortData"> & {
   select: Selected | null;
   sortData: NetworkRowSortData;
 };

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -120,10 +120,12 @@
 
 // devices
 @import "~app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces";
+@import "~app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable";
 @import "~app/devices/views/DeviceDetails/DeviceSummary";
 @import "~app/devices/views/DeviceList/DeviceListTable";
 @include AddDeviceInterfaces;
 @include DeviceListTable;
+@include DeviceNetworkTable;
 @include DeviceSummary;
 
 // images


### PR DESCRIPTION
## Done

- Add a table to display the interfaces for a device.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the network tab for a device.
- You should see the interfaces listed and the data should be the same as the legacy version (note: there are a couple of additions to make it consistent with what we show for machines).

## Fixes

Fixes: canonical-web-and-design/app-tribe#574.

## Screenshots:

![Uploading Screen Shot 2021-12-09 at 1.57.27 pm.png…]()
