### PR TITLE
feat(ui): build device add interface form

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
@@ -1,0 +1,87 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import AddInterface from "./AddInterface";
+
+import { actions as deviceActions } from "app/store/device";
+import { DeviceIpAssignment } from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+import {
+  device as deviceFactory,
+  deviceDetails as deviceDetailsFactory,
+  deviceState as deviceStateFactory,
+  deviceStatus as deviceStatusFactory,
+  deviceStatuses as deviceStatusesFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+import { submitFormikForm } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("AddInterface", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [
+          deviceDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        loaded: true,
+        statuses: deviceStatusesFactory({
+          abc123: deviceStatusFactory(),
+        }),
+      }),
+      subnet: subnetStateFactory({
+        items: [subnetFactory({ id: 1 }), subnetFactory({ id: 2 })],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a spinner if device is not detailed version", () => {
+    state.device.items[0] = deviceFactory({ system_id: "abc123" });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddInterface systemId="abc123" closeForm={jest.fn()} />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-testid='loading-device-details']").exists()
+    ).toBe(true);
+  });
+
+  it("correctly dispatches action to create an interface", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddInterface closeForm={jest.fn()} systemId="abc123" />
+      </Provider>
+    );
+    const formValues = {
+      ip_address: "192.168.1.1",
+      ip_assignment: DeviceIpAssignment.STATIC,
+      mac_address: "11:22:33:44:55:66",
+      name: "eth123",
+      subnet: 2,
+      tags: ["tag1", "tag2"],
+    };
+
+    submitFormikForm(wrapper, formValues);
+
+    const expectedAction = deviceActions.createInterface({
+      ...formValues,
+      system_id: "abc123",
+    });
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.tsx
@@ -1,0 +1,127 @@
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import AddInterfaceFields from "./AddInterfaceFields";
+
+import FormCard from "app/base/components/FormCard";
+import FormikForm from "app/base/components/FormikForm";
+import { useCycled, useScrollOnRender } from "app/base/hooks";
+import { MAC_ADDRESS_REGEX } from "app/base/validation";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type {
+  CreateInterfaceParams,
+  Device,
+  DeviceMeta,
+} from "app/store/device/types";
+import { DeviceIpAssignment } from "app/store/device/types";
+import { isDeviceDetails } from "app/store/device/utils";
+import type { RootState } from "app/store/root/types";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import { getNextNicName } from "app/store/utils";
+import { preparePayload } from "app/utils";
+
+type Props = {
+  closeForm: () => void;
+  systemId: Device[DeviceMeta.PK];
+};
+
+export type AddInterfaceValues = {
+  ip_address: string;
+  ip_assignment: DeviceIpAssignment;
+  mac_address: string;
+  name: string;
+  subnet: Subnet[SubnetMeta.PK] | "";
+  tags: string[];
+};
+
+const AddInterfaceSchema = Yup.object().shape({
+  ip_address: Yup.string().when("ip_assignment", {
+    is: (ipAssignment: DeviceIpAssignment) =>
+      ipAssignment === DeviceIpAssignment.STATIC ||
+      ipAssignment === DeviceIpAssignment.EXTERNAL,
+    then: Yup.string().required("IP address is required"),
+  }),
+  ip_assignment: Yup.string().required("IP assignment is required"),
+  mac_address: Yup.string()
+    .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
+    .required("MAC address is required"),
+  name: Yup.string(),
+  subnet: Yup.number().when("ip_assignment", {
+    is: (ipAssignment: DeviceIpAssignment) =>
+      ipAssignment === DeviceIpAssignment.STATIC,
+    then: Yup.number().required("Subnet is required"),
+  }),
+  tags: Yup.array().of(Yup.string()),
+});
+
+const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, systemId)
+  );
+  const errors = useSelector(deviceSelectors.errors);
+  const creatingInterface = useSelector((state: RootState) =>
+    deviceSelectors.getStatusForDevice(state, systemId, "creatingInterface")
+  );
+  const createInterfaceErrored =
+    useSelector((state: RootState) =>
+      deviceSelectors.eventErrorsForDevices(
+        state,
+        systemId,
+        "creatingInterface"
+      )
+    ).length > 0;
+  const [createdInterface] = useCycled(
+    !creatingInterface && createInterfaceErrored
+  );
+  const onRenderRef = useScrollOnRender<HTMLDivElement>();
+
+  if (!isDeviceDetails(device)) {
+    return <Spinner data-testid="loading-device-details" text="Loading..." />;
+  }
+  const nextName = getNextNicName(device, NetworkInterfaceTypes.PHYSICAL);
+  return (
+    <div ref={onRenderRef}>
+      <FormCard sidebar={false}>
+        <FormikForm<AddInterfaceValues>
+          cleanup={deviceActions.cleanup}
+          errors={errors}
+          initialValues={{
+            ip_address: "",
+            ip_assignment: DeviceIpAssignment.DYNAMIC,
+            mac_address: "",
+            name: nextName || "",
+            subnet: "",
+            tags: [],
+          }}
+          onSaveAnalytics={{
+            action: "Add interface",
+            category: "Device details networking",
+            label: "Add interface form",
+          }}
+          onCancel={closeForm}
+          onSubmit={(values) => {
+            dispatch(deviceActions.cleanup());
+            const payload = preparePayload({
+              ...values,
+              system_id: device.system_id,
+            }) as CreateInterfaceParams;
+            dispatch(deviceActions.createInterface(payload));
+          }}
+          onSuccess={closeForm}
+          saved={createdInterface}
+          saving={creatingInterface}
+          submitLabel="Save interface"
+          validationSchema={AddInterfaceSchema}
+        >
+          <AddInterfaceFields />
+        </FormikForm>
+      </FormCard>
+    </div>
+  );
+};
+
+export default AddInterface;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.tsx
@@ -68,15 +68,12 @@ const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
   );
   const createInterfaceErrored =
     useSelector((state: RootState) =>
-      deviceSelectors.eventErrorsForDevices(
-        state,
-        systemId,
-        "creatingInterface"
-      )
+      deviceSelectors.eventErrorsForDevices(state, systemId, "createInterface")
     ).length > 0;
-  const [createdInterface] = useCycled(
-    !creatingInterface && createInterfaceErrored
+  const [createdInterface, resetCreatedInterface] = useCycled(
+    !creatingInterface
   );
+  const saved = createdInterface && !createInterfaceErrored;
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
 
   if (!isDeviceDetails(device)) {
@@ -104,6 +101,7 @@ const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
           }}
           onCancel={closeForm}
           onSubmit={(values) => {
+            resetCreatedInterface();
             dispatch(deviceActions.cleanup());
             const payload = preparePayload({
               ...values,
@@ -112,7 +110,7 @@ const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
             dispatch(deviceActions.createInterface(payload));
           }}
           onSuccess={closeForm}
-          saved={createdInterface}
+          saved={saved}
           saving={creatingInterface}
           submitLabel="Save interface"
           validationSchema={AddInterfaceSchema}

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/AddInterfaceFields.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/AddInterfaceFields.test.tsx
@@ -1,0 +1,133 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import type { AddInterfaceValues } from "../AddInterface";
+
+import AddInterfaceFields from "./AddInterfaceFields";
+
+import { DeviceIpAssignment } from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+import {
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("AddInterfaceFields", () => {
+  let initialValues: AddInterfaceValues;
+  let state: RootState;
+  beforeEach(() => {
+    initialValues = {
+      ip_address: "",
+      ip_assignment: DeviceIpAssignment.DYNAMIC,
+      mac_address: "",
+      name: "",
+      subnet: "",
+      tags: [],
+    };
+    state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnetFactory({ id: 1 }), subnetFactory({ id: 2 })],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("does not show subnet or IP address fields for dynamic IP assignment", () => {
+    initialValues.ip_assignment = DeviceIpAssignment.DYNAMIC;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <AddInterfaceFields />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-testid='subnet-field']").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='ip-address-field']").exists()).toBe(
+      false
+    );
+  });
+
+  it("shows the IP address field for external IP assignment", () => {
+    initialValues.ip_assignment = DeviceIpAssignment.EXTERNAL;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <AddInterfaceFields />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-testid='subnet-field']").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='ip-address-field']").exists()).toBe(
+      true
+    );
+  });
+
+  it("shows both the subnet and IP address fields for static IP assignment", () => {
+    initialValues.ip_assignment = DeviceIpAssignment.STATIC;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <AddInterfaceFields />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-testid='subnet-field']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='ip-address-field']").exists()).toBe(
+      true
+    );
+  });
+
+  it("clears subnet and IP address values when changing IP assignment", async () => {
+    initialValues.ip_assignment = DeviceIpAssignment.STATIC;
+    initialValues.subnet = 1;
+    initialValues.ip_address = "192.168.1.1";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <AddInterfaceFields />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("select[data-testid='subnet-field']").prop("value")
+    ).toBe(1);
+    expect(
+      wrapper.find("input[data-testid='ip-address-field']").prop("value")
+    ).toBe("192.168.1.1");
+
+    // Change IP assignment to something else then back to the original value.
+    wrapper
+      .find("select[data-testid='ip-assignment-field']")
+      .simulate("change", {
+        target: { name: "ip_assignment", value: DeviceIpAssignment.DYNAMIC },
+      });
+    await waitForComponentToPaint(wrapper);
+    wrapper
+      .find("select[data-testid='ip-assignment-field']")
+      .simulate("change", {
+        target: { name: "ip_assignment", value: DeviceIpAssignment.STATIC },
+      });
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper.find("select[data-testid='subnet-field']").prop("value")
+    ).toBe("");
+    expect(
+      wrapper.find("input[data-testid='ip-address-field']").prop("value")
+    ).toBe("");
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/AddInterfaceFields.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/AddInterfaceFields.tsx
@@ -1,0 +1,70 @@
+import type { ChangeEvent } from "react";
+
+import { Col, Input, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { AddInterfaceValues } from "../AddInterface";
+
+import FormikField from "app/base/components/FormikField";
+import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
+import MacAddressField from "app/base/components/MacAddressField";
+import SubnetSelect from "app/base/components/SubnetSelect";
+import TagField from "app/base/components/TagField";
+import { DeviceIpAssignment } from "app/store/device/types";
+
+const AddInterfaceFields = (): JSX.Element => {
+  const { handleChange, setFieldValue, values } =
+    useFormikContext<AddInterfaceValues>();
+  const showSubnetField = values.ip_assignment === DeviceIpAssignment.STATIC;
+  const showIpAddressField =
+    values.ip_assignment === DeviceIpAssignment.STATIC ||
+    values.ip_assignment === DeviceIpAssignment.EXTERNAL;
+
+  return (
+    <>
+      <Row>
+        <Col size={6}>
+          <FormikField label="Name" type="text" name="name" />
+        </Col>
+      </Row>
+      <hr />
+      <Row>
+        <Col size={6}>
+          <Input
+            disabled
+            label="Type"
+            value="Physical"
+            type="text"
+            name="type"
+          />
+          <MacAddressField label="MAC address" name="mac_address" />
+          <TagField name="tags" />
+        </Col>
+        <Col size={6}>
+          <IpAssignmentSelect
+            data-testid="ip-assignment-field"
+            name="ip_assignment"
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+              handleChange(e);
+              setFieldValue("subnet", "");
+              setFieldValue("ip_address", "");
+            }}
+          />
+          {showSubnetField && (
+            <SubnetSelect data-testid="subnet-field" name="subnet" />
+          )}
+          {showIpAddressField && (
+            <FormikField
+              data-testid="ip-address-field"
+              label="IP address"
+              name="ip_address"
+              type="text"
+            />
+          )}
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default AddInterfaceFields;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddInterfaceFields";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddInterface";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import AddInterface from "./AddInterface";
 import DeviceNetworkTable from "./DeviceNetworkTable";
 
 import DHCPTable from "app/base/components/DHCPTable";
@@ -37,7 +38,12 @@ const DeviceNetwork = ({ systemId }: Props): JSX.Element => {
             setExpanded={setExpanded}
           />
         )}
-        addInterface={() => "Add interface"}
+        addInterface={(_, setExpanded) => (
+          <AddInterface
+            closeForm={() => setExpanded(null)}
+            systemId={systemId}
+          />
+        )}
         dhcpTable={() => (
           <DHCPTable node={device} nodeType={DeviceMeta.MODEL} />
         )}


### PR DESCRIPTION
## Done

- Built "Add interface" form for devices

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab of a device in the React rebuild
- Click "Add interface"
- Add some valid form values and check that you can successfully add an interface
- Reopen the form, this time choose "Static" IP assignment, any subnet, then enter a bogus IP address
- The API error should display under the IP address field
- Enter a valid IP address that does not belong to the selected subnet.
- Submit the form and check that an error shows at the top of the form.

## Fixes

Fixes canonical-web-and-design/app-tribe#573

## Screenshot

![Screenshot 2021-12-09 at 14-51-18 test-device test network bolla MAAS](https://user-images.githubusercontent.com/25733845/145336793-0eba4ca5-eaf1-4d05-8a1c-1a10f142ed07.png)

