### PR TITLE
feat(ui): build device delete interface form

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.test.tsx
@@ -1,0 +1,127 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import RemoveInterface from "./RemoveInterface";
+
+import * as analyticsHooks from "app/base/hooks/analytics";
+import * as baseHooks from "app/base/hooks/base";
+import { actions as deviceActions } from "app/store/device";
+import type { RootState } from "app/store/root/types";
+import {
+  deviceDetails as deviceDetailsFactory,
+  deviceEventError as deviceEventErrorFactory,
+  deviceState as deviceStateFactory,
+  deviceStatus as deviceStatusFactory,
+  deviceStatuses as deviceStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("RemoveInterface", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [deviceDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+        statuses: deviceStatusesFactory({
+          abc123: deviceStatusFactory(),
+        }),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("sends an analytics event and closes the form when saved", () => {
+    const closeExpanded = jest.fn();
+    const useSendMock = jest.spyOn(analyticsHooks, "useSendAnalyticsWhen");
+    // Mock interface successfully being deleted.
+    jest.spyOn(baseHooks, "useCycled").mockReturnValue([true, () => null]);
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <RemoveInterface
+          closeExpanded={closeExpanded}
+          nicId={1}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(closeExpanded).toHaveBeenCalled();
+    expect(useSendMock.mock.calls[0]).toEqual([
+      true,
+      "Device network",
+      "Remove interface",
+      "Remove",
+    ]);
+  });
+
+  it("can show errors related to deleting the interface", () => {
+    state.device.eventErrors = [
+      deviceEventErrorFactory({
+        id: "someOtherDevice",
+        error: "Some other error for some other device",
+        event: "someOtherError",
+      }),
+      deviceEventErrorFactory({
+        id: "abc123",
+        error: "Some other error for this device",
+        event: "someOtherError",
+      }),
+      deviceEventErrorFactory({
+        id: "abc123",
+        error: "Delete interface error for this device",
+        event: "deleteInterface",
+      }),
+      deviceEventErrorFactory({
+        id: "someOtherDevice",
+        error: "Delete interface error for this device",
+        event: "deleteInterface",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RemoveInterface
+          closeExpanded={jest.fn()}
+          nicId={1}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-testid='error-message']").text()).toBe(
+      "Delete interface error for this device"
+    );
+  });
+
+  it("correctly dispatches an action to delete an interface", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RemoveInterface
+          closeExpanded={jest.fn()}
+          nicId={1}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    wrapper.find("button[data-testid='confirm-delete']").simulate("click");
+
+    const expectedAction = deviceActions.deleteInterface({
+      interface_id: 1,
+      system_id: "abc123",
+    });
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from "react";
+
+import {
+  ActionButton,
+  Button,
+  Col,
+  Notification,
+  Row,
+} from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import { useCycled, useSendAnalyticsWhen } from "app/base/hooks";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type {
+  Device,
+  DeviceMeta,
+  DeviceNetworkInterface,
+} from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+import { formatErrors } from "app/utils";
+
+type Props = {
+  closeExpanded: () => void;
+  nicId: DeviceNetworkInterface["id"];
+  systemId: Device[DeviceMeta.PK];
+};
+
+const RemoveInterface = ({
+  closeExpanded,
+  nicId,
+  systemId,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const deletingInterface = useSelector((state: RootState) =>
+    deviceSelectors.getStatusForDevice(state, systemId, "deletingInterface")
+  );
+  const deleteInterfaceError = useSelector((state: RootState) =>
+    deviceSelectors.eventErrorsForDevices(state, systemId, "deleteInterface")
+  )[0]?.error;
+  const [deletedInterface] = useCycled(
+    !deletingInterface && !deleteInterfaceError
+  );
+  useSendAnalyticsWhen(
+    deletedInterface,
+    "Device network",
+    "Remove interface",
+    "Remove"
+  );
+  useEffect(() => {
+    if (deletedInterface) {
+      closeExpanded();
+    }
+  }, [closeExpanded, deletedInterface]);
+
+  return (
+    <Row>
+      {deleteInterfaceError ? (
+        <Notification severity="negative">
+          <span data-testid="error-message">
+            {formatErrors(deleteInterfaceError)}
+          </span>
+        </Notification>
+      ) : null}
+      <Col size={8}>
+        <p className="u-no-margin--bottom u-no-max-width">
+          <i className="p-icon--warning is-inline">Warning</i>
+          Are you sure you want to remove this interface?
+        </p>
+      </Col>
+      <Col size={4} className="u-align--right">
+        <Button className="u-no-margin--bottom" onClick={closeExpanded}>
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="negative"
+          className="u-no-margin--bottom"
+          data-testid="confirm-delete"
+          loading={deletingInterface}
+          onClick={() => {
+            dispatch(deviceActions.cleanup());
+            dispatch(
+              deviceActions.deleteInterface({
+                interface_id: nicId,
+                system_id: systemId,
+              })
+            );
+          }}
+          type="button"
+        >
+          Remove
+        </ActionButton>
+      </Col>
+    </Row>
+  );
+};
+
+export default RemoveInterface;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RemoveInterface";


### PR DESCRIPTION
## Done

- Added table action menu to devices table
- Added delete device interface confirmation

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab for a device
- Click the action dropdown for an interface and select "Remove Physical"
- Confirm by clicking "Remove" and check that the interface is deleted successfully

## Fixes

Fixes canonical-web-and-design/app-tribe#542
Fixes canonical-web-and-design/app-tribe#596

## Screenshot

![Screenshot 2021-12-10 at 10-52-48 test-device test network bolla MAAS](https://user-images.githubusercontent.com/25733845/145499880-54553f10-7128-4701-a305-2562276b633c.png)

