### PR TITLE
fix(ui): re-add removed KVM form cancel buttons

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
@@ -452,6 +452,7 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
           zone: `${zones[0]?.id}` || "",
         }}
         modelName="machine"
+        onCancel={clearHeaderContent}
         onSaveAnalytics={{
           action: "Submit",
           category: "KVM details action form",

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -86,6 +86,7 @@ const DeleteForm = ({
         decompose: false,
       }}
       modelName={pod ? "KVM host" : "cluster"}
+      onCancel={clearHeaderContent}
       onSaveAnalytics={{
         action: "Submit",
         category: "KVM details action form",

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.tsx
@@ -29,6 +29,7 @@ const RefreshForm = ({
       errors={errors}
       initialValues={{}}
       modelName="KVM host"
+      onCancel={clearHeaderContent}
       onSaveAnalytics={{
         action: "Submit",
         category: "KVM details action form",


### PR DESCRIPTION
## Done

- Added missing "Cancel" buttons in KVM forms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM's details page and open each of the "Compose", "Refresh" and "Delete" forms
- There should be a cancel button that closes the form for each of them

## Fixes

Fixes #3415 
