### PR TITLE
enable local cypress configuration

### DIFF
--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -19,6 +19,7 @@ yarn.lock
 # cypress
 cypress/screenshots
 cypress/videos
+cypress.env.json
 
 # misc
 *.swp

--- a/integration/README.md
+++ b/integration/README.md
@@ -16,14 +16,16 @@ This will automatically start legacy, ui and proxy servers and run the Cypress t
 
 ## Edit local configuration
 
-By default cypress will run tests using configuration defined in cypress.json.
+By default, cypress will run tests using the configuration defined in [cypress.json](/integration/cypress.json).
 
-If you wish to overwrite any of the settings (like test a MAAS under a different URL or username/password) you can create a local configuration file:
+If you wish to overwrite any of the settings (e.g. MAAS URL or username/password) you can create a local configuration file:
 
 ```shell
 cd integration
 touch cypress.env.json
 ```
+
+Values from `cypress.env.json` will overwrite conflicting variables in the main `cypress.json` configuration file.
 
 ## Developing cypress tests
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -14,6 +14,17 @@ yarn test-cypress
 
 This will automatically start legacy, ui and proxy servers and run the Cypress tests, in which results are logged to the console. After running the tests, the servers and process will close.
 
+## Edit local configuration
+
+By default cypress will run tests using configuration defined in cypress.json.
+
+If you wish to overwrite any of the settings (like test a MAAS under a different URL or username/password) you can create a local configuration file:
+
+```shell
+cd integration
+touch cypress.env.json
+```
+
 ## Developing cypress tests
 
 ### On your host machine

--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:8400",
+  "baseUrl": "http://0.0.0.0:8400",
   "env": {
     "username": "admin",
     "password": "test"

--- a/integration/package.json
+++ b/integration/package.json
@@ -10,8 +10,8 @@
     "cypress-test": "yarn --cwd ../shared build && start-server-and-test serve-frontends '8401|8402' serve-base 'tcp:8400|8404' cypress-run",
     "serve-frontends": "yarn --cwd ../proxy serve-frontends",
     "serve-base": "yarn --cwd ../proxy serve-base",
-    "cypress-run": "yarn cypress run -c baseUrl=http://0.0.0.0:8400",
-    "cypress-open": "yarn cypress open -c baseUrl=http://0.0.0.0:8400"
+    "cypress-run": "yarn cypress run",
+    "cypress-open": "yarn cypress open"
   },
   "devDependencies": {
     "@maas-ui/maas-ui-shared": "3.2.0",


### PR DESCRIPTION
## Done

- enable local cypress configuration
  - remove fixed baseUrl from npm scripts
  - move the default baseUrl to cypress.json
  - add description to README


## Fixes

Fixes: #594 .
