### PR TITLE
fix(single-spa): fix maas in Safari for 3.0

### DIFF
--- a/ui/src/single-spa-entry.js
+++ b/ui/src/single-spa-entry.js
@@ -27,14 +27,13 @@ const reactLifecycles = singleSpaReact({
 
 export const { bootstrap } = reactLifecycles;
 export const mount = (props) => {
-  // Get the full path, querystring and hash. The regex gets the first
-  // forward slash that is not a double forward slash and everything after it.
-  const matches = window.location.href.match(/(?<!\/)\/(?!\/).+/);
-  // The app should never reach this entrypoint witout the basename and react
+  const { pathname, search, hash } = window.location;
+  const location = pathname + search + hash;
+  // The app should never reach this entrypoint without the basename and react
   // path set, but to prevent possible future problems this sets the path if
   // there isn't one already.
-  let currentURL =
-    matches && matches.length ? matches[0] : `/${BASENAME}/${REACT_BASENAME}`;
+  const baseURL = `${BASENAME}${REACT_BASENAME}`;
+  let currentURL = location.startsWith(baseURL) ? location : baseURL;
   // When the app is mounted there needs to be a history change so that
   // react-router updates with the new url. This is re-queried when navigating
   // between the new/legacy clients.


### PR DESCRIPTION
## Done

- Backport the fix for loading the UI in Safari to 3.0 (3.1 PR here: https://github.com/canonical-web-and-design/maas-ui/pull/3220).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the app with `yarn start, so that you are viewing the site with single-spa.
- Open the ui in Safari, it should load.
- Double check that it still works in Firefox/Chrome.

## Fixes

Fixes: canonical-web-and-design/maas-ui#3426.