### PR TITLE
refactor(ui): make the device interface form reusable

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.tsx
@@ -1,13 +1,10 @@
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 
-import AddInterfaceFields from "./AddInterfaceFields";
+import InterfaceForm from "../InterfaceForm";
 
 import FormCard from "app/base/components/FormCard";
-import FormikForm from "app/base/components/FormikForm";
 import { useCycled, useScrollOnRender } from "app/base/hooks";
-import { MAC_ADDRESS_REGEX } from "app/base/validation";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type {
@@ -15,12 +12,8 @@ import type {
   Device,
   DeviceMeta,
 } from "app/store/device/types";
-import { DeviceIpAssignment } from "app/store/device/types";
 import { isDeviceDetails } from "app/store/device/utils";
 import type { RootState } from "app/store/root/types";
-import type { Subnet, SubnetMeta } from "app/store/subnet/types";
-import { NetworkInterfaceTypes } from "app/store/types/enum";
-import { getNextNicName } from "app/store/utils";
 import { preparePayload } from "app/utils";
 
 type Props = {
@@ -28,41 +21,11 @@ type Props = {
   systemId: Device[DeviceMeta.PK];
 };
 
-export type AddInterfaceValues = {
-  ip_address: string;
-  ip_assignment: DeviceIpAssignment;
-  mac_address: string;
-  name: string;
-  subnet: Subnet[SubnetMeta.PK] | "";
-  tags: string[];
-};
-
-const AddInterfaceSchema = Yup.object().shape({
-  ip_address: Yup.string().when("ip_assignment", {
-    is: (ipAssignment: DeviceIpAssignment) =>
-      ipAssignment === DeviceIpAssignment.STATIC ||
-      ipAssignment === DeviceIpAssignment.EXTERNAL,
-    then: Yup.string().required("IP address is required"),
-  }),
-  ip_assignment: Yup.string().required("IP assignment is required"),
-  mac_address: Yup.string()
-    .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
-    .required("MAC address is required"),
-  name: Yup.string(),
-  subnet: Yup.number().when("ip_assignment", {
-    is: (ipAssignment: DeviceIpAssignment) =>
-      ipAssignment === DeviceIpAssignment.STATIC,
-    then: Yup.number().required("Subnet is required"),
-  }),
-  tags: Yup.array().of(Yup.string()),
-});
-
 const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const device = useSelector((state: RootState) =>
     deviceSelectors.getById(state, systemId)
   );
-  const errors = useSelector(deviceSelectors.errors);
   const creatingInterface = useSelector((state: RootState) =>
     deviceSelectors.getStatusForDevice(state, systemId, "creatingInterface")
   );
@@ -79,27 +42,16 @@ const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
   if (!isDeviceDetails(device)) {
     return <Spinner data-testid="loading-device-details" text="Loading..." />;
   }
-  const nextName = getNextNicName(device, NetworkInterfaceTypes.PHYSICAL);
   return (
     <div ref={onRenderRef}>
       <FormCard sidebar={false}>
-        <FormikForm<AddInterfaceValues>
-          cleanup={deviceActions.cleanup}
-          errors={errors}
-          initialValues={{
-            ip_address: "",
-            ip_assignment: DeviceIpAssignment.DYNAMIC,
-            mac_address: "",
-            name: nextName || "",
-            subnet: "",
-            tags: [],
-          }}
+        <InterfaceForm
+          closeForm={closeForm}
           onSaveAnalytics={{
             action: "Add interface",
             category: "Device details networking",
             label: "Add interface form",
           }}
-          onCancel={closeForm}
           onSubmit={(values) => {
             resetCreatedInterface();
             dispatch(deviceActions.cleanup());
@@ -109,14 +61,10 @@ const AddInterface = ({ closeForm, systemId }: Props): JSX.Element => {
             }) as CreateInterfaceParams;
             dispatch(deviceActions.createInterface(payload));
           }}
-          onSuccess={closeForm}
           saved={saved}
           saving={creatingInterface}
-          submitLabel="Save interface"
-          validationSchema={AddInterfaceSchema}
-        >
-          <AddInterfaceFields />
-        </FormikForm>
+          systemId={systemId}
+        />
       </FormCard>
     </div>
   );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterfaceFields/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./AddInterfaceFields";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.test.tsx
@@ -1,0 +1,146 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import InterfaceForm from "./InterfaceForm";
+
+import FormikForm from "app/base/components/FormikForm";
+import type { DeviceNetworkInterface } from "app/store/device/types";
+import { DeviceIpAssignment } from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import {
+  device as deviceFactory,
+  deviceDetails as deviceDetailsFactory,
+  deviceInterface as deviceInterfaceFactory,
+  deviceState as deviceStateFactory,
+  deviceStatus as deviceStatusFactory,
+  deviceStatuses as deviceStatusesFactory,
+  fabric as fabricFactory,
+  networkLink as networkLinkFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("InterfaceForm", () => {
+  let state: RootState;
+  let nic: DeviceNetworkInterface;
+  beforeEach(() => {
+    nic = deviceInterfaceFactory();
+    state = rootStateFactory({
+      device: deviceStateFactory({
+        items: [
+          deviceDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        loaded: true,
+        statuses: deviceStatusesFactory({
+          abc123: deviceStatusFactory(),
+        }),
+      }),
+      subnet: subnetStateFactory({
+        items: [subnetFactory({ id: 1 }), subnetFactory({ id: 2 })],
+        loaded: true,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("displays a spinner if device is not detailed version", () => {
+    state.device.items[0] = deviceFactory({ system_id: "abc123" });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceForm
+          nicId={nic.id}
+          onSubmit={jest.fn()}
+          systemId="abc123"
+          closeForm={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-testid='loading-device-details']").exists()
+    ).toBe(true);
+  });
+
+  it("prefills the initial data if an existing nic is provided", () => {
+    const nicData = {
+      ip_address: "192.168.1.1",
+      ip_assignment: DeviceIpAssignment.STATIC,
+      mac_address: "11:22:33:44:55:66",
+      name: "eth123",
+      tags: ["tag1", "tag2"],
+    };
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    state.vlan.items = [vlan];
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    state.subnet.items = [subnet];
+    const link = networkLinkFactory({ subnet_id: subnet.id });
+    nic = deviceInterfaceFactory({
+      ...nicData,
+      discovered: [],
+      links: [link],
+      type: NetworkInterfaceTypes.PHYSICAL,
+      vlan_id: vlan.id,
+    });
+    state.device.items = [
+      deviceDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceForm
+          nicId={nic.id}
+          linkId={link.id}
+          onSubmit={jest.fn()}
+          closeForm={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find(FormikForm).prop("initialValues")).toStrictEqual({
+      ...nicData,
+      subnet: subnet.id,
+    });
+  });
+
+  it("sets the initial data if no nic is provided", () => {
+    state.device.items[0] = deviceDetailsFactory({
+      interfaces: [deviceInterfaceFactory({ name: "eth20" })],
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceForm
+          onSubmit={jest.fn()}
+          closeForm={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find(FormikForm).prop("initialValues")).toStrictEqual({
+      ip_address: "",
+      ip_assignment: DeviceIpAssignment.DYNAMIC,
+      mac_address: "",
+      name: "eth21",
+      subnet: "",
+      tags: [],
+    });
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.tsx
@@ -1,0 +1,146 @@
+import { useEffect } from "react";
+
+import type { PropsWithSpread } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import InterfaceFormFields from "./InterfaceFormFields";
+
+import type { FormikFormProps } from "app/base/components/FormikForm";
+import FormikForm from "app/base/components/FormikForm";
+import { useIsAllNetworkingDisabled } from "app/base/hooks";
+import { MAC_ADDRESS_REGEX } from "app/base/validation";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type {
+  Device,
+  DeviceMeta,
+  DeviceNetworkInterface,
+} from "app/store/device/types";
+import { DeviceIpAssignment } from "app/store/device/types";
+import { isDeviceDetails } from "app/store/device/utils";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import type { NetworkLink } from "app/store/types/node";
+import {
+  getInterfaceSubnet,
+  getLinkFromNic,
+  getNextNicName,
+} from "app/store/utils";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = PropsWithSpread<
+  {
+    closeForm: () => void;
+    linkId?: NetworkLink["id"] | null;
+    nicId?: DeviceNetworkInterface["id"] | null;
+    onSubmit: FormikFormProps<InterfaceFormValues>["onSubmit"];
+    showTitles?: boolean;
+    systemId: Device[DeviceMeta.PK];
+  },
+  Partial<Omit<FormikFormProps<InterfaceFormValues>, "onSubmit">>
+>;
+
+export type InterfaceFormValues = {
+  ip_address: string;
+  ip_assignment: DeviceIpAssignment;
+  mac_address: string;
+  name: string;
+  subnet: Subnet[SubnetMeta.PK] | "";
+  tags: string[];
+};
+
+const InterfaceFormSchema = Yup.object().shape({
+  ip_address: Yup.string().when("ip_assignment", {
+    is: (ipAssignment: DeviceIpAssignment) =>
+      ipAssignment === DeviceIpAssignment.STATIC ||
+      ipAssignment === DeviceIpAssignment.EXTERNAL,
+    then: Yup.string().required("IP address is required"),
+  }),
+  ip_assignment: Yup.string().required("IP assignment is required"),
+  mac_address: Yup.string()
+    .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
+    .required("MAC address is required"),
+  name: Yup.string(),
+  subnet: Yup.number().when("ip_assignment", {
+    is: (ipAssignment: DeviceIpAssignment) =>
+      ipAssignment === DeviceIpAssignment.STATIC,
+    then: Yup.number().required("Subnet is required"),
+  }),
+  tags: Yup.array().of(Yup.string()),
+});
+
+const InterfaceForm = ({
+  closeForm,
+  linkId,
+  showTitles,
+  nicId,
+  onSubmit,
+  systemId,
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const fabrics = useSelector(fabricSelectors.all);
+  const subnets = useSelector(subnetSelectors.all);
+  const vlans = useSelector(vlanSelectors.all);
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, systemId)
+  );
+  const nic = useSelector((state: RootState) =>
+    deviceSelectors.getInterfaceById(state, systemId, nicId, linkId)
+  );
+  const link = getLinkFromNic(nic, linkId);
+  const errors = useSelector(deviceSelectors.errors);
+  const isAllNetworkingDisabled = useIsAllNetworkingDisabled(device);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+    dispatch(subnetActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  if (!isDeviceDetails(device)) {
+    return <Spinner data-testid="loading-device-details" text="Loading..." />;
+  }
+  const nextName = getNextNicName(device, NetworkInterfaceTypes.PHYSICAL);
+  const subnet = getInterfaceSubnet(
+    device,
+    subnets,
+    fabrics,
+    vlans,
+    isAllNetworkingDisabled,
+    nic,
+    link
+  );
+  return (
+    <FormikForm<InterfaceFormValues>
+      cleanup={deviceActions.cleanup}
+      errors={errors}
+      initialValues={{
+        ip_address: nic?.ip_address || "",
+        ip_assignment: nic?.ip_assignment || DeviceIpAssignment.DYNAMIC,
+        mac_address: nic?.mac_address || "",
+        name: nic?.name || nextName || "",
+        subnet: subnet?.id || "",
+        tags: nic?.tags || [],
+      }}
+      onCancel={closeForm}
+      onSubmit={onSubmit}
+      onSuccess={closeForm}
+      submitLabel="Save interface"
+      validationSchema={InterfaceFormSchema}
+      {...props}
+    >
+      <InterfaceFormFields showTitles={showTitles} />
+    </FormikForm>
+  );
+};
+
+export default InterfaceForm;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.test.tsx
@@ -3,9 +3,9 @@ import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import type { AddInterfaceValues } from "../AddInterface";
+import type { InterfaceFormValues } from "../InterfaceForm";
 
-import AddInterfaceFields from "./AddInterfaceFields";
+import InterfaceFormFields from "./InterfaceFormFields";
 
 import { DeviceIpAssignment } from "app/store/device/types";
 import type { RootState } from "app/store/root/types";
@@ -18,8 +18,8 @@ import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
-describe("AddInterfaceFields", () => {
-  let initialValues: AddInterfaceValues;
+describe("InterfaceFormFields", () => {
+  let initialValues: InterfaceFormValues;
   let state: RootState;
   beforeEach(() => {
     initialValues = {
@@ -38,13 +38,45 @@ describe("AddInterfaceFields", () => {
     });
   });
 
+  it("can render without headings", () => {
+    initialValues.ip_assignment = DeviceIpAssignment.DYNAMIC;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <InterfaceFormFields />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-testid='interface-form-heading']").exists()
+    ).toBe(false);
+  });
+
+  it("can render with headings", () => {
+    initialValues.ip_assignment = DeviceIpAssignment.DYNAMIC;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <InterfaceFormFields showTitles />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-testid='interface-form-heading']").exists()
+    ).toBe(true);
+  });
+
   it("does not show subnet or IP address fields for dynamic IP assignment", () => {
     initialValues.ip_assignment = DeviceIpAssignment.DYNAMIC;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <AddInterfaceFields />
+          <InterfaceFormFields />
         </Formik>
       </Provider>
     );
@@ -61,7 +93,7 @@ describe("AddInterfaceFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <AddInterfaceFields />
+          <InterfaceFormFields />
         </Formik>
       </Provider>
     );
@@ -78,7 +110,7 @@ describe("AddInterfaceFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <AddInterfaceFields />
+          <InterfaceFormFields />
         </Formik>
       </Provider>
     );
@@ -97,7 +129,7 @@ describe("AddInterfaceFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <AddInterfaceFields />
+          <InterfaceFormFields />
         </Formik>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.tsx
@@ -3,7 +3,7 @@ import type { ChangeEvent } from "react";
 import { Col, Input, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
-import type { AddInterfaceValues } from "../AddInterface";
+import type { InterfaceFormValues } from "../InterfaceForm";
 
 import FormikField from "app/base/components/FormikField";
 import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
@@ -12,24 +12,43 @@ import SubnetSelect from "app/base/components/SubnetSelect";
 import TagField from "app/base/components/TagField";
 import { DeviceIpAssignment } from "app/store/device/types";
 
-const AddInterfaceFields = (): JSX.Element => {
+type Props = {
+  showTitles?: boolean;
+};
+
+const InterfaceFormFields = ({ showTitles = false }: Props): JSX.Element => {
   const { handleChange, setFieldValue, values } =
-    useFormikContext<AddInterfaceValues>();
+    useFormikContext<InterfaceFormValues>();
   const showSubnetField = values.ip_assignment === DeviceIpAssignment.STATIC;
   const showIpAddressField =
     values.ip_assignment === DeviceIpAssignment.STATIC ||
     values.ip_assignment === DeviceIpAssignment.EXTERNAL;
 
+  const nameField = <FormikField label="Name" type="text" name="name" />;
+
   return (
     <>
+      {showTitles ? null : (
+        <>
+          <Row>
+            <Col size={6}>{nameField}</Col>
+          </Row>
+          <hr />
+        </>
+      )}
       <Row>
         <Col size={6}>
-          <FormikField label="Name" type="text" name="name" />
-        </Col>
-      </Row>
-      <hr />
-      <Row>
-        <Col size={6}>
+          {showTitles ? (
+            <>
+              <h3
+                className="p-heading--five u-no-margin--bottom"
+                data-testid="interface-form-heading"
+              >
+                Physical details
+              </h3>
+              {nameField}
+            </>
+          ) : null}
           <Input
             disabled
             label="Type"
@@ -41,6 +60,14 @@ const AddInterfaceFields = (): JSX.Element => {
           <TagField name="tags" />
         </Col>
         <Col size={6}>
+          {showTitles ? (
+            <h3
+              className="p-heading--five u-no-margin--bottom"
+              data-testid="interface-form-heading"
+            >
+              Network
+            </h3>
+          ) : null}
           <IpAssignmentSelect
             data-testid="ip-assignment-field"
             name="ip_assignment"
@@ -67,4 +94,4 @@ const AddInterfaceFields = (): JSX.Element => {
   );
 };
 
-export default AddInterfaceFields;
+export default InterfaceFormFields;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InterfaceFormFields";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InterfaceForm";


### PR DESCRIPTION
## Done

- Update the device interface form to be reusable for adding and editing interfaces.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/devices.
- Click on a device and then go to the network tab.
- You should be able to add interfaces as you could previously.

## Fixes

Fixes: canonical-web-and-design/app-tribe#603.