### PR TITLE
feat(ui): split ip address and mode column

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -112,9 +112,7 @@ describe("DeviceNetworkTable", () => {
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
       "Unconfigured"
     );
-    expect(wrapper.find("[data-testid='ip-address']").text()).toBe(
-      "Unconfigured"
-    );
+    expect(wrapper.find("[data-testid='ip-mode']").text()).toBe("Unconfigured");
   });
 
   it("can display an interface that has a link", () => {

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
@@ -117,9 +117,7 @@ const generateRow = (
         ),
       },
       {
-        content: (
-          <span data-testid="ip-address">{getLinkModeDisplay(link)}</span>
-        ),
+        content: <span data-testid="ip-mode">{getLinkModeDisplay(link)}</span>,
       },
       {
         className: "u-align--right",

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
@@ -30,11 +30,12 @@ import type { Subnet } from "app/store/subnet/types";
 import { getSubnetDisplay } from "app/store/subnet/utils";
 import type { NetworkInterface, NetworkLink } from "app/store/types/node";
 import {
-  getInterfaceIPAddressOrMode,
+  getInterfaceIPAddress,
   getInterfaceName,
   getInterfaceSubnet,
   getInterfaceTypeText,
   getLinkInterface,
+  getLinkModeDisplay,
 } from "app/store/utils";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -42,7 +43,8 @@ import type { VLAN } from "app/store/vlan/types";
 import { isComparable } from "app/utils";
 
 type NetworkRowSortData = {
-  ip: string | null;
+  ip_address: string | null;
+  ip_mode: string | null;
   mac_address: NetworkInterface["mac_address"];
   subnet: string | null;
 };
@@ -110,8 +112,13 @@ const generateRow = (
       {
         content: (
           <span data-testid="ip-address">
-            {getInterfaceIPAddressOrMode(device, fabrics, vlans, nic, link)}
+            {getInterfaceIPAddress(device, fabrics, vlans, nic, link)}
           </span>
+        ),
+      },
+      {
+        content: (
+          <span data-testid="ip-address">{getLinkModeDisplay(link)}</span>
         ),
       },
       {
@@ -164,8 +171,9 @@ const generateRow = (
     ),
     key: name,
     sortData: {
-      ip:
-        getInterfaceIPAddressOrMode(device, fabrics, vlans, nic, link) || null,
+      ip_address:
+        getInterfaceIPAddress(device, fabrics, vlans, nic, link) || null,
+      ip_mode: getLinkModeDisplay(link) || null,
       mac_address: nic.mac_address,
       subnet: getSubnetDisplay(subnet),
     },
@@ -293,10 +301,21 @@ const DeviceNetworkTable = ({
           content: (
             <TableHeader
               currentSort={currentSort}
-              onClick={() => updateSort("ip")}
-              sortKey="ip"
+              onClick={() => updateSort("ip_address")}
+              sortKey="ip_address"
             >
               IP Address
+            </TableHeader>
+          ),
+        },
+        {
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              onClick={() => updateSort("ip_mode")}
+              sortKey="ip_mode"
+            >
+              IP mode
             </TableHeader>
           ),
         },

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/_index.scss
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/_index.scss
@@ -10,13 +10,16 @@
         @include breakpoint-widths(0.3);
       }
       &:nth-child(2) {
-        @include breakpoint-widths(0.3);
+        @include breakpoint-widths(0.2);
       }
       &:nth-child(3) {
-        @include breakpoint-widths(0.3);
+        @include breakpoint-widths(0.2);
       }
       &:nth-child(4) {
-        @include breakpoint-widths(10);
+        @include breakpoint-widths(0.2);
+      }
+      &:nth-child(5) {
+        @include breakpoint-widths(0.1);
       }
     }
   }


### PR DESCRIPTION
## Done

- Split the ip address and mode columns in the device interfaces table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a device's details page and click on the network tab.
- Check that the ip address and mode are in separate columns.

## Fixes

Fixes: canonical-web-and-design/app-tribe#605.

## Screenshots

<img width="1420" alt="Screen Shot 2022-01-04 at 12 46 26 pm" src="https://user-images.githubusercontent.com/361637/147999229-1e232d3d-3838-4849-a221-d56c38504aba.png">
