### PR TITLE
feat(ui): add the edit interface form table

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.tsx
@@ -3,6 +3,8 @@ import { useDispatch, useSelector } from "react-redux";
 
 import InterfaceForm from "../InterfaceForm";
 
+import EditInterfaceTable from "./EditInterfaceTable";
+
 import FormCard from "app/base/components/FormCard";
 import { useCycled } from "app/base/hooks";
 import { actions as deviceActions } from "app/store/device";
@@ -53,6 +55,7 @@ const EditInterface = ({
   }
   return (
     <FormCard sidebar={false} stacked title="Edit physical">
+      <EditInterfaceTable linkId={linkId} nicId={nicId} systemId={systemId} />
       <InterfaceForm
         closeForm={closeForm}
         linkId={linkId}

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
@@ -102,8 +102,6 @@ describe("EditInterfaceTable", () => {
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
       "Unconfigured"
     );
-    expect(wrapper.find("[data-testid='ip-address']").text()).toBe(
-      "Unconfigured"
-    );
+    expect(wrapper.find("[data-testid='ip-mode']").text()).toBe("Unconfigured");
   });
 });

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
@@ -1,0 +1,109 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import EditInterfaceTable from "./EditInterfaceTable";
+
+import type { DeviceNetworkInterface } from "app/store/device/types";
+import type { RootState } from "app/store/root/types";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import {
+  deviceDetails as deviceDetailsFactory,
+  deviceInterface as deviceInterfaceFactory,
+  deviceState as deviceStateFactory,
+  deviceStatus as deviceStatusFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("EditInterfaceTable", () => {
+  let state: RootState;
+  let nic: DeviceNetworkInterface;
+  beforeEach(() => {
+    nic = deviceInterfaceFactory();
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        loaded: true,
+      }),
+      device: deviceStateFactory({
+        items: [
+          deviceDetailsFactory({ interfaces: [nic], system_id: "abc123" }),
+        ],
+        loaded: true,
+        statuses: {
+          abc123: deviceStatusFactory(),
+        },
+      }),
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.device.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a table when loaded", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+
+  it("can display an interface", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    state.vlan.items = [vlan];
+    const subnets = [
+      subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" }),
+      subnetFactory({ cidr: "subnet2-cidr", name: "subnet2-name" }),
+    ];
+    state.subnet.items = subnets;
+    nic = deviceInterfaceFactory({
+      discovered: null,
+      links: [],
+      type: NetworkInterfaceTypes.PHYSICAL,
+      vlan_id: vlan.id,
+    });
+    state.device.items = [
+      deviceDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
+      "Unconfigured"
+    );
+    expect(wrapper.find("[data-testid='ip-address']").text()).toBe(
+      "Unconfigured"
+    );
+  });
+});

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.tsx
@@ -1,0 +1,139 @@
+import { useEffect } from "react";
+
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import TableHeader from "app/base/components/TableHeader";
+import DHCPColumn from "app/base/components/node/networking/DHCPColumn";
+import FabricColumn from "app/base/components/node/networking/FabricColumn";
+import NameColumn from "app/base/components/node/networking/NameColumn";
+import SubnetColumn from "app/base/components/node/networking/SubnetColumn";
+import deviceSelectors from "app/store/device/selectors";
+import type {
+  Device,
+  DeviceMeta,
+  DeviceNetworkInterface,
+} from "app/store/device/types";
+import { isDeviceDetails } from "app/store/device/utils";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { RootState } from "app/store/root/types";
+import type { NetworkLink } from "app/store/types/node";
+import {
+  getInterfaceIPAddress,
+  getInterfaceTypeText,
+  getLinkFromNic,
+  getLinkModeDisplay,
+} from "app/store/utils";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = {
+  linkId?: NetworkLink["id"] | null;
+  nicId?: DeviceNetworkInterface["id"] | null;
+  systemId: Device[DeviceMeta.PK];
+};
+
+const EditInterfaceTable = ({
+  linkId,
+  nicId,
+  systemId,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const device = useSelector((state: RootState) =>
+    deviceSelectors.getById(state, systemId)
+  );
+  const fabrics = useSelector(fabricSelectors.all);
+  const vlans = useSelector(vlanSelectors.all);
+  const nic = useSelector((state: RootState) =>
+    deviceSelectors.getInterfaceById(state, systemId, nicId, linkId)
+  );
+  const link = getLinkFromNic(nic, linkId);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  if (!isDeviceDetails(device) || !nic) {
+    return <Spinner text="Loading..." />;
+  }
+  const typeDisplay = getInterfaceTypeText(device, nic, link);
+  return (
+    <MainTable
+      headers={[
+        {
+          content: (
+            <div>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Mac</TableHeader>
+            </div>
+          ),
+        },
+        {
+          content: <TableHeader>Type</TableHeader>,
+        },
+        {
+          content: (
+            <div>
+              <TableHeader>Fabric</TableHeader>
+              <TableHeader>Vlan</TableHeader>
+            </div>
+          ),
+        },
+        {
+          content: <TableHeader>Subnet</TableHeader>,
+        },
+        {
+          content: <TableHeader>IP address</TableHeader>,
+        },
+        {
+          content: <TableHeader>IP mode</TableHeader>,
+        },
+        {
+          content: (
+            <TableHeader className="p-double-row__header-spacer">
+              DHCP
+            </TableHeader>
+          ),
+        },
+      ]}
+      rows={[
+        {
+          columns: [
+            {
+              content: <NameColumn link={link} nic={nic} node={device} />,
+            },
+            {
+              content: typeDisplay,
+            },
+            {
+              content: <FabricColumn link={link} nic={nic} node={device} />,
+            },
+            {
+              content: <SubnetColumn link={link} nic={nic} node={device} />,
+            },
+            {
+              content: (
+                <span data-testid="ip-address">
+                  {getInterfaceIPAddress(device, fabrics, vlans, nic, link)}
+                </span>
+              ),
+            },
+            {
+              content: (
+                <span data-testid="ip-mode">{getLinkModeDisplay(link)}</span>
+              ),
+            },
+            {
+              content: <DHCPColumn nic={nic} />,
+            },
+          ],
+          key: systemId,
+        },
+      ]}
+    />
+  );
+};
+
+export default EditInterfaceTable;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditInterfaceTable";


### PR DESCRIPTION
## Done

- Add a table to the edit interface form to display the interface's details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a device's details.
- Click on the network tab.
- Open the row menu for an interface and click on "Edit physical".
- You should see a table above the form fields that contains the interface's details.

## Fixes

Fixes: canonical-web-and-design/app-tribe#604.