### PR TITLE
fix(all): fix webpack-dev-server config

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -24,7 +24,7 @@
     "prettier": "prettier --write 'src/**/*.{js,scss}' '!**/build.scss' '!**/*-min.js'",
     "prettier-check": "prettier --check 'src/**/*.{js,scss}' '!**/build.scss' '!**/*-min.js'",
     "prepublishOnly": "yarn build",
-    "start": "NODE_ENV=development webpack serve --config webpack.dev.js --port 8402 --host 0.0.0.0 --disable-host-check",
+    "start": "NODE_ENV=development webpack serve --config webpack.dev.js",
     "test": "jest",
     "watch": "NODE_ENV=development webpack --watch"
   },

--- a/legacy/webpack.dev.js
+++ b/legacy/webpack.dev.js
@@ -8,15 +8,24 @@ const common = require("./webpack.common.js");
 module.exports = merge(common, {
   mode: "development",
   devServer: {
-    contentBase: path.resolve(__dirname, "./src"),
-    host: "0.0.0.0",
-    // This may not be necessary once https://github.com/webpack/webpack-dev-server/issues/2484 is released.
-    injectClient: false,
+    allowedHosts: "all",
+    client: {
+      webSocketURL: {
+        hostname: "0.0.0.0",
+        pathname: "/sockjs-legacy",
+        port: 8400,
+      },
+    },
     compress: true,
-    public: "0.0.0.0:8400",
-    publicPath: BASENAME,
-    sockPath: "/sockjs-legacy",
-    writeToDisk: true,
+    devMiddleware: {
+      publicPath: BASENAME,
+      writeToDisk: true,
+    },
+    host: "0.0.0.0",
+    port: 8402,
+    static: {
+      directory: path.resolve(__dirname, "./src"),
+    },
   },
   devtool: "eval-source-map",
   plugins: [

--- a/root/package.json
+++ b/root/package.json
@@ -4,7 +4,7 @@
   "description": "SingleSPA app which registers maas-ui-legacy and maas-ui apps.",
   "main": "src/root-application.js",
   "scripts": {
-    "start": "GIT_SHA=`git rev-parse --short HEAD` webpack serve --host 0.0.0.0 --port 8404 --config webpack.dev.js",
+    "start": "GIT_SHA=`git rev-parse --short HEAD` webpack serve --config webpack.dev.js",
     "serve": "yarn start",
     "build": "GIT_SHA=`git rev-parse --short HEAD` webpack --config webpack.prod.js --progress",
     "clean": "rm -rf dist node_modules",

--- a/root/webpack.dev.js
+++ b/root/webpack.dev.js
@@ -24,11 +24,13 @@ module.exports = merge(common, {
   ],
   devtool: "inline-source-map",
   devServer: {
-    disableHostCheck: true,
+    allowedHosts: "all",
+    devMiddleware: {
+      writeToDisk: true,
+    },
     historyApiFallback: true,
-    open: true,
-    openPage: "MAAS/r/machines",
-    public: "0.0.0.0:8400",
-    writeToDisk: true,
+    host: "0.0.0.0",
+    open: ["http://0.0.0.0:8400/MAAS/r/machines"],
+    port: 8404,
   },
 });


### PR DESCRIPTION
## Done

- Followed [this migration guide](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) to update our webpack configs to be compatible with v4.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the whole app with `yarn start`
- Check that the app runs properly, i.e. you can successfully navigate to both ui and legacy pages
- Run `yarn ui` and check that the app runs in React standalone mode

