### PR TITLE
fix(legacy): fix the webpack dev server websocket port

### DIFF
--- a/legacy/webpack.dev.js
+++ b/legacy/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
       webSocketURL: {
         hostname: "0.0.0.0",
         pathname: "/sockjs-legacy",
-        port: 8400,
+        port: 8402,
       },
     },
     compress: true,


### PR DESCRIPTION
## Done

- fix the webpack dev server websocket port

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the full client with `yarn start`.
- Check that you can load legacy and React urls in Firefox and Chrome.