### PR TITLE
refactor(deps): remove enzyme from maas-ui-shared

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -33,12 +33,9 @@
     "@testing-library/user-event": "13.5.0",
     "@typescript-eslint/eslint-plugin": "5.9.0",
     "@typescript-eslint/parser": "5.9.0",
-    "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",
     "babel-plugin-inline-dotenv": "1.6.0",
-    "enzyme": "3.11.0",
-    "enzyme-to-json": "3.6.2",
     "eslint": "7.32.0",
     "eslint-config-react-app": "6.0.0",
     "eslint-plugin-flowtype": "5.10.0",
@@ -53,7 +50,6 @@
     "npm-package-json-lint": "5.4.2"
   },
   "dependencies": {
-    "@types/enzyme": "3.10.11",
     "@types/google.analytics": "0.0.42",
     "@types/history": "4.7.9",
     "@types/jest": "26.0.24",

--- a/shared/setup-jest.js
+++ b/shared/setup-jest.js
@@ -1,6 +1,2 @@
 import "@testing-library/react";
 import "@testing-library/jest-dom";
-import Enzyme from "enzyme";
-import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
-
-Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
## Done

- remove all remaining enzyme dependencies from maas-ui-shared

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #3460 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
