### PR TITLE
refactor(shared): handle page change events without a listener

### DIFF
--- a/legacy/webpack.dev.js
+++ b/legacy/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
       webSocketURL: {
         hostname: "0.0.0.0",
         pathname: "/sockjs-legacy",
-        port: 8400,
+        port: 8402,
       },
     },
     compress: true,


### PR DESCRIPTION
## Done

- Update the analytics page change events to work without a listener so that it can be used with React Router v6.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open `shared/src/components/Header/Header.tsx`.
- Insert `debug = false;` at line 92.
- Run the full client with `yarn start`.
- Visit `/MAAS/r/settings/configuration/general` and check that analytics is enabled.
- In your browser console run `window.ga = (a, b, c) => console.log(a, b, c)`.
- Now navigate between a few React pages and you should see the events in your console.
- Navigate to the legacy client and then navigate between some legacy pages and you should see the events in your console.

## Fixes

Fixes: #3459.