### PR TITLE
refactor(ui): use a map instead of an array of paths

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -47,22 +47,22 @@ const Routes = (): JSX.Element => (
         </ErrorBoundary>
       )}
     />
-    <Route
-      path={[devicesURLs.devices.index, devicesURLs.device.index(null, true)]}
-      render={() => (
-        <ErrorBoundary>
-          <Devices />
-        </ErrorBoundary>
-      )}
-    />
-    <Route
-      path={[domainsURLs.domains, domainsURLs.details(null, true)]}
-      render={() => (
+    {[devicesURLs.devices.index, devicesURLs.device.index(null, true)].map(
+      (path) => (
+        <Route key={path} path={path}>
+          <ErrorBoundary>
+            <Devices />
+          </ErrorBoundary>
+        </Route>
+      )
+    )}
+    {[domainsURLs.domains, domainsURLs.details(null, true)].map((path) => (
+      <Route exact key={path} path={path}>
         <ErrorBoundary>
           <Domains />
         </ErrorBoundary>
-      )}
-    />
+      </Route>
+    ))}
     <Route
       path={imagesURLs.index}
       render={() => (
@@ -111,14 +111,13 @@ const Routes = (): JSX.Element => (
         </ErrorBoundary>
       )}
     />
-    <Route
-      path={[zonesURLs.index, zonesURLs.details(null, true)]}
-      render={() => (
+    {[zonesURLs.index, zonesURLs.details(null, true)].map((path) => (
+      <Route exact key={path} path={path}>
         <ErrorBoundary>
           <Zones />
         </ErrorBoundary>
-      )}
-    />
+      </Route>
+    ))}
     <Route
       path={dashboardURLs.index}
       render={() => (

--- a/ui/src/app/dashboard/views/Dashboard.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.tsx
@@ -35,10 +35,10 @@ const Dashboard = (): JSX.Element => {
         </Notification>
       )}
       <Switch>
-        <Route exact path={[dashboardURLs.index]}>
+        <Route exact path={dashboardURLs.index}>
           <DiscoveriesList />
         </Route>
-        <Route exact path={[dashboardURLs.configuration]}>
+        <Route exact path={dashboardURLs.configuration}>
           <DashboardConfigurationForm />
         </Route>
         <Route path="*">

--- a/ui/src/app/devices/views/Devices.tsx
+++ b/ui/src/app/devices/views/Devices.tsx
@@ -9,20 +9,19 @@ import devicesURLs from "app/devices/urls";
 const Devices = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={[devicesURLs.devices.index]}>
+      <Route exact path={devicesURLs.devices.index}>
         <DeviceList />
       </Route>
-      <Route
-        exact
-        path={[
-          devicesURLs.device.configuration(null, true),
-          devicesURLs.device.index(null, true),
-          devicesURLs.device.network(null, true),
-          devicesURLs.device.summary(null, true),
-        ]}
-      >
-        <DeviceDetails />
-      </Route>
+      {[
+        devicesURLs.device.configuration(null, true),
+        devicesURLs.device.index(null, true),
+        devicesURLs.device.network(null, true),
+        devicesURLs.device.summary(null, true),
+      ].map((path) => (
+        <Route exact key={path} path={path}>
+          <DeviceDetails />
+        </Route>
+      ))}
       <Route path="*">
         <NotFound />
       </Route>

--- a/ui/src/app/images/views/Images.tsx
+++ b/ui/src/app/images/views/Images.tsx
@@ -7,7 +7,7 @@ import ImageList from "app/images/views/ImageList";
 const Images = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={[imagesURLs.index]}>
+      <Route exact path={imagesURLs.index}>
         <ImageList />
       </Route>
       <Route path="*">

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -11,45 +11,44 @@ import kvmURLs from "app/kvm/urls";
 const KVM = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={[kvmURLs.kvm, kvmURLs.lxd.index, kvmURLs.virsh.index]}>
-        <KVMList />
-      </Route>
-      <Route
-        exact
-        path={[
-          kvmURLs.lxd.cluster.index(null, true),
-          kvmURLs.lxd.cluster.edit(null, true),
-          kvmURLs.lxd.cluster.host.edit(null, true),
-          kvmURLs.lxd.cluster.host.index(null, true),
-          kvmURLs.lxd.cluster.hosts(null, true),
-          kvmURLs.lxd.cluster.resources(null, true),
-          kvmURLs.lxd.cluster.vms.host(null, true),
-          kvmURLs.lxd.cluster.vms.index(null, true),
-        ]}
-      >
-        <LXDClusterDetails />
-      </Route>
-      <Route
-        exact
-        path={[
-          kvmURLs.lxd.single.index(null, true),
-          kvmURLs.lxd.single.edit(null, true),
-          kvmURLs.lxd.single.resources(null, true),
-          kvmURLs.lxd.single.vms(null, true),
-        ]}
-      >
-        <LXDSingleDetails />
-      </Route>
-      <Route
-        exact
-        path={[
-          kvmURLs.virsh.details.index(null, true),
-          kvmURLs.virsh.details.edit(null, true),
-          kvmURLs.virsh.details.resources(null, true),
-        ]}
-      >
-        <VirshDetails />
-      </Route>
+      {[kvmURLs.kvm, kvmURLs.lxd.index, kvmURLs.virsh.index].map((path) => (
+        <Route exact key={path} path={path}>
+          <KVMList />
+        </Route>
+      ))}
+      {[
+        kvmURLs.lxd.cluster.index(null, true),
+        kvmURLs.lxd.cluster.edit(null, true),
+        kvmURLs.lxd.cluster.host.edit(null, true),
+        kvmURLs.lxd.cluster.host.index(null, true),
+        kvmURLs.lxd.cluster.hosts(null, true),
+        kvmURLs.lxd.cluster.resources(null, true),
+        kvmURLs.lxd.cluster.vms.host(null, true),
+        kvmURLs.lxd.cluster.vms.index(null, true),
+      ].map((path) => (
+        <Route exact key={path} path={path}>
+          <LXDClusterDetails />
+        </Route>
+      ))}
+      {[
+        kvmURLs.lxd.single.index(null, true),
+        kvmURLs.lxd.single.edit(null, true),
+        kvmURLs.lxd.single.resources(null, true),
+        kvmURLs.lxd.single.vms(null, true),
+      ].map((path) => (
+        <Route exact key={path} path={path}>
+          <LXDSingleDetails />
+        </Route>
+      ))}
+      {[
+        kvmURLs.virsh.details.index(null, true),
+        kvmURLs.virsh.details.edit(null, true),
+        kvmURLs.virsh.details.resources(null, true),
+      ].map((path) => (
+        <Route exact key={path} path={path}>
+          <VirshDetails />
+        </Route>
+      ))}
       <Route path="*">
         <NotFound />
       </Route>

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -60,15 +60,14 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
       >
         <InstallationOutput systemId={systemId} />
       </Route>
-      <Route
-        exact
-        path={[
-          machineURLs.machine.logs.index(null, true),
-          machineURLs.machine.logs.events(null, true),
-        ]}
-      >
-        <EventLogs systemId={systemId} />
-      </Route>
+      {[
+        machineURLs.machine.logs.index(null, true),
+        machineURLs.machine.logs.events(null, true),
+      ].map((path) => (
+        <Route exact key={path} path={path}>
+          <EventLogs systemId={systemId} />
+        </Route>
+      ))}
     </>
   );
 };

--- a/ui/src/app/zones/views/Zones.tsx
+++ b/ui/src/app/zones/views/Zones.tsx
@@ -8,7 +8,7 @@ import ZonesList from "app/zones/views/ZonesList";
 const Zones = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={[zonesURLs.index]}>
+      <Route exact path={zonesURLs.index}>
         <ZonesList />
       </Route>
       <Route exact path={zonesURLs.details(null, true)}>


### PR DESCRIPTION
## Done

- Update the urls to map routes instead of using paths as React Router v6 doesn't support an array.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that you can visit the list, details and tabs for: devices, domains, zones and kvm.
- Check that you can view the logs and events sub-tabs in machine details. 

## Fixes

Fixes: #3463.