### PR TITLE
feat(ui): add support for multiple choice power fields

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
@@ -5,6 +5,7 @@ import BasePowerField from "./BasePowerField";
 
 import { PowerFieldType } from "app/store/general/types";
 import { powerField as powerFieldFactory } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 describe("BasePowerField", () => {
   it("can be disabled", () => {
@@ -66,5 +67,38 @@ describe("BasePowerField", () => {
     expect(wrapper.find("input[type='text']").exists()).toBe(false);
     expect(wrapper.find("input[type='password']").exists()).toBe(false);
     expect(wrapper.find("select").exists()).toBe(true);
+  });
+
+  it("correctly handles a multiple choice field type", async () => {
+    const field = powerFieldFactory({
+      choices: [
+        ["value1", "label1"],
+        ["value2", "label2"],
+      ],
+      field_type: PowerFieldType.MULTIPLE_CHOICE,
+      label: "label",
+      name: "field",
+    });
+    const wrapper = mount(
+      <Formik
+        initialValues={{ power_parameters: { field: ["value1"] } }}
+        onSubmit={jest.fn()}
+      >
+        <BasePowerField field={field} />
+      </Formik>
+    );
+    const findCheckbox = (i: number) =>
+      wrapper.find("input[data-testid='multi-choice-checkbox']").at(i);
+
+    expect(wrapper.find("[data-testid='field-label']").text()).toBe("label");
+    expect(findCheckbox(0).prop("checked")).toBe(true);
+    expect(findCheckbox(1).prop("checked")).toBe(false);
+
+    findCheckbox(0).simulate("change");
+    findCheckbox(1).simulate("change");
+    await waitForComponentToPaint(wrapper);
+
+    expect(findCheckbox(0).prop("checked")).toBe(false);
+    expect(findCheckbox(1).prop("checked")).toBe(true);
   });
 });

--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
@@ -1,28 +1,68 @@
 import { Input, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
 
 import FormikField from "app/base/components/FormikField";
-import type { PowerField as PowerFieldType } from "app/store/general/types";
+import type { AnyObject } from "app/base/types";
+import { PowerFieldType } from "app/store/general/types";
+import type { PowerField } from "app/store/general/types";
+import type { PowerParameters } from "app/store/types/node";
 
 type Props = {
   disabled?: boolean;
-  field: PowerFieldType;
+  field: PowerField;
   powerParametersValueName?: string;
 };
 
-export const BasePowerField = ({
+export const BasePowerField = <V extends AnyObject>({
   disabled = false,
   field,
   powerParametersValueName = "power_parameters",
 }: Props): JSX.Element => {
+  const { setFieldValue, values } = useFormikContext<V>();
   const { choices, field_type, label, name, required } = field;
+  const fieldName = `${powerParametersValueName}.${name}`;
 
+  if (field_type === PowerFieldType.MULTIPLE_CHOICE) {
+    // If the field is a multiple choice field, we know that its value must be
+    // an array of strings.
+    const fieldValue = (values[powerParametersValueName] as PowerParameters)[
+      name
+    ] as string[];
+    return (
+      <>
+        <p data-testid="field-label">{label}</p>
+        {choices.map(([checkboxValue, label]) => {
+          const checked = fieldValue.includes(checkboxValue);
+          const id = `${fieldName}.${checkboxValue}`;
+          return (
+            <Input
+              checked={checked}
+              data-testid="multi-choice-checkbox"
+              disabled={disabled}
+              id={id}
+              key={id}
+              label={label}
+              onChange={() => {
+                const newFieldValue = checked
+                  ? fieldValue.filter((val) => val !== checkboxValue)
+                  : [...fieldValue, checkboxValue];
+                setFieldValue(fieldName, newFieldValue);
+              }}
+              type="checkbox"
+              value={checkboxValue}
+            />
+          );
+        })}
+      </>
+    );
+  }
   return (
     <FormikField
-      component={field_type === "choice" ? Select : Input}
+      component={field_type === PowerFieldType.CHOICE ? Select : Input}
       disabled={disabled}
-      key={name}
+      key={fieldName}
       label={label}
-      name={`${powerParametersValueName}.${name}`}
+      name={fieldName}
       options={
         field_type === "choice"
           ? choices.map((choice) => ({
@@ -34,8 +74,8 @@ export const BasePowerField = ({
       }
       required={required}
       type={
-        (field_type === "string" && "text") ||
-        (field_type === "password" && "password") ||
+        (field_type === PowerFieldType.STRING && "text") ||
+        (field_type === PowerFieldType.PASSWORD && "password") ||
         undefined
       }
     />

--- a/ui/src/app/store/general/types/base.ts
+++ b/ui/src/app/store/general/types/base.ts
@@ -177,7 +177,7 @@ export type Choice = [string, string];
 
 export type PowerField = {
   choices: Choice[];
-  default: number | string;
+  default: number | string | string[];
   field_type: PowerFieldType;
   label: string;
   name: string;

--- a/ui/src/app/store/general/types/enum.ts
+++ b/ui/src/app/store/general/types/enum.ts
@@ -38,6 +38,7 @@ export enum PowerFieldScope {
 export enum PowerFieldType {
   CHOICE = "choice",
   MAC_ADDRESS = "mac_address",
+  MULTIPLE_CHOICE = "multiple_choice",
   PASSWORD = "password",
   STRING = "string",
 }

--- a/ui/src/app/store/general/utils/powerTypes.ts
+++ b/ui/src/app/store/general/utils/powerTypes.ts
@@ -2,7 +2,7 @@ import * as Yup from "yup";
 import type { ObjectShape } from "yup/lib/object";
 
 import type { PowerType } from "app/store/general/types";
-import { PowerFieldScope } from "app/store/general/types";
+import { PowerFieldScope, PowerFieldType } from "app/store/general/types";
 import type { PowerParameters } from "app/store/types/node";
 
 /**
@@ -63,11 +63,14 @@ export const generatePowerParametersSchema = (
 ): ObjectShape =>
   powerType?.fields?.reduce<ObjectShape>((schema, field) => {
     if (fieldScopes.includes(field.scope)) {
+      let fieldSchema =
+        field.field_type === PowerFieldType.MULTIPLE_CHOICE
+          ? Yup.array().of(Yup.string())
+          : Yup.string();
       if (field.required) {
-        schema[field.name] = Yup.string().required(`${field.label} required`);
-      } else {
-        schema[field.name] = Yup.string();
+        fieldSchema = fieldSchema.required(`${field.label} required`);
       }
+      schema[field.name] = fieldSchema;
     }
     return schema;
   }, {}) || {};

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -359,7 +359,9 @@ export type NodeNumaNode = Model & {
 };
 
 // Power parameters are dynamic and depend on the power type of the node.
-export type PowerParameters = { [x: string]: string | number };
+export type PowerParameters = {
+  [x: string]: string | number | string[];
+};
 
 export type SupportedFilesystem = {
   key: Filesystem["fstype"];


### PR DESCRIPTION
## Done

- Added support for `multiple_choice` power fields, which currently only exist for the `ipmi` power type

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and click "Add machine"
- Change the power type to IPMI and check that you see a list of checkboxes for workaround flags
- Fill in the required fields, check some workaround flags and submit the form
- Check that the machine is added successfully, then go into the configuration page for that machine
- Check that the workaround flags have persisted
- Click "Edit" for the power parameters, change the workaround flags and submit the form
- Check that the updated power parameters persist correctly

## Fixes

Fixes #3388 

## Launchpad issue

[lp#1953395](https://bugs.launchpad.net/maas/+bug/1953395)