### PR TITLE
feat(ui): set up controller list

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -3,6 +3,8 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import ErrorBoundary from "app/base/components/ErrorBoundary";
 import baseURLs from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
+import controllersURLs from "app/controllers/urls";
+import Controllers from "app/controllers/views/Controllers";
 import dashboardURLs from "app/dashboard/urls";
 import Dashboard from "app/dashboard/views/Dashboard";
 import devicesURLs from "app/devices/urls";
@@ -39,6 +41,11 @@ const Routes = (): JSX.Element => (
     <Route path={prefsURLs.prefs}>
       <ErrorBoundary>
         <Preferences />
+      </ErrorBoundary>
+    </Route>
+    <Route path={controllersURLs.controllers.index}>
+      <ErrorBoundary>
+        <Controllers />
       </ErrorBoundary>
     </Route>
     {[devicesURLs.devices.index, devicesURLs.device.index(null, true)].map(

--- a/ui/src/app/controllers/constants.ts
+++ b/ui/src/app/controllers/constants.ts
@@ -1,0 +1,23 @@
+import { NodeActions } from "app/store/types/node";
+
+export const ControllerActionHeaderViews = {
+  DELETE_CONTROLLER: ["controllerActionForm", NodeActions.DELETE],
+  IMPORT_IMAGES_CONTROLLER: ["controllerActionForm", NodeActions.IMPORT_IMAGES],
+  OFF_CONTROLLER: ["controllerActionForm", NodeActions.OFF],
+  ON_CONTROLLER: ["controllerActionForm", NodeActions.ON],
+  OVERRIDE_FAILED_TESTING_CONTROLLER: [
+    "controllerActionForm",
+    NodeActions.OVERRIDE_FAILED_TESTING,
+  ],
+  SET_ZONE_CONTROLLER: ["controllerActionForm", NodeActions.SET_ZONE],
+  TEST_CONTROLLER: ["controllerActionForm", NodeActions.TEST],
+} as const;
+
+export const ControllerNonActionHeaderViews = {
+  ADD_CONTROLLER: ["controllerNonActionForm", "addController"],
+} as const;
+
+export const ControllerHeaderViews = {
+  ...ControllerActionHeaderViews,
+  ...ControllerNonActionHeaderViews,
+} as const;

--- a/ui/src/app/controllers/types.ts
+++ b/ui/src/app/controllers/types.ts
@@ -1,0 +1,11 @@
+import type { ValueOf } from "@canonical/react-components";
+
+import type { HeaderContent, SetHeaderContent } from "app/base/types";
+import type { ControllerHeaderViews } from "app/controllers/constants";
+
+export type ControllerHeaderContent = HeaderContent<
+  ValueOf<typeof ControllerHeaderViews>
+>;
+
+export type ControllerSetHeaderContent =
+  SetHeaderContent<ControllerHeaderContent>;

--- a/ui/src/app/controllers/urls.ts
+++ b/ui/src/app/controllers/urls.ts
@@ -1,0 +1,7 @@
+const urls = {
+  controllers: {
+    index: "/controllers",
+  },
+};
+
+export default urls;

--- a/ui/src/app/controllers/utils.ts
+++ b/ui/src/app/controllers/utils.ts
@@ -1,0 +1,26 @@
+import { ControllerHeaderViews } from "./constants";
+import type { ControllerHeaderContent } from "./types";
+
+import { getNodeActionTitle } from "app/store/utils";
+
+/**
+ * Get title depending on header content.
+ * @param defaultTitle - Title to show if no header content open.
+ * @param headerContentName - The name of the header content to check.
+ * @returns Header title string.
+ */
+export const getHeaderTitle = (
+  defaultTitle: string,
+  headerContent: ControllerHeaderContent | null
+): string => {
+  if (headerContent) {
+    const [, name] = headerContent.view;
+    switch (name) {
+      case ControllerHeaderViews.ADD_CONTROLLER[1]:
+        return "Add controller";
+      default:
+        return getNodeActionTitle(name);
+    }
+  }
+  return defaultTitle;
+};

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -1,0 +1,74 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { useLocation } from "react-router";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ControllerList from "./ControllerList";
+import ControllerListControls from "./ControllerListControls";
+
+import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ControllerList", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
+  it("sets the search text from the URL on load", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/controllers",
+              search: "?q=test+search",
+              key: "testKey",
+            },
+          ]}
+        >
+          <ControllerList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find(ControllerListControls).prop("filter")).toBe(
+      "test search"
+    );
+  });
+
+  it("changes the URL when the search text changes", () => {
+    let search: string | null = null;
+    const store = mockStore(state);
+    const FetchRoute = () => {
+      const location = useLocation();
+      search = location.search;
+      return null;
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
+          ]}
+        >
+          <ControllerList />
+          <Route path="*">
+            <FetchRoute />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => {
+      wrapper.find(ControllerListControls).prop("setFilter")("hostname:foo");
+    });
+
+    expect(search).toBe("?hostname=foo");
+  });
+});

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.tsx
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useDispatch } from "react-redux";
+import { useHistory, useLocation } from "react-router";
+
+import ControllerListControls from "./ControllerListControls";
+import ControllerListHeader from "./ControllerListHeader";
+
+import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
+import type { ControllerHeaderContent } from "app/controllers/types";
+import { actions as controllerActions } from "app/store/controller";
+import { FilterControllers } from "app/store/controller/utils";
+
+const ControllerList = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const location = useLocation();
+  const currentFilters = FilterControllers.queryStringToFilters(
+    location.search
+  );
+  const [headerContent, setHeaderContent] =
+    useState<ControllerHeaderContent | null>(null);
+  const [searchFilter, setFilter] = useState(
+    // Initialise the filter state from the URL.
+    FilterControllers.filtersToString(currentFilters)
+  );
+  useWindowTitle("Controllers");
+
+  useEffect(() => {
+    dispatch(controllerActions.fetch());
+  }, [dispatch]);
+
+  // Update the URL when filters are changed.
+  const setSearchFilter = useCallback(
+    (searchText) => {
+      setFilter(searchText);
+      const filters = FilterControllers.getCurrentFilters(searchText);
+      history.push({ search: FilterControllers.filtersToQueryString(filters) });
+    },
+    [history, setFilter]
+  );
+
+  return (
+    <Section
+      header={
+        <ControllerListHeader
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
+          setSearchFilter={setSearchFilter}
+        />
+      }
+    >
+      <ControllerListControls
+        filter={searchFilter}
+        setFilter={setSearchFilter}
+      />
+    </Section>
+  );
+};
+
+export default ControllerList;

--- a/ui/src/app/controllers/views/ControllerList/ControllerListControls/ControllerListControls.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListControls/ControllerListControls.test.tsx
@@ -1,0 +1,40 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ControllerListControls from "./ControllerListControls";
+
+import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ControllerListControls", () => {
+  let initialState: RootState;
+
+  beforeEach(() => {
+    initialState = rootStateFactory();
+  });
+
+  it("changes the search text when the filters change", () => {
+    const store = mockStore(initialState);
+    const Proxy = ({ filter }: { filter: string }) => (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
+          ]}
+        >
+          <ControllerListControls filter={filter} setFilter={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const wrapper = mount(<Proxy filter="" />);
+    expect(wrapper.find("SearchBox").prop("value")).toBe("");
+
+    wrapper.setProps({ filter: "free-text" });
+    wrapper.update();
+    expect(wrapper.find("SearchBox").prop("value")).toBe("free-text");
+  });
+});

--- a/ui/src/app/controllers/views/ControllerList/ControllerListControls/ControllerListControls.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListControls/ControllerListControls.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+import { Col, Row } from "@canonical/react-components";
+
+import DebounceSearchBox from "app/base/components/DebounceSearchBox";
+import type { SetSearchFilter } from "app/base/types";
+
+type Props = {
+  filter: string;
+  setFilter: SetSearchFilter;
+};
+
+const ControllerListControls = ({ filter, setFilter }: Props): JSX.Element => {
+  const [searchText, setSearchText] = useState(filter);
+
+  useEffect(() => {
+    // If the filters change then update the search input text.
+    setSearchText(filter);
+  }, [filter]);
+
+  return (
+    <Row>
+      <Col size={12}>
+        <DebounceSearchBox
+          searchText={searchText}
+          onDebounced={(debouncedText) => setFilter(debouncedText)}
+          setSearchText={setSearchText}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default ControllerListControls;

--- a/ui/src/app/controllers/views/ControllerList/ControllerListControls/index.ts
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListControls/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerListControls";

--- a/ui/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.test.tsx
@@ -1,0 +1,113 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ControllerListHeader from "./ControllerListHeader";
+
+import { ControllerHeaderViews } from "app/controllers/constants";
+import type { RootState } from "app/store/root/types";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ControllerListHeader", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      controller: controllerStateFactory({
+        loaded: true,
+        items: [
+          controllerFactory({ system_id: "abc123" }),
+          controllerFactory({ system_id: "def456" }),
+        ],
+      }),
+    });
+  });
+
+  it("displays a spinner in the header subtitle if controllers have not loaded", () => {
+    state.controller.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ControllerListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-testid='section-header-subtitle'] Spinner").exists()
+    ).toBe(true);
+  });
+
+  it("displays a controllers count if controllers have loaded", () => {
+    state.controller.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ControllerListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-testid="section-header-subtitle"]').text()).toBe(
+      "2 controllers available"
+    );
+  });
+
+  it("disables the add controller button if any controllers are selected", () => {
+    state.controller.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ControllerListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find('button[data-testid="add-controller-button"]')
+        .prop("disabled")
+    ).toBe(true);
+  });
+
+  it("can open the add controller form", () => {
+    const setHeaderContent = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ControllerListHeader
+            headerContent={null}
+            setHeaderContent={setHeaderContent}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("Button[data-testid='add-controller-button']")
+      .simulate("click");
+    expect(setHeaderContent).toHaveBeenCalledWith({
+      view: ControllerHeaderViews.ADD_CONTROLLER,
+    });
+  });
+});

--- a/ui/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import ModelListSubtitle from "app/base/components/ModelListSubtitle";
+import NodeActionMenu from "app/base/components/NodeActionMenu";
+import SectionHeader from "app/base/components/SectionHeader";
+import type { SetSearchFilter } from "app/base/types";
+import { ControllerHeaderViews } from "app/controllers/constants";
+import type {
+  ControllerHeaderContent,
+  ControllerSetHeaderContent,
+} from "app/controllers/types";
+import { getHeaderTitle } from "app/controllers/utils";
+import controllerSelectors from "app/store/controller/selectors";
+
+type Props = {
+  headerContent: ControllerHeaderContent | null;
+  setHeaderContent: ControllerSetHeaderContent;
+  setSearchFilter: SetSearchFilter;
+};
+
+const ControllerListHeader = ({
+  headerContent,
+  setHeaderContent,
+  setSearchFilter,
+}: Props): JSX.Element => {
+  const controllers = useSelector(controllerSelectors.all);
+  const controllersLoaded = useSelector(controllerSelectors.loaded);
+  const selectedControllers = useSelector(controllerSelectors.selected);
+
+  return (
+    <SectionHeader
+      buttons={[
+        <Button
+          appearance="neutral"
+          data-testid="add-controller-button"
+          disabled={selectedControllers.length > 0}
+          onClick={() =>
+            setHeaderContent({ view: ControllerHeaderViews.ADD_CONTROLLER })
+          }
+        >
+          Add rack controller
+        </Button>,
+        <NodeActionMenu
+          nodes={selectedControllers}
+          nodeDisplay="controller"
+          onActionClick={(action) => {
+            const view = Object.values(ControllerHeaderViews).find(
+              ([, actionName]) => actionName === action
+            );
+            if (view) {
+              setHeaderContent({ view });
+            }
+          }}
+        />,
+      ]}
+      headerContent={headerContent && "ControllerHeaderForms"}
+      subtitle={
+        <ModelListSubtitle
+          available={controllers.length}
+          filterSelected={() => setSearchFilter("in:(Selected)")}
+          modelName="controller"
+          selected={selectedControllers.length}
+        />
+      }
+      subtitleLoading={!controllersLoaded}
+      title={getHeaderTitle("Controllers", headerContent)}
+    />
+  );
+};
+
+export default ControllerListHeader;

--- a/ui/src/app/controllers/views/ControllerList/ControllerListHeader/index.ts
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerListHeader";

--- a/ui/src/app/controllers/views/ControllerList/index.ts
+++ b/ui/src/app/controllers/views/ControllerList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerList";

--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -1,0 +1,21 @@
+import { Route, Switch } from "react-router-dom";
+
+import ControllerList from "./ControllerList";
+
+import NotFound from "app/base/views/NotFound";
+import controllersURLs from "app/controllers/urls";
+
+const Controllers = (): JSX.Element => {
+  return (
+    <Switch>
+      <Route exact path={controllersURLs.controllers.index}>
+        <ControllerList />
+      </Route>
+      <Route path="*">
+        <NotFound />
+      </Route>
+    </Switch>
+  );
+};
+
+export default Controllers;


### PR DESCRIPTION
**Note: this has all been copied and pasted from devices.**

## Done

- Set up the view for displaying a list of controllers.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/controllers.
- The page should load the controllers view (with no content except the search box).

## Fixes

Fixes: canonical-web-and-design/app-tribe#608.

## Screenshots

<img width="1461" alt="Screen Shot 2022-01-07 at 10 38 05 am" src="https://user-images.githubusercontent.com/361637/148467822-beb7f022-2118-4165-ae0d-5415dacc5655.png">
