### PR TITLE
feat(ui): add check_images handlers to the controller slice

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.ts.snap
+++ b/ui/src/__snapshots__/root-reducer.test.ts.snap
@@ -35,6 +35,7 @@ Object {
     "active": null,
     "errors": null,
     "eventErrors": Array [],
+    "imageSyncStatuses": Object {},
     "items": Array [],
     "loaded": false,
     "loading": false,

--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -654,7 +654,7 @@ describe("websocket sagas", () => {
       return expectSaga(handlePolling, action)
         .put({
           type: "testActionPollingStarted",
-          payload: { id: undefined },
+          meta: { pollId: undefined },
         })
         .run();
     });
@@ -674,7 +674,7 @@ describe("websocket sagas", () => {
       return expectSaga(handlePolling, action)
         .put({
           type: "testActionPollingStopped",
-          payload: { id: undefined },
+          meta: { pollId: undefined },
         })
         .dispatch({
           type: "testAction",
@@ -704,7 +704,7 @@ describe("websocket sagas", () => {
       return expectSaga(handlePolling, action)
         .put({
           type: "testActionPollingStarted",
-          payload: { id: "poll123" },
+          meta: { pollId: "poll123" },
         })
         .run();
     });

--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -244,10 +244,11 @@ describe("websocket sagas", () => {
     );
   });
 
-  it("can handle params as an array", () => {
+  it("can handle dispatching for each param in an array", () => {
     const action = {
       type: "test/action",
       meta: {
+        dispatchMultiple: true,
         model: "test",
         method: "method",
         type: WebSocketMessageType.REQUEST,
@@ -653,6 +654,7 @@ describe("websocket sagas", () => {
       return expectSaga(handlePolling, action)
         .put({
           type: "testActionPollingStarted",
+          payload: { id: undefined },
         })
         .run();
     });
@@ -663,7 +665,7 @@ describe("websocket sagas", () => {
         meta: {
           model: "test",
           method: "method",
-          poll: true,
+          pollStop: true,
         },
         payload: {
           params: {},
@@ -672,6 +674,7 @@ describe("websocket sagas", () => {
       return expectSaga(handlePolling, action)
         .put({
           type: "testActionPollingStopped",
+          payload: { id: undefined },
         })
         .dispatch({
           type: "testAction",
@@ -681,6 +684,57 @@ describe("websocket sagas", () => {
             pollStop: true,
           },
           payload: null,
+        })
+        .run();
+    });
+
+    it("can start polling with an id", () => {
+      const action = {
+        type: "testAction",
+        meta: {
+          model: "test",
+          method: "method",
+          poll: true,
+          pollId: "poll123",
+        },
+        payload: {
+          params: {},
+        },
+      };
+      return expectSaga(handlePolling, action)
+        .put({
+          type: "testActionPollingStarted",
+          payload: { id: "poll123" },
+        })
+        .run();
+    });
+
+    it("can stop polling with an id", () => {
+      const action = {
+        type: "testAction",
+        meta: {
+          model: "test",
+          method: "method",
+          pollStop: true,
+          pollId: "poll123",
+        },
+        payload: {
+          params: {},
+        },
+      };
+      return expectSaga(handlePolling, action)
+        .put({
+          type: "testActionPollingStopped",
+          payload: { id: "poll123" },
+        })
+        .dispatch({
+          type: "testAction",
+          meta: {
+            model: "test",
+            method: "method",
+            pollStop: true,
+          },
+          payload: { id: "poll123" },
         })
         .run();
     });

--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -725,7 +725,7 @@ describe("websocket sagas", () => {
       return expectSaga(handlePolling, action)
         .put({
           type: "testActionPollingStopped",
-          payload: { id: "poll123" },
+          meta: { pollId: "poll123" },
         })
         .dispatch({
           type: "testAction",
@@ -733,8 +733,8 @@ describe("websocket sagas", () => {
             model: "test",
             method: "method",
             pollStop: true,
+            pollId: "poll123",
           },
-          payload: { id: "poll123" },
         })
         .run();
     });

--- a/ui/src/app/base/sagas/websockets.ts
+++ b/ui/src/app/base/sagas/websockets.ts
@@ -377,7 +377,7 @@ export function* pollAction(action: WebSocketAction): SagaGenerator<void> {
     if (yield* cancelled()) {
       yield* put({
         type: `${action.type}PollingStopped`,
-        payload: { id: action.meta?.pollId },
+        meta: { pollId: action.meta?.pollId },
       });
       pollingRequests.delete(id);
     }
@@ -395,7 +395,7 @@ export function* handlePolling(action: WebSocketAction): SagaGenerator<void> {
   while (poll) {
     yield* put({
       type: `${action.type}PollingStarted`,
-      payload: { id: action.meta?.pollId },
+      meta: { pollId: action.meta?.pollId },
     });
     // Start polling the action.
     const pollingTask = yield* fork(pollAction, action);

--- a/ui/src/app/base/sagas/websockets.ts
+++ b/ui/src/app/base/sagas/websockets.ts
@@ -47,6 +47,8 @@ export type WebSocketChannel = EventChannel<
   | MessageEvent<string>
 >;
 
+type PollRequestId = string;
+
 let loadedEndpoints: WebSocketEndpoint[] = [];
 
 // A map of request ids to action creators. This is used to dispatch actions
@@ -71,7 +73,13 @@ export const fileContextRequests = new Map<
 >();
 
 // A store of websocket endpoints that are being polled.
-const pollingRequests = new Set<WebSocketEndpoint>();
+const pollingRequests = new Set<PollRequestId>();
+
+const pollRequestId = (action: WebSocketAction | AnyAction): PollRequestId => {
+  const endpoint = `${action.meta?.model}.${action.meta?.method}`;
+  const id = action.meta?.pollId;
+  return id ? `${endpoint}:${id}` : endpoint;
+};
 
 /**
  * Whether the data is fetching or has been fetched into state.
@@ -356,7 +364,7 @@ export function* handleFileContextRequest({
  * @param action - A websocket action.
  */
 export function* pollAction(action: WebSocketAction): SagaGenerator<void> {
-  const endpoint = `${action.meta?.model}.${action.meta?.method}`;
+  const id = pollRequestId(action);
   try {
     while (true) {
       // The delay is put first as the action will have already been handled
@@ -367,8 +375,11 @@ export function* pollAction(action: WebSocketAction): SagaGenerator<void> {
     }
   } finally {
     if (yield* cancelled()) {
-      yield* put({ type: `${action.type}PollingStopped` });
-      pollingRequests.delete(endpoint);
+      yield* put({
+        type: `${action.type}PollingStopped`,
+        payload: { id: action.meta?.pollId },
+      });
+      pollingRequests.delete(id);
     }
   }
 }
@@ -378,19 +389,21 @@ export function* pollAction(action: WebSocketAction): SagaGenerator<void> {
  * @param action - A websocket action.
  */
 export function* handlePolling(action: WebSocketAction): SagaGenerator<void> {
-  const endpoint = `${action.meta?.model}.${action.meta?.method}`;
-  pollingRequests.add(endpoint);
+  const id = pollRequestId(action);
+  pollingRequests.add(id);
   let poll = true;
   while (poll) {
-    yield* put({ type: `${action.type}PollingStarted` });
+    yield* put({
+      type: `${action.type}PollingStarted`,
+      payload: { id: action.meta?.pollId },
+    });
     // Start polling the action.
     const pollingTask = yield* fork(pollAction, action);
     // Wait for the stop polling action for this endpoint.
     yield* take(
       (dispatchedAction: AnyAction) =>
         isStopPollingAction(dispatchedAction) &&
-        `${dispatchedAction.meta?.model}.${dispatchedAction.meta?.method}` ===
-          endpoint
+        pollRequestId(dispatchedAction) === id
     );
     // Cancel polling.
     yield* cancel(pollingTask);
@@ -501,7 +514,7 @@ export function* handleMessage(
  * @returns {Bool} - action is a request action.
  */
 const isPolling = (action: AnyAction): boolean =>
-  pollingRequests.has(`${action.meta?.model}.${action.meta?.method}`);
+  pollingRequests.has(pollRequestId(action));
 
 /**
  * Whether this is an action that starts polling a websocket request.
@@ -545,7 +558,8 @@ const buildMessage = (
     method: `${meta.model}.${meta.method}`,
     type: WebSocketMessageType.REQUEST,
   };
-  if (params && !Array.isArray(params)) {
+  const hasMultipleDispatches = meta.dispatchMultiple && Array.isArray(params);
+  if (params && !hasMultipleDispatches) {
     message.params = params;
   }
   return message;
@@ -563,12 +577,15 @@ export function* sendMessage(
   const params = payload ? payload.params : null;
   const { cache, method, model, nocache } = meta;
   const endpoint = `${model}.${method}`;
+  const hasMultipleDispatches = meta.dispatchMultiple && Array.isArray(params);
   // If method is 'list' and data has loaded/is loading, do not fetch again
   // unless this is fetching a new batch or 'nocache' is specified.
   if (
     cache ||
     (method.endsWith("list") &&
-      (!params || Array.isArray(params) || !params.start) &&
+      (!params ||
+        hasMultipleDispatches ||
+        (!Array.isArray(params) && !params.start)) &&
       !nocache)
   ) {
     if (isLoaded(endpoint)) {
@@ -579,7 +596,7 @@ export function* sendMessage(
   yield* put({ meta: { item: params || payload }, type: `${type}Start` });
   const requestIDs = [];
   try {
-    if (params && Array.isArray(params)) {
+    if (params && hasMultipleDispatches) {
       // We deliberately do not * in parallel here with 'all'
       // to avoid races for dependant config.
       for (const param of params) {

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -93,6 +93,7 @@ describe("CommissioningForm", () => {
         ],
       },
       meta: {
+        dispatchMultiple: true,
         model: "config",
         method: "update",
       },

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -76,6 +76,7 @@ describe("DnsForm", () => {
           ],
         },
         meta: {
+          dispatchMultiple: true,
           model: "config",
           method: "update",
         },

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -89,6 +89,7 @@ describe("NetworkDiscoveryForm", () => {
           ],
         },
         meta: {
+          dispatchMultiple: true,
           model: "config",
           method: "update",
         },

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -68,6 +68,7 @@ describe("NtpForm", () => {
           ],
         },
         meta: {
+          dispatchMultiple: true,
           model: "config",
           method: "update",
         },

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -65,6 +65,7 @@ describe("SyslogForm", () => {
           ],
         },
         meta: {
+          dispatchMultiple: true,
           model: "config",
           method: "update",
         },

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -75,6 +75,7 @@ describe("StorageForm", () => {
           ],
         },
         meta: {
+          dispatchMultiple: true,
           model: "config",
           method: "update",
         },

--- a/ui/src/app/store/config/actions.test.ts
+++ b/ui/src/app/store/config/actions.test.ts
@@ -27,6 +27,7 @@ describe("config actions", () => {
         ],
       },
       meta: {
+        dispatchMultiple: true,
         model: "config",
         method: "update",
       },

--- a/ui/src/app/store/config/slice.ts
+++ b/ui/src/app/store/config/slice.ts
@@ -49,6 +49,7 @@ const statusSlice = createSlice({
         }));
         return {
           meta: {
+            dispatchMultiple: true,
             model: "config",
             method: "update",
           },

--- a/ui/src/app/store/controller/actions.test.ts
+++ b/ui/src/app/store/controller/actions.test.ts
@@ -4,6 +4,44 @@ import { NodeActions } from "app/store/types/node";
 import { script as scriptFactory } from "testing/factories";
 
 describe("controller actions", () => {
+  it("should handle checking images", () => {
+    expect(actions.checkImages(["abc123", "def456"])).toEqual({
+      type: "controller/checkImages",
+      meta: {
+        model: "controller",
+        method: "check_images",
+      },
+      payload: { params: [{ system_id: "abc123" }, { system_id: "def456" }] },
+    });
+  });
+
+  it("should handle polling checking images", () => {
+    expect(actions.pollCheckImages(["abc123", "def456"], "pollid123")).toEqual({
+      type: "controller/pollCheckImages",
+      meta: {
+        model: "controller",
+        method: "check_images",
+        poll: true,
+        pollId: "pollid123",
+        pollInterval: 30000,
+      },
+      payload: { params: [{ system_id: "abc123" }, { system_id: "def456" }] },
+    });
+  });
+
+  it("should handle stop polling checking images", () => {
+    expect(actions.pollCheckImagesStop("pollid123")).toEqual({
+      type: "controller/pollCheckImagesStop",
+      meta: {
+        model: "controller",
+        method: "check_images",
+        pollId: "pollid123",
+        pollStop: true,
+      },
+      payload: null,
+    });
+  });
+
   it("should handle fetching controllers", () => {
     expect(actions.fetch()).toEqual({
       type: "controller/fetch",

--- a/ui/src/app/store/controller/reducers.test.ts
+++ b/ui/src/app/store/controller/reducers.test.ts
@@ -1,10 +1,12 @@
 import reducers, { actions } from "./slice";
 import { ControllerMeta } from "./types";
+import { ImageSyncStatus } from "./types/enum";
 
 import {
   controller as controllerFactory,
   controllerDetails as controllerDetailsFactory,
   controllerEventError as controllerEventErrorFactory,
+  controllerImageSyncStatuses as controllerImageSyncStatusesFactory,
   controllerStatus as controllerStatusFactory,
   controllerState as controllerStateFactory,
 } from "testing/factories";
@@ -15,6 +17,7 @@ describe("controller reducers", () => {
       active: null,
       errors: null,
       eventErrors: [],
+      imageSyncStatuses: {},
       items: [],
       loaded: false,
       loading: false,
@@ -23,6 +26,219 @@ describe("controller reducers", () => {
       selected: [],
       statuses: {},
     });
+  });
+
+  it("reduces checkImagesStart", () => {
+    expect(
+      reducers(
+        controllerStateFactory({
+          statuses: {
+            abc123: controllerStatusFactory({ checkingImages: false }),
+            def456: controllerStatusFactory({ checkingImages: false }),
+          },
+        }),
+        actions.checkImagesStart([
+          { [ControllerMeta.PK]: "abc123" },
+          { [ControllerMeta.PK]: "def456" },
+        ])
+      )
+    ).toEqual(
+      controllerStateFactory({
+        statuses: {
+          abc123: controllerStatusFactory({ checkingImages: true }),
+          def456: controllerStatusFactory({ checkingImages: true }),
+        },
+      })
+    );
+  });
+
+  it("reduces checkImagesError", () => {
+    const items = [controllerFactory({ system_id: "abc123" })];
+    expect(
+      reducers(
+        controllerStateFactory({
+          errors: "It's realllll bad",
+          eventErrors: [],
+          items,
+          statuses: {
+            abc123: controllerStatusFactory({ checkingImages: true }),
+            def456: controllerStatusFactory({ checkingImages: true }),
+          },
+        }),
+        actions.checkImagesError(
+          [
+            { [ControllerMeta.PK]: "abc123" },
+            { [ControllerMeta.PK]: "def456" },
+          ],
+          "It's realllll bad"
+        )
+      )
+    ).toEqual(
+      controllerStateFactory({
+        errors: "It's realllll bad",
+        eventErrors: [
+          controllerEventErrorFactory({
+            error: "It's realllll bad",
+            event: "checkImages",
+            id: "abc123",
+          }),
+          controllerEventErrorFactory({
+            error: "It's realllll bad",
+            event: "checkImages",
+            id: "def456",
+          }),
+        ],
+        items,
+        statuses: {
+          abc123: controllerStatusFactory({ checkingImages: false }),
+          def456: controllerStatusFactory({ checkingImages: false }),
+        },
+      })
+    );
+  });
+
+  it("reduces checkImagesSuccess", () => {
+    expect(
+      reducers(
+        controllerStateFactory({
+          imageSyncStatuses: controllerImageSyncStatusesFactory({
+            abc123: ImageSyncStatus.Synced,
+            ghi789: ImageSyncStatus.Synced,
+          }),
+          statuses: {
+            abc123: controllerStatusFactory({ checkingImages: true }),
+            def456: controllerStatusFactory({ checkingImages: true }),
+          },
+        }),
+        actions.checkImagesSuccess(
+          [
+            { [ControllerMeta.PK]: "abc123" },
+            { [ControllerMeta.PK]: "def456" },
+          ],
+          controllerImageSyncStatusesFactory({
+            abc123: ImageSyncStatus.OutOfSync,
+            def456: ImageSyncStatus.Syncing,
+          })
+        )
+      )
+    ).toEqual(
+      controllerStateFactory({
+        imageSyncStatuses: controllerImageSyncStatusesFactory({
+          abc123: ImageSyncStatus.OutOfSync,
+          def456: ImageSyncStatus.Syncing,
+          ghi789: ImageSyncStatus.Synced,
+        }),
+        statuses: {
+          abc123: controllerStatusFactory({ checkingImages: false }),
+          def456: controllerStatusFactory({ checkingImages: false }),
+        },
+      })
+    );
+  });
+
+  it("reduces pollCheckImagesStart", () => {
+    expect(
+      reducers(
+        controllerStateFactory({
+          statuses: {
+            abc123: controllerStatusFactory({ checkingImages: false }),
+            def456: controllerStatusFactory({ checkingImages: false }),
+          },
+        }),
+        actions.pollCheckImagesStart([
+          { [ControllerMeta.PK]: "abc123" },
+          { [ControllerMeta.PK]: "def456" },
+        ])
+      )
+    ).toEqual(
+      controllerStateFactory({
+        statuses: {
+          abc123: controllerStatusFactory({ checkingImages: true }),
+          def456: controllerStatusFactory({ checkingImages: true }),
+        },
+      })
+    );
+  });
+
+  it("reduces pollCheckImagesError", () => {
+    expect(
+      reducers(
+        controllerStateFactory({
+          errors: "It's realllll bad",
+          eventErrors: [],
+          statuses: {
+            abc123: controllerStatusFactory({ checkingImages: true }),
+            def456: controllerStatusFactory({ checkingImages: true }),
+          },
+        }),
+        actions.pollCheckImagesError(
+          [
+            { [ControllerMeta.PK]: "abc123" },
+            { [ControllerMeta.PK]: "def456" },
+          ],
+          "It's realllll bad"
+        )
+      )
+    ).toEqual(
+      controllerStateFactory({
+        errors: "It's realllll bad",
+        eventErrors: [
+          controllerEventErrorFactory({
+            error: "It's realllll bad",
+            event: "checkImages",
+            id: "abc123",
+          }),
+          controllerEventErrorFactory({
+            error: "It's realllll bad",
+            event: "checkImages",
+            id: "def456",
+          }),
+        ],
+        statuses: {
+          abc123: controllerStatusFactory({ checkingImages: false }),
+          def456: controllerStatusFactory({ checkingImages: false }),
+        },
+      })
+    );
+  });
+
+  it("reduces pollCheckImagesSuccess", () => {
+    expect(
+      reducers(
+        controllerStateFactory({
+          imageSyncStatuses: controllerImageSyncStatusesFactory({
+            abc123: ImageSyncStatus.Synced,
+            ghi789: ImageSyncStatus.Synced,
+          }),
+          statuses: {
+            abc123: controllerStatusFactory({ checkingImages: true }),
+            def456: controllerStatusFactory({ checkingImages: true }),
+          },
+        }),
+        actions.pollCheckImagesSuccess(
+          [
+            { [ControllerMeta.PK]: "abc123" },
+            { [ControllerMeta.PK]: "def456" },
+          ],
+          controllerImageSyncStatusesFactory({
+            abc123: ImageSyncStatus.OutOfSync,
+            def456: ImageSyncStatus.Syncing,
+          })
+        )
+      )
+    ).toEqual(
+      controllerStateFactory({
+        imageSyncStatuses: controllerImageSyncStatusesFactory({
+          abc123: ImageSyncStatus.OutOfSync,
+          def456: ImageSyncStatus.Syncing,
+          ghi789: ImageSyncStatus.Synced,
+        }),
+        statuses: {
+          abc123: controllerStatusFactory({ checkingImages: false }),
+          def456: controllerStatusFactory({ checkingImages: false }),
+        },
+      })
+    );
   });
 
   it("reduces fetchStart", () => {

--- a/ui/src/app/store/controller/selectors.test.ts
+++ b/ui/src/app/store/controller/selectors.test.ts
@@ -1,8 +1,10 @@
 import controller from "./selectors";
+import { ImageSyncStatus } from "./types/enum";
 
 import {
   rootState as rootStateFactory,
   controller as controllerFactory,
+  controllerImageSyncStatuses as controllerImageSyncStatusesFactory,
   controllerState as controllerStateFactory,
   controllerStatus as controllerStatusFactory,
   controllerStatuses as controllerStatusesFactory,
@@ -99,5 +101,36 @@ describe("controller selectors", () => {
       }),
     });
     expect(controller.processing(state)).toStrictEqual(["abc123"]);
+  });
+
+  it("can get the loaded state", () => {
+    const state = rootStateFactory({
+      controller: controllerStateFactory({
+        imageSyncStatuses: controllerImageSyncStatusesFactory({
+          abc123: ImageSyncStatus.OutOfSync,
+          def456: ImageSyncStatus.Syncing,
+        }),
+      }),
+    });
+    expect(controller.imageSyncStatuses(state)).toStrictEqual(
+      controllerImageSyncStatusesFactory({
+        abc123: ImageSyncStatus.OutOfSync,
+        def456: ImageSyncStatus.Syncing,
+      })
+    );
+  });
+
+  it("can get a controller by id", () => {
+    const state = rootStateFactory({
+      controller: controllerStateFactory({
+        imageSyncStatuses: controllerImageSyncStatusesFactory({
+          abc123: ImageSyncStatus.OutOfSync,
+          def456: ImageSyncStatus.Syncing,
+        }),
+      }),
+    });
+    expect(controller.imageSyncStatusesForController(state, "abc123")).toBe(
+      ImageSyncStatus.OutOfSync
+    );
   });
 });

--- a/ui/src/app/store/controller/selectors.test.ts
+++ b/ui/src/app/store/controller/selectors.test.ts
@@ -103,7 +103,7 @@ describe("controller selectors", () => {
     expect(controller.processing(state)).toStrictEqual(["abc123"]);
   });
 
-  it("can get the loaded state", () => {
+  it("can get the image sync state for all controllers", () => {
     const state = rootStateFactory({
       controller: controllerStateFactory({
         imageSyncStatuses: controllerImageSyncStatusesFactory({
@@ -120,7 +120,7 @@ describe("controller selectors", () => {
     );
   });
 
-  it("can get a controller by id", () => {
+  it("can get the image sync state for a controller", () => {
     const state = rootStateFactory({
       controller: controllerStateFactory({
         imageSyncStatuses: controllerImageSyncStatusesFactory({

--- a/ui/src/app/store/controller/selectors.ts
+++ b/ui/src/app/store/controller/selectors.ts
@@ -249,6 +249,35 @@ const search = createSelector(
   }
 );
 
+/**
+ * Get image sync statuses.
+ * @param state - The redux state.
+ * @returns The controller state.
+ */
+const imageSyncStatuses = createSelector(
+  [controllerState],
+  (controllerState) => controllerState.imageSyncStatuses
+);
+
+/**
+ * Get the statuses for a controller.
+ * @param state - The redux state.
+ * @param id - A controller's system id.
+ * @returns The controller's statuses
+ */
+const imageSyncStatusesForController = createSelector(
+  [
+    imageSyncStatuses,
+    (
+      _state: RootState,
+      id: Controller[ControllerMeta.PK] | null | undefined
+    ) => ({
+      id,
+    }),
+  ],
+  (statuses, { id }) => (id && id in statuses ? statuses[id] : null)
+);
+
 const selectors = {
   ...defaultSelectors,
   active,
@@ -257,6 +286,8 @@ const selectors = {
   eventErrorsForControllers,
   getStatuses,
   getStatusForController,
+  imageSyncStatuses,
+  imageSyncStatusesForController,
   processing,
   search,
   selected,

--- a/ui/src/app/store/controller/slice.ts
+++ b/ui/src/app/store/controller/slice.ts
@@ -147,7 +147,9 @@ const controllerSlice = createSlice({
       ) => {
         state = setErrors(state, action, "checkImages");
         action.meta.item.forEach(({ system_id }) => {
-          state.statuses[system_id].checkingImages = false;
+          if (system_id in state.statuses) {
+            state.statuses[system_id].checkingImages = false;
+          }
         });
       },
     },
@@ -163,7 +165,9 @@ const controllerSlice = createSlice({
         action: PayloadAction<null, string, GenericItemMeta<CheckImagesItem[]>>
       ) => {
         action.meta.item.forEach(({ system_id }) => {
-          state.statuses[system_id].checkingImages = true;
+          if (system_id in state.statuses) {
+            state.statuses[system_id].checkingImages = true;
+          }
         });
       },
     },
@@ -188,7 +192,9 @@ const controllerSlice = createSlice({
           ...action.payload,
         };
         action.meta.item.forEach(({ system_id }) => {
-          state.statuses[system_id].checkingImages = false;
+          if (system_id in state.statuses) {
+            state.statuses[system_id].checkingImages = false;
+          }
         });
       },
     },
@@ -429,7 +435,9 @@ const controllerSlice = createSlice({
       ) => {
         state = setErrors(state, action, "checkImages");
         action.meta.item.forEach(({ system_id }) => {
-          state.statuses[system_id].checkingImages = false;
+          if (system_id in state.statuses) {
+            state.statuses[system_id].checkingImages = false;
+          }
         });
       },
     },
@@ -445,7 +453,9 @@ const controllerSlice = createSlice({
         action: PayloadAction<null, string, GenericItemMeta<CheckImagesItem[]>>
       ) => {
         action.meta.item.forEach(({ system_id }) => {
-          state.statuses[system_id].checkingImages = true;
+          if (system_id in state.statuses) {
+            state.statuses[system_id].checkingImages = true;
+          }
         });
       },
     },
@@ -484,7 +494,9 @@ const controllerSlice = createSlice({
           ...action.payload,
         };
         action.meta.item.forEach(({ system_id }) => {
-          state.statuses[system_id].checkingImages = false;
+          if (system_id in state.statuses) {
+            state.statuses[system_id].checkingImages = false;
+          }
         });
       },
     },

--- a/ui/src/app/store/controller/types/base.ts
+++ b/ui/src/app/store/controller/types/base.ts
@@ -2,6 +2,7 @@ import type {
   ControllerInstallType,
   ControllerMeta,
   ControllerVersionIssues,
+  ImageSyncStatus,
 } from "./enum";
 
 import type { APIError } from "app/base/types";
@@ -144,6 +145,7 @@ export type ControllerDetails = BaseController & {
 export type Controller = BaseController | ControllerDetails;
 
 export type ControllerStatus = {
+  checkingImages: boolean;
   deleting: boolean;
   importingImages: boolean;
   turningOff: boolean;
@@ -158,9 +160,15 @@ export type ControllerStatuses = Record<
   ControllerStatus
 >;
 
+export type ImageSyncStatuses = Record<
+  Controller[ControllerMeta.PK],
+  ImageSyncStatus
+>;
+
 export type ControllerState = {
   active: Controller[ControllerMeta.PK] | null;
   eventErrors: EventError<Controller, APIError, ControllerMeta.PK>[];
+  imageSyncStatuses: ImageSyncStatuses;
   selected: Controller[ControllerMeta.PK][];
   statuses: ControllerStatuses;
 } & GenericState<Controller, APIError>;

--- a/ui/src/app/store/controller/types/enum.ts
+++ b/ui/src/app/store/controller/types/enum.ts
@@ -13,3 +13,11 @@ export enum ControllerVersionIssues {
   DIFFERENT_CHANNEL = "different-channel",
   DIFFERENT_COHORT = "different-cohort",
 }
+
+export enum ImageSyncStatus {
+  OutOfSync = "Out Of Sync",
+  RegionImporting = "Region Importing",
+  Synced = "Synced",
+  Syncing = "Syncing",
+  Unknown = "Unknown",
+}

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -119,16 +119,20 @@ export const updateErrors = <
     return state;
   }
   const item = action?.meta?.item;
-  const metaId = item ? item[indexKey] : null;
-  // Clean any existing errors that match the event and machine.
-  const newErrors = (state.eventErrors as S["eventErrors"][0][]).filter(
-    (errorItem) => errorItem.event !== event || errorItem.id !== metaId
-  );
-  // Set the new error.
-  newErrors.push({
-    error: action?.payload ?? null,
-    event,
-    id: metaId,
+  const items = Array.isArray(item) ? item : [item];
+  let newErrors = state.eventErrors as S["eventErrors"][0][];
+  items.forEach((item) => {
+    const metaId = item ? item[indexKey] : null;
+    // Clean any existing errors that match the event and machine.
+    newErrors = newErrors.filter(
+      (errorItem) => errorItem.event !== event || errorItem.id !== metaId
+    );
+    // Set the new error.
+    newErrors.push({
+      error: action?.payload ?? null,
+      event,
+      id: metaId,
+    });
   });
   // Replace the event errors with the cleaned/updated list.
   state.eventErrors = newErrors as S["eventErrors"];

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -6,6 +6,7 @@ export {
   componentsToDisableState,
   configState,
   controllerEventError,
+  controllerImageSyncStatuses,
   controllerState,
   controllerStatus,
   controllerStatuses,

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -14,6 +14,8 @@ import type {
   ControllerStatus,
   ControllerStatuses,
 } from "app/store/controller/types";
+import type { ImageSyncStatuses } from "app/store/controller/types/base";
+import { ImageSyncStatus } from "app/store/controller/types/enum";
 import { DEFAULT_STATUSES as DEFAULT_DEVICE_STATUSES } from "app/store/device/slice";
 import type {
   Device,
@@ -137,6 +139,10 @@ export const controllerStatuses = define<ControllerStatuses>({
   testNode: controllerStatus,
 });
 
+export const controllerImageSyncStatuses = define<ImageSyncStatuses>({
+  testNode: ImageSyncStatus.Synced,
+});
+
 export const controllerEventError = define<
   EventError<Controller, APIError, ControllerMeta.PK>
 >({
@@ -150,6 +156,7 @@ export const controllerState = define<ControllerState>({
   active: null,
   errors: null,
   eventErrors: () => [],
+  imageSyncStatuses: () => ({}),
   selected: () => [],
   statuses: () => ({}),
 });

--- a/ui/src/websocket-client.ts
+++ b/ui/src/websocket-client.ts
@@ -29,7 +29,7 @@ type WebSocketMessage = {
 export type WebSocketRequestMessage = {
   method: WebSocketEndpoint;
   type: WebSocketMessageType;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | Record<string, unknown>[];
 };
 
 export type WebSocketRequest = WebSocketMessage & WebSocketRequestMessage;
@@ -67,6 +67,9 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     batch?: boolean;
     // Whether the request should only be fetched the first time.
     cache?: boolean;
+    // Whether each item in the params should be dispatched separately. The
+    // params need to be an array for this to work.
+    dispatchMultiple?: boolean;
     // A key to be used to identify a file in the file context.
     fileContextKey?: string;
     // Whether the response contains JSON that needs to be parsed.
@@ -79,6 +82,9 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     nocache?: boolean;
     // Whether the request should be polled.
     poll?: boolean;
+    // An id for the polling request. This can be used to have multiple polling
+    // events for the same endpoint.
+    pollId?: string;
     // The amount of time in milliseconds between requests.
     pollInterval?: number;
     // Whether polling should be stopped for the request.


### PR DESCRIPTION
## Done

- Add support for checking images with polling to the controllers slice.
- Add support for multiple polling events for the same endpoint to the websocket client.

## Fixes

Fixes: canonical-web-and-design/app-tribe#611.