### PR TITLE
refactor(ui): setup Subnets React page

### DIFF
--- a/integration/cypress/integration/legacy/subnets.spec.ts
+++ b/integration/cypress/integration/legacy/subnets.spec.ts
@@ -35,18 +35,25 @@ context("Subnets", () => {
       "Available IPs",
       "Space",
     ];
-    expectedHeaders.forEach((name) => {
-      cy.findByRole("columnheader", { name }).should("exist");
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      expectedHeaders.forEach((name) => {
+        cy.findByRole("columnheader", { name }).should("exist");
+      });
     });
   });
 
   it("allows filtering by 'fabrics' or 'spaces' via the 'Group by' drop-down", () => {
-    cy.findAllByRole("columnheader").first().should("have.text", "Fabric");
-    cy.findByRole("combobox", { name: "Group by" }).within(() => {
-      cy.findByRole("option", { selected: true }).contains("Fabrics");
-      cy.findByRole("option", { name: "Spaces" }).should("exist");
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findAllByRole("columnheader").first().should("have.text", "Fabric");
     });
-    cy.findByRole("combobox", { name: "Group by" }).select("Spaces");
-    cy.findAllByRole("columnheader").first().should("have.text", "Space");
+    cy.findByRole("combobox", { name: "Group by" })
+      .within(() => {
+        cy.findByRole("option", { selected: true }).contains("Fabrics");
+        cy.findByRole("option", { name: "Spaces" }).should("exist");
+      })
+      .select("Spaces");
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findAllByRole("columnheader").first().should("have.text", "Space");
+    });
   });
 });

--- a/integration/cypress/integration/legacy/subnets.spec.ts
+++ b/integration/cypress/integration/legacy/subnets.spec.ts
@@ -4,10 +4,11 @@ context("Subnets", () => {
   beforeEach(() => {
     cy.login();
     cy.visit(generateLegacyURL("/networks?by=fabric"));
+    cy.viewport("macbook-11");
   });
 
   it("renders the correct heading", () => {
-    cy.get(".page-header__title").contains("Subnets");
+    cy.findByRole("heading", { level: 1 }).contains("Subnets");
   });
 
   it("highlights the correct navigation link", () => {
@@ -16,5 +17,36 @@ context("Subnets", () => {
       "href",
       generateLegacyURL("/networks?by=fabric")
     );
+    cy.findByRole("navigation", { name: "primary" }).within(() => {
+      cy.findByRole("link", { current: "page" }).should(
+        "have.attr",
+        "href",
+        generateLegacyURL("/networks?by=fabric")
+      );
+    });
+  });
+
+  it("displays the main networking view correctly", () => {
+    const expectedHeaders = [
+      "Fabric",
+      "VLAN",
+      "DHCP",
+      "Subnet",
+      "Available IPs",
+      "Space",
+    ];
+    expectedHeaders.forEach((name) => {
+      cy.findByRole("columnheader", { name }).should("exist");
+    });
+  });
+
+  it("allows filtering by 'fabrics' or 'spaces' via the 'Group by' drop-down", () => {
+    cy.findAllByRole("columnheader").first().should("have.text", "Fabric");
+    cy.findByRole("combobox", { name: "Group by" }).within(() => {
+      cy.findByRole("option", { selected: true }).contains("Fabrics");
+      cy.findByRole("option", { name: "Spaces" }).should("exist");
+    });
+    cy.findByRole("combobox", { name: "Group by" }).select("Spaces");
+    cy.findAllByRole("columnheader").first().should("have.text", "Space");
   });
 });

--- a/legacy/src/app/partials/networks-list.html
+++ b/legacy/src/app/partials/networks-list.html
@@ -317,7 +317,7 @@
     <div class="col-4">
       <form class="p-form p-form--inline">
         <div class="p-form__group">
-          <label class="p-form__label u-no-margin--bottom" for="network-filter"
+          <label class="p-form__label u-no-margin--bottom" for="networks-groupby"
             >Group by</label
           >
           <div class="p-form__control">

--- a/legacy/src/app/partials/networks-list.html
+++ b/legacy/src/app/partials/networks-list.html
@@ -370,6 +370,7 @@
       <table
         class="p-table--subnets p-table--grouped"
         ng-if="groupBy === 'space'"
+        aria-label="Subnets"
       >
         <thead>
           <tr>
@@ -499,6 +500,7 @@
       <table
         class="p-table--subnets p-table--grouped u-no-margin--top"
         ng-if="groupBy === 'fabric'"
+        aria-label="Subnets"
       >
         <thead>
           <tr>

--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -25,6 +25,8 @@ import prefsURLs from "app/preferences/urls";
 import Preferences from "app/preferences/views/Preferences";
 import settingsURLs from "app/settings/urls";
 import Settings from "app/settings/views/Settings";
+import subnetsURLs from "app/subnets/urls";
+import Subnets from "app/subnets/views/Subnets";
 import zonesURLs from "app/zones/urls";
 import Zones from "app/zones/views/Zones";
 
@@ -94,6 +96,14 @@ const Routes = (): JSX.Element => (
         <Settings />
       </ErrorBoundary>
     </Route>
+    <Route
+      path={subnetsURLs.index}
+      render={() => (
+        <ErrorBoundary>
+          <Subnets />
+        </ErrorBoundary>
+      )}
+    />
     {[zonesURLs.index, zonesURLs.details(null, true)].map((path) => (
       <Route exact key={path} path={path}>
         <ErrorBoundary>

--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -1,0 +1,5 @@
+const urls = {
+  index: "/networks", // ?by = 'fabric' | 'space'
+};
+
+export default urls;

--- a/ui/src/app/subnets/views/Subnets.tsx
+++ b/ui/src/app/subnets/views/Subnets.tsx
@@ -1,0 +1,16 @@
+import { Route, Switch } from "react-router-dom";
+
+import NotFound from "app/base/views/NotFound";
+import subnetsURLs from "app/subnets/urls";
+import SubnetsList from "app/subnets/views/SubnetsList";
+
+const Routes = (): JSX.Element => {
+  return (
+    <Switch>
+      <Route exact path={subnetsURLs.index} component={SubnetsList} />
+      <Route path="*" component={NotFound} />
+    </Switch>
+  );
+};
+
+export default Routes;

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+const SubnetsList = (): React.ReactElement => (
+  <header className="p-strip--light is-shallow u-no-padding--bottom">
+    <div className="row">
+      <div className="col-medium-4 col-8">
+        <h1 data-testid="section-header-title">Subnets</h1>
+      </div>
+    </div>
+  </header>
+);
+
+export default SubnetsList;


### PR DESCRIPTION
## Done
Subnets React page setup
- add cypress tests for the main subnets view
  - based on user journeys descriptions - more in [MAAS Subnets React migration plan - User Journeys](https://docs.google.com/document/d/1Vlih_9RyfNKKwLeBXS6tnRnNZTTR1BtXG_MHHC-Bi1s/edit#heading=h.h5ndvhge2k7u)
- fix "Group by" label (`cypress-testing-library` reported this,  HTML`for` attribute was pointing to the `name` attribute instead of the `id`) - a good example how user-centric testing (and `byRole` queries) help identify UI bugs
- add "Subnets" aria-label to table - describes it for screen readers and allowis to target specifically in tests

https://docs.google.com/document/d/1Vlih_9RyfNKKwLeBXS6tnRnNZTTR1BtXG_MHHC-Bi1s/edit#heading=h.faeke7zfhcfj

### QA steps

- Manually enter `/MAAS/r/networks` URL and verify "Subnets" h1 element is displayed

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/148766897-453e491b-9487-4210-bcd4-5e80b4cdc624.png)
*New Subnets page*

### Before
![Pasted Graphic](https://user-images.githubusercontent.com/7452681/148769769-e00113e1-ca61-4540-822c-f81d10e492da.png)
*no label for "group by" combobox*

![combobox](https://user-images.githubusercontent.com/7452681/148766937-f43cb7b0-a446-4e0c-b452-d7989a25a4a6.png)
*cypress error*

### After
![Pasted Graphic 1](https://user-images.githubusercontent.com/7452681/148769740-1d8d742b-db80-476e-b37e-34d32e39e4e1.png)
*correct label*

![margin--bottom ng-pristine ng-untouched ng-valid ng-not-](https://user-images.githubusercontent.com/7452681/148766957-24b175a5-ef66-4e61-8148-f2670b6b6bd6.png)
*cypress success*

## Cypress tests
https://user-images.githubusercontent.com/7452681/148773257-0c9f6e9d-f600-4980-bc5b-9ab03e83c6e1.mp4


## Fixes

Fixes: [#615 .](https://github.com/canonical-web-and-design/app-tribe/issues/615)
