### PR TITLE
feat(ui): add controller statuses

### DIFF
--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
@@ -55,7 +55,7 @@ describe("ControllerStatus", () => {
       </Provider>
     );
     expect(wrapper.find("Icon").prop("name")).toEqual("power-error");
-    expect(wrapper.find("Icon").prop("title")).toEqual("2 dead");
+    expect(wrapper.find("Tooltip").prop("message")).toEqual("2 dead");
   });
 
   it("handles a degraded controller", () => {
@@ -82,7 +82,7 @@ describe("ControllerStatus", () => {
       </Provider>
     );
     expect(wrapper.find("Icon").prop("name")).toEqual("warning");
-    expect(wrapper.find("Icon").prop("title")).toEqual("2 degraded");
+    expect(wrapper.find("Tooltip").prop("message")).toEqual("2 degraded");
   });
 
   it("handles a running controller", () => {
@@ -109,6 +109,6 @@ describe("ControllerStatus", () => {
       </Provider>
     );
     expect(wrapper.find("Icon").prop("name")).toEqual("success");
-    expect(wrapper.find("Icon").prop("title")).toEqual("2 running");
+    expect(wrapper.find("Tooltip").prop("message")).toEqual("2 running");
   });
 });

--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
@@ -1,0 +1,114 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { ControllerStatus } from "./ControllerStatus";
+
+import type { RootState } from "app/store/root/types";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+  service as serviceFactory,
+  serviceState as serviceStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ControllerStatus", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      controller: controllerStateFactory({
+        items: [
+          controllerFactory({
+            system_id: "abc123",
+            service_ids: [1, 2],
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("handles a dead controller", () => {
+    state.service = serviceStateFactory({
+      items: [
+        serviceFactory({
+          id: 1,
+          status: "dead",
+        }),
+        serviceFactory({
+          id: 2,
+          status: "dead",
+        }),
+      ],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ControllerStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").prop("name")).toEqual("power-error");
+    expect(wrapper.find("Icon").prop("title")).toEqual("2 dead");
+  });
+
+  it("handles a degraded controller", () => {
+    state.service = serviceStateFactory({
+      items: [
+        serviceFactory({
+          id: 1,
+          status: "degraded",
+        }),
+        serviceFactory({
+          id: 2,
+          status: "degraded",
+        }),
+      ],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ControllerStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").prop("name")).toEqual("warning");
+    expect(wrapper.find("Icon").prop("title")).toEqual("2 degraded");
+  });
+
+  it("handles a running controller", () => {
+    state.service = serviceStateFactory({
+      items: [
+        serviceFactory({
+          id: 1,
+          status: "success",
+        }),
+        serviceFactory({
+          id: 2,
+          status: "success",
+        }),
+      ],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ControllerStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").prop("name")).toEqual("success");
+    expect(wrapper.find("Icon").prop("title")).toEqual("2 running");
+  });
+});

--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { Icon } from "@canonical/react-components";
+import { Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import controllerSelectors from "app/store/controller/selectors";
@@ -33,21 +33,25 @@ export const ControllerStatus = ({ systemId }: Props): JSX.Element | null => {
     return null;
   }
   let icon: string | null = null;
-  let text: string | null = null;
+  let message: string | null = null;
   const dead = countStatus(services, "dead");
   const degraded = countStatus(services, "degraded");
   const success = countStatus(services, "success");
   if (dead) {
     icon = "power-error";
-    text = `${dead} dead`;
+    message = `${dead} dead`;
   } else if (degraded) {
     icon = "warning";
-    text = `${degraded} degraded`;
+    message = `${degraded} degraded`;
   } else {
     icon = "success";
-    text = `${success} running`;
+    message = `${success} running`;
   }
-  return <Icon name={icon} title={text} />;
+  return (
+    <Tooltip message={message}>
+      <Icon name={icon} />
+    </Tooltip>
+  );
 };
 
 export default ControllerStatus;

--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+import { Icon } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+import { actions as serviceActions } from "app/store/service";
+import type { Service } from "app/store/service/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const countStatus = (services: Service[], status: Service["status"]) =>
+  services.filter((service) => service.status === status).length;
+
+export const ControllerStatus = ({ systemId }: Props): JSX.Element | null => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  const dispatch = useDispatch();
+  const services = useSelector((state: RootState) =>
+    controllerSelectors.servicesForController(state, controller?.system_id)
+  );
+
+  useEffect(() => {
+    dispatch(serviceActions.fetch());
+  }, [dispatch]);
+
+  if (!controller || !services?.length) {
+    return null;
+  }
+  let icon: string | null = null;
+  let text: string | null = null;
+  const dead = countStatus(services, "dead");
+  const degraded = countStatus(services, "degraded");
+  const success = countStatus(services, "success");
+  if (dead) {
+    icon = "power-error";
+    text = `${dead} dead`;
+  } else if (degraded) {
+    icon = "warning";
+    text = `${degraded} degraded`;
+  } else {
+    icon = "success";
+    text = `${success} running`;
+  }
+  return <Icon name={icon} title={text} />;
+};
+
+export default ControllerStatus;

--- a/ui/src/app/controllers/components/ControllerStatus/index.ts
+++ b/ui/src/app/controllers/components/ControllerStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerStatus";

--- a/ui/src/app/controllers/components/ImageStatus/ImageStatus.test.tsx
+++ b/ui/src/app/controllers/components/ImageStatus/ImageStatus.test.tsx
@@ -1,0 +1,130 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { ImageStatus } from "./ImageStatus";
+
+import { ImageSyncStatus } from "app/store/controller/types/enum";
+import type { RootState } from "app/store/root/types";
+import {
+  controller as controllerFactory,
+  controllerImageSyncStatuses as controllerImageSyncStatusesFactory,
+  controllerState as controllerStateFactory,
+  controllerStatus as controllerStatusFactory,
+  controllerStatuses as controllerStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ImageStatus", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      controller: controllerStateFactory({
+        loaded: true,
+        items: [
+          controllerFactory({
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("starts polling the image status", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ImageStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "controller/pollCheckImages")
+    ).toBe(true);
+  });
+
+  it("stops polling when unmounting", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <ImageStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => {
+      wrapper.unmount();
+    });
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "controller/pollCheckImagesStop")
+    ).toBe(true);
+  });
+
+  it("shows a spinner when polling", () => {
+    state.controller.statuses = controllerStatusesFactory({
+      abc123: controllerStatusFactory({ checkingImages: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ImageStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("shows the synced state", () => {
+    state.controller.imageSyncStatuses = controllerImageSyncStatusesFactory({
+      abc123: ImageSyncStatus.Synced,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ImageStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").exists()).toBe(true);
+    expect(wrapper.find('[data-testid="status"]').text()).toEqual(
+      ImageSyncStatus.Synced
+    );
+  });
+
+  it("shows a state that is not synced", () => {
+    state.controller.imageSyncStatuses = controllerImageSyncStatusesFactory({
+      abc123: ImageSyncStatus.Syncing,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ImageStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").exists()).toBe(false);
+    expect(wrapper.find('[data-testid="status"]').text()).toEqual(
+      ImageSyncStatus.Syncing
+    );
+  });
+});

--- a/ui/src/app/controllers/components/ImageStatus/ImageStatus.tsx
+++ b/ui/src/app/controllers/components/ImageStatus/ImageStatus.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+
+import { Icon, Spinner } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+import { useDispatch, useSelector } from "react-redux";
+
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors from "app/store/controller/selectors";
+import { ControllerMeta } from "app/store/controller/types";
+import type { Controller } from "app/store/controller/types";
+import { ImageSyncStatus } from "app/store/controller/types/enum";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+export const ImageStatus = ({ systemId }: Props): JSX.Element | null => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  const dispatch = useDispatch();
+  const pollId = useRef(nanoid());
+  const status = useSelector((state: RootState) =>
+    controllerSelectors.imageSyncStatusesForController(
+      state,
+      controller?.system_id
+    )
+  );
+  const checkingImages = useSelector((state: RootState) =>
+    controllerSelectors.getStatusForController(
+      state,
+      controller?.system_id || null,
+      "checkingImages"
+    )
+  );
+
+  useEffect(() => {
+    const id = pollId.current;
+    if (controller) {
+      dispatch(
+        controllerActions.pollCheckImages([controller[ControllerMeta.PK]], id)
+      );
+    }
+    return () => {
+      dispatch(controllerActions.pollCheckImagesStop(id));
+    };
+  }, [dispatch, controller]);
+
+  if (!controller) {
+    return null;
+  }
+  if (checkingImages) {
+    return <Spinner />;
+  }
+  return (
+    <>
+      {status === ImageSyncStatus.Synced && (
+        <>
+          <Icon name="success-grey" />{" "}
+        </>
+      )}
+      <span data-testid="status">{status ?? "Asking for status..."}</span>
+    </>
+  );
+};
+
+export default ImageStatus;

--- a/ui/src/app/controllers/components/ImageStatus/index.ts
+++ b/ui/src/app/controllers/components/ImageStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ImageStatus";

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -1,5 +1,6 @@
 import { MainTable, Spinner } from "@canonical/react-components";
 
+import StatusColumn from "./StatusColumn";
 import VLANsColumn from "./VLANsColumn";
 import VersionColumn from "./VersionColumn";
 
@@ -11,6 +12,7 @@ import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import baseURLs from "app/base/urls";
+import ImageStatus from "app/controllers/components/ImageStatus";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
 import { generateCheckboxHandlers, isComparable } from "app/utils";
 import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
@@ -75,9 +77,7 @@ const generateRows = (
         },
         {
           className: "status-col u-align--center",
-          // TODO: Add the controller status.
-          // https://github.com/canonical-web-and-design/app-tribe/issues/617
-          content: null,
+          content: <StatusColumn systemId={controller.system_id} />,
         },
         {
           className: "type-col",
@@ -101,10 +101,11 @@ const generateRows = (
         },
         {
           className: "images-col",
-          // TODO: Add the image status.
-          // https://github.com/canonical-web-and-design/app-tribe/issues/617
           content: (
-            <DoubleRow primary={controller.last_image_sync || "Never"} />
+            <DoubleRow
+              primary={controller.last_image_sync || "Never"}
+              secondary={<ImageStatus systemId={system_id} />}
+            />
           ),
         },
       ],

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.test.tsx
@@ -1,0 +1,64 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { StatusColumn } from "./StatusColumn";
+
+import { ControllerVersionIssues } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  controllerVersions as controllerVersionsFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("StatusColumn", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      controller: controllerStateFactory({
+        loaded: true,
+        items: [
+          controllerFactory({
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("displays a warning if there is a version error", () => {
+    state.controller.items[0].versions = controllerVersionsFactory({
+      issues: [ControllerVersionIssues.DIFFERENT_CHANNEL],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-testid="version-error"]').exists()).toBe(true);
+  });
+
+  it("displays the controller status if there are no errors", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("ControllerStatus").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
@@ -1,0 +1,51 @@
+import { Icon, Tooltip } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import ControllerStatus from "app/controllers/components/ControllerStatus";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+export const StatusColumn = ({ systemId }: Props): JSX.Element | null => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+
+  if (!controller) {
+    return null;
+  }
+  // Map the issue id to the type of issue.
+  const issues = (controller.versions?.issues || []).map((issue) =>
+    issue.replace("different-", "")
+  );
+  const issue = issues.length
+    ? `Different ${issues.join(" and ")} detected.`
+    : null;
+
+  return issue ? (
+    <span data-testid="version-error">
+      <Icon name="error" />{" "}
+      <Tooltip
+        className="status-icon--negative-space"
+        message={
+          <>
+            {issue}
+            <br />
+            <a href="https://discourse.maas.io/t/4555">More info</a>
+          </>
+        }
+        position="top-center"
+      >
+        <Icon name="information" />
+      </Tooltip>
+    </span>
+  ) : (
+    <ControllerStatus systemId={systemId} />
+  );
+};
+
+export default StatusColumn;

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/index.ts
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StatusColumn";

--- a/ui/src/app/store/controller/selectors.test.ts
+++ b/ui/src/app/store/controller/selectors.test.ts
@@ -8,6 +8,8 @@ import {
   controllerState as controllerStateFactory,
   controllerStatus as controllerStatusFactory,
   controllerStatuses as controllerStatusesFactory,
+  service as serviceFactory,
+  serviceState as serviceStateFactory,
 } from "testing/factories";
 
 describe("controller selectors", () => {
@@ -131,6 +133,26 @@ describe("controller selectors", () => {
     });
     expect(controller.imageSyncStatusesForController(state, "abc123")).toBe(
       ImageSyncStatus.OutOfSync
+    );
+  });
+
+  it("can get the services for a controller", () => {
+    const services = [serviceFactory(), serviceFactory()];
+    const state = rootStateFactory({
+      controller: controllerStateFactory({
+        items: [
+          controllerFactory({
+            system_id: "abc123",
+            service_ids: services.map(({ id }) => id),
+          }),
+        ],
+      }),
+      service: serviceStateFactory({
+        items: services,
+      }),
+    });
+    expect(controller.servicesForController(state, "abc123")).toStrictEqual(
+      services
     );
   });
 });

--- a/ui/src/app/store/controller/selectors.ts
+++ b/ui/src/app/store/controller/selectors.ts
@@ -2,6 +2,7 @@ import type { Selector } from "@reduxjs/toolkit";
 import { createSelector } from "@reduxjs/toolkit";
 
 import type { RootState } from "../root/types";
+import type { Service } from "../service/types";
 
 import { ACTIONS } from "./slice";
 import { FilterControllers } from "./utils";
@@ -13,6 +14,7 @@ import type {
   ControllerStatus,
   ControllerStatuses,
 } from "app/store/controller/types";
+import serviceSelectors from "app/store/service/selectors";
 import { generateBaseSelectors } from "app/store/utils";
 
 const defaultSelectors = generateBaseSelectors<
@@ -250,6 +252,43 @@ const search = createSelector(
 );
 
 /**
+ * Get controllers that match search terms.
+ * @param state - The redux state.
+ * @param terms - The search terms to match against.
+ * @returns A filtered list of controllers.
+ */
+const servicesForController = createSelector(
+  [
+    defaultSelectors.all,
+    serviceSelectors.all,
+    (_state: RootState, systemId?: Controller[ControllerMeta.PK] | null) => ({
+      systemId,
+    }),
+  ],
+  (controllers: Controller[], services: Service[], { systemId }) => {
+    if (!systemId) {
+      return null;
+    }
+    const controller = controllers.find(
+      ({ system_id }) => system_id === systemId
+    );
+    if (!controller) {
+      return null;
+    }
+    return controller.service_ids.reduce<Service[]>(
+      (serviceList, serviceId) => {
+        const service = services.find(({ id }) => id === serviceId);
+        if (service) {
+          serviceList.push(service);
+        }
+        return serviceList;
+      },
+      []
+    );
+  }
+);
+
+/**
  * Get image sync statuses.
  * @param state - The redux state.
  * @returns The controller state.
@@ -292,6 +331,7 @@ const selectors = {
   search,
   selected,
   selectedIDs,
+  servicesForController,
   statuses,
 };
 

--- a/ui/src/app/store/controller/selectors.ts
+++ b/ui/src/app/store/controller/selectors.ts
@@ -252,7 +252,7 @@ const search = createSelector(
 );
 
 /**
- * Get controllers that match search terms.
+ * Get the services for a controller.
  * @param state - The redux state.
  * @param terms - The search terms to match against.
  * @returns A filtered list of controllers.


### PR DESCRIPTION
## Done

- Add the controller and image statuses to the controller table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/controllers
- Check that there is content in the status column that matches the legacy view.
- Check that the image sync status is show in the images column.

## Fixes

Fixes: canonical-web-and-design/app-tribe#617.