### PR TITLE
feat(ui): add controller header forms

### DIFF
--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.test.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.test.tsx
@@ -1,0 +1,48 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ControllerActionFormWrapper from "./ControllerActionFormWrapper";
+
+import { actions as controllerActions } from "app/store/controller";
+import { NodeActions } from "app/store/types/node";
+import {
+  controller as controllerFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ControllerActionFormWrapper", () => {
+  it("can set selected controllers to those that can perform action", () => {
+    const state = rootStateFactory();
+    const controllers = [
+      controllerFactory({ system_id: "abc123", actions: [NodeActions.DELETE] }),
+      controllerFactory({ system_id: "def456", actions: [] }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ControllerActionFormWrapper
+            action={NodeActions.DELETE}
+            clearHeaderContent={jest.fn()}
+            controllers={controllers}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find('button[data-testid="on-update-selected"]').simulate("click");
+
+    const expectedAction = controllerActions.setSelected(["abc123"]);
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
@@ -1,0 +1,154 @@
+import { useDispatch, useSelector } from "react-redux";
+
+import DeleteForm from "app/base/components/node/DeleteForm";
+import FieldlessForm from "app/base/components/node/FieldlessForm";
+import NodeActionFormWrapper from "app/base/components/node/NodeActionFormWrapper";
+import SetZoneForm from "app/base/components/node/SetZoneForm";
+import TestForm from "app/base/components/node/TestForm";
+import type { HardwareType } from "app/base/enum";
+import type { ClearHeaderContent } from "app/base/types";
+import controllerURLs from "app/controllers/urls";
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors, {
+  statusSelectors,
+} from "app/store/controller/selectors";
+import { ACTIONS } from "app/store/controller/slice";
+import type { Controller, ControllerActions } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
+import { kebabToCamelCase } from "app/utils";
+
+type Props = {
+  action: ControllerActions;
+  applyConfiguredNetworking?: boolean;
+  clearHeaderContent: ClearHeaderContent;
+  hardwareType?: HardwareType;
+  controllers: Controller[];
+  viewingDetails: boolean;
+};
+
+const getProcessingCount = (
+  selectedControllers: Controller[],
+  processingControllers: Controller[]
+) => {
+  return processingControllers.reduce<number>((count, processingController) => {
+    const controllerInSelection = selectedControllers.some(
+      (controller) => controller.system_id === processingController.system_id
+    );
+    return controllerInSelection ? count + 1 : count;
+  }, 0);
+};
+
+export const ControllerActionFormWrapper = ({
+  action,
+  applyConfiguredNetworking,
+  clearHeaderContent,
+  hardwareType,
+  controllers,
+  viewingDetails,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const actionStatus = ACTIONS.find(({ name }) => name === action)?.status;
+  const processingControllers = useSelector(
+    actionStatus ? statusSelectors[actionStatus] : () => []
+  );
+  // The form expects one error, so we only show the latest error with the
+  // assumption that all selected controllers fail in the same way.
+  const errors = useSelector((state: RootState) =>
+    controllerSelectors.eventErrorsForControllers(
+      state,
+      controllers.map(({ system_id }) => system_id),
+      kebabToCamelCase(action)
+    )
+  )[0]?.error;
+  const processingCount = getProcessingCount(
+    controllers,
+    processingControllers
+  );
+  const commonNodeFormProps = {
+    cleanup: controllerActions.cleanup,
+    clearHeaderContent,
+    errors,
+    modelName: "controller",
+    nodes: controllers,
+    processingCount,
+    viewingDetails,
+  };
+
+  const getFormComponent = () => {
+    switch (action) {
+      case NodeActions.DELETE:
+        return (
+          <DeleteForm
+            onSubmit={() => {
+              controllers.forEach((controller) => {
+                dispatch(controllerActions.delete(controller.system_id));
+              });
+            }}
+            redirectURL={controllerURLs.controllers.index}
+            {...commonNodeFormProps}
+          />
+        );
+      case NodeActions.OVERRIDE_FAILED_TESTING:
+        // TODO: Add override failed testing form.
+        // https://github.com/canonical-web-and-design/app-tribe/issues/618
+        return null;
+      case NodeActions.SET_ZONE:
+        return (
+          <SetZoneForm
+            onSubmit={(zoneID) => {
+              dispatch(controllerActions.cleanup());
+              controllers.forEach((controller) => {
+                dispatch(
+                  controllerActions.setZone({
+                    systemId: controller.system_id,
+                    zoneId: zoneID,
+                  })
+                );
+              });
+            }}
+            {...commonNodeFormProps}
+          />
+        );
+      case NodeActions.TEST:
+        return (
+          <TestForm
+            applyConfiguredNetworking={applyConfiguredNetworking}
+            hardwareType={hardwareType}
+            onTest={(args) => {
+              dispatch(controllerActions.test(args));
+            }}
+            {...commonNodeFormProps}
+          />
+        );
+      case NodeActions.IMPORT_IMAGES:
+      case NodeActions.OFF:
+      case NodeActions.ON:
+        return (
+          <FieldlessForm
+            action={action}
+            actions={controllerActions}
+            {...commonNodeFormProps}
+          />
+        );
+    }
+  };
+
+  return (
+    <NodeActionFormWrapper
+      action={action}
+      clearHeaderContent={clearHeaderContent}
+      nodes={controllers}
+      nodeType="controller"
+      processingCount={processingCount}
+      onUpdateSelected={(controllerIDs) =>
+        dispatch(controllerActions.setSelected(controllerIDs))
+      }
+      viewingDetails={viewingDetails}
+    >
+      {getFormComponent()}
+    </NodeActionFormWrapper>
+  );
+};
+
+export default ControllerActionFormWrapper;

--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/index.ts
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerActionFormWrapper";

--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.test.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.test.tsx
@@ -1,0 +1,33 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ControllerHeaderForms from "./ControllerHeaderForms";
+
+import { ControllerHeaderViews } from "app/controllers/constants";
+import {
+  controller as controllerFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ControllerHeaderForms", () => {
+  it("can render the action form wrapper", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ControllerHeaderForms
+            controllers={[controllerFactory()]}
+            headerContent={{ view: ControllerHeaderViews.SET_ZONE_CONTROLLER }}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("ControllerActionFormWrapper").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.tsx
@@ -1,0 +1,58 @@
+import { useCallback } from "react";
+
+import type { ValueOf } from "@canonical/react-components";
+
+import ControllerActionFormWrapper from "./ControllerActionFormWrapper";
+
+import type { ControllerActionHeaderViews } from "app/controllers/constants";
+import { ControllerHeaderViews } from "app/controllers/constants";
+import type {
+  ControllerHeaderContent,
+  ControllerSetHeaderContent,
+} from "app/controllers/types";
+import type { Controller } from "app/store/controller/types";
+
+type Props = {
+  controllers: Controller[];
+  headerContent: ControllerHeaderContent;
+  setHeaderContent: ControllerSetHeaderContent;
+  viewingDetails?: boolean;
+};
+
+const ControllerHeaderForms = ({
+  controllers,
+  headerContent,
+  setHeaderContent,
+  viewingDetails = false,
+}: Props): JSX.Element | null => {
+  const clearHeaderContent = useCallback(
+    () => setHeaderContent(null),
+    [setHeaderContent]
+  );
+
+  switch (headerContent.view) {
+    case ControllerHeaderViews.ADD_CONTROLLER:
+      // TODO: Add the add controller instructions.
+      // https://github.com/canonical-web-and-design/app-tribe/issues/612
+      return null;
+    default:
+      // We need to explicitly cast headerContent.view here - TypeScript doesn't
+      // seem to be able to infer remaining object tuple values as with string
+      // values.
+      // https://github.com/canonical-web-and-design/maas-ui/issues/3040
+      const { view } = headerContent as {
+        view: ValueOf<typeof ControllerActionHeaderViews>;
+      };
+      const [, action] = view;
+      return (
+        <ControllerActionFormWrapper
+          action={action}
+          clearHeaderContent={clearHeaderContent}
+          controllers={controllers}
+          viewingDetails={viewingDetails}
+        />
+      );
+  }
+};
+
+export default ControllerHeaderForms;

--- a/ui/src/app/controllers/components/ControllerHeaderForms/index.ts
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerHeaderForms";

--- a/ui/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
@@ -5,6 +5,7 @@ import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
 import type { SetSearchFilter } from "app/base/types";
+import ControllerHeaderForms from "app/controllers/components/ControllerHeaderForms";
 import { ControllerHeaderViews } from "app/controllers/constants";
 import type {
   ControllerHeaderContent,
@@ -54,7 +55,15 @@ const ControllerListHeader = ({
           }}
         />,
       ]}
-      headerContent={headerContent && "ControllerHeaderForms"}
+      headerContent={
+        headerContent && (
+          <ControllerHeaderForms
+            controllers={selectedControllers}
+            headerContent={headerContent}
+            setHeaderContent={setHeaderContent}
+          />
+        )
+      }
       subtitle={
         <ModelListSubtitle
           available={controllers.length}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
@@ -166,7 +166,6 @@ export const ActionFormWrapper = ({
             {...commonNodeFormProps}
           />
         );
-
       case NodeActions.ABORT:
       case NodeActions.ACQUIRE:
       case NodeActions.EXIT_RESCUE_MODE:

--- a/ui/src/app/store/utils/node/base.ts
+++ b/ui/src/app/store/utils/node/base.ts
@@ -29,6 +29,8 @@ export const getNodeActionTitle = (actionName: NodeActions): string => {
       return "Deploy";
     case NodeActions.EXIT_RESCUE_MODE:
       return "Exit rescue mode";
+    case NodeActions.IMPORT_IMAGES:
+      return "Import images";
     case NodeActions.LOCK:
       return "Lock";
     case NodeActions.MARK_BROKEN:


### PR DESCRIPTION
## Done

- Add the header forms to the controller list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/controllers.
- Tick some controllers and use the take action to perform actions on the controllers (except override failed testing which will be done in a followup: https://github.com/canonical-web-and-design/app-tribe/issues/618).

## Fixes

Fixes: canonical-web-and-design/app-tribe#613.