### PR TITLE
feat(ui): add controller instructions

### DIFF
--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
@@ -1,0 +1,58 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddController from "./AddController";
+
+import type { RootState } from "app/store/root/types";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddController", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          { name: "maas_url", value: "http://1.2.3.4/MAAS" },
+          { name: "rpc_shared_secret", value: "veryverysecret" },
+        ],
+      }),
+    });
+  });
+
+  it("includes the config in the instructions", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AddController clearHeaderContent={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const instructions = wrapper.find("[data-testid='instructions']").text();
+    expect(instructions.includes("http://1.2.3.4/MAAS")).toBe(true);
+    expect(instructions.includes("veryverysecret")).toBe(true);
+  });
+
+  it("can close the instructions", () => {
+    state.zone.loaded = false;
+    const store = mockStore(state);
+    const clearHeaderContent = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AddController clearHeaderContent={clearHeaderContent} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button[data-testid='close']").simulate("click");
+    expect(clearHeaderContent).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
@@ -36,13 +36,14 @@ describe("AddController", () => {
         </MemoryRouter>
       </Provider>
     );
-    const instructions = wrapper.find("[data-testid='instructions']").text();
+    const instructions = wrapper
+      .find("[data-testid='register-snippet']")
+      .text();
     expect(instructions.includes("http://1.2.3.4/MAAS")).toBe(true);
     expect(instructions.includes("veryverysecret")).toBe(true);
   });
 
   it("can close the instructions", () => {
-    state.zone.loaded = false;
     const store = mockStore(state);
     const clearHeaderContent = jest.fn();
     const wrapper = mount(
@@ -52,7 +53,9 @@ describe("AddController", () => {
         </MemoryRouter>
       </Provider>
     );
-    wrapper.find("Button[data-testid='close']").simulate("click");
+    wrapper
+      .find("Button[data-testid='add-controller-close']")
+      .simulate("click");
     expect(clearHeaderContent).toHaveBeenCalled();
   });
 });

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -1,0 +1,47 @@
+import { Button, Col, Row } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import type { ClearHeaderContent } from "app/base/types";
+import configSelectors from "app/store/config/selectors";
+
+type Props = {
+  clearHeaderContent: ClearHeaderContent;
+};
+
+export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
+  const maasUrl = useSelector(configSelectors.maasUrl);
+  const rpcSharedSecret = useSelector(configSelectors.rpcSharedSecret);
+
+  return (
+    <>
+      <pre>
+        <code data-testid="instructions">{`# To add a new rack controller, SSH into the rack controller.
+# Install the maas-rack-controller package.
+# Confirm that the MAAS version is the same as the main rack controller.
+sudo apt install maas-rack-controller
+# Or if you use snap
+sudo snap install maas
+
+# Register the rack controller with this MAAS. If the rack controller (and machines)
+# don't have access to the URL, use a different IP address to allow connection.
+sudo maas-rack register --url ${maasUrl} --secret ${rpcSharedSecret}
+# Or if you use snap
+sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`}</code>
+      </pre>
+      <Row>
+        <Col size={6}>
+          <a href="https://maas.io/docs/rack-controller">
+            Help with adding a rack controller
+          </a>
+        </Col>
+        <Col className="u-align--right" size={6}>
+          <Button data-testid="close" onClick={clearHeaderContent}>
+            Close
+          </Button>
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default AddController;

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Row } from "@canonical/react-components";
+import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import type { ClearHeaderContent } from "app/base/types";
@@ -14,20 +14,47 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
 
   return (
     <>
-      <pre>
-        <code data-testid="instructions">{`# To add a new rack controller, SSH into the rack controller.
-# Install the maas-rack-controller package.
-# Confirm that the MAAS version is the same as the main rack controller.
-sudo apt install maas-rack-controller
-# Or if you use snap
-sudo snap install maas
-
-# Register the rack controller with this MAAS. If the rack controller (and machines)
-# don't have access to the URL, use a different IP address to allow connection.
-sudo maas-rack register --url ${maasUrl} --secret ${rpcSharedSecret}
-# Or if you use snap
-sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`}</code>
-      </pre>
+      <p>
+        To add a new rack controller, SSH into the rack controller. Install the
+        maas-rack-controller package. Confirm that the MAAS version is the same
+        as the main rack controller.
+      </p>
+      <CodeSnippet
+        blocks={[
+          {
+            code: "sudo apt install maas-rack-controller",
+          },
+        ]}
+      />
+      <p>Or if you use snap</p>
+      <CodeSnippet
+        blocks={[
+          {
+            code: "sudo snap install maas",
+          },
+        ]}
+      />
+      <p>
+        Register the rack controller with this MAAS. If the rack controller (and
+        machines) don't have access to the URL, use a different IP address to
+        allow connection.
+      </p>
+      <CodeSnippet
+        data-testid="register-snippet"
+        blocks={[
+          {
+            code: `sudo maas-rack register --url ${maasUrl} --secret ${rpcSharedSecret}`,
+          },
+        ]}
+      />
+      <p>Or if you use snap</p>
+      <CodeSnippet
+        blocks={[
+          {
+            code: `sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`,
+          },
+        ]}
+      />
       <Row>
         <Col size={6}>
           <a href="https://maas.io/docs/rack-controller">
@@ -35,7 +62,10 @@ sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`}</code>
           </a>
         </Col>
         <Col className="u-align--right" size={6}>
-          <Button data-testid="close" onClick={clearHeaderContent}>
+          <Button
+            data-testid="add-controller-close"
+            onClick={clearHeaderContent}
+          >
             Close
           </Button>
         </Col>

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/index.ts
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddController";

--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.test.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.test.tsx
@@ -30,4 +30,21 @@ describe("ControllerHeaderForms", () => {
     );
     expect(wrapper.find("ControllerActionFormWrapper").exists()).toBe(true);
   });
+
+  it("can render add controller instructions", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ControllerHeaderForms
+            controllers={[controllerFactory()]}
+            headerContent={{ view: ControllerHeaderViews.ADD_CONTROLLER }}
+            setHeaderContent={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("AddController").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
 
+import AddController from "./AddController";
 import ControllerActionFormWrapper from "./ControllerActionFormWrapper";
 
 import type { ControllerActionHeaderViews } from "app/controllers/constants";
@@ -32,9 +33,7 @@ const ControllerHeaderForms = ({
 
   switch (headerContent.view) {
     case ControllerHeaderViews.ADD_CONTROLLER:
-      // TODO: Add the add controller instructions.
-      // https://github.com/canonical-web-and-design/app-tribe/issues/612
-      return null;
+      return <AddController clearHeaderContent={clearHeaderContent} />;
     default:
       // We need to explicitly cast headerContent.view here - TypeScript doesn't
       // seem to be able to infer remaining object tuple values as with string

--- a/ui/src/app/store/config/selectors.test.ts
+++ b/ui/src/app/store/config/selectors.test.ts
@@ -482,4 +482,36 @@ describe("config selectors", () => {
       expect(config.bootImagesAutoImport(state)).toBe(true);
     });
   });
+
+  describe("maasUrl", () => {
+    it("returns MAAS config for boot images auto import", () => {
+      const state = rootStateFactory({
+        config: configStateFactory({
+          items: [
+            configFactory({
+              name: "maas_url",
+              value: "http://1.2.3.4/MAAS",
+            }),
+          ],
+        }),
+      });
+      expect(config.maasUrl(state)).toBe("http://1.2.3.4/MAAS");
+    });
+  });
+
+  describe("rpcSharedSecret", () => {
+    it("returns MAAS config for boot images auto import", () => {
+      const state = rootStateFactory({
+        config: configStateFactory({
+          items: [
+            configFactory({
+              name: "rpc_shared_secret",
+              value: "veryverysecret",
+            }),
+          ],
+        }),
+      });
+      expect(config.rpcSharedSecret(state)).toBe("veryverysecret");
+    });
+  });
 });

--- a/ui/src/app/store/config/selectors.ts
+++ b/ui/src/app/store/config/selectors.ts
@@ -470,6 +470,15 @@ const maasAutoIpmiKGBmcKey = createSelector([all], (configs) =>
 );
 
 /**
+ * Returns the MAAS url.
+ * @param state - The redux state.
+ * @returns MAAS url.
+ */
+const maasUrl = createSelector([all], (configs) =>
+  getValueFromName<string>(configs, "maas_url")
+);
+
+/**
  * Returns the MAAS config for whether the intro has been completed.
  * @param state - The redux state.
  * @returns Whether the intro has been completed
@@ -485,6 +494,15 @@ const completedIntro = createSelector([all], (configs) =>
  */
 const releaseNotifications = createSelector([all], (configs) =>
   getValueFromName<boolean>(configs, "release_notifications")
+);
+
+/**
+ * Returns the RPC shared secret.
+ * @param state - The redux state.
+ * @returns RPC shared secret.
+ */
+const rpcSharedSecret = createSelector([all], (configs) =>
+  getValueFromName<string>(configs, "rpc_shared_secret")
 );
 
 /**
@@ -526,6 +544,7 @@ const config = {
   maasAutoIpmiUser,
   maasAutoIpmiKGBmcKey,
   maasAutoUserPrivilegeLevel,
+  maasUrl,
   networkDiscovery,
   networkDiscoveryOptions,
   ntpExternalOnly,
@@ -533,6 +552,7 @@ const config = {
   proxyType,
   releaseNotifications,
   remoteSyslog,
+  rpcSharedSecret,
   saved,
   saving,
   storageLayoutOptions,


### PR DESCRIPTION
## Done

- Add instructions for adding a controller.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the controllers list.
- Click on "Add controller".
- You should see instructions on how to add a controller.
- Click "Close" and the header should close.

## Fixes

Fixes: canonical-web-and-design/app-tribe#612.