### PR TITLE
feat(ui): add controller override testing

### DIFF
--- a/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
@@ -89,10 +89,6 @@ export const ControllerActionFormWrapper = ({
             {...commonNodeFormProps}
           />
         );
-      case NodeActions.OVERRIDE_FAILED_TESTING:
-        // TODO: Add override failed testing form.
-        // https://github.com/canonical-web-and-design/app-tribe/issues/618
-        return null;
       case NodeActions.SET_ZONE:
         return (
           <SetZoneForm
@@ -124,6 +120,7 @@ export const ControllerActionFormWrapper = ({
       case NodeActions.IMPORT_IMAGES:
       case NodeActions.OFF:
       case NodeActions.ON:
+      case NodeActions.OVERRIDE_FAILED_TESTING:
         return (
           <FieldlessForm
             action={action}


### PR DESCRIPTION
## Done

- Use the fieldless form for overriding failed testing for controllers.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the controller list and tick a machine that has failed testing.
- Use the take action menu to open the override failed testing and submit. It should work.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/618.
