### PR TITLE
fix(ui): fix incorrect status tooltip

### DIFF
--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import { ControllerStatus } from "./ControllerStatus";
 
 import type { RootState } from "app/store/root/types";
+import { ServiceStatus } from "app/store/service/types";
 import {
   controller as controllerFactory,
   controllerState as controllerStateFactory,
@@ -36,11 +37,11 @@ describe("ControllerStatus", () => {
       items: [
         serviceFactory({
           id: 1,
-          status: "dead",
+          status: ServiceStatus.DEAD,
         }),
         serviceFactory({
           id: 2,
-          status: "dead",
+          status: ServiceStatus.DEAD,
         }),
       ],
     });
@@ -63,11 +64,11 @@ describe("ControllerStatus", () => {
       items: [
         serviceFactory({
           id: 1,
-          status: "degraded",
+          status: ServiceStatus.DEGRADED,
         }),
         serviceFactory({
           id: 2,
-          status: "degraded",
+          status: ServiceStatus.DEGRADED,
         }),
       ],
     });
@@ -90,11 +91,11 @@ describe("ControllerStatus", () => {
       items: [
         serviceFactory({
           id: 1,
-          status: "success",
+          status: ServiceStatus.RUNNING,
         }),
         serviceFactory({
           id: 2,
-          status: "success",
+          status: ServiceStatus.RUNNING,
         }),
       ],
     });
@@ -110,5 +111,59 @@ describe("ControllerStatus", () => {
     );
     expect(wrapper.find("Icon").prop("name")).toEqual("success");
     expect(wrapper.find("Tooltip").prop("message")).toEqual("2 running");
+  });
+
+  it("handles a powered off controller", () => {
+    state.service = serviceStateFactory({
+      items: [
+        serviceFactory({
+          id: 1,
+          status: ServiceStatus.OFF,
+        }),
+        serviceFactory({
+          id: 2,
+          status: ServiceStatus.OFF,
+        }),
+      ],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ControllerStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").prop("name")).toEqual("power-off");
+    expect(wrapper.find("Tooltip").prop("message")).toEqual("2 off");
+  });
+
+  it("handles a controller with unknown status", () => {
+    state.service = serviceStateFactory({
+      items: [
+        serviceFactory({
+          id: 1,
+          status: ServiceStatus.UNKNOWN,
+        }),
+        serviceFactory({
+          id: 2,
+          status: ServiceStatus.UNKNOWN,
+        }),
+      ],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/controllers", key: "testKey" }]}
+        >
+          <ControllerStatus systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Icon").prop("name")).toEqual("power-unknown");
+    expect(wrapper.find("Tooltip").prop("message")).toBe(null);
   });
 });

--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
@@ -7,13 +7,14 @@ import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
 import { actions as serviceActions } from "app/store/service";
+import { ServiceStatus } from "app/store/service/types";
 import type { Service } from "app/store/service/types";
 
 type Props = {
   systemId: Controller[ControllerMeta.PK];
 };
 
-const countStatus = (services: Service[], status: Service["status"]) =>
+const countStatus = (services: Service[], status: ServiceStatus) =>
   services.filter((service) => service.status === status).length;
 
 export const ControllerStatus = ({ systemId }: Props): JSX.Element | null => {
@@ -34,18 +35,24 @@ export const ControllerStatus = ({ systemId }: Props): JSX.Element | null => {
   }
   let icon: string | null = null;
   let message: string | null = null;
-  const dead = countStatus(services, "dead");
-  const degraded = countStatus(services, "degraded");
-  const success = countStatus(services, "success");
+  const dead = countStatus(services, ServiceStatus.DEAD);
+  const degraded = countStatus(services, ServiceStatus.DEGRADED);
+  const running = countStatus(services, ServiceStatus.RUNNING);
+  const off = countStatus(services, ServiceStatus.OFF);
   if (dead) {
     icon = "power-error";
     message = `${dead} dead`;
   } else if (degraded) {
     icon = "warning";
     message = `${degraded} degraded`;
-  } else {
+  } else if (running) {
     icon = "success";
-    message = `${success} running`;
+    message = `${running} running`;
+  } else if (off) {
+    icon = "power-off";
+    message = `${off} off`;
+  } else {
+    icon = "power-unknown";
   }
   return (
     <Tooltip message={message}>

--- a/ui/src/app/store/service/types/base.ts
+++ b/ui/src/app/store/service/types/base.ts
@@ -1,10 +1,12 @@
+import type { ServiceStatus } from "./enum";
+
 import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
 export type Service = Model & {
   name: string;
-  status: string;
+  status: ServiceStatus;
   status_info: string;
 };
 

--- a/ui/src/app/store/service/types/enum.ts
+++ b/ui/src/app/store/service/types/enum.ts
@@ -2,3 +2,11 @@ export enum ServiceMeta {
   MODEL = "service",
   PK = "id",
 }
+
+export enum ServiceStatus {
+  DEAD = "dead", // Service is dead. (Should be on but is off).
+  DEGRADED = "degraded", // Service is running but is in a degraded state.
+  OFF = "off", // Service is off. (Should be off and is off).
+  RUNNING = "running", // Service is running and operational.
+  UNKNOWN = "unknown", // Status of the service is not known.
+}

--- a/ui/src/app/store/service/types/index.ts
+++ b/ui/src/app/store/service/types/index.ts
@@ -1,3 +1,3 @@
 export type { Service, ServiceState } from "./base";
 
-export { ServiceMeta } from "./enum";
+export { ServiceMeta, ServiceStatus } from "./enum";

--- a/ui/src/testing/factories/service.ts
+++ b/ui/src/testing/factories/service.ts
@@ -2,11 +2,12 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
+import { ServiceStatus } from "app/store/service/types";
 import type { Service } from "app/store/service/types";
 import type { Model } from "app/store/types/model";
 
 export const service = extend<Model, Service>(model, {
   name: "test name",
-  status: "test status",
+  status: ServiceStatus.RUNNING,
   status_info: "test info",
 });


### PR DESCRIPTION
## Done

- Added an enum for the possible service statuses
- Used enum for determining controller status tooltip

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the controller list for bolla and check that the status tooltip matches what's shown in the legacy details page

## Fixes

Fixes #3499 
