### PR TITLE
refactor(ui): subnets header, add fabric, add space

### DIFF
--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -1,0 +1,29 @@
+import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateId } from "../utils";
+
+context("Subnets - Add Fabric", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateNewURL("/networks?by=fabric"));
+  });
+
+  it("displays an error when trying to add a fabric with a name that already exists", () => {
+    const fabricName = `cypress-fabric-${generateId()}`;
+
+    cy.findByRole("button", { name: "Add" }).click();
+    cy.findByRole("button", { name: "Fabric" }).click();
+    cy.findByRole("textbox", { name: "Name (optional)" }).type(fabricName);
+    cy.findByRole("button", { name: /Add Fabric/ }).click();
+
+    cy.waitUntil(() =>
+      cy
+        .findByRole("textbox", { name: "Name (optional)" })
+        .should("not.be.disabled")
+    );
+
+    cy.findByRole("textbox", { name: "Name (optional)" }).type(fabricName);
+    cy.findByRole("button", { name: /Add Fabric/ }).click();
+
+    cy.findByText(/Fabric with this Name already exists/).should("exist");
+  });
+});

--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -1,29 +1,31 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 import { generateId } from "../utils";
 
-context("Subnets - Add Fabric", () => {
+context("Subnets - Add", () => {
   beforeEach(() => {
     cy.login();
     cy.visit(generateNewURL("/networks?by=fabric"));
   });
 
-  it("displays an error when trying to add a fabric with a name that already exists", () => {
-    const fabricName = `cypress-fabric-${generateId()}`;
+  ["Space", "Fabric"].forEach((type) => {
+    it(`displays an error when trying to add a ${type} with a name that already exists`, () => {
+      const name = `cypress-${generateId()}`;
 
-    cy.findByRole("button", { name: "Add" }).click();
-    cy.findByRole("button", { name: "Fabric" }).click();
-    cy.findByRole("textbox", { name: "Name (optional)" }).type(fabricName);
-    cy.findByRole("button", { name: /Add Fabric/ }).click();
+      cy.findByRole("button", { name: "Add" }).click();
+      cy.findByRole("button", { name: type }).click();
+      cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
+      cy.findByRole("button", { name: `Add ${type}` }).click();
 
-    cy.waitUntil(() =>
-      cy
-        .findByRole("textbox", { name: "Name (optional)" })
-        .should("not.be.disabled")
-    );
+      cy.waitUntil(() =>
+        cy
+          .findByRole("textbox", { name: "Name (optional)" })
+          .should("not.be.disabled")
+      );
 
-    cy.findByRole("textbox", { name: "Name (optional)" }).type(fabricName);
-    cy.findByRole("button", { name: /Add Fabric/ }).click();
+      cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
+      cy.findByRole("button", { name: `Add ${type}` }).click();
 
-    cy.findByText(/Fabric with this Name already exists/).should("exist");
+      cy.findByText(/this Name already exists/).should("exist");
+    });
   });
 });

--- a/integration/cypress/integration/utils.ts
+++ b/integration/cypress/integration/utils.ts
@@ -13,3 +13,4 @@ export const generateMac = () =>
   );
 
 export const generateEmail = () => `${nanoid()}@example.com`;
+export const generateId = () => nanoid();

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -64,6 +64,7 @@ module.exports = {
           },
         ],
         "@typescript-eslint/consistent-type-imports": 2,
+        "@typescript-eslint/explicit-module-boundary-types": ["error"],
         "import/namespace": "off",
         "import/no-named-as-default": 0,
         "import/order": [

--- a/ui/src/app/base/components/ArchitectureSelect/__snapshots__/ArchitectureSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ArchitectureSelect/__snapshots__/ArchitectureSelect.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ArchitectureSelect renders a list of all architectures in state 1`] = `
 <select
+  aria-label="Architecture"
   className="p-form-validation__input"
   disabled={false}
   name="architecture"

--- a/ui/src/app/base/components/DomainSelect/__snapshots__/DomainSelect.test.tsx.snap
+++ b/ui/src/app/base/components/DomainSelect/__snapshots__/DomainSelect.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`DomainSelect renders a list of all domains in state 1`] = `
 <select
+  aria-label="Domain"
   className="p-form-validation__input"
   disabled={false}
   name="domain"

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -20,6 +20,7 @@ const FormikField = <C extends ElementType | ComponentType = typeof Input>({
   component: Component = Input,
   name,
   value,
+  label,
   ...props
 }: Props<C>): JSX.Element => {
   const id = useRef(nanoid());
@@ -28,6 +29,8 @@ const FormikField = <C extends ElementType | ComponentType = typeof Input>({
     <Component
       error={meta.touched ? meta.error : null}
       id={id.current}
+      aria-label={label}
+      label={label}
       {...field}
       {...props}
     />

--- a/ui/src/app/base/components/FormikField/__snapshots__/FormikField.test.tsx.snap
+++ b/ui/src/app/base/components/FormikField/__snapshots__/FormikField.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`FormikField can render 1`] = `
   type="text"
 >
   <Input
+    aria-label="Username"
     error={null}
     help="Required."
     id="username"
@@ -47,6 +48,7 @@ exports[`FormikField can render 1`] = `
         >
           <input
             aria-invalid={false}
+            aria-label="Username"
             className="p-form-validation__input"
             id="username"
             name="username"

--- a/ui/src/app/base/components/MinimumKernelSelect/__snapshots__/MinimumKernelSelect.test.tsx.snap
+++ b/ui/src/app/base/components/MinimumKernelSelect/__snapshots__/MinimumKernelSelect.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`MinimumKernelSelect renders a list of all hwe kernels in state 1`] = `
 <select
+  aria-label="Minimum kernel"
   className="p-form-validation__input"
   disabled={false}
   name="minKernel"

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`NodeNameFields displays the fields 1`] = `
       wrapperClassName="u-nudge-left u-no-margin--right"
     >
       <Select
+        aria-label={null}
         className="u-no-margin--bottom"
         disabled={false}
         error={null}
@@ -132,6 +133,7 @@ exports[`NodeNameFields displays the fields 1`] = `
                 className="p-form-validation__select-wrapper"
               >
                 <select
+                  aria-label={null}
                   className="p-form-validation__input u-no-margin--bottom"
                   disabled={false}
                   name="domain"

--- a/ui/src/app/base/components/ResourcePoolSelect/__snapshots__/ResourcePoolSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ResourcePoolSelect/__snapshots__/ResourcePoolSelect.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ResourcePoolSelect renders a list of all resource pools in state 1`] = `
 <select
+  aria-label="Resource pool"
   className="p-form-validation__input"
   disabled={false}
   name="pool"

--- a/ui/src/app/base/components/ZoneSelect/__snapshots__/ZoneSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ZoneSelect/__snapshots__/ZoneSelect.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ZoneSelect renders a list of all zones in state 1`] = `
 <select
+  aria-label="Zone"
   className="p-form-validation__input"
   disabled={false}
   name="zone"

--- a/ui/src/app/store/fabric/types/actions.ts
+++ b/ui/src/app/store/fabric/types/actions.ts
@@ -2,9 +2,9 @@ import type { Fabric } from "./base";
 import type { FabricMeta } from "./enum";
 
 export type CreateParams = {
-  class_type: Fabric["class_type"];
-  description: Fabric["description"];
-  name: Fabric["name"];
+  class_type?: Fabric["class_type"];
+  description?: Fabric["description"];
+  name?: Fabric["name"];
 };
 
 export type UpdateParams = CreateParams & {

--- a/ui/src/app/store/fabric/types/actions.ts
+++ b/ui/src/app/store/fabric/types/actions.ts
@@ -4,7 +4,7 @@ import type { FabricMeta } from "./enum";
 export type CreateParams = {
   class_type?: Fabric["class_type"];
   description?: Fabric["description"];
-  name?: Fabric["name"];
+  name: Fabric["name"];
 };
 
 export type UpdateParams = CreateParams & {

--- a/ui/src/app/store/space/types/actions.ts
+++ b/ui/src/app/store/space/types/actions.ts
@@ -2,7 +2,7 @@ import type { Space } from "./base";
 import type { SpaceMeta } from "./enum";
 
 export type CreateParams = {
-  description: Space["description"];
+  description?: Space["description"];
   name: Space["name"];
 };
 

--- a/ui/src/app/subnets/enum.ts
+++ b/ui/src/app/subnets/enum.ts
@@ -1,0 +1,6 @@
+export enum SubnetForms {
+  Fabric = "Fabric",
+  VLAN = "VLAN",
+  Space = "Space",
+  Subnet = "Subnet",
+}

--- a/ui/src/app/subnets/types.ts
+++ b/ui/src/app/subnets/types.ts
@@ -1,0 +1,3 @@
+import type { SubnetForms } from "app/subnets/enum";
+
+export type SubnetForm = keyof typeof SubnetForms;

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -15,25 +15,19 @@ const FormComponents: Record<
 };
 
 export interface FormActionProps {
-  activeForm: SubnetForm | null;
+  activeForm: SubnetForm;
   setActiveForm: React.Dispatch<React.SetStateAction<SubnetForm | null>>;
 }
 
 const FormActions = ({ activeForm, setActiveForm }: FormActionProps) => {
   const FormComponent = activeForm ? FormComponents[activeForm] : () => null;
 
-  const Form = () =>
-    activeForm ? (
-      <section className="p-strip is-shallow u-no-padding--top">
-        <div className="row">
-          <h2 className="p-heading--5">Add {activeForm}</h2>
-          <FormComponent
-            activeForm={activeForm}
-            setActiveForm={setActiveForm}
-          />
-        </div>
-      </section>
-    ) : null;
+  const Form = () => (
+    <>
+      <h2 className="p-heading--5">Add {activeForm}</h2>
+      <FormComponent activeForm={activeForm} setActiveForm={setActiveForm} />
+    </>
+  );
 
   return <Form />;
 };

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -1,4 +1,5 @@
 import AddFabric from "./components/AddFabric";
+import AddSpace from "./components/AddSpace";
 
 import { SubnetForms } from "app/subnets/enum";
 import type { SubnetForm } from "app/subnets/types";
@@ -9,7 +10,7 @@ const FormComponents: Record<
 > = {
   [SubnetForms.Fabric]: AddFabric,
   [SubnetForms.VLAN]: () => null,
-  [SubnetForms.Space]: () => null,
+  [SubnetForms.Space]: AddSpace,
   [SubnetForms.Subnet]: () => null,
 };
 

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -25,14 +25,9 @@ const FormActions = ({
 }: FormActionProps): JSX.Element => {
   const FormComponent = activeForm ? FormComponents[activeForm] : () => null;
 
-  const Form = () => (
-    <>
-      <h2 className="p-heading--5">Add {activeForm}</h2>
-      <FormComponent activeForm={activeForm} setActiveForm={setActiveForm} />
-    </>
+  return (
+    <FormComponent activeForm={activeForm} setActiveForm={setActiveForm} />
   );
-
-  return <Form />;
 };
 
 export default FormActions;

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -1,0 +1,40 @@
+import { useDispatch } from "react-redux";
+
+import AddFabric from "./components/AddFabric";
+import type { SubnetForm } from "app/subnets/types";
+import { SubnetForms } from "app/subnets/enum";
+
+const FormComponents: Record<
+  SubnetForm,
+  ({ activeForm, setActiveForm }: FormActionProps) => JSX.Element | null
+> = {
+  [SubnetForms.Fabric]: AddFabric,
+  [SubnetForms.VLAN]: () => null,
+  [SubnetForms.Space]: () => null,
+  [SubnetForms.Subnet]: () => null,
+};
+
+export interface FormActionProps {
+  activeForm?: SubnetForm;
+  setActiveForm: React.Dispatch<React.SetStateAction<SubnetForm | undefined>>;
+}
+
+const FormActions = ({ activeForm, setActiveForm }: FormActionProps) => {
+  const FormComponent = activeForm ? FormComponents[activeForm] : () => null;
+
+  const Form = () =>
+    activeForm ? (
+      <section className="p-strip is-shallow">
+        <div className="row">
+          <FormComponent
+            activeForm={activeForm}
+            setActiveForm={setActiveForm}
+          />
+        </div>
+      </section>
+    ) : null;
+
+  return <Form />;
+};
+
+export default FormActions;

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -23,7 +23,7 @@ const FormActions = ({ activeForm, setActiveForm }: FormActionProps) => {
 
   const Form = () =>
     activeForm ? (
-      <section className="p-strip is-shallow">
+      <section className="p-strip is-shallow u-no-padding--top">
         <div className="row">
           <h2 className="p-heading--5">Add {activeForm}</h2>
           <FormComponent

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -15,8 +15,8 @@ const FormComponents: Record<
 };
 
 export interface FormActionProps {
-  activeForm?: SubnetForm;
-  setActiveForm: React.Dispatch<React.SetStateAction<SubnetForm | undefined>>;
+  activeForm: SubnetForm | null;
+  setActiveForm: React.Dispatch<React.SetStateAction<SubnetForm | null>>;
 }
 
 const FormActions = ({ activeForm, setActiveForm }: FormActionProps) => {

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -19,7 +19,10 @@ export interface FormActionProps {
   setActiveForm: React.Dispatch<React.SetStateAction<SubnetForm | null>>;
 }
 
-const FormActions = ({ activeForm, setActiveForm }: FormActionProps) => {
+const FormActions = ({
+  activeForm,
+  setActiveForm,
+}: FormActionProps): JSX.Element => {
   const FormComponent = activeForm ? FormComponents[activeForm] : () => null;
 
   const Form = () => (

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -1,8 +1,7 @@
-import { useDispatch } from "react-redux";
-
 import AddFabric from "./components/AddFabric";
-import type { SubnetForm } from "app/subnets/types";
+
 import { SubnetForms } from "app/subnets/enum";
+import type { SubnetForm } from "app/subnets/types";
 
 const FormComponents: Record<
   SubnetForm,
@@ -26,6 +25,7 @@ const FormActions = ({ activeForm, setActiveForm }: FormActionProps) => {
     activeForm ? (
       <section className="p-strip is-shallow">
         <div className="row">
+          <h2 className="p-heading--5">Add {activeForm}</h2>
           <FormComponent
             activeForm={activeForm}
             setActiveForm={setActiveForm}

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddFabric from "./AddFabric";
+
+import { rootState as rootStateFactory } from "testing/factories";
+
+test("correctly dispatches fabric create action on form submit", async () => {
+  const store = configureStore()(rootStateFactory());
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/networks", key: "testKey" }]}
+      >
+        <AddFabric activeForm="Fabric" setActiveForm={() => undefined} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+
+  const name = "Fabric name";
+
+  userEvent.type(screen.getByRole("textbox", { name: /Name/ }), "Fabric name");
+  userEvent.click(screen.getByRole("button", { name: /Add Fabric/ }));
+
+  await waitFor(() =>
+    expect(store.getActions()).toEqual([
+      {
+        meta: { method: "create", model: "fabric" },
+        payload: { params: { name } },
+        type: "fabric/create",
+      },
+    ])
+  );
+});

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import AddFabric from "./AddFabric";
 
+import { actions as fabricActions } from "app/store/fabric";
 import { rootState as rootStateFactory } from "testing/factories";
 
 test("correctly dispatches fabric create action on form submit", async () => {
@@ -29,12 +30,6 @@ test("correctly dispatches fabric create action on form submit", async () => {
   userEvent.click(screen.getByRole("button", { name: /Add Fabric/ }));
 
   await waitFor(() =>
-    expect(store.getActions()).toEqual([
-      {
-        meta: { method: "create", model: "fabric" },
-        payload: { params: { name } },
-        type: "fabric/create",
-      },
-    ])
+    expect(store.getActions()).toStrictEqual([fabricActions.create({ name })])
   );
 });

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -1,12 +1,11 @@
+import { Input } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Input } from "@canonical/react-components";
-
-import FormikForm from "app/base/components/FormikForm";
-import FormikField from "app/base/components/FormikField";
-
-import { actions as fabricActions } from "app/store/fabric";
 import type { FormActionProps } from "../FormActions";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 
 type AddFabricValues = {
@@ -17,11 +16,17 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
   const dispatch = useDispatch();
   const isSaving = useSelector(fabricSelectors.saving);
   const isSaved = useSelector(fabricSelectors.saved);
+  const errors = useSelector(fabricSelectors.errors);
 
   return (
     <FormikForm<AddFabricValues>
-      buttonsBordered={true}
+      buttonsBordered={false}
       initialValues={{ name: "" }}
+      onSaveAnalytics={{
+        action: "Add fabric",
+        category: "Subnets form actions",
+        label: "Create fabric",
+      }}
       submitLabel={`Add ${activeForm}`}
       onSubmit={({ name }: { name?: string }) => {
         dispatch(fabricActions.create({ name }));
@@ -30,15 +35,17 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
       resetOnSave
       saving={isSaving}
       saved={isSaved}
+      errors={errors}
     >
       <hr />
       <FormikField
-        autoFocus
+        takeFocus
+        stacked
         type="text"
         name="name"
         component={Input}
         disabled={isSaving}
-        label="Add fabric"
+        label="Name (optional)"
         placeholder="Name (optional)"
       />
     </FormikForm>

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -29,10 +29,10 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
         label: "Add fabric",
       }}
       submitLabel={`Add ${activeForm}`}
-      onSubmit={({ name }: { name: string }) => {
+      onSubmit={({ name }) => {
         dispatch(fabricActions.create({ name }));
       }}
-      onCancel={() => setActiveForm(undefined)}
+      onCancel={() => setActiveForm(null)}
       resetOnSave
       saving={isSaving}
       saved={isSaved}
@@ -40,7 +40,6 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
     >
       <FormikField
         takeFocus
-        stacked
         type="text"
         name="name"
         component={Input}

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -20,7 +20,7 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
 
   return (
     <FormikForm<AddFabricValues>
-      buttonsBordered={false}
+      buttonsBordered
       initialValues={{ name: "" }}
       onSaveAnalytics={{
         action: "Add fabric",
@@ -37,7 +37,6 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
       saved={isSaved}
       errors={errors}
     >
-      <hr />
       <FormikField
         takeFocus
         stacked
@@ -46,7 +45,6 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
         component={Input}
         disabled={isSaving}
         label="Name (optional)"
-        placeholder="Name (optional)"
       />
     </FormikForm>
   );

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -12,7 +12,10 @@ type AddFabricValues = {
   name: string;
 };
 
-const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
+const AddFabric = ({
+  activeForm,
+  setActiveForm,
+}: FormActionProps): JSX.Element => {
   const dispatch = useDispatch();
   const isSaving = useSelector(fabricSelectors.saving);
   const isSaved = useSelector(fabricSelectors.saved);

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -21,14 +21,15 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
   return (
     <FormikForm<AddFabricValues>
       buttonsBordered
+      allowAllEmpty
       initialValues={{ name: "" }}
       onSaveAnalytics={{
         action: "Add fabric",
         category: "Subnets form actions",
-        label: "Create fabric",
+        label: "Add fabric",
       }}
       submitLabel={`Add ${activeForm}`}
-      onSubmit={({ name }: { name?: string }) => {
+      onSubmit={({ name }: { name: string }) => {
         dispatch(fabricActions.create({ name }));
       }}
       onCancel={() => setActiveForm(undefined)}

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -1,0 +1,48 @@
+import { useDispatch, useSelector } from "react-redux";
+
+import { Input } from "@canonical/react-components";
+
+import FormikForm from "app/base/components/FormikForm";
+import FormikField from "app/base/components/FormikField";
+
+import { actions as fabricActions } from "app/store/fabric";
+import type { FormActionProps } from "../FormActions";
+import fabricSelectors from "app/store/fabric/selectors";
+
+type AddFabricValues = {
+  name: string;
+};
+
+const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
+  const dispatch = useDispatch();
+  const isSaving = useSelector(fabricSelectors.saving);
+  const isSaved = useSelector(fabricSelectors.saved);
+
+  return (
+    <FormikForm<AddFabricValues>
+      buttonsBordered={true}
+      initialValues={{ name: "" }}
+      submitLabel={`Add ${activeForm}`}
+      onSubmit={({ name }: { name?: string }) => {
+        dispatch(fabricActions.create({ name }));
+      }}
+      onCancel={() => setActiveForm(undefined)}
+      resetOnSave
+      saving={isSaving}
+      saved={isSaved}
+    >
+      <hr />
+      <FormikField
+        autoFocus
+        type="text"
+        name="name"
+        component={Input}
+        disabled={isSaving}
+        label="Add fabric"
+        placeholder="Name (optional)"
+      />
+    </FormikForm>
+  );
+};
+
+export default AddFabric;

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -36,7 +36,7 @@ const AddFabric = ({
         dispatch(fabricActions.create({ name }));
       }}
       onCancel={() => setActiveForm(null)}
-      resetOnSave
+      onSuccess={() => setActiveForm(null)}
       saving={isSaving}
       saved={isSaved}
       errors={errors}

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -20,7 +20,7 @@ const AddFabric = ({ activeForm, setActiveForm }: FormActionProps) => {
 
   return (
     <FormikForm<AddFabricValues>
-      buttonsBordered
+      buttonsBordered={false}
       allowAllEmpty
       initialValues={{ name: "" }}
       onSaveAnalytics={{

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import AddFabric from "./AddFabric";
+import AddSpace from "./AddSpace";
 
 import { rootState as rootStateFactory } from "testing/factories";
 
@@ -16,24 +16,24 @@ test("correctly dispatches fabric create action on form submit", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/networks", key: "testKey" }]}
       >
-        <AddFabric activeForm="Fabric" setActiveForm={() => undefined} />
+        <AddSpace activeForm="Space" setActiveForm={() => undefined} />
       </MemoryRouter>
     </Provider>
   );
 
   expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
 
-  const name = "Fabric name";
+  const name = "Space name";
 
   userEvent.type(screen.getByRole("textbox", { name: /Name/ }), name);
-  userEvent.click(screen.getByRole("button", { name: /Add Fabric/ }));
+  userEvent.click(screen.getByRole("button", { name: /Add Space/ }));
 
   await waitFor(() =>
     expect(store.getActions()).toEqual([
       {
-        meta: { method: "create", model: "fabric" },
+        meta: { method: "create", model: "space" },
         payload: { params: { name } },
-        type: "fabric/create",
+        type: "space/create",
       },
     ])
   );

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -6,9 +6,10 @@ import configureStore from "redux-mock-store";
 
 import AddSpace from "./AddSpace";
 
+import { actions as spaceActions } from "app/store/space";
 import { rootState as rootStateFactory } from "testing/factories";
 
-test("correctly dispatches fabric create action on form submit", async () => {
+test("correctly dispatches space create action on form submit", async () => {
   const store = configureStore()(rootStateFactory());
 
   render(
@@ -29,12 +30,6 @@ test("correctly dispatches fabric create action on form submit", async () => {
   userEvent.click(screen.getByRole("button", { name: /Add Space/ }));
 
   await waitFor(() =>
-    expect(store.getActions()).toEqual([
-      {
-        meta: { method: "create", model: "space" },
-        payload: { params: { name } },
-        type: "space/create",
-      },
-    ])
+    expect(store.getActions()).toStrictEqual([spaceActions.create({ name })])
   );
 });

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -12,7 +12,10 @@ type AddSpaceValues = {
   name: string;
 };
 
-const AddSpace = ({ activeForm, setActiveForm }: FormActionProps) => {
+const AddSpace = ({
+  activeForm,
+  setActiveForm,
+}: FormActionProps): JSX.Element => {
   const dispatch = useDispatch();
   const isSaving = useSelector(spaceSelectors.saving);
   const isSaved = useSelector(spaceSelectors.saved);

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -1,0 +1,54 @@
+import { Input } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import type { FormActionProps } from "../FormActions";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as spaceActions } from "app/store/space";
+import spaceSelectors from "app/store/space/selectors";
+
+type AddSpaceValues = {
+  name: string;
+};
+
+const AddSpace = ({ activeForm, setActiveForm }: FormActionProps) => {
+  const dispatch = useDispatch();
+  const isSaving = useSelector(spaceSelectors.saving);
+  const isSaved = useSelector(spaceSelectors.saved);
+  const errors = useSelector(spaceSelectors.errors);
+
+  return (
+    <FormikForm<AddSpaceValues>
+      buttonsBordered
+      allowAllEmpty
+      initialValues={{ name: "" }}
+      onSaveAnalytics={{
+        action: "Add space",
+        category: "Subnets form actions",
+        label: "Add space",
+      }}
+      submitLabel={`Add ${activeForm}`}
+      onSubmit={({ name }: { name: string }) => {
+        dispatch(spaceActions.create({ name }));
+      }}
+      onCancel={() => setActiveForm(undefined)}
+      resetOnSave
+      saving={isSaving}
+      saved={isSaved}
+      errors={errors}
+    >
+      <FormikField
+        takeFocus
+        stacked
+        type="text"
+        name="name"
+        component={Input}
+        disabled={isSaving}
+        label="Name (optional)"
+      />
+    </FormikForm>
+  );
+};
+
+export default AddSpace;

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -20,7 +20,7 @@ const AddSpace = ({ activeForm, setActiveForm }: FormActionProps) => {
 
   return (
     <FormikForm<AddSpaceValues>
-      buttonsBordered
+      buttonsBordered={false}
       allowAllEmpty
       initialValues={{ name: "" }}
       onSaveAnalytics={{

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -29,10 +29,10 @@ const AddSpace = ({ activeForm, setActiveForm }: FormActionProps) => {
         label: "Add space",
       }}
       submitLabel={`Add ${activeForm}`}
-      onSubmit={({ name }: { name: string }) => {
+      onSubmit={({ name }) => {
         dispatch(spaceActions.create({ name }));
       }}
-      onCancel={() => setActiveForm(undefined)}
+      onCancel={() => setActiveForm(null)}
       resetOnSave
       saving={isSaving}
       saved={isSaved}
@@ -40,7 +40,6 @@ const AddSpace = ({ activeForm, setActiveForm }: FormActionProps) => {
     >
       <FormikField
         takeFocus
-        stacked
         type="text"
         name="name"
         component={Input}

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -36,7 +36,7 @@ const AddSpace = ({
         dispatch(spaceActions.create({ name }));
       }}
       onCancel={() => setActiveForm(null)}
-      resetOnSave
+      onSuccess={() => setActiveForm(null)}
       saving={isSaving}
       saved={isSaved}
       errors={errors}

--- a/ui/src/app/subnets/views/FormActions/index.ts
+++ b/ui/src/app/subnets/views/FormActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FormActions";

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -34,8 +34,15 @@ const SubnetsList = (): React.ReactElement => {
                 }))}
               />,
             ]}
+            headerContent={
+              activeForm ? (
+                <FormActions
+                  activeForm={activeForm}
+                  setActiveForm={setActiveForm}
+                />
+              ) : null
+            }
           />
-          <FormActions activeForm={activeForm} setActiveForm={setActiveForm} />
         </>
       }
     ></Section>

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -1,13 +1,33 @@
 import React from "react";
 
+import { ContextualMenu } from "@canonical/react-components";
+
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+
+const getButtons = (links: string[]) =>
+  links.map((children) => ({
+    children,
+    onClick: () => null,
+  }));
+
 const SubnetsList = (): React.ReactElement => (
-  <header className="p-strip--light is-shallow u-no-padding--bottom">
-    <div className="row">
-      <div className="col-medium-4 col-8">
-        <h1 data-testid="section-header-title">Subnets</h1>
-      </div>
-    </div>
-  </header>
+  <Section
+    header={
+      <SectionHeader
+        title="Subnets"
+        buttons={[
+          <ContextualMenu
+            toggleLabel="Add"
+            toggleAppearance="positive"
+            hasToggleIcon
+            position="right"
+            links={getButtons(["Fabric", "VLAN", "Space", "Subnet"])}
+          />,
+        ]}
+      />
+    }
+  />
 );
 
 export default SubnetsList;

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -9,9 +9,7 @@ import type { SubnetForm } from "app/subnets/types";
 import FormActions from "app/subnets/views/FormActions";
 
 const SubnetsList = (): React.ReactElement => {
-  const [activeForm, setActiveForm] = React.useState<SubnetForm | undefined>(
-    undefined
-  );
+  const [activeForm, setActiveForm] = React.useState<SubnetForm | null>(null);
 
   return (
     <Section

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -4,30 +4,47 @@ import { ContextualMenu } from "@canonical/react-components";
 
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
+import FormActions from "app/subnets/views/FormActions";
+import type { SubnetForm } from "app/subnets/types";
 
-const getButtons = (links: string[]) =>
+const getButtons = (
+  links: SubnetForm[],
+  onClick: React.Dispatch<React.SetStateAction<SubnetForm | undefined>>
+) =>
   links.map((children) => ({
-    children,
-    onClick: () => null,
+    children: children as React.ReactNode,
+    onClick: () => onClick(children) as any,
   }));
 
-const SubnetsList = (): React.ReactElement => (
-  <Section
-    header={
-      <SectionHeader
-        title="Subnets"
-        buttons={[
-          <ContextualMenu
-            toggleLabel="Add"
-            toggleAppearance="positive"
-            hasToggleIcon
-            position="right"
-            links={getButtons(["Fabric", "VLAN", "Space", "Subnet"])}
-          />,
-        ]}
-      />
-    }
-  />
-);
+const SubnetsList = (): React.ReactElement => {
+  const [activeForm, setActiveForm] = React.useState<SubnetForm | undefined>(
+    undefined
+  );
+
+  return (
+    <Section
+      header={
+        <>
+          <SectionHeader
+            title="Subnets"
+            buttons={[
+              <ContextualMenu
+                toggleLabel="Add"
+                toggleAppearance="positive"
+                hasToggleIcon
+                position="right"
+                links={getButtons(
+                  ["Fabric", "VLAN", "Space", "Subnet"],
+                  setActiveForm
+                )}
+              />,
+            ]}
+          />
+          <FormActions activeForm={activeForm} setActiveForm={setActiveForm} />
+        </>
+      }
+    ></Section>
+  );
+};
 
 export default SubnetsList;

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -4,8 +4,8 @@ import { ContextualMenu } from "@canonical/react-components";
 
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
-import FormActions from "app/subnets/views/FormActions";
 import type { SubnetForm } from "app/subnets/types";
+import FormActions from "app/subnets/views/FormActions";
 
 const getButtons = (
   links: SubnetForm[],
@@ -13,7 +13,7 @@ const getButtons = (
 ) =>
   links.map((children) => ({
     children: children as React.ReactNode,
-    onClick: () => onClick(children) as any,
+    onClick: () => onClick(children),
   }));
 
 const SubnetsList = (): React.ReactElement => {

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -16,7 +16,7 @@ const SubnetsList = (): JSX.Element => {
       header={
         <>
           <SectionHeader
-            title="Subnets"
+            title={activeForm ? `Add ${activeForm}` : "Subnets"}
             buttons={[
               <ContextualMenu
                 toggleLabel="Add"

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -8,7 +8,7 @@ import { SubnetForms } from "app/subnets/enum";
 import type { SubnetForm } from "app/subnets/types";
 import FormActions from "app/subnets/views/FormActions";
 
-const SubnetsList = (): React.ReactElement => {
+const SubnetsList = (): JSX.Element => {
   const [activeForm, setActiveForm] = React.useState<SubnetForm | null>(null);
 
   return (

--- a/ui/src/app/subnets/views/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList.tsx
@@ -4,17 +4,9 @@ import { ContextualMenu } from "@canonical/react-components";
 
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
+import { SubnetForms } from "app/subnets/enum";
 import type { SubnetForm } from "app/subnets/types";
 import FormActions from "app/subnets/views/FormActions";
-
-const getButtons = (
-  links: SubnetForm[],
-  onClick: React.Dispatch<React.SetStateAction<SubnetForm | undefined>>
-) =>
-  links.map((children) => ({
-    children: children as React.ReactNode,
-    onClick: () => onClick(children),
-  }));
 
 const SubnetsList = (): React.ReactElement => {
   const [activeForm, setActiveForm] = React.useState<SubnetForm | undefined>(
@@ -33,10 +25,15 @@ const SubnetsList = (): React.ReactElement => {
                 toggleAppearance="positive"
                 hasToggleIcon
                 position="right"
-                links={getButtons(
-                  ["Fabric", "VLAN", "Space", "Subnet"],
-                  setActiveForm
-                )}
+                links={[
+                  SubnetForms.Fabric,
+                  SubnetForms.VLAN,
+                  SubnetForms.Space,
+                  SubnetForms.Subnet,
+                ].map((children) => ({
+                  children,
+                  onClick: () => setActiveForm(children),
+                }))}
               />,
             ]}
           />


### PR DESCRIPTION
## Done

migrate subnets header, add fabric, add space to React
- add aria-label to FormikField (there was no label associated with an input element)
- add cypress tests for adding a fabric (1 using legacy, 1 new UI)
- reported an issue with ContextualMenu and incorrect tab order https://github.com/canonical-web-and-design/react-components/issues/687

### Slight UX changes
I made a suggestion for a few changes that's been approved by design in the [planning doc](https://docs.google.com/document/d/1Vlih_9RyfNKKwLeBXS6tnRnNZTTR1BtXG_MHHC-Bi1s/edit#heading=h.wqx5o7fcpb6i)
- Add heading to the form (closer to https://vanillaframework.io/docs/layouts/application#panels-example)
- Add auto-focus on first form input for better accessibility


### QA steps

- go to `MAAS/r/networks?by=fabric` to verify the new UI

## Screenshots

![image](https://user-images.githubusercontent.com/7452681/149166655-f1394004-7f34-49b7-9a57-b4499fad644c.png)

![image](https://user-images.githubusercontent.com/7452681/149166734-c827a8c8-f68c-4388-889c-25e48733d7c9.png)

![Pasted Graphic 7](https://user-images.githubusercontent.com/7452681/149166508-a5965b47-4e72-4fdf-9fd6-e0eee554c54d.png)

