### PR TITLE
refactor(ui): wrap routes in component prop

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -32,90 +32,136 @@ import Zones from "app/zones/views/Zones";
 
 const Routes = (): JSX.Element => (
   <Switch>
-    <Route exact path={baseURLs.index}>
-      <Redirect to={machineURLs.machines.index} />
-    </Route>
-    <Route path={introURLs.index}>
-      <ErrorBoundary>
-        <Intro />
-      </ErrorBoundary>
-    </Route>
-    <Route path={prefsURLs.prefs}>
-      <ErrorBoundary>
-        <Preferences />
-      </ErrorBoundary>
-    </Route>
-    <Route path={controllersURLs.controllers.index}>
-      <ErrorBoundary>
-        <Controllers />
-      </ErrorBoundary>
-    </Route>
+    <Route
+      exact
+      path={baseURLs.index}
+      component={() => <Redirect to={machineURLs.machines.index} />}
+    />
+    <Route
+      path={introURLs.index}
+      component={() => (
+        <ErrorBoundary>
+          <Intro />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={prefsURLs.prefs}
+      component={() => (
+        <ErrorBoundary>
+          <Preferences />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={controllersURLs.controllers.index}
+      component={() => (
+        <ErrorBoundary>
+          <Controllers />
+        </ErrorBoundary>
+      )}
+    />
     {[devicesURLs.devices.index, devicesURLs.device.index(null, true)].map(
       (path) => (
-        <Route key={path} path={path}>
-          <ErrorBoundary>
-            <Devices />
-          </ErrorBoundary>
-        </Route>
+        <Route
+          key={path}
+          path={path}
+          component={() => (
+            <ErrorBoundary>
+              <Devices />
+            </ErrorBoundary>
+          )}
+        />
       )
     )}
     {[domainsURLs.domains, domainsURLs.details(null, true)].map((path) => (
-      <Route exact key={path} path={path}>
-        <ErrorBoundary>
-          <Domains />
-        </ErrorBoundary>
-      </Route>
+      <Route
+        exact
+        key={path}
+        path={path}
+        component={() => (
+          <ErrorBoundary>
+            <Domains />
+          </ErrorBoundary>
+        )}
+      />
     ))}
-    <Route path={imagesURLs.index}>
-      <ErrorBoundary>
-        <Images />
-      </ErrorBoundary>
-    </Route>
-    <Route path={kvmURLs.kvm}>
-      <ErrorBoundary>
-        <KVM />
-      </ErrorBoundary>
-    </Route>
-    <Route path={machineURLs.machines.index}>
-      <ErrorBoundary>
-        <Machines />
-      </ErrorBoundary>
-    </Route>
-    <Route path={machineURLs.machine.index(null, true)}>
-      <ErrorBoundary>
-        <MachineDetails />
-      </ErrorBoundary>
-    </Route>
-    <Route path={poolsURLs.pools}>
-      <ErrorBoundary>
-        <Machines />
-      </ErrorBoundary>
-    </Route>
-    <Route path={settingsURLs.index}>
-      <ErrorBoundary>
-        <Settings />
-      </ErrorBoundary>
-    </Route>
+    <Route
+      path={imagesURLs.index}
+      component={() => (
+        <ErrorBoundary>
+          <Images />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={kvmURLs.kvm}
+      component={() => (
+        <ErrorBoundary>
+          <KVM />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={machineURLs.machines.index}
+      component={() => (
+        <ErrorBoundary>
+          <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={machineURLs.machine.index(null, true)}
+      component={() => (
+        <ErrorBoundary>
+          <MachineDetails />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={poolsURLs.pools}
+      component={() => (
+        <ErrorBoundary>
+          <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={settingsURLs.index}
+      component={() => (
+        <ErrorBoundary>
+          <Settings />
+        </ErrorBoundary>
+      )}
+    />
     <Route
       path={subnetsURLs.index}
-      render={() => (
+      component={() => (
         <ErrorBoundary>
           <Subnets />
         </ErrorBoundary>
       )}
     />
     {[zonesURLs.index, zonesURLs.details(null, true)].map((path) => (
-      <Route exact key={path} path={path}>
-        <ErrorBoundary>
-          <Zones />
-        </ErrorBoundary>
-      </Route>
+      <Route
+        exact
+        key={path}
+        path={path}
+        component={() => (
+          <ErrorBoundary>
+            <Zones />
+          </ErrorBoundary>
+        )}
+      />
     ))}
-    <Route path={dashboardURLs.index}>
-      <ErrorBoundary>
-        <Dashboard />
-      </ErrorBoundary>
-    </Route>
+    <Route
+      path={dashboardURLs.index}
+      component={() => (
+        <ErrorBoundary>
+          <Dashboard />
+        </ErrorBoundary>
+      )}
+    />
     <Route path="*" component={() => <NotFound includeSection />} />
   </Switch>
 );

--- a/ui/src/app/base/hooks/urls.test.tsx
+++ b/ui/src/app/base/hooks/urls.test.tsx
@@ -17,9 +17,7 @@ const generateWrapper =
     (
       <Provider store={mockStore(rootStateFactory())}>
         <MemoryRouter initialEntries={[{ pathname }]}>
-          <Route exact path={route}>
-            {children}
-          </Route>
+          <Route exact path={route} component={() => <>{children}</>} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -58,9 +58,7 @@ describe("ControllerList", () => {
           ]}
         >
           <ControllerList />
-          <Route path="*">
-            <FetchRoute />
-          </Route>
+          <Route path="*" component={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -8,12 +8,12 @@ import controllersURLs from "app/controllers/urls";
 const Controllers = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={controllersURLs.controllers.index}>
-        <ControllerList />
-      </Route>
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route
+        exact
+        path={controllersURLs.controllers.index}
+        component={() => <ControllerList />}
+      />
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/dashboard/views/Dashboard.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.tsx
@@ -35,15 +35,17 @@ const Dashboard = (): JSX.Element => {
         </Notification>
       )}
       <Switch>
-        <Route exact path={dashboardURLs.index}>
-          <DiscoveriesList />
-        </Route>
-        <Route exact path={dashboardURLs.configuration}>
-          <DashboardConfigurationForm />
-        </Route>
-        <Route path="*">
-          <NotFound />
-        </Route>
+        <Route
+          exact
+          path={dashboardURLs.index}
+          component={() => <DiscoveriesList />}
+        />
+        <Route
+          exact
+          path={dashboardURLs.configuration}
+          component={() => <DashboardConfigurationForm />}
+        />
+        <Route path="*" component={() => <NotFound />} />
       </Switch>
     </Section>
   );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -65,15 +65,21 @@ const DeviceDetails = (): JSX.Element => {
     >
       {device && (
         <Switch>
-          <Route exact path={deviceURLs.device.summary(null, true)}>
-            <DeviceSummary systemId={id} />
-          </Route>
-          <Route exact path={deviceURLs.device.network(null, true)}>
-            <DeviceNetwork systemId={id} />
-          </Route>
-          <Route exact path={deviceURLs.device.configuration(null, true)}>
-            <DeviceConfiguration systemId={id} />
-          </Route>
+          <Route
+            exact
+            path={deviceURLs.device.summary(null, true)}
+            component={() => <DeviceSummary systemId={id} />}
+          />
+          <Route
+            exact
+            path={deviceURLs.device.network(null, true)}
+            component={() => <DeviceNetwork systemId={id} />}
+          />
+          <Route
+            exact
+            path={deviceURLs.device.configuration(null, true)}
+            component={() => <DeviceConfiguration systemId={id} />}
+          />
           <Redirect
             from={deviceURLs.device.index(null, true)}
             to={deviceURLs.device.summary(null, true)}

--- a/ui/src/app/devices/views/DeviceList/DeviceList.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.test.tsx
@@ -52,9 +52,7 @@ describe("DeviceList", () => {
           ]}
         >
           <DeviceList />
-          <Route path="*">
-            <FetchRoute />
-          </Route>
+          <Route path="*" component={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/Devices.tsx
+++ b/ui/src/app/devices/views/Devices.tsx
@@ -9,22 +9,25 @@ import devicesURLs from "app/devices/urls";
 const Devices = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={devicesURLs.devices.index}>
-        <DeviceList />
-      </Route>
+      <Route
+        exact
+        path={devicesURLs.devices.index}
+        component={() => <DeviceList />}
+      />
       {[
         devicesURLs.device.configuration(null, true),
         devicesURLs.device.index(null, true),
         devicesURLs.device.network(null, true),
         devicesURLs.device.summary(null, true),
       ].map((path) => (
-        <Route exact key={path} path={path}>
-          <DeviceDetails />
-        </Route>
+        <Route
+          exact
+          key={path}
+          path={path}
+          component={() => <DeviceDetails />}
+        />
       ))}
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/domains/views/Domains.tsx
+++ b/ui/src/app/domains/views/Domains.tsx
@@ -9,15 +9,17 @@ import domainsURLs from "app/domains/urls";
 const Domains = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={domainsURLs.domains}>
-        <DomainsList />
-      </Route>
-      <Route exact path={domainsURLs.details(null, true)}>
-        <DomainDetails />
-      </Route>
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route
+        exact
+        path={domainsURLs.domains}
+        component={() => <DomainsList />}
+      />
+      <Route
+        exact
+        path={domainsURLs.details(null, true)}
+        component={() => <DomainDetails />}
+      />
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/domains/views/DomainsList/DomainsList.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsList.tsx
@@ -25,9 +25,11 @@ const DomainsList = (): JSX.Element => {
   return (
     <Section header={<DomainListHeader />}>
       <Switch>
-        <Route exact path={domainsURLs.domains}>
-          {domains.length > 0 && <DomainsTable />}
-        </Route>
+        <Route
+          exact
+          path={domainsURLs.domains}
+          component={() => <>{domains.length > 0 && <DomainsTable />}</>}
+        />
       </Switch>
     </Section>
   );

--- a/ui/src/app/images/views/Images.tsx
+++ b/ui/src/app/images/views/Images.tsx
@@ -7,12 +7,8 @@ import ImageList from "app/images/views/ImageList";
 const Images = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={imagesURLs.index}>
-        <ImageList />
-      </Route>
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route exact path={imagesURLs.index} component={() => <ImageList />} />
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -53,21 +53,15 @@ const Intro = (): JSX.Element => {
   }
   return (
     <Switch>
-      <Route exact path={introURLs.index}>
-        <MaasIntro />
-      </Route>
-      <Route exact path={introURLs.images}>
-        <ImagesIntro />
-      </Route>
-      <Route exact path={introURLs.success}>
-        <MaasIntroSuccess />
-      </Route>
-      <Route exact path={introURLs.user}>
-        <UserIntro />
-      </Route>
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route exact path={introURLs.index} component={() => <MaasIntro />} />
+      <Route exact path={introURLs.images} component={() => <ImagesIntro />} />
+      <Route
+        exact
+        path={introURLs.success}
+        component={() => <MaasIntroSuccess />}
+      />
+      <Route exact path={introURLs.user} component={() => <UserIntro />} />
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -12,9 +12,7 @@ const KVM = (): JSX.Element => {
   return (
     <Switch>
       {[kvmURLs.kvm, kvmURLs.lxd.index, kvmURLs.virsh.index].map((path) => (
-        <Route exact key={path} path={path}>
-          <KVMList />
-        </Route>
+        <Route exact key={path} path={path} component={() => <KVMList />} />
       ))}
       {[
         kvmURLs.lxd.cluster.index(null, true),
@@ -26,9 +24,12 @@ const KVM = (): JSX.Element => {
         kvmURLs.lxd.cluster.vms.host(null, true),
         kvmURLs.lxd.cluster.vms.index(null, true),
       ].map((path) => (
-        <Route exact key={path} path={path}>
-          <LXDClusterDetails />
-        </Route>
+        <Route
+          exact
+          key={path}
+          path={path}
+          component={() => <LXDClusterDetails />}
+        />
       ))}
       {[
         kvmURLs.lxd.single.index(null, true),
@@ -36,22 +37,26 @@ const KVM = (): JSX.Element => {
         kvmURLs.lxd.single.resources(null, true),
         kvmURLs.lxd.single.vms(null, true),
       ].map((path) => (
-        <Route exact key={path} path={path}>
-          <LXDSingleDetails />
-        </Route>
+        <Route
+          exact
+          key={path}
+          path={path}
+          component={() => <LXDSingleDetails />}
+        />
       ))}
       {[
         kvmURLs.virsh.details.index(null, true),
         kvmURLs.virsh.details.edit(null, true),
         kvmURLs.virsh.details.resources(null, true),
       ].map((path) => (
-        <Route exact key={path} path={path}>
-          <VirshDetails />
-        </Route>
+        <Route
+          exact
+          key={path}
+          path={path}
+          component={() => <VirshDetails />}
+        />
       ))}
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -109,45 +109,71 @@ const LXDClusterDetails = (): JSX.Element => {
       }
     >
       <Switch>
-        <Route exact path={kvmURLs.lxd.cluster.hosts(null, true)}>
-          <LXDClusterHosts
-            clusterId={clusterId}
-            setHeaderContent={setHeaderContent}
-          />
-        </Route>
-        <Route exact path={kvmURLs.lxd.cluster.vms.index(null, true)}>
-          <LXDClusterVMs
-            clusterId={clusterId}
-            searchFilter={searchFilter}
-            setHeaderContent={setHeaderContent}
-            setSearchFilter={setSearchFilter}
-          />
-        </Route>
-        <Route exact path={kvmURLs.lxd.cluster.resources(null, true)}>
-          <LXDClusterResources clusterId={clusterId} />
-        </Route>
-        <Route exact path={kvmURLs.lxd.cluster.edit(null, true)}>
-          <LXDClusterSettings
-            clusterId={clusterId}
-            setHeaderContent={setHeaderContent}
-          />
-        </Route>
-        <Route exact path={kvmURLs.lxd.cluster.vms.host(null, true)}>
-          {hostId !== null && (
-            <LXDClusterHostVMs
+        <Route
+          exact
+          path={kvmURLs.lxd.cluster.hosts(null, true)}
+          component={() => (
+            <LXDClusterHosts
               clusterId={clusterId}
-              hostId={hostId}
+              setHeaderContent={setHeaderContent}
+            />
+          )}
+        />
+        <Route
+          exact
+          path={kvmURLs.lxd.cluster.vms.index(null, true)}
+          component={() => (
+            <LXDClusterVMs
+              clusterId={clusterId}
               searchFilter={searchFilter}
               setHeaderContent={setHeaderContent}
               setSearchFilter={setSearchFilter}
             />
           )}
-        </Route>
-        <Route exact path={kvmURLs.lxd.cluster.host.edit(null, true)}>
-          {hostId !== null && (
-            <LXDClusterHostSettings clusterId={clusterId} hostId={hostId} />
+        />
+        <Route
+          exact
+          path={kvmURLs.lxd.cluster.resources(null, true)}
+          component={() => <LXDClusterResources clusterId={clusterId} />}
+        />
+        <Route
+          exact
+          path={kvmURLs.lxd.cluster.edit(null, true)}
+          component={() => (
+            <LXDClusterSettings
+              clusterId={clusterId}
+              setHeaderContent={setHeaderContent}
+            />
           )}
-        </Route>
+        />
+        <Route
+          exact
+          path={kvmURLs.lxd.cluster.vms.host(null, true)}
+          component={() => (
+            <>
+              {hostId !== null && (
+                <LXDClusterHostVMs
+                  clusterId={clusterId}
+                  hostId={hostId}
+                  searchFilter={searchFilter}
+                  setHeaderContent={setHeaderContent}
+                  setSearchFilter={setSearchFilter}
+                />
+              )}
+            </>
+          )}
+        />
+        <Route
+          exact
+          path={kvmURLs.lxd.cluster.host.edit(null, true)}
+          component={() => (
+            <>
+              {hostId !== null && (
+                <LXDClusterHostSettings clusterId={clusterId} hostId={hostId} />
+              )}
+            </>
+          )}
+        />
         <Redirect
           from={kvmURLs.lxd.cluster.index(null, true)}
           to={kvmURLs.lxd.cluster.hosts(null, true)}

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -73,20 +73,30 @@ const LXDSingleDetails = (): JSX.Element => {
     >
       {pod && (
         <Switch>
-          <Route exact path={kvmURLs.lxd.single.vms(null, true)}>
-            <LXDSingleVMs
-              id={id}
-              searchFilter={searchFilter}
-              setSearchFilter={setSearchFilter}
-              setHeaderContent={setHeaderContent}
-            />
-          </Route>
-          <Route exact path={kvmURLs.lxd.single.resources(null, true)}>
-            <LXDSingleResources id={id} />
-          </Route>
-          <Route exact path={kvmURLs.lxd.single.edit(null, true)}>
-            <LXDSingleSettings id={id} setHeaderContent={setHeaderContent} />
-          </Route>
+          <Route
+            exact
+            path={kvmURLs.lxd.single.vms(null, true)}
+            component={() => (
+              <LXDSingleVMs
+                id={id}
+                searchFilter={searchFilter}
+                setSearchFilter={setSearchFilter}
+                setHeaderContent={setHeaderContent}
+              />
+            )}
+          />
+          <Route
+            exact
+            path={kvmURLs.lxd.single.resources(null, true)}
+            component={() => <LXDSingleResources id={id} />}
+          />
+          <Route
+            exact
+            path={kvmURLs.lxd.single.edit(null, true)}
+            component={() => (
+              <LXDSingleSettings id={id} setHeaderContent={setHeaderContent} />
+            )}
+          />
           <Redirect
             from={kvmURLs.lxd.single.index(null, true)}
             to={kvmURLs.lxd.single.vms(null, true)}

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
@@ -54,12 +54,16 @@ const VirshDetails = (): JSX.Element => {
     >
       {pod && (
         <Switch>
-          <Route exact path={kvmURLs.virsh.details.resources(null, true)}>
-            <VirshResources id={id} />
-          </Route>
-          <Route exact path={kvmURLs.virsh.details.edit(null, true)}>
-            <VirshSettings id={id} />
-          </Route>
+          <Route
+            exact
+            path={kvmURLs.virsh.details.resources(null, true)}
+            component={() => <VirshResources id={id} />}
+          />
+          <Route
+            exact
+            path={kvmURLs.virsh.details.edit(null, true)}
+            component={() => <VirshSettings id={id} />}
+          />
           <Redirect
             from={kvmURLs.virsh.details.index(null, true)}
             to={kvmURLs.virsh.details.resources(null, true)}

--- a/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
@@ -74,9 +74,10 @@ describe("MachineCommissioning", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineCommissioning />
-          </Route>
+          <Route
+            path="/machine/:id"
+            component={() => <MachineCommissioning />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -96,9 +97,10 @@ describe("MachineCommissioning", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineCommissioning />
-          </Route>
+          <Route
+            path="/machine/:id"
+            component={() => <MachineCommissioning />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -146,9 +148,10 @@ describe("MachineCommissioning", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineCommissioning />
-          </Route>
+          <Route
+            path="/machine/:id"
+            component={() => <MachineCommissioning />}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -81,60 +81,98 @@ const MachineDetails = (): JSX.Element => {
     >
       {machine && (
         <Switch>
-          <Route exact path={machineURLs.machine.summary(null, true)}>
-            <SummaryNotifications id={id} />
-            <MachineSummary setHeaderContent={setHeaderContent} />
-          </Route>
-          <Route exact path={machineURLs.machine.instances(null, true)}>
-            <MachineInstances />
-          </Route>
-          <Route exact path={machineURLs.machine.network(null, true)}>
-            <NetworkNotifications id={id} />
-            <MachineNetwork id={id} setHeaderContent={setHeaderContent} />
-          </Route>
-          <Route exact path={machineURLs.machine.storage(null, true)}>
-            <StorageNotifications id={id} />
-            <MachineStorage />
-          </Route>
-          <Route exact path={machineURLs.machine.pciDevices(null, true)}>
-            <MachinePCIDevices setHeaderContent={setHeaderContent} />
-          </Route>
-          <Route exact path={machineURLs.machine.usbDevices(null, true)}>
-            <MachineUSBDevices setHeaderContent={setHeaderContent} />
-          </Route>
+          <Route
+            exact
+            path={machineURLs.machine.summary(null, true)}
+            component={() => (
+              <>
+                <SummaryNotifications id={id} />
+                <MachineSummary setHeaderContent={setHeaderContent} />
+              </>
+            )}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.instances(null, true)}
+            component={() => <MachineInstances />}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.network(null, true)}
+            component={() => (
+              <>
+                <NetworkNotifications id={id} />
+                <MachineNetwork id={id} setHeaderContent={setHeaderContent} />
+              </>
+            )}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.storage(null, true)}
+            component={() => (
+              <>
+                <StorageNotifications id={id} />
+                <MachineStorage />
+              </>
+            )}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.pciDevices(null, true)}
+            component={() => (
+              <MachinePCIDevices setHeaderContent={setHeaderContent} />
+            )}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.usbDevices(null, true)}
+            component={() => (
+              <MachineUSBDevices setHeaderContent={setHeaderContent} />
+            )}
+          />
           <Route
             exact
             path={machineURLs.machine.commissioning.index(null, true)}
-          >
-            <MachineComissioning />
-          </Route>
+            component={() => <MachineComissioning />}
+          />
           <Route
             exact
             path={machineURLs.machine.commissioning.scriptResult(null, true)}
-          >
-            <MachineTestsDetails />
-          </Route>
-          <Route exact path={machineURLs.machine.testing.index(null, true)}>
-            <MachineTests />
-          </Route>
+            component={() => <MachineTestsDetails />}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.testing.index(null, true)}
+            component={() => <MachineTests />}
+          />
           <Route
             exact
             path={machineURLs.machine.testing.scriptResult(null, true)}
-          >
-            <MachineTestsDetails />
-          </Route>
-          <Route path={machineURLs.machine.logs.index(null, true)}>
-            <MachineLogs systemId={id} />
-          </Route>
-          <Route exact path={machineURLs.machine.events(null, true)}>
-            <Redirect to={machineURLs.machine.logs.events(null, true)} />
-          </Route>
-          <Route exact path={machineURLs.machine.configuration(null, true)}>
-            <MachineConfiguration />
-          </Route>
-          <Route exact path={machineURLs.machine.index(null, true)}>
-            <Redirect to={machineURLs.machine.summary({ id })} />
-          </Route>
+            component={() => <MachineTestsDetails />}
+          />
+          <Route
+            path={machineURLs.machine.logs.index(null, true)}
+            component={() => <MachineLogs systemId={id} />}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.events(null, true)}
+            component={() => (
+              <Redirect to={machineURLs.machine.logs.events(null, true)} />
+            )}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.configuration(null, true)}
+            component={() => <MachineConfiguration />}
+          />
+          <Route
+            exact
+            path={machineURLs.machine.index(null, true)}
+            component={() => (
+              <Redirect to={machineURLs.machine.summary({ id })} />
+            )}
+          />
         </Switch>
       )}
     </Section>

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -57,16 +57,18 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
       <Route
         exact
         path={machineURLs.machine.logs.installationOutput(null, true)}
-      >
-        <InstallationOutput systemId={systemId} />
-      </Route>
+        component={() => <InstallationOutput systemId={systemId} />}
+      />
       {[
         machineURLs.machine.logs.index(null, true),
         machineURLs.machine.logs.events(null, true),
       ].map((path) => (
-        <Route exact key={path} path={path}>
-          <EventLogs systemId={systemId} />
-        </Route>
+        <Route
+          exact
+          key={path}
+          path={path}
+          component={() => <EventLogs systemId={systemId} />}
+        />
       ))}
     </>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -78,9 +78,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -126,9 +124,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -166,9 +162,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -204,9 +198,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -224,9 +216,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -246,9 +236,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -296,9 +284,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id">
-            <MachineTests />
-          </Route>
+          <Route path="/machine/:id" component={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
@@ -59,9 +59,10 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -74,9 +75,10 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -92,9 +94,10 @@ describe("MachineTestDetails", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -123,9 +126,10 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -151,9 +155,10 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -178,9 +183,10 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -217,9 +223,10 @@ describe("MachineTestDetails", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route path="/machine/:id/testing/:scriptResultId/details">
-            <MachineTestsDetails />
-          </Route>
+          <Route
+            path="/machine/:id/testing/:scriptResultId/details"
+            component={() => <MachineTestsDetails />}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/Machines.test.tsx
+++ b/ui/src/app/machines/views/Machines.test.tsx
@@ -200,9 +200,7 @@ describe("Machines", () => {
           ]}
         >
           <Machines />
-          <Route path="*">
-            <FetchRoute />
-          </Route>
+          <Route path="*" component={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/Machines.tsx
+++ b/ui/src/app/machines/views/Machines.tsx
@@ -71,25 +71,25 @@ const Machines = (): JSX.Element => {
       }
     >
       <Switch>
-        <Route exact path={machineURLs.machines.index}>
-          <MachineList
-            headerFormOpen={!!headerContent}
-            searchFilter={searchFilter}
-            setSearchFilter={setSearchFilter}
-          />
-        </Route>
-        <Route exact path={poolsURLs.pools}>
-          <Pools />
-        </Route>
-        <Route exact path={poolsURLs.add}>
-          <PoolAdd />
-        </Route>
-        <Route exact path={poolsURLs.edit(null, true)}>
-          <PoolEdit />
-        </Route>
-        <Route path="*">
-          <NotFound />
-        </Route>
+        <Route
+          exact
+          path={machineURLs.machines.index}
+          component={() => (
+            <MachineList
+              headerFormOpen={!!headerContent}
+              searchFilter={searchFilter}
+              setSearchFilter={setSearchFilter}
+            />
+          )}
+        />
+        <Route exact path={poolsURLs.pools} component={() => <Pools />} />
+        <Route exact path={poolsURLs.add} component={() => <PoolAdd />} />
+        <Route
+          exact
+          path={poolsURLs.edit(null, true)}
+          component={() => <PoolEdit />}
+        />
+        <Route path="*" component={() => <NotFound />} />
       </Switch>
     </Section>
   );

--- a/ui/src/app/settings/components/Routes/Routes.tsx
+++ b/ui/src/app/settings/components/Routes/Routes.tsx
@@ -99,18 +99,26 @@ const Routes = (): JSX.Element => {
         from={settingsURLs.network.index}
         to={settingsURLs.network.proxy}
       />
-      <Route exact path={settingsURLs.scripts.commissioning.index}>
-        <ScriptsList type="commissioning" />
-      </Route>
-      <Route exact path={settingsURLs.scripts.commissioning.upload}>
-        <ScriptsUpload type="commissioning" />
-      </Route>
-      <Route exact path={settingsURLs.scripts.testing.index}>
-        <ScriptsList type="testing" />
-      </Route>
-      <Route exact path={settingsURLs.scripts.testing.upload}>
-        <ScriptsUpload type="testing" />
-      </Route>
+      <Route
+        exact
+        path={settingsURLs.scripts.commissioning.index}
+        component={() => <ScriptsList type="commissioning" />}
+      />
+      <Route
+        exact
+        path={settingsURLs.scripts.commissioning.upload}
+        component={() => <ScriptsUpload type="commissioning" />}
+      />
+      <Route
+        exact
+        path={settingsURLs.scripts.testing.index}
+        component={() => <ScriptsList type="testing" />}
+      />
+      <Route
+        exact
+        path={settingsURLs.scripts.testing.upload}
+        component={() => <ScriptsUpload type="testing" />}
+      />
       <Route exact path={settingsURLs.dhcp.index} component={DhcpList} />
       <Route exact path={settingsURLs.dhcp.add} component={DhcpAdd} />
       <Route

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
@@ -238,9 +238,7 @@ describe("ScriptsUpload", () => {
           ]}
         >
           <ScriptsUpload type="commissioning" />
-          <Route path="*">
-            <FetchRoute />
-          </Route>
+          <Route path="*" component={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );
@@ -261,9 +259,7 @@ describe("ScriptsUpload", () => {
           initialEntries={[{ pathname: "/settings/scripts/testing/upload" }]}
         >
           <ScriptsUpload type="testing" />
-          <Route path="*">
-            <FetchRoute />
-          </Route>
+          <Route path="*" component={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/zones/views/Zones.tsx
+++ b/ui/src/app/zones/views/Zones.tsx
@@ -8,15 +8,13 @@ import ZonesList from "app/zones/views/ZonesList";
 const Zones = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={zonesURLs.index}>
-        <ZonesList />
-      </Route>
-      <Route exact path={zonesURLs.details(null, true)}>
-        <ZoneDetails />
-      </Route>
-      <Route path="*">
-        <NotFound />
-      </Route>
+      <Route exact path={zonesURLs.index} component={() => <ZonesList />} />
+      <Route
+        exact
+        path={zonesURLs.details(null, true)}
+        component={() => <ZoneDetails />}
+      />
+      <Route path="*" component={() => <NotFound />} />
     </Switch>
   );
 };


### PR DESCRIPTION
## Done

- Update the routes to wrap the content in a `component` prop.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load the UI and have a poke around the React pages. They should load as expected.

## Fixes

Fixes: #3507.