### PR TITLE
refactor: subnets add VLAN

### DIFF
--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -11,21 +11,35 @@ context("Subnets - Add", () => {
     it(`displays an error when trying to add a ${type} with a name that already exists`, () => {
       const name = `cypress-${generateId()}`;
 
-      cy.findByRole("button", { name: "Add" }).click();
-      cy.findByRole("button", { name: type }).click();
-      cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
-      cy.findByRole("button", { name: `Add ${type}` }).click();
+      const completeForm = () => {
+        cy.findByRole("button", { name: "Add" }).click();
+        cy.findByRole("button", { name: type }).click();
+        cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
+        cy.findByRole("button", { name: `Add ${type}` }).click();
+      };
 
-      cy.waitUntil(() =>
-        cy
-          .findByRole("textbox", { name: "Name (optional)" })
-          .should("not.be.disabled")
-      );
+      completeForm();
+      completeForm();
 
-      cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
-      cy.findByRole("button", { name: `Add ${type}` }).click();
-
-      cy.findByText(/this Name already exists/).should("exist");
+      cy.findByText(/this Name already exists/).should("be.visible");
     });
+  });
+
+  it("displays an error when trying to add a VLAN with a VID that already exists", () => {
+    const VID = `${Math.floor(Math.random() * 100)}`;
+
+    const completeForm = () => {
+      cy.findByRole("button", { name: "Add" }).click();
+      cy.findByRole("button", { name: "VLAN" }).click();
+      cy.findByRole("textbox", { name: "VID" }).type(VID);
+      cy.findByRole("button", { name: "Add VLAN" }).click();
+    };
+
+    completeForm();
+    completeForm();
+
+    cy.findByText(
+      /A VLAN with the specified VID already exists in the destination fabric./
+    ).should("exist");
   });
 });

--- a/ui/src/app/base/components/FabricSelect/FabricSelect.test.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.test.tsx
@@ -27,7 +27,7 @@ describe("FabricSelect", () => {
     });
   });
 
-  it("shows a spinner if the fabrics haven't loaded", () => {
+  it("is disabled if the fabrics haven't loaded", () => {
     state.fabric.loaded = false;
     const store = mockStore(state);
     const wrapper = mount(
@@ -37,7 +37,7 @@ describe("FabricSelect", () => {
         </Formik>
       </Provider>
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.find("FormikField").prop("disabled")).toBe(true);
   });
 
   it("displays the fabric options", () => {
@@ -55,7 +55,7 @@ describe("FabricSelect", () => {
       </Provider>
     );
     expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
-      { label: "Select fabric", value: "" },
+      { disabled: true, label: "Select fabric", value: "" },
       {
         label: items[0].name,
         value: items[0].id.toString(),

--- a/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 
-import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
 import DynamicSelect from "app/base/components/DynamicSelect";
@@ -22,17 +21,10 @@ export const FabricSelect = ({
   const dispatch = useDispatch();
   const fabrics = useSelector(fabricSelectors.all);
   const fabricsLoaded = useSelector(fabricSelectors.loaded);
-  const { setFieldValue } = useFormikContext();
 
   useEffect(() => {
     if (!fabricsLoaded) dispatch(fabricActions.fetch());
   }, [dispatch, fabricsLoaded]);
-
-  useEffect(() => {
-    if (fabricsLoaded) {
-      setFieldValue(name, fabrics[0]?.id?.toString());
-    }
-  }, [name, fabricsLoaded, fabrics, setFieldValue]);
 
   return (
     <DynamicSelect

--- a/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
@@ -1,49 +1,51 @@
 import { useEffect } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
 import DynamicSelect from "app/base/components/DynamicSelect";
 import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
-import type { Fabric } from "app/store/fabric/types";
 
 type Props = {
-  defaultOption?: { label: string; value: string } | null;
+  defaultOption?: { label: string; value: string; disabled?: boolean } | null;
 } & FormikFieldProps;
 
 export const FabricSelect = ({
-  defaultOption = { label: "Select fabric", value: "" },
+  defaultOption = { label: "Select fabric", value: "", disabled: true },
   name,
+  label = "Fabric",
+  disabled,
   ...props
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const fabrics: Fabric[] = useSelector(fabricSelectors.all);
+  const fabrics = useSelector(fabricSelectors.all);
   const fabricsLoaded = useSelector(fabricSelectors.loaded);
+  const { setFieldValue } = useFormikContext();
 
   useEffect(() => {
-    dispatch(fabricActions.fetch());
-  }, [dispatch]);
+    if (!fabricsLoaded) dispatch(fabricActions.fetch());
+  }, [dispatch, fabricsLoaded]);
 
-  if (!fabricsLoaded) {
-    return <Spinner />;
-  }
-
-  const fabricOptions = fabrics.map((fabric) => ({
-    label: fabric.name,
-    value: fabric.id.toString(),
-  }));
-
-  if (defaultOption) {
-    fabricOptions.unshift(defaultOption);
-  }
+  useEffect(() => {
+    if (fabricsLoaded) {
+      setFieldValue(name, fabrics[0]?.id);
+    }
+  }, [name, fabricsLoaded, fabrics, setFieldValue]);
 
   return (
     <DynamicSelect
-      label="Fabric"
+      disabled={!fabricsLoaded || disabled}
+      label={label}
       name={name}
-      options={fabricOptions}
+      options={[
+        ...(defaultOption ? [defaultOption] : []),
+        ...fabrics.map((fabric) => ({
+          label: fabric.name,
+          value: fabric.id.toString(),
+        })),
+      ]}
       {...props}
     />
   );

--- a/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
@@ -30,7 +30,7 @@ export const FabricSelect = ({
 
   useEffect(() => {
     if (fabricsLoaded) {
-      setFieldValue(name, fabrics[0]?.id);
+      setFieldValue(name, fabrics[0]?.id?.toString());
     }
   }, [name, fabricsLoaded, fabrics, setFieldValue]);
 

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import SpaceSelect from "./SpaceSelect";
+
+import type { RootState } from "app/store/root/types";
+import {
+  space as spaceFactory,
+  spaceState as spaceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    space: spaceStateFactory({
+      items: [],
+      loaded: false,
+    }),
+  });
+});
+
+it("is disabled if spaces haven't loaded", () => {
+  state.space.loaded = false;
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <Formik initialValues={{ space: "" }} onSubmit={jest.fn()}>
+        <SpaceSelect name="space" />
+      </Formik>
+    </Provider>
+  );
+  expect(screen.getByRole("combobox", { name: "Space" })).toBeDisabled();
+  expect(
+    screen.getByRole("option", { name: "Select space", selected: true })
+  ).toBeDisabled();
+});
+
+it("renders options correctly", () => {
+  const space = spaceFactory({ id: 1, name: "space1" });
+  state.space.items = [space];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <Formik initialValues={{ space: "" }} onSubmit={jest.fn()}>
+        <SpaceSelect name="space" />
+      </Formik>
+    </Provider>
+  );
+
+  const allOptions: HTMLOptionElement[] = screen.getAllByRole("option");
+  expect(allOptions).toHaveLength(2);
+
+  const defaultOption = allOptions[0];
+  expect(defaultOption).toHaveTextContent("Select space");
+  expect(defaultOption).toBeDisabled();
+
+  const option = allOptions[1];
+  expect(option.selected).toBe(true);
+  expect(option).toHaveTextContent(space.name);
+  expect(option).not.toBeDisabled();
+  expect(option).toHaveValue(space.id.toString());
+});
+
+it("can hide the default option", () => {
+  state.space.items = [];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <Formik initialValues={{ space: "" }} onSubmit={jest.fn()}>
+        <SpaceSelect name="space" defaultOption={null} />
+      </Formik>
+    </Provider>
+  );
+  expect(screen.queryAllByRole("option")).toHaveLength(0);
+});

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -41,9 +41,10 @@ it("is disabled if spaces haven't loaded", () => {
   ).toBeDisabled();
 });
 
-it("renders options correctly", () => {
+it("renders options correctly", async () => {
   const space = spaceFactory({ id: 1, name: "space1" });
   state.space.items = [space];
+  state.space.loaded = true;
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -61,7 +62,7 @@ it("renders options correctly", () => {
   expect(defaultOption).toBeDisabled();
 
   const option = allOptions[1];
-  expect(option.selected).toBe(true);
+  await waitFor(() => expect(option.selected).toBe(true));
   expect(option).toHaveTextContent(space.name);
   expect(option).not.toBeDisabled();
   expect(option).toHaveValue(space.id.toString());

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -57,13 +57,19 @@ it("renders options correctly", async () => {
   const allOptions: HTMLOptionElement[] = screen.getAllByRole("option");
   expect(allOptions).toHaveLength(2);
 
-  const defaultOption = allOptions[0];
-  expect(defaultOption).toHaveTextContent("Select space");
+  const defaultOption = screen.getByRole("option", {
+    name: "Select space",
+    selected: true,
+  });
+  expect(defaultOption).toBeInTheDocument();
   expect(defaultOption).toBeDisabled();
+  expect(defaultOption).toHaveValue("");
 
-  const option = allOptions[1];
-  await waitFor(() => expect(option.selected).toBe(true));
-  expect(option).toHaveTextContent(space.name);
+  const option = screen.getByRole("option", {
+    name: space.name,
+    selected: false,
+  });
+  expect(defaultOption).toBeInTheDocument();
   expect(option).not.toBeDisabled();
   expect(option).toHaveValue(space.id.toString());
 });

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 
 import { Select } from "@canonical/react-components";
-import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
@@ -23,17 +22,10 @@ export const SpaceSelect = ({
   const dispatch = useDispatch();
   const spaces = useSelector(spaceSelectors.all);
   const spacesLoaded = useSelector(spaceSelectors.loaded);
-  const { setFieldValue } = useFormikContext();
 
   useEffect(() => {
     if (!spacesLoaded) dispatch(spaceActions.fetch());
   }, [dispatch, spacesLoaded]);
-
-  useEffect(() => {
-    if (spacesLoaded) {
-      setFieldValue(name, spaces[0]?.id?.toString());
-    }
-  }, [name, spacesLoaded, spaces, setFieldValue]);
 
   return (
     <FormikField

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+
+import { Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikField from "app/base/components/FormikField";
+import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
+import { actions as spaceActions } from "app/store/space";
+import spaceSelectors from "app/store/space/selectors";
+
+type Props = {
+  defaultOption?: { label: string; value: string; disabled?: boolean } | null;
+} & FormikFieldProps;
+
+export const SpaceSelect = ({
+  defaultOption = { label: "Select space", value: "", disabled: true },
+  name,
+  label = "Space",
+  disabled,
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const spaces = useSelector(spaceSelectors.all);
+  const spacesLoaded = useSelector(spaceSelectors.loaded);
+  const { setFieldValue } = useFormikContext();
+
+  useEffect(() => {
+    if (!spacesLoaded) dispatch(spaceActions.fetch());
+  }, [dispatch, spacesLoaded]);
+
+  useEffect(() => {
+    if (spacesLoaded) {
+      setFieldValue(name, spaces[0]?.id);
+    }
+  }, [name, spacesLoaded, spaces, setFieldValue]);
+
+  return (
+    <FormikField
+      component={Select}
+      disabled={!spacesLoaded || disabled}
+      label={label}
+      name={name}
+      options={[
+        ...(defaultOption ? [defaultOption] : []),
+        ...spaces.map((space) => ({
+          label: space.name,
+          value: space.id.toString(),
+        })),
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default SpaceSelect;

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
@@ -31,7 +31,7 @@ export const SpaceSelect = ({
 
   useEffect(() => {
     if (spacesLoaded) {
-      setFieldValue(name, spaces[0]?.id);
+      setFieldValue(name, spaces[0]?.id?.toString());
     }
   }, [name, spacesLoaded, spaces, setFieldValue]);
 

--- a/ui/src/app/base/components/SpaceSelect/index.ts
+++ b/ui/src/app/base/components/SpaceSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceSelect";

--- a/ui/src/app/store/vlan/types/actions.ts
+++ b/ui/src/app/store/vlan/types/actions.ts
@@ -2,11 +2,11 @@ import type { VLAN } from "./base";
 import type { VLANMeta } from "./enum";
 
 export type CreateParams = {
-  description: VLAN["description"];
+  description?: VLAN["description"];
   dhcp_on?: VLAN["dhcp_on"];
   fabric?: VLAN["fabric"];
   mtu?: VLAN["mtu"];
-  name: VLAN["name"];
+  name?: VLAN["name"];
   primary_rack?: VLAN["primary_rack"];
   relay_vlan?: VLAN["relay_vlan"];
   secondary_rack?: VLAN["secondary_rack"];

--- a/ui/src/app/subnets/views/FormActions/FormActions.tsx
+++ b/ui/src/app/subnets/views/FormActions/FormActions.tsx
@@ -1,5 +1,6 @@
 import AddFabric from "./components/AddFabric";
 import AddSpace from "./components/AddSpace";
+import AddVlan from "./components/AddVlan";
 
 import { SubnetForms } from "app/subnets/enum";
 import type { SubnetForm } from "app/subnets/types";
@@ -9,7 +10,7 @@ const FormComponents: Record<
   ({ activeForm, setActiveForm }: FormActionProps) => JSX.Element | null
 > = {
   [SubnetForms.Fabric]: AddFabric,
-  [SubnetForms.VLAN]: () => null,
+  [SubnetForms.VLAN]: AddVlan,
   [SubnetForms.Space]: AddSpace,
   [SubnetForms.Subnet]: () => null,
 };

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@canonical/react-components";
+import { Row, Col, Input } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import type { FormActionProps } from "../FormActions";
@@ -41,14 +41,18 @@ const AddFabric = ({
       saved={isSaved}
       errors={errors}
     >
-      <FormikField
-        takeFocus
-        type="text"
-        name="name"
-        component={Input}
-        disabled={isSaving}
-        label="Name (optional)"
-      />
+      <Row>
+        <Col size={6}>
+          <FormikField
+            takeFocus
+            type="text"
+            name="name"
+            component={Input}
+            disabled={isSaving}
+            label="Name (optional)"
+          />
+        </Col>
+      </Row>
     </FormikForm>
   );
 };

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@canonical/react-components";
+import { Row, Col, Input } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import type { FormActionProps } from "../FormActions";
@@ -41,14 +41,18 @@ const AddSpace = ({
       saved={isSaved}
       errors={errors}
     >
-      <FormikField
-        takeFocus
-        type="text"
-        name="name"
-        component={Input}
-        disabled={isSaving}
-        label="Name (optional)"
-      />
+      <Row>
+        <Col size={6}>
+          <FormikField
+            takeFocus
+            type="text"
+            name="name"
+            component={Input}
+            disabled={isSaving}
+            label="Name (optional)"
+          />
+        </Col>
+      </Row>
     </FormikForm>
   );
 };

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddVlan from "./AddVlan";
+
+import { actions as vlanActions } from "app/store/vlan";
+import {
+  space as spaceFactory,
+  fabric as fabricFactory,
+  spaceState as spaceStateFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+it("displays validation messages for VID", async () => {
+  const store = configureStore()(rootStateFactory());
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <AddVlan activeForm="VLAN" setActiveForm={() => undefined} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const VidTextBox = screen.getByRole("textbox", { name: /VID/ });
+  const submitButton = screen.getByRole("button", { name: "Add VLAN" });
+  const errorMessage = /must be a numeric value/;
+
+  userEvent.type(VidTextBox, "abc");
+  userEvent.click(submitButton);
+
+  await waitFor(() =>
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  );
+
+  userEvent.clear(VidTextBox);
+  userEvent.type(VidTextBox, "123");
+
+  await waitFor(() =>
+    expect(screen.queryByText(errorMessage)).not.toBeInTheDocument()
+  );
+
+  userEvent.clear(VidTextBox);
+  userEvent.type(VidTextBox, "99999");
+
+  await waitFor(() =>
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  );
+});
+
+it("correctly dispatches VLAN create action on form submit", async () => {
+  const vid = 123;
+  const name = "VLAN name";
+  const space = { id: 1, name: "space1" };
+  const fabric = { id: 1, name: "fabric1" };
+
+  const state = rootStateFactory({
+    space: spaceStateFactory({
+      items: [spaceFactory(space)],
+      loaded: true,
+    }),
+    fabric: fabricStateFactory({
+      items: [fabricFactory(fabric)],
+      loaded: true,
+    }),
+  });
+  const store = configureStore()(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <AddVlan activeForm="VLAN" setActiveForm={() => undefined} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  userEvent.type(screen.getByRole("textbox", { name: /VID/ }), `${vid}`);
+  userEvent.type(screen.getByRole("textbox", { name: /Name/ }), `${name}`);
+  userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Fabric" }),
+    fabric.name
+  );
+  userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Space" }),
+    space.name
+  );
+
+  userEvent.click(screen.getByRole("button", { name: "Add VLAN" }));
+
+  await waitFor(() =>
+    expect(store.getActions()).toStrictEqual([
+      vlanActions.create({ vid, name, fabric: fabric.id, space: space.id }),
+    ])
+  );
+});

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -23,12 +23,16 @@ type AddVlanValues = {
   space?: string;
 };
 
+const vidRangeError = "VID must be a numeric value between 1 and 4094";
 const vlanSchema = Yup.object()
   .shape({
     space: Yup.number().required("Space is required"),
     fabric: Yup.number().required("Fabric is required"),
     name: Yup.string(),
-    vid: Yup.number().required("VID is required"),
+    vid: Yup.number()
+      .required("VID is required")
+      .min(1, vidRangeError)
+      .max(4094, vidRangeError),
   })
   .defined();
 
@@ -89,6 +93,7 @@ const AddVlan = ({
             component={Input}
             disabled={isSaving}
             label="VID"
+            help="Numeric value between 1 and 4094"
           />
         </Col>
         <Col size={6}>

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+
+import { Input } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import type { FormActionProps } from "../FormActions";
+
+import FabricSelect from "app/base/components/FabricSelect";
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import SpaceSelect from "app/base/components/SpaceSelect";
+import { actions as fabricActions } from "app/store/fabric";
+import { actions as spaceActions } from "app/store/space";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import { toFormikNumber } from "app/utils";
+
+type AddVlanValues = {
+  name?: string;
+  fabric?: number;
+  vid?: number;
+  space?: number;
+};
+
+const vlanSchema = Yup.object()
+  .shape({
+    space: Yup.number().required("Space is required"),
+    fabric: Yup.number().required("Fabric is required"),
+    name: Yup.string(),
+    vid: Yup.number().required("VID is required"),
+  })
+  .defined();
+
+const AddVlan = ({
+  activeForm,
+  setActiveForm,
+}: FormActionProps): JSX.Element => {
+  const dispatch = useDispatch();
+  const isSaving = useSelector(vlanSelectors.saving);
+  const isSaved = useSelector(vlanSelectors.saved);
+  const errors = useSelector(vlanSelectors.errors);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+    dispatch(spaceActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <FormikForm<AddVlanValues>
+      validationSchema={vlanSchema}
+      buttonsBordered={false}
+      allowAllEmpty
+      initialValues={{ vid: undefined }}
+      onSaveAnalytics={{
+        action: "Add VLAN",
+        category: "Subnets form actions",
+        label: "Add VLAN",
+      }}
+      submitLabel={`Add ${activeForm}`}
+      onSubmit={({ name, fabric, vid, space }) => {
+        dispatch(
+          vlanActions.create({
+            name,
+            fabric: toFormikNumber(fabric),
+            vid: toFormikNumber(vid) as number,
+            space: toFormikNumber(space),
+          })
+        );
+      }}
+      onCancel={() => setActiveForm(null)}
+      onSuccess={() => setActiveForm(null)}
+      saving={isSaving}
+      saved={isSaved}
+      errors={errors}
+    >
+      <FormikField
+        takeFocus
+        required
+        type="text"
+        name="vid"
+        component={Input}
+        disabled={isSaving}
+        label="VID"
+      />
+      <FormikField
+        type="text"
+        name="name"
+        component={Input}
+        disabled={isSaving}
+        label="Name"
+      />
+      <FabricSelect required name="fabric" disabled={isSaving} />
+      <SpaceSelect required name="space" disabled={isSaving} />
+    </FormikForm>
+  );
+};
+
+export default AddVlan;

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { Input } from "@canonical/react-components";
+import { Row, Col, Input } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -79,24 +79,36 @@ const AddVlan = ({
       saved={isSaved}
       errors={errors}
     >
-      <FormikField
-        takeFocus
-        required
-        type="text"
-        name="vid"
-        component={Input}
-        disabled={isSaving}
-        label="VID"
-      />
-      <FormikField
-        type="text"
-        name="name"
-        component={Input}
-        disabled={isSaving}
-        label="Name"
-      />
-      <FabricSelect required name="fabric" disabled={isSaving} />
-      <SpaceSelect required name="space" disabled={isSaving} />
+      <Row>
+        <Col size={6}>
+          <FormikField
+            takeFocus
+            required
+            type="text"
+            name="vid"
+            component={Input}
+            disabled={isSaving}
+            label="VID"
+          />
+        </Col>
+        <Col size={6}>
+          <FormikField
+            type="text"
+            name="name"
+            component={Input}
+            disabled={isSaving}
+            label="Name"
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Col size={6}>
+          <FabricSelect required name="fabric" disabled={isSaving} />
+        </Col>
+        <Col size={6}>
+          <SpaceSelect required name="space" disabled={isSaving} />
+        </Col>
+      </Row>
     </FormikForm>
   );
 };

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -19,10 +19,10 @@ import vlanSelectors from "app/store/vlan/selectors";
 import { toFormikNumber } from "app/utils";
 
 type AddVlanValues = {
-  vid?: string;
-  name?: string;
-  fabric?: string;
-  space?: string;
+  vid: string;
+  name: string;
+  fabric: string;
+  space: string;
 };
 
 const vidRangeError = "VID must be a numeric value between 1 and 4094";
@@ -59,7 +59,6 @@ const AddVlan = ({
     <FormikForm<AddVlanValues>
       validationSchema={vlanSchema}
       buttonsBordered={false}
-      allowAllEmpty
       initialValues={{
         vid: "",
         name: "",

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -17,10 +17,10 @@ import vlanSelectors from "app/store/vlan/selectors";
 import { toFormikNumber } from "app/utils";
 
 type AddVlanValues = {
+  vid?: string;
   name?: string;
-  fabric?: number;
-  vid?: number;
-  space?: number;
+  fabric?: string;
+  space?: string;
 };
 
 const vlanSchema = Yup.object()
@@ -51,7 +51,12 @@ const AddVlan = ({
       validationSchema={vlanSchema}
       buttonsBordered={false}
       allowAllEmpty
-      initialValues={{ vid: undefined }}
+      initialValues={{
+        vid: "",
+        name: "",
+        fabric: "",
+        space: "",
+      }}
       onSaveAnalytics={{
         action: "Add VLAN",
         category: "Subnets form actions",

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -11,7 +11,9 @@ import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import SpaceSelect from "app/base/components/SpaceSelect";
 import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
 import { actions as spaceActions } from "app/store/space";
+import spaceSelectors from "app/store/space/selectors";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import { toFormikNumber } from "app/utils";
@@ -30,9 +32,10 @@ const vlanSchema = Yup.object()
     fabric: Yup.number().required("Fabric is required"),
     name: Yup.string(),
     vid: Yup.number()
-      .required("VID is required")
+      .typeError(vidRangeError)
       .min(1, vidRangeError)
-      .max(4094, vidRangeError),
+      .max(4094, vidRangeError)
+      .required("VID is required"),
   })
   .defined();
 
@@ -44,11 +47,13 @@ const AddVlan = ({
   const isSaving = useSelector(vlanSelectors.saving);
   const isSaved = useSelector(vlanSelectors.saved);
   const errors = useSelector(vlanSelectors.errors);
+  const spacesLoaded = useSelector(spaceSelectors.loaded);
+  const fabricsLoaded = useSelector(fabricSelectors.loaded);
 
   useEffect(() => {
-    dispatch(fabricActions.fetch());
-    dispatch(spaceActions.fetch());
-  }, [dispatch]);
+    if (!fabricsLoaded) dispatch(fabricActions.fetch());
+    if (!spacesLoaded) dispatch(spaceActions.fetch());
+  }, [dispatch, fabricsLoaded, spacesLoaded]);
 
   return (
     <FormikForm<AddVlanValues>


### PR DESCRIPTION
## Done

migrate Subnets / add VLAN to React
- add SpaceSelect component
- wrap forms in .col-6
- add cypress test

**design changes:**
- change input fields order (set VID input before Name input as it’s required)
- add help text to VID (Numeric value between 1 and 4094)

## Screenshots
### Before
![Pasted Graphic](https://user-images.githubusercontent.com/7452681/149507256-49f929b1-a7b6-4b81-85d3-b70ae8650803.png)

### After
![image](https://user-images.githubusercontent.com/7452681/149749709-18d8f3ac-3487-4f79-b7f1-ea06218a4118.png)


![image](https://user-images.githubusercontent.com/7452681/149515250-59605fe6-7918-44f4-8ec8-ab57be06dd3c.png)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to `/MAAS/r/networks?by=fabric` and verify adding a VLAN works correctly.