### PR TITLE
feat(ui): add get and set_active actions to networking models

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.ts.snap
+++ b/ui/src/__snapshots__/root-reducer.test.ts.snap
@@ -90,6 +90,7 @@ Object {
     "saving": false,
   },
   "fabric": Object {
+    "active": null,
     "errors": null,
     "items": Array [],
     "loaded": false,
@@ -276,6 +277,7 @@ Object {
     "saving": false,
   },
   "space": Object {
+    "active": null,
     "errors": null,
     "items": Array [],
     "loaded": false,
@@ -304,6 +306,7 @@ Object {
     "authenticating": false,
   },
   "subnet": Object {
+    "active": null,
     "errors": null,
     "items": Array [],
     "loaded": false,
@@ -348,6 +351,7 @@ Object {
     },
   },
   "vlan": Object {
+    "active": null,
     "errors": null,
     "items": Array [],
     "loaded": false,

--- a/ui/src/app/store/fabric/actions.test.ts
+++ b/ui/src/app/store/fabric/actions.test.ts
@@ -81,4 +81,30 @@ describe("fabric actions", () => {
       payload: undefined,
     });
   });
+
+  it("can create an action to get a fabric", () => {
+    expect(actions.get(0)).toEqual({
+      type: "fabric/get",
+      meta: {
+        model: "fabric",
+        method: "get",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
+
+  it("can create an action to set an active fabric", () => {
+    expect(actions.setActive(0)).toEqual({
+      type: "fabric/setActive",
+      meta: {
+        model: "fabric",
+        method: "set_active",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
 });

--- a/ui/src/app/store/fabric/reducers.test.ts
+++ b/ui/src/app/store/fabric/reducers.test.ts
@@ -201,4 +201,89 @@ describe("fabric reducer", () => {
       );
     });
   });
+
+  describe("get", () => {
+    it("reduces getStart", () => {
+      const initialState = fabricStateFactory({ loading: false });
+
+      expect(reducers(initialState, actions.getStart())).toEqual(
+        fabricStateFactory({ loading: true })
+      );
+    });
+
+    it("reduces getError", () => {
+      const initialState = fabricStateFactory({ errors: null, loading: true });
+
+      expect(
+        reducers(initialState, actions.getError({ id: "id was not supplied" }))
+      ).toEqual(
+        fabricStateFactory({
+          errors: { id: "id was not supplied" },
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when fabric already exists in state", () => {
+      const initialState = fabricStateFactory({
+        items: [fabricFactory({ id: 0, name: "fabric-1" })],
+        loading: true,
+      });
+      const updatedFabric = fabricFactory({
+        id: 0,
+        name: "fabric-1-new",
+      });
+
+      expect(reducers(initialState, actions.getSuccess(updatedFabric))).toEqual(
+        fabricStateFactory({
+          items: [updatedFabric],
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when fabric does not exist yet in state", () => {
+      const initialState = fabricStateFactory({
+        items: [fabricFactory({ id: 0 })],
+        loading: true,
+      });
+      const newFabric = fabricFactory({ id: 1 });
+
+      expect(reducers(initialState, actions.getSuccess(newFabric))).toEqual(
+        fabricStateFactory({
+          items: [...initialState.items, newFabric],
+          loading: false,
+        })
+      );
+    });
+  });
+
+  describe("setActive", () => {
+    it("reduces setActiveSuccess", () => {
+      const initialState = fabricStateFactory({ active: null });
+
+      expect(
+        reducers(
+          initialState,
+          actions.setActiveSuccess(fabricFactory({ id: 0 }))
+        )
+      ).toEqual(fabricStateFactory({ active: 0 }));
+    });
+
+    it("reduces setActiveError", () => {
+      const initialState = fabricStateFactory({
+        active: 0,
+        errors: null,
+      });
+
+      expect(
+        reducers(initialState, actions.setActiveError("Fabric does not exist"))
+      ).toEqual(
+        fabricStateFactory({
+          active: null,
+          errors: "Fabric does not exist",
+        })
+      );
+    });
+  });
 });

--- a/ui/src/app/store/fabric/selectors.test.ts
+++ b/ui/src/app/store/fabric/selectors.test.ts
@@ -84,4 +84,24 @@ describe("fabric selectors", () => {
     });
     expect(fabric.search(state, "d")).toStrictEqual([items[1]]);
   });
+
+  it("can get the active fabric's id", () => {
+    const state = rootStateFactory({
+      fabric: fabricStateFactory({
+        active: 0,
+      }),
+    });
+    expect(fabric.activeID(state)).toEqual(0);
+  });
+
+  it("can get the active fabric", () => {
+    const activeFabric = fabricFactory();
+    const state = rootStateFactory({
+      fabric: fabricStateFactory({
+        active: activeFabric.id,
+        items: [activeFabric],
+      }),
+    });
+    expect(fabric.active(state)).toEqual(activeFabric);
+  });
 });

--- a/ui/src/app/store/fabric/selectors.ts
+++ b/ui/src/app/store/fabric/selectors.ts
@@ -1,14 +1,52 @@
+import { createSelector } from "reselect";
+
 import { FabricMeta } from "app/store/fabric/types";
 import type { Fabric, FabricState } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
 import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (fabric: Fabric, term: string) =>
   fabric.name.includes(term);
 
-const selectors = generateBaseSelectors<FabricState, Fabric, FabricMeta.PK>(
-  FabricMeta.MODEL,
-  FabricMeta.PK,
-  searchFunction
+const defaultSelectors = generateBaseSelectors<
+  FabricState,
+  Fabric,
+  FabricMeta.PK
+>(FabricMeta.MODEL, FabricMeta.PK, searchFunction);
+
+/**
+ * Get the fabric state object.
+ * @param state - The redux state.
+ * @returns The fabric state.
+ */
+const fabricState = (state: RootState): FabricState => state[FabricMeta.MODEL];
+
+/**
+ * Returns currently active fabric's id.
+ * @param state - The redux state.
+ * @returns Active fabric id.
+ */
+const activeID = createSelector(
+  [fabricState],
+  (fabricState) => fabricState.active
 );
+
+/**
+ * Returns currently active fabric.
+ * @param state - The redux state.
+ * @returns Active fabric.
+ */
+const active = createSelector(
+  [defaultSelectors.all, activeID],
+  (fabrics: Fabric[], activeID: Fabric[FabricMeta.PK] | null) =>
+    fabrics.find((fabric) => activeID === fabric.id)
+);
+
+const selectors = {
+  ...defaultSelectors,
+  active,
+  activeID,
+  fabricState,
+};
 
 export default selectors;

--- a/ui/src/app/store/fabric/slice.ts
+++ b/ui/src/app/store/fabric/slice.ts
@@ -1,7 +1,8 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { FabricMeta } from "./types";
-import type { CreateParams, FabricState, UpdateParams } from "./types";
+import type { CreateParams, Fabric, FabricState, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
@@ -10,13 +11,85 @@ import {
 
 const fabricSlice = createSlice({
   name: FabricMeta.MODEL,
-  initialState: genericInitialState as FabricState,
-  reducers: generateCommonReducers<
-    FabricState,
-    FabricMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(FabricMeta.MODEL, FabricMeta.PK),
+  initialState: {
+    ...genericInitialState,
+    active: null,
+  } as FabricState,
+  reducers: {
+    ...generateCommonReducers<
+      FabricState,
+      FabricMeta.PK,
+      CreateParams,
+      UpdateParams
+    >(FabricMeta.MODEL, FabricMeta.PK),
+    get: {
+      prepare: (id: Fabric[FabricMeta.PK]) => ({
+        meta: {
+          model: FabricMeta.MODEL,
+          method: "get",
+        },
+        payload: {
+          params: { [FabricMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    getError: (
+      state: FabricState,
+      action: PayloadAction<FabricState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+      state.saving = false;
+    },
+    getStart: (state: FabricState) => {
+      state.loading = true;
+    },
+    getSuccess: (state: FabricState, action: PayloadAction<Fabric>) => {
+      const fabric = action.payload;
+      // If the item already exists, update it, otherwise
+      // add it to the store.
+      const i = state.items.findIndex(
+        (draftItem: Fabric) =>
+          draftItem[FabricMeta.PK] === fabric[FabricMeta.PK]
+      );
+      if (i !== -1) {
+        state.items[i] = fabric;
+      } else {
+        state.items.push(fabric);
+      }
+      state.loading = false;
+    },
+    setActive: {
+      prepare: (id: Fabric[FabricMeta.PK] | null) => ({
+        meta: {
+          model: FabricMeta.MODEL,
+          method: "set_active",
+        },
+        payload: {
+          params: { [FabricMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    setActiveError: (
+      state: FabricState,
+      action: PayloadAction<FabricState["errors"]>
+    ) => {
+      state.active = null;
+      state.errors = action.payload;
+    },
+    setActiveSuccess: (
+      state: FabricState,
+      action: PayloadAction<Fabric | null>
+    ) => {
+      state.active = action.payload ? action.payload[FabricMeta.PK] : null;
+    },
+  },
 });
 
 export const { actions } = fabricSlice;

--- a/ui/src/app/store/fabric/types/base.ts
+++ b/ui/src/app/store/fabric/types/base.ts
@@ -1,3 +1,5 @@
+import type { FabricMeta } from "./enum";
+
 import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
@@ -12,4 +14,6 @@ export type Fabric = Model & {
   vlan_ids: number[];
 };
 
-export type FabricState = GenericState<Fabric, APIError>;
+export type FabricState = GenericState<Fabric, APIError> & {
+  active: Fabric[FabricMeta.PK] | null;
+};

--- a/ui/src/app/store/space/actions.test.ts
+++ b/ui/src/app/store/space/actions.test.ts
@@ -68,4 +68,30 @@ describe("space actions", () => {
       payload: undefined,
     });
   });
+
+  it("can create an action to get a space", () => {
+    expect(actions.get(0)).toEqual({
+      type: "space/get",
+      meta: {
+        model: "space",
+        method: "get",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
+
+  it("can create an action to set an active space", () => {
+    expect(actions.setActive(0)).toEqual({
+      type: "space/setActive",
+      meta: {
+        model: "space",
+        method: "set_active",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
 });

--- a/ui/src/app/store/space/reducers.test.ts
+++ b/ui/src/app/store/space/reducers.test.ts
@@ -185,4 +185,89 @@ describe("space reducer", () => {
       );
     });
   });
+
+  describe("get", () => {
+    it("reduces getStart", () => {
+      const initialState = spaceStateFactory({ loading: false });
+
+      expect(reducers(initialState, actions.getStart())).toEqual(
+        spaceStateFactory({ loading: true })
+      );
+    });
+
+    it("reduces getError", () => {
+      const initialState = spaceStateFactory({ errors: null, loading: true });
+
+      expect(
+        reducers(initialState, actions.getError({ id: "id was not supplied" }))
+      ).toEqual(
+        spaceStateFactory({
+          errors: { id: "id was not supplied" },
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when space already exists in state", () => {
+      const initialState = spaceStateFactory({
+        items: [spaceFactory({ id: 0, name: "space-1" })],
+        loading: true,
+      });
+      const updatedSpace = spaceFactory({
+        id: 0,
+        name: "space-1-new",
+      });
+
+      expect(reducers(initialState, actions.getSuccess(updatedSpace))).toEqual(
+        spaceStateFactory({
+          items: [updatedSpace],
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when space does not exist yet in state", () => {
+      const initialState = spaceStateFactory({
+        items: [spaceFactory({ id: 0 })],
+        loading: true,
+      });
+      const newSpace = spaceFactory({ id: 1 });
+
+      expect(reducers(initialState, actions.getSuccess(newSpace))).toEqual(
+        spaceStateFactory({
+          items: [...initialState.items, newSpace],
+          loading: false,
+        })
+      );
+    });
+  });
+
+  describe("setActive", () => {
+    it("reduces setActiveSuccess", () => {
+      const initialState = spaceStateFactory({ active: null });
+
+      expect(
+        reducers(
+          initialState,
+          actions.setActiveSuccess(spaceFactory({ id: 0 }))
+        )
+      ).toEqual(spaceStateFactory({ active: 0 }));
+    });
+
+    it("reduces setActiveError", () => {
+      const initialState = spaceStateFactory({
+        active: 0,
+        errors: null,
+      });
+
+      expect(
+        reducers(initialState, actions.setActiveError("Space does not exist"))
+      ).toEqual(
+        spaceStateFactory({
+          active: null,
+          errors: "Space does not exist",
+        })
+      );
+    });
+  });
 });

--- a/ui/src/app/store/space/selectors.test.ts
+++ b/ui/src/app/store/space/selectors.test.ts
@@ -84,4 +84,24 @@ describe("space selectors", () => {
     });
     expect(space.search(state, "d")).toStrictEqual([items[1]]);
   });
+
+  it("can get the active space's id", () => {
+    const state = rootStateFactory({
+      space: spaceStateFactory({
+        active: 0,
+      }),
+    });
+    expect(space.activeID(state)).toEqual(0);
+  });
+
+  it("can get the active space", () => {
+    const activeFabric = spaceFactory();
+    const state = rootStateFactory({
+      space: spaceStateFactory({
+        active: activeFabric.id,
+        items: [activeFabric],
+      }),
+    });
+    expect(space.active(state)).toEqual(activeFabric);
+  });
 });

--- a/ui/src/app/store/space/selectors.ts
+++ b/ui/src/app/store/space/selectors.ts
@@ -1,3 +1,6 @@
+import { createSelector } from "reselect";
+
+import type { RootState } from "app/store/root/types";
 import { SpaceMeta } from "app/store/space/types";
 import type { Space, SpaceState } from "app/store/space/types";
 import { generateBaseSelectors } from "app/store/utils";
@@ -5,10 +8,45 @@ import { generateBaseSelectors } from "app/store/utils";
 const searchFunction = (space: Space, term: string) =>
   space.name.includes(term);
 
-const selectors = generateBaseSelectors<SpaceState, Space, SpaceMeta.PK>(
+const defaultSelectors = generateBaseSelectors<SpaceState, Space, SpaceMeta.PK>(
   SpaceMeta.MODEL,
   SpaceMeta.PK,
   searchFunction
 );
+
+/**
+ * Get the space state object.
+ * @param state - The redux state.
+ * @returns The space state.
+ */
+const spaceState = (state: RootState): SpaceState => state[SpaceMeta.MODEL];
+
+/**
+ * Returns currently active space's id.
+ * @param state - The redux state.
+ * @returns Active space id.
+ */
+const activeID = createSelector(
+  [spaceState],
+  (spaceState) => spaceState.active
+);
+
+/**
+ * Returns currently active space.
+ * @param state - The redux state.
+ * @returns Active space.
+ */
+const active = createSelector(
+  [defaultSelectors.all, activeID],
+  (spaces: Space[], activeID: Space[SpaceMeta.PK] | null) =>
+    spaces.find((space) => activeID === space.id)
+);
+
+const selectors = {
+  ...defaultSelectors,
+  active,
+  activeID,
+  spaceState,
+};
 
 export default selectors;

--- a/ui/src/app/store/space/slice.ts
+++ b/ui/src/app/store/space/slice.ts
@@ -1,7 +1,8 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { SpaceMeta } from "./types";
-import type { CreateParams, SpaceState, UpdateParams } from "./types";
+import type { CreateParams, Space, SpaceState, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
@@ -10,13 +11,84 @@ import {
 
 const spaceSlice = createSlice({
   name: SpaceMeta.MODEL,
-  initialState: genericInitialState as SpaceState,
-  reducers: generateCommonReducers<
-    SpaceState,
-    SpaceMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(SpaceMeta.MODEL, SpaceMeta.PK),
+  initialState: {
+    ...genericInitialState,
+    active: null,
+  } as SpaceState,
+  reducers: {
+    ...generateCommonReducers<
+      SpaceState,
+      SpaceMeta.PK,
+      CreateParams,
+      UpdateParams
+    >(SpaceMeta.MODEL, SpaceMeta.PK),
+    get: {
+      prepare: (id: Space[SpaceMeta.PK]) => ({
+        meta: {
+          model: SpaceMeta.MODEL,
+          method: "get",
+        },
+        payload: {
+          params: { [SpaceMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    getError: (
+      state: SpaceState,
+      action: PayloadAction<SpaceState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+      state.saving = false;
+    },
+    getStart: (state: SpaceState) => {
+      state.loading = true;
+    },
+    getSuccess: (state: SpaceState, action: PayloadAction<Space>) => {
+      const space = action.payload;
+      // If the item already exists, update it, otherwise
+      // add it to the store.
+      const i = state.items.findIndex(
+        (draftItem: Space) => draftItem[SpaceMeta.PK] === space[SpaceMeta.PK]
+      );
+      if (i !== -1) {
+        state.items[i] = space;
+      } else {
+        state.items.push(space);
+      }
+      state.loading = false;
+    },
+    setActive: {
+      prepare: (id: Space[SpaceMeta.PK] | null) => ({
+        meta: {
+          model: SpaceMeta.MODEL,
+          method: "set_active",
+        },
+        payload: {
+          params: { [SpaceMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    setActiveError: (
+      state: SpaceState,
+      action: PayloadAction<SpaceState["errors"]>
+    ) => {
+      state.active = null;
+      state.errors = action.payload;
+    },
+    setActiveSuccess: (
+      state: SpaceState,
+      action: PayloadAction<Space | null>
+    ) => {
+      state.active = action.payload ? action.payload[SpaceMeta.PK] : null;
+    },
+  },
 });
 
 export const { actions } = spaceSlice;

--- a/ui/src/app/store/space/types/base.ts
+++ b/ui/src/app/store/space/types/base.ts
@@ -1,3 +1,5 @@
+import type { SpaceMeta } from "./enum";
+
 import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
@@ -11,4 +13,6 @@ export type Space = Model & {
   vlan_ids: number[];
 };
 
-export type SpaceState = GenericState<Space, APIError>;
+export type SpaceState = GenericState<Space, APIError> & {
+  active: Space[SpaceMeta.PK] | null;
+};

--- a/ui/src/app/store/subnet/actions.test.ts
+++ b/ui/src/app/store/subnet/actions.test.ts
@@ -70,4 +70,30 @@ describe("subnet actions", () => {
       payload: undefined,
     });
   });
+
+  it("can create an action to get a subnet", () => {
+    expect(actions.get(0)).toEqual({
+      type: "subnet/get",
+      meta: {
+        model: "subnet",
+        method: "get",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
+
+  it("can create an action to set an active subnet", () => {
+    expect(actions.setActive(0)).toEqual({
+      type: "subnet/setActive",
+      meta: {
+        model: "subnet",
+        method: "set_active",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
 });

--- a/ui/src/app/store/subnet/reducers.test.ts
+++ b/ui/src/app/store/subnet/reducers.test.ts
@@ -201,4 +201,89 @@ describe("subnet reducer", () => {
       );
     });
   });
+
+  describe("get", () => {
+    it("reduces getStart", () => {
+      const initialState = subnetStateFactory({ loading: false });
+
+      expect(reducers(initialState, actions.getStart())).toEqual(
+        subnetStateFactory({ loading: true })
+      );
+    });
+
+    it("reduces getError", () => {
+      const initialState = subnetStateFactory({ errors: null, loading: true });
+
+      expect(
+        reducers(initialState, actions.getError({ id: "id was not supplied" }))
+      ).toEqual(
+        subnetStateFactory({
+          errors: { id: "id was not supplied" },
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when subnet already exists in state", () => {
+      const initialState = subnetStateFactory({
+        items: [subnetFactory({ id: 0, name: "subnet-1" })],
+        loading: true,
+      });
+      const updatedSubnet = subnetFactory({
+        id: 0,
+        name: "subnet-1-new",
+      });
+
+      expect(reducers(initialState, actions.getSuccess(updatedSubnet))).toEqual(
+        subnetStateFactory({
+          items: [updatedSubnet],
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when subnet does not exist yet in state", () => {
+      const initialState = subnetStateFactory({
+        items: [subnetFactory({ id: 0 })],
+        loading: true,
+      });
+      const newSubnet = subnetFactory({ id: 1 });
+
+      expect(reducers(initialState, actions.getSuccess(newSubnet))).toEqual(
+        subnetStateFactory({
+          items: [...initialState.items, newSubnet],
+          loading: false,
+        })
+      );
+    });
+  });
+
+  describe("setActive", () => {
+    it("reduces setActiveSuccess", () => {
+      const initialState = subnetStateFactory({ active: null });
+
+      expect(
+        reducers(
+          initialState,
+          actions.setActiveSuccess(subnetFactory({ id: 0 }))
+        )
+      ).toEqual(subnetStateFactory({ active: 0 }));
+    });
+
+    it("reduces setActiveError", () => {
+      const initialState = subnetStateFactory({
+        active: 0,
+        errors: null,
+      });
+
+      expect(
+        reducers(initialState, actions.setActiveError("Subnet does not exist"))
+      ).toEqual(
+        subnetStateFactory({
+          active: null,
+          errors: "Subnet does not exist",
+        })
+      );
+    });
+  });
 });

--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -91,4 +91,24 @@ describe("subnet selectors", () => {
       subnets[1],
     ]);
   });
+
+  it("can get the active subnet's id", () => {
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        active: 0,
+      }),
+    });
+    expect(subnet.activeID(state)).toEqual(0);
+  });
+
+  it("can get the active subnet", () => {
+    const activeFabric = subnetFactory();
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        active: activeFabric.id,
+        items: [activeFabric],
+      }),
+    });
+    expect(subnet.active(state)).toEqual(activeFabric);
+  });
 });

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -16,6 +16,34 @@ const defaultSelectors = generateBaseSelectors<
 >(SubnetMeta.MODEL, SubnetMeta.PK, searchFunction);
 
 /**
+ * Get the subnet state object.
+ * @param state - The redux state.
+ * @returns The subnet state.
+ */
+const subnetState = (state: RootState): SubnetState => state[SubnetMeta.MODEL];
+
+/**
+ * Returns currently active subnet's id.
+ * @param state - The redux state.
+ * @returns Active subnet id.
+ */
+const activeID = createSelector(
+  [subnetState],
+  (subnetState) => subnetState.active
+);
+
+/**
+ * Returns currently active subnet.
+ * @param state - The redux state.
+ * @returns Active subnet.
+ */
+const active = createSelector(
+  [defaultSelectors.all, activeID],
+  (subnets: Subnet[], activeID: Subnet[SubnetMeta.PK] | null) =>
+    subnets.find((subnet) => activeID === subnet.id)
+);
+
+/**
  * Get subnets for a given cidr.
  * @param state - The redux state.
  * @param cidr - The cidr to filter by.
@@ -70,9 +98,12 @@ const getPxeEnabledByPod = createSelector(
 
 const selectors = {
   ...defaultSelectors,
+  active,
+  activeID,
   getByCIDR,
   getByPod,
   getPxeEnabledByPod,
+  subnetState,
 };
 
 export default selectors;

--- a/ui/src/app/store/subnet/slice.ts
+++ b/ui/src/app/store/subnet/slice.ts
@@ -1,7 +1,8 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { SubnetMeta } from "./types";
-import type { CreateParams, SubnetState, UpdateParams } from "./types";
+import type { CreateParams, Subnet, SubnetState, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
@@ -10,13 +11,85 @@ import {
 
 const subnetSlice = createSlice({
   name: SubnetMeta.MODEL,
-  initialState: genericInitialState as SubnetState,
-  reducers: generateCommonReducers<
-    SubnetState,
-    SubnetMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(SubnetMeta.MODEL, SubnetMeta.PK),
+  initialState: {
+    ...genericInitialState,
+    active: null,
+  } as SubnetState,
+  reducers: {
+    ...generateCommonReducers<
+      SubnetState,
+      SubnetMeta.PK,
+      CreateParams,
+      UpdateParams
+    >(SubnetMeta.MODEL, SubnetMeta.PK),
+    get: {
+      prepare: (id: Subnet[SubnetMeta.PK]) => ({
+        meta: {
+          model: SubnetMeta.MODEL,
+          method: "get",
+        },
+        payload: {
+          params: { [SubnetMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    getError: (
+      state: SubnetState,
+      action: PayloadAction<SubnetState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+      state.saving = false;
+    },
+    getStart: (state: SubnetState) => {
+      state.loading = true;
+    },
+    getSuccess: (state: SubnetState, action: PayloadAction<Subnet>) => {
+      const subnet = action.payload;
+      // If the item already exists, update it, otherwise
+      // add it to the store.
+      const i = state.items.findIndex(
+        (draftItem: Subnet) =>
+          draftItem[SubnetMeta.PK] === subnet[SubnetMeta.PK]
+      );
+      if (i !== -1) {
+        state.items[i] = subnet;
+      } else {
+        state.items.push(subnet);
+      }
+      state.loading = false;
+    },
+    setActive: {
+      prepare: (id: Subnet[SubnetMeta.PK] | null) => ({
+        meta: {
+          model: SubnetMeta.MODEL,
+          method: "set_active",
+        },
+        payload: {
+          params: { [SubnetMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    setActiveError: (
+      state: SubnetState,
+      action: PayloadAction<SubnetState["errors"]>
+    ) => {
+      state.active = null;
+      state.errors = action.payload;
+    },
+    setActiveSuccess: (
+      state: SubnetState,
+      action: PayloadAction<Subnet | null>
+    ) => {
+      state.active = action.payload ? action.payload[SubnetMeta.PK] : null;
+    },
+  },
 });
 
 export const { actions } = subnetSlice;

--- a/ui/src/app/store/subnet/types/base.ts
+++ b/ui/src/app/store/subnet/types/base.ts
@@ -1,3 +1,5 @@
+import type { SubnetMeta } from "./enum";
+
 import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
@@ -45,4 +47,6 @@ export type Subnet = Model & {
   vlan: VLAN["id"];
 };
 
-export type SubnetState = GenericState<Subnet, APIError>;
+export type SubnetState = GenericState<Subnet, APIError> & {
+  active: Subnet[SubnetMeta.PK] | null;
+};

--- a/ui/src/app/store/vlan/actions.test.ts
+++ b/ui/src/app/store/vlan/actions.test.ts
@@ -71,4 +71,30 @@ describe("vlan actions", () => {
       type: "vlan/cleanup",
     });
   });
+
+  it("can create an action to get a vlan", () => {
+    expect(actions.get(0)).toEqual({
+      type: "vlan/get",
+      meta: {
+        model: "vlan",
+        method: "get",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
+
+  it("can create an action to set an active vlan", () => {
+    expect(actions.setActive(0)).toEqual({
+      type: "vlan/setActive",
+      meta: {
+        model: "vlan",
+        method: "set_active",
+      },
+      payload: {
+        params: { id: 0 },
+      },
+    });
+  });
 });

--- a/ui/src/app/store/vlan/reducers.test.ts
+++ b/ui/src/app/store/vlan/reducers.test.ts
@@ -11,6 +11,7 @@ describe("vlan reducer", () => {
       const initialState = undefined;
 
       expect(reducers(initialState, { type: "" })).toEqual({
+        active: null,
         errors: null,
         items: [],
         loaded: false,
@@ -177,6 +178,88 @@ describe("vlan reducer", () => {
         reducers(initialState, actions.deleteError("Could not delete vlan"))
       ).toEqual(
         vlanStateFactory({ errors: "Could not delete vlan", saving: false })
+      );
+    });
+  });
+
+  describe("get", () => {
+    it("reduces getStart", () => {
+      const initialState = vlanStateFactory({ loading: false });
+
+      expect(reducers(initialState, actions.getStart())).toEqual(
+        vlanStateFactory({ loading: true })
+      );
+    });
+
+    it("reduces getError", () => {
+      const initialState = vlanStateFactory({ errors: null, loading: true });
+
+      expect(
+        reducers(initialState, actions.getError({ id: "id was not supplied" }))
+      ).toEqual(
+        vlanStateFactory({
+          errors: { id: "id was not supplied" },
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when vlan already exists in state", () => {
+      const initialState = vlanStateFactory({
+        items: [vlanFactory({ id: 0, name: "vlan-1" })],
+        loading: true,
+      });
+      const updatedVLAN = vlanFactory({
+        id: 0,
+        name: "vlan-1-new",
+      });
+
+      expect(reducers(initialState, actions.getSuccess(updatedVLAN))).toEqual(
+        vlanStateFactory({
+          items: [updatedVLAN],
+          loading: false,
+        })
+      );
+    });
+
+    it("reduces getSuccess when vlan does not exist yet in state", () => {
+      const initialState = vlanStateFactory({
+        items: [vlanFactory({ id: 0 })],
+        loading: true,
+      });
+      const newVLAN = vlanFactory({ id: 1 });
+
+      expect(reducers(initialState, actions.getSuccess(newVLAN))).toEqual(
+        vlanStateFactory({
+          items: [...initialState.items, newVLAN],
+          loading: false,
+        })
+      );
+    });
+  });
+
+  describe("setActive", () => {
+    it("reduces setActiveSuccess", () => {
+      const initialState = vlanStateFactory({ active: null });
+
+      expect(
+        reducers(initialState, actions.setActiveSuccess(vlanFactory({ id: 0 })))
+      ).toEqual(vlanStateFactory({ active: 0 }));
+    });
+
+    it("reduces setActiveError", () => {
+      const initialState = vlanStateFactory({
+        active: 0,
+        errors: null,
+      });
+
+      expect(
+        reducers(initialState, actions.setActiveError("VLAN does not exist"))
+      ).toEqual(
+        vlanStateFactory({
+          active: null,
+          errors: "VLAN does not exist",
+        })
       );
     });
   });

--- a/ui/src/app/store/vlan/selectors.test.ts
+++ b/ui/src/app/store/vlan/selectors.test.ts
@@ -180,4 +180,24 @@ describe("vlan selectors", () => {
       expect(vlan.getUnusedForInterface(state, machine, nic)).toStrictEqual([]);
     });
   });
+
+  it("can get the active vlan's id", () => {
+    const state = rootStateFactory({
+      vlan: vlanStateFactory({
+        active: 0,
+      }),
+    });
+    expect(vlan.activeID(state)).toEqual(0);
+  });
+
+  it("can get the active vlan", () => {
+    const activeFabric = vlanFactory();
+    const state = rootStateFactory({
+      vlan: vlanStateFactory({
+        active: activeFabric.id,
+        items: [activeFabric],
+      }),
+    });
+    expect(vlan.active(state)).toEqual(activeFabric);
+  });
 });

--- a/ui/src/app/store/vlan/selectors.ts
+++ b/ui/src/app/store/vlan/selectors.ts
@@ -18,6 +18,31 @@ const defaultSelectors = generateBaseSelectors<VLANState, VLAN, VLANMeta.PK>(
 );
 
 /**
+ * Get the vlan state object.
+ * @param state - The redux state.
+ * @returns The vlan state.
+ */
+const vlanState = (state: RootState): VLANState => state[VLANMeta.MODEL];
+
+/**
+ * Returns currently active vlan's id.
+ * @param state - The redux state.
+ * @returns Active vlan id.
+ */
+const activeID = createSelector([vlanState], (vlanState) => vlanState.active);
+
+/**
+ * Returns currently active vlan.
+ * @param state - The redux state.
+ * @returns Active vlan.
+ */
+const active = createSelector(
+  [defaultSelectors.all, activeID],
+  (vlans: VLAN[], activeID: VLAN[VLANMeta.PK] | null) =>
+    vlans.find((vlan) => activeID === vlan.id)
+);
+
+/**
  * Get a list of unused VLANs for an interface.
  * @param machine - The nic's machine.
  * @param nic - A network interface.
@@ -64,7 +89,10 @@ const getUnusedForInterface = createSelector(
 
 const selectors = {
   ...defaultSelectors,
+  active,
+  activeID,
   getUnusedForInterface,
+  vlanState,
 };
 
 export default selectors;

--- a/ui/src/app/store/vlan/slice.ts
+++ b/ui/src/app/store/vlan/slice.ts
@@ -1,7 +1,8 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { VLANMeta } from "./types";
-import type { CreateParams, UpdateParams, VLANState } from "./types";
+import type { CreateParams, VLAN, VLANState, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
@@ -10,13 +11,84 @@ import {
 
 const vlanSlice = createSlice({
   name: VLANMeta.MODEL,
-  initialState: genericInitialState as VLANState,
-  reducers: generateCommonReducers<
-    VLANState,
-    VLANMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(VLANMeta.MODEL, VLANMeta.PK),
+  initialState: {
+    ...genericInitialState,
+    active: null,
+  } as VLANState,
+  reducers: {
+    ...generateCommonReducers<
+      VLANState,
+      VLANMeta.PK,
+      CreateParams,
+      UpdateParams
+    >(VLANMeta.MODEL, VLANMeta.PK),
+    get: {
+      prepare: (id: VLAN[VLANMeta.PK]) => ({
+        meta: {
+          model: VLANMeta.MODEL,
+          method: "get",
+        },
+        payload: {
+          params: { [VLANMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    getError: (
+      state: VLANState,
+      action: PayloadAction<VLANState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+      state.saving = false;
+    },
+    getStart: (state: VLANState) => {
+      state.loading = true;
+    },
+    getSuccess: (state: VLANState, action: PayloadAction<VLAN>) => {
+      const vlan = action.payload;
+      // If the item already exists, update it, otherwise
+      // add it to the store.
+      const i = state.items.findIndex(
+        (draftItem: VLAN) => draftItem[VLANMeta.PK] === vlan[VLANMeta.PK]
+      );
+      if (i !== -1) {
+        state.items[i] = vlan;
+      } else {
+        state.items.push(vlan);
+      }
+      state.loading = false;
+    },
+    setActive: {
+      prepare: (id: VLAN[VLANMeta.PK] | null) => ({
+        meta: {
+          model: VLANMeta.MODEL,
+          method: "set_active",
+        },
+        payload: {
+          params: { [VLANMeta.PK]: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    setActiveError: (
+      state: VLANState,
+      action: PayloadAction<VLANState["errors"]>
+    ) => {
+      state.active = null;
+      state.errors = action.payload;
+    },
+    setActiveSuccess: (
+      state: VLANState,
+      action: PayloadAction<VLAN | null>
+    ) => {
+      state.active = action.payload ? action.payload[VLANMeta.PK] : null;
+    },
+  },
 });
 
 export const { actions } = vlanSlice;

--- a/ui/src/app/store/vlan/types/base.ts
+++ b/ui/src/app/store/vlan/types/base.ts
@@ -1,4 +1,4 @@
-import type { VlanVid } from "./enum";
+import type { VLANMeta, VlanVid } from "./enum";
 
 import type { APIError } from "app/base/types";
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
@@ -22,4 +22,6 @@ export type VLAN = Model & {
   vid: VlanVid.UNTAGGED | number;
 };
 
-export type VLANState = GenericState<VLAN, APIError>;
+export type VLANState = GenericState<VLAN, APIError> & {
+  active: VLAN[VLANMeta.PK] | null;
+};

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -201,6 +201,7 @@ export const eventState = define<EventState>({
 
 export const fabricState = define<FabricState>({
   ...defaultState,
+  active: null,
   errors: null,
 });
 
@@ -236,6 +237,7 @@ export const scriptState = define<ScriptState>({
 
 export const spaceState = define<SpaceState>({
   ...defaultState,
+  active: null,
   errors: null,
 });
 
@@ -404,6 +406,7 @@ export const serviceState = define<ServiceState>({
 
 export const subnetState = define<SubnetState>({
   ...defaultState,
+  active: null,
   errors: null,
 });
 
@@ -413,6 +416,7 @@ export const tagState = define<TagState>({
 
 export const vlanState = define<VLANState>({
   ...defaultState,
+  active: null,
 });
 
 export const vmClusterStatuses = define<VMClusterStatuses>({


### PR DESCRIPTION
## Done

- Added `get` and `setActive` actions+reducers+selectors to fabric+space+subnet+vlan models

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes canonical-web-and-design/app-tribe#635

