### PR TITLE
fix(ui): handle tags in machine and device config

### DIFF
--- a/ui/src/app/base/components/TagField/TagField.test.tsx
+++ b/ui/src/app/base/components/TagField/TagField.test.tsx
@@ -4,46 +4,20 @@ import { Formik } from "formik";
 import TagField from "./TagField";
 
 describe("FormikField", () => {
-  it("maps the initial value to the tag format", () => {
-    const wrapper = mount(
-      <Formik
-        initialValues={{ tags: ["koala", "wallaby"] }}
-        onSubmit={jest.fn()}
-      >
-        <TagField />
-      </Formik>
-    );
-    expect(wrapper.find("FormikField").prop("initialSelected")).toStrictEqual([
-      {
-        name: "koala",
-      },
-      {
-        name: "wallaby",
-      },
-    ]);
-    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
-      {
-        name: "koala",
-      },
-      {
-        name: "wallaby",
-      },
-    ]);
-  });
-
-  it("can override the field name", () => {
+  it("sorts the tags by name", () => {
     const wrapper = mount(
       <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
-        <TagField name="wombatTags" />
-      </Formik>
-    );
-    expect(wrapper.find("FormikField").prop("name")).toBe("wombatTags");
-  });
-
-  it("can populate the list of tags", () => {
-    const wrapper = mount(
-      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
-        <TagField tagList={["koala", "wallaby"]} />
+        <TagField
+          name="wombatTags"
+          tags={[
+            {
+              name: "wallaby",
+            },
+            {
+              name: "koala",
+            },
+          ]}
+        />
       </Formik>
     );
     expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([

--- a/ui/src/app/base/components/TagField/TagField.tsx
+++ b/ui/src/app/base/components/TagField/TagField.tsx
@@ -5,48 +5,38 @@ import type { Props as FormikFieldProps } from "app/base/components/FormikField/
 import TagSelector from "app/base/components/TagSelector";
 import type {
   Props as TagSelectorProps,
-  Tag,
+  Tag as TagSelectorTag,
 } from "app/base/components/TagSelector/TagSelector";
 import type { AnyObject } from "app/base/types";
 
-type Props = {
-  tagList?: string[] | null;
-  name?: string;
+export type Props = {
+  storedValue?: "name" | "id";
+  name: string;
+  tags: TagSelectorProps["tags"];
 } & Omit<Partial<FormikFieldProps>, "name"> &
-  Partial<TagSelectorProps>;
+  Omit<Partial<TagSelectorProps>, "tags">;
 
 const TagField = <V extends AnyObject = AnyObject>({
-  name = "tags",
-  placeholder = "Select or create tags",
-  tagList,
+  storedValue = "name",
+  name,
+  tags,
   ...props
 }: Props): JSX.Element => {
-  const { initialValues, setFieldValue } = useFormikContext<V>();
-  let initial: string[] = [];
-  if (name in initialValues && Array.isArray(initialValues[name])) {
-    initial = initialValues[name] as string[];
-  }
+  const { setFieldValue } = useFormikContext<V>();
+
   return (
     <FormikField
       allowNewTags
       component={TagSelector}
-      initialSelected={initial.map((tag: string) => ({
-        name: tag,
-      }))}
       label="Tags"
       name={name}
-      onTagsUpdate={(tags: Tag[]) =>
+      onTagsUpdate={(tags: TagSelectorTag[]) =>
         setFieldValue(
           name,
-          tags.map(({ name }) => name)
+          tags.map((tag) => tag[storedValue])
         )
       }
-      placeholder={placeholder}
-      // Populate the list of tags with the provided list or with the initial values list.
-      // The initial values array uses spread to make it writable by `sort()`.
-      tags={(tagList || [...initial] || [])
-        .sort()
-        .map((tag: string) => ({ name: tag }))}
+      tags={[...tags].sort((a, b) => a.name.localeCompare(b.name))}
       {...props}
     />
   );

--- a/ui/src/app/base/components/TagIdField/TagIdField.test.tsx
+++ b/ui/src/app/base/components/TagIdField/TagIdField.test.tsx
@@ -1,0 +1,69 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import TagIdField from "./TagIdField";
+
+import type { Tag } from "app/store/tag/types";
+import { tag as tagFactory } from "testing/factories";
+
+describe("FormikField", () => {
+  let tags: Tag[];
+
+  beforeEach(() => {
+    tags = [
+      tagFactory({ id: 1, name: "tag1" }),
+      tagFactory({ id: 2, name: "tag2" }),
+    ];
+  });
+
+  it("maps the initial value to the tag format", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: [2] }} onSubmit={jest.fn()}>
+        <TagIdField tagList={tags} />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("initialSelected")).toStrictEqual([
+      {
+        id: tags[1].id,
+        name: tags[1].name,
+      },
+    ]);
+    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
+      {
+        id: tags[0].id,
+        name: tags[0].name,
+      },
+      {
+        id: tags[1].id,
+        name: tags[1].name,
+      },
+    ]);
+  });
+
+  it("can override the field name", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
+        <TagIdField name="wombatTags" tagList={tags} />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("name")).toBe("wombatTags");
+  });
+
+  it("can populate the list of tags", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
+        <TagIdField tagList={tags} />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
+      {
+        id: tags[0].id,
+        name: tags[0].name,
+      },
+      {
+        id: tags[1].id,
+        name: tags[1].name,
+      },
+    ]);
+  });
+});

--- a/ui/src/app/base/components/TagIdField/TagIdField.tsx
+++ b/ui/src/app/base/components/TagIdField/TagIdField.tsx
@@ -1,0 +1,48 @@
+import type { PropsWithSpread } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import TagField from "app/base/components/TagField";
+import type { Props as TagFieldProps } from "app/base/components/TagField/TagField";
+import type { Tag as TagSelectorTag } from "app/base/components/TagSelector/TagSelector";
+import type { AnyObject } from "app/base/types";
+import type { Tag, TagMeta } from "app/store/tag/types";
+
+type Props = PropsWithSpread<
+  {
+    tagList: Tag[];
+    name?: string;
+  },
+  Omit<TagFieldProps, "tags">
+>;
+
+const generateTags = (tagIds: Tag[TagMeta.PK][], tagList: Tag[]) =>
+  tagIds.reduce<TagSelectorTag[]>((tags, tagId) => {
+    const tag = tagList.find(({ id }) => id === tagId);
+    if (tag) {
+      tags.push({ id: tag.id, name: tag.name });
+    }
+    return tags;
+  }, []);
+
+const TagIdField = <V extends AnyObject = AnyObject>({
+  name = "tags",
+  tagList,
+  ...props
+}: Props): JSX.Element => {
+  const { initialValues } = useFormikContext<V>();
+  let initial: Tag[TagMeta.PK][] = [];
+  if (name in initialValues && Array.isArray(initialValues[name])) {
+    initial = initialValues[name] as Tag[TagMeta.PK][];
+  }
+  return (
+    <TagField
+      initialSelected={generateTags(initial, tagList)}
+      storedValue="id"
+      name={name}
+      tags={tagList.map((tag) => ({ id: tag.id, name: tag.name }))}
+      {...props}
+    />
+  );
+};
+
+export default TagIdField;

--- a/ui/src/app/base/components/TagIdField/index.ts
+++ b/ui/src/app/base/components/TagIdField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagIdField";

--- a/ui/src/app/base/components/TagLinks/TagLinks.tsx
+++ b/ui/src/app/base/components/TagLinks/TagLinks.tsx
@@ -1,19 +1,30 @@
 import { Link } from "react-router-dom";
 
-type Props = {
-  getLinkURL: (tag: string) => string;
-  tags: string[];
+import type { Tag } from "app/store/tag/types";
+
+type Props<T extends string | Tag> = {
+  getLinkURL: (tag: T) => string;
+  tags: T[];
 };
 
-const TagLinks = ({ getLinkURL, tags }: Props): JSX.Element => {
-  const sortedTags = [...tags].sort();
+const getTagName = <T extends string | Tag>(tag: T) =>
+  typeof tag === "string" ? tag : tag.name;
+
+const TagLinks = <T extends string | Tag>({
+  getLinkURL,
+  tags,
+}: Props<T>): JSX.Element => {
+  const sortedTags = [...tags].sort((a, b) =>
+    getTagName(a).localeCompare(getTagName(b))
+  );
   return (
     <span className="u-break-word">
       {sortedTags.map((tag, i) => {
+        const tagName = getTagName(tag);
         const url = getLinkURL(tag);
         return (
-          <span key={tag}>
-            <Link to={url}>{tag}</Link>
+          <span key={tagName}>
+            <Link to={url}>{tagName}</Link>
             {i !== tags.length - 1 && ", "}
           </span>
         );

--- a/ui/src/app/base/components/TagNameField/TagNameField.test.tsx
+++ b/ui/src/app/base/components/TagNameField/TagNameField.test.tsx
@@ -1,0 +1,58 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import TagNameField from "./TagNameField";
+
+describe("FormikField", () => {
+  it("maps the initial value to the tag format", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ tags: ["koala", "wallaby"] }}
+        onSubmit={jest.fn()}
+      >
+        <TagNameField />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("initialSelected")).toStrictEqual([
+      {
+        name: "koala",
+      },
+      {
+        name: "wallaby",
+      },
+    ]);
+    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
+      {
+        name: "koala",
+      },
+      {
+        name: "wallaby",
+      },
+    ]);
+  });
+
+  it("can override the field name", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
+        <TagNameField name="wombatTags" />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("name")).toBe("wombatTags");
+  });
+
+  it("can populate the list of tags", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
+        <TagNameField tagList={["koala", "wallaby"]} />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
+      {
+        name: "koala",
+      },
+      {
+        name: "wallaby",
+      },
+    ]);
+  });
+});

--- a/ui/src/app/base/components/TagNameField/TagNameField.tsx
+++ b/ui/src/app/base/components/TagNameField/TagNameField.tsx
@@ -1,0 +1,41 @@
+import type { PropsWithSpread } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import TagField from "app/base/components/TagField";
+import type { Props as TagFieldProps } from "app/base/components/TagField/TagField";
+import type { AnyObject } from "app/base/types";
+
+type Props = PropsWithSpread<
+  {
+    tagList?: string[] | null;
+    name?: string;
+  },
+  Omit<TagFieldProps, "tags">
+>;
+
+const TagNameField = <V extends AnyObject = AnyObject>({
+  name = "tags",
+  tagList,
+  ...props
+}: Props): JSX.Element => {
+  const { initialValues } = useFormikContext<V>();
+  let initial: string[] = [];
+  if (name in initialValues && Array.isArray(initialValues[name])) {
+    initial = initialValues[name] as string[];
+  }
+  return (
+    <TagField
+      initialSelected={initial.map((tag: string) => ({
+        name: tag,
+      }))}
+      name={name}
+      // Populate the list of tags with the provided list or with the initial values list.
+      tags={(tagList || [...initial] || []).map((tag: string) => ({
+        name: tag,
+      }))}
+      {...props}
+    />
+  );
+};
+
+export default TagNameField;

--- a/ui/src/app/base/components/TagNameField/index.ts
+++ b/ui/src/app/base/components/TagNameField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagNameField";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
@@ -13,7 +13,7 @@ import * as Yup from "yup";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
-import TagField from "app/base/components/TagField";
+import TagIdField from "app/base/components/TagIdField";
 import TagLinks from "app/base/components/TagLinks";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import { useWindowTitle } from "app/base/hooks";
@@ -55,6 +55,9 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
   const deviceSaved = useSelector(deviceSelectors.saved);
   const deviceSaving = useSelector(deviceSelectors.saving);
   const allTags = useSelector(tagSelectors.all);
+  const deviceTags = useSelector((state: RootState) =>
+    tagSelectors.getByIDs(state, device?.tags || null)
+  );
   const zonesLoaded = useSelector(zoneSelectors.loaded);
   const [editing, setEditing] = useState(false);
   const loaded = isDeviceDetails(device) && zonesLoaded;
@@ -125,10 +128,10 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
                 label="Note"
                 name="description"
               />
-              <TagField
+              <TagIdField
                 name="tags"
                 placeholder="Create or remove tags"
-                tagList={allTags.map((tag) => tag.name)}
+                tagList={allTags}
               />
             </Col>
           </Row>
@@ -150,11 +153,11 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
                 <TagLinks
                   getLinkURL={(tag) => {
                     const filter = FilterDevices.filtersToQueryString({
-                      tags: [`=${tag}`],
+                      tags: [`=${tag.name}`],
                     });
                     return `${deviceURLs.devices.index}${filter}`;
                   }}
-                  tags={device.tags.map((tag) => tag.toString())}
+                  tags={deviceTags}
                 />
               ) : (
                 "—"

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.tsx
@@ -9,7 +9,7 @@ import FormikField from "app/base/components/FormikField";
 import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
 import MacAddressField from "app/base/components/MacAddressField";
 import SubnetSelect from "app/base/components/SubnetSelect";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import { DeviceIpAssignment } from "app/store/device/types";
 
 type Props = {
@@ -57,7 +57,7 @@ const InterfaceFormFields = ({ showTitles = false }: Props): JSX.Element => {
             name="type"
           />
           <MacAddressField label="MAC address" name="mac_address" />
-          <TagField name="tags" />
+          <TagNameField name="tags" />
         </Col>
         <Col size={6}>
           {showTitles ? (

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.tsx
@@ -8,7 +8,7 @@ import type { KVMConfigurationValues } from "../KVMConfigurationCard";
 
 import FormikField from "app/base/components/FormikField";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import { PodType } from "app/store/pod/constants";
 import { formatHostType } from "app/store/pod/utils";
@@ -41,7 +41,7 @@ const KVMConfigurationCardFields = ({
           valueKey="id"
         />
         <ResourcePoolSelect name="pool" required valueKey="id" />
-        <TagField tagList={tags.map(({ name }) => name)} />
+        <TagNameField tagList={tags.map(({ name }) => name)} />
       </Col>
       <Col size={5}>
         <FormikField

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
@@ -17,7 +17,7 @@ import PoolSelect from "./PoolSelect";
 
 import FormikField from "app/base/components/FormikField";
 import TableActions from "app/base/components/TableActions";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
@@ -126,7 +126,7 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
                     />
                   </TableCell>
                   <TableCell aria-label="Tags">
-                    <TagField
+                    <TagNameField
                       label={null}
                       name={`disks[${i}].tags`}
                       placeholder="Add tags"

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -1,7 +1,7 @@
 import { Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import tagSelectors from "app/store/tag/selectors";
 
 export const TagFormFields = (): JSX.Element => {
@@ -9,7 +9,7 @@ export const TagFormFields = (): JSX.Element => {
   return (
     <Row>
       <Col size={6}>
-        <TagField required tagList={tags.map(({ name }) => name)} />
+        <TagNameField required tagList={tags.map(({ name }) => name)} />
       </Col>
     </Row>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
@@ -8,11 +8,12 @@ import ArchitectureSelect from "app/base/components/ArchitectureSelect";
 import FormikField from "app/base/components/FormikField";
 import MinimumKernelSelect from "app/base/components/MinimumKernelSelect";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
-import TagField from "app/base/components/TagField";
+import TagIdField from "app/base/components/TagIdField";
 import TagLinks from "app/base/components/TagLinks";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import machineURLs from "app/machines/urls";
 import { FilterMachines } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 
 type Props = { editing: boolean };
@@ -20,6 +21,9 @@ type Props = { editing: boolean };
 const MachineFormFields = ({ editing }: Props): JSX.Element => {
   const tags = useSelector(tagSelectors.all);
   const { initialValues } = useFormikContext<MachineFormValues>();
+  const initialTags = useSelector((state: RootState) =>
+    tagSelectors.getByIDs(state, initialValues.tags)
+  );
 
   return (
     <Row>
@@ -35,18 +39,18 @@ const MachineFormFields = ({ editing }: Props): JSX.Element => {
           type="text"
         />
         {editing ? (
-          <TagField tagList={tags.map(({ name }) => name)} />
+          <TagIdField tagList={tags} />
         ) : (
           <>
             <p>Tags</p>
             <TagLinks
               getLinkURL={(tag) => {
                 const filter = FilterMachines.filtersToQueryString({
-                  tags: [`=${tag}`],
+                  tags: [`=${tag.name}`],
                 });
                 return `${machineURLs.machines.index}${filter}`;
               }}
-              tags={initialValues.tags.map((tag) => tag.toString())}
+              tags={initialTags}
             />
           </>
         )}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
@@ -34,7 +34,7 @@ describe("AddAliasOrVlanFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("TagField").exists()).toBe(true);
+    expect(wrapper.find("TagNameField").exists()).toBe(true);
   });
 
   it("does not display a tag field for an ALIAS", () => {
@@ -53,6 +53,6 @@ describe("AddAliasOrVlanFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("TagField").exists()).toBe(false);
+    expect(wrapper.find("TagNameField").exists()).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import NetworkFields from "../../NetworkFields";
 import type { AddAliasOrVlanValues } from "../types";
 
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -56,7 +56,7 @@ export const AddAliasOrVlanFields = ({
           type="text"
           name="type"
         />
-        {isVLAN ? <TagField /> : null}
+        {isVLAN ? <TagNameField /> : null}
       </Col>
       <Col size={6}>
         <NetworkFields

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
@@ -15,7 +15,7 @@ import FormCard from "app/base/components/FormCard";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import MacAddressField from "app/base/components/MacAddressField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import { useScrollOnRender } from "app/base/hooks";
 import { MAC_ADDRESS_REGEX } from "app/base/validation";
 import { useMachineDetailsForm } from "app/machines/hooks";
@@ -121,7 +121,7 @@ const AddInterface = ({ close, systemId }: Props): JSX.Element | null => {
                 name="type"
               />
               <MacAddressField label="MAC address" name="mac_address" />
-              <TagField />
+              <TagNameField />
             </Col>
             <Col size={6}>
               <NetworkFields interfaceType={NetworkInterfaceTypes.PHYSICAL} />

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
@@ -11,7 +11,7 @@ import { MacSource, LinkMonitoring } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 import MacAddressField from "app/base/components/MacAddressField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import type { Selected } from "app/base/components/node/networking/types";
 import { BondMode } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
@@ -80,7 +80,7 @@ const BondFormFields = ({ selected, systemId }: Props): JSX.Element | null => {
           <LACPRateSelect defaultOption={null} name="bond_lacp_rate" />
         )}
         <FormikField label="Bond name" name="name" type="text" />
-        <TagField className="u-sv2" />
+        <TagNameField className="u-sv2" />
         <h3 className="p-heading--five">Advanced options</h3>
         <FormikField
           label="Use MAC address from bond member"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.tsx
@@ -7,7 +7,7 @@ import NetworkFields from "../NetworkFields";
 import FormikField from "app/base/components/FormikField";
 import MacAddressField from "app/base/components/MacAddressField";
 import SwitchField from "app/base/components/SwitchField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import { BridgeType, NetworkInterfaceTypes } from "app/store/types/enum";
 
 type Props = {
@@ -34,7 +34,7 @@ const BridgeFormFields = ({ typeDisabled }: Props): JSX.Element | null => {
           required
         />
         <MacAddressField label="MAC address" name="mac_address" required />
-        <TagField className="u-sv2" />
+        <TagNameField className="u-sv2" />
         <h3 className="p-heading--five u-no-margin--bottom">
           Advanced options
         </h3>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -124,7 +124,7 @@ describe("EditAliasOrVlanForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("TagField").exists()).toBe(true);
+    expect(wrapper.find("TagNameField").exists()).toBe(true);
   });
 
   it("dispatches an action to update an alias", async () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
@@ -10,7 +10,7 @@ import NetworkFields, {
 import type { NetworkValues } from "../NetworkFields/NetworkFields";
 
 import FormikForm from "app/base/components/FormikForm";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import { useIsAllNetworkingDisabled } from "app/base/hooks";
 import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as fabricActions } from "app/store/fabric";
@@ -146,7 +146,7 @@ const EditAliasOrVlanForm = ({
             <h3 className="p-heading--five u-no-margin--bottom">
               VLAN details
             </h3>
-            <TagField />
+            <TagNameField />
           </Col>
         ) : null}
         <Col size={6}>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.tsx
@@ -6,7 +6,7 @@ import type { EditPhysicalValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 import MacAddressField from "app/base/components/MacAddressField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import type { NetworkInterface } from "app/store/types/node";
 
@@ -32,7 +32,7 @@ const EditPhysicalFields = ({ nic }: Props): JSX.Element | null => {
         </h3>
         <FormikField label="Name" type="text" name="name" />
         <MacAddressField label="MAC address" name="mac_address" />
-        <TagField />
+        <TagNameField />
         <FormikField
           caution={generateCaution(values)}
           label="Link speed (Gbps)"

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolumeFields/AddLogicalVolumeFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolumeFields/AddLogicalVolumeFields.tsx
@@ -5,7 +5,7 @@ import FilesystemFields from "../../FilesystemFields";
 import type { AddLogicalVolumeValues } from "../AddLogicalVolume";
 
 import FormikField from "app/base/components/FormikField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import type { Machine } from "app/store/machine/types";
 
 type Props = {
@@ -51,7 +51,7 @@ export const AddLogicalVolumeFields = ({ systemId }: Props): JSX.Element => {
             { label: "TB", value: "TB" },
           ]}
         />
-        <TagField />
+        <TagNameField />
       </Col>
       <Col emptyLarge={7} size={5}>
         <FilesystemFields systemId={systemId} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
@@ -5,7 +5,7 @@ import FilesystemFields from "../../../FilesystemFields";
 import type { CreateRaidValues } from "../CreateRaid";
 
 import FormikField from "app/base/components/FormikField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import { RAID_MODES } from "app/store/machine/constants";
 import type { RaidMode } from "app/store/machine/constants";
 import type { Machine } from "app/store/machine/types";
@@ -157,7 +157,7 @@ export const CreateRaidFields = ({
             type="text"
             value={formatSize(raidSize)}
           />
-          <TagField />
+          <TagNameField />
         </Col>
         <Col emptyLarge={7} size={5}>
           <FilesystemFields systemId={systemId} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/CreateBcacheFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/CreateBcacheFields.tsx
@@ -3,7 +3,7 @@ import { Col, Input, Row, Select } from "@canonical/react-components";
 import FilesystemFields from "../../FilesystemFields";
 
 import FormikField from "app/base/components/FormikField";
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import type { Machine } from "app/store/machine/types";
 import { BcacheModes } from "app/store/machine/types";
 import { formatSize } from "app/store/machine/utils";
@@ -56,7 +56,7 @@ export const CreateBcacheFields = ({
             },
           ]}
         />
-        <TagField />
+        <TagNameField />
       </Col>
       <Col emptyLarge={7} size={5}>
         <FilesystemFields systemId={systemId} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDiskFields/EditDiskFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDiskFields/EditDiskFields.tsx
@@ -2,7 +2,7 @@ import { Col, Input, Row } from "@canonical/react-components";
 
 import FilesystemFields from "../../FilesystemFields";
 
-import TagField from "app/base/components/TagField";
+import TagNameField from "app/base/components/TagNameField";
 import type { Machine } from "app/store/machine/types";
 import { formatSize, formatType } from "app/store/machine/utils";
 import type { Disk } from "app/store/types/node";
@@ -27,7 +27,7 @@ export const EditDiskFields = ({ disk, systemId }: Props): JSX.Element => {
       </Col>
       <Col emptyLarge={7} size={5}>
         {disk.is_boot === false && <FilesystemFields systemId={systemId} />}
-        <TagField />
+        <TagNameField />
       </Col>
     </Row>
   );


### PR DESCRIPTION
## Done

- Create components for handling tags as ids or strings.
- Update the config forms for machines and devices to handle tag ids instead of names.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the config tab for a machine that has tags.
- You should see the tag names and clicking on a tag should take you to the search list with the tag name in the search box.
- Go back to the config tab and click Edit.
- You should be able to add and remove the tags on the machine (but not create new one).
- Repeat the same for devices and kvms (virsh or single lxd host).

## Fixes

Fixes: #3512.