### PR TITLE
feat(ui): set up scaffolding for networking details components

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -134,14 +134,24 @@ const Routes = (): JSX.Element => (
         </ErrorBoundary>
       )}
     />
-    <Route
-      path={subnetsURLs.index}
-      component={() => (
-        <ErrorBoundary>
-          <Subnets />
-        </ErrorBoundary>
-      )}
-    />
+    {[
+      subnetsURLs.index,
+      subnetsURLs.fabric.index(null, true),
+      subnetsURLs.space.index(null, true),
+      subnetsURLs.subnet.index(null, true),
+      subnetsURLs.vlan.index(null, true),
+    ].map((path) => (
+      <Route
+        exact
+        key={path}
+        path={path}
+        component={() => (
+          <ErrorBoundary>
+            <Subnets />
+          </ErrorBoundary>
+        )}
+      />
+    ))}
     {[zonesURLs.index, zonesURLs.details(null, true)].map((path) => (
       <Route
         exact

--- a/ui/src/app/base/sagas/websockets.ts
+++ b/ui/src/app/base/sagas/websockets.ts
@@ -485,7 +485,9 @@ export function* handleMessage(
             result = response.result;
           }
         }
-        if (error) {
+        // Sometimes the error response is the original payload sent back, which
+        // can be 0 when requesting a model with an id of 0.
+        if (error || error === 0) {
           yield* put({
             meta: { item },
             type: `${action.type}Error`,

--- a/ui/src/app/store/fabric/slice.ts
+++ b/ui/src/app/store/fabric/slice.ts
@@ -69,7 +69,8 @@ const fabricSlice = createSlice({
           method: "set_active",
         },
         payload: {
-          params: { [FabricMeta.PK]: id },
+          // Server unsets active item if primary key is not sent.
+          params: id === null ? null : { [FabricMeta.PK]: id },
         },
       }),
       reducer: () => {

--- a/ui/src/app/store/space/slice.ts
+++ b/ui/src/app/store/space/slice.ts
@@ -68,7 +68,8 @@ const spaceSlice = createSlice({
           method: "set_active",
         },
         payload: {
-          params: { [SpaceMeta.PK]: id },
+          // Server unsets active item if primary key is not sent.
+          params: id === null ? null : { [SpaceMeta.PK]: id },
         },
       }),
       reducer: () => {

--- a/ui/src/app/store/subnet/slice.ts
+++ b/ui/src/app/store/subnet/slice.ts
@@ -69,7 +69,8 @@ const subnetSlice = createSlice({
           method: "set_active",
         },
         payload: {
-          params: { [SubnetMeta.PK]: id },
+          // Server unsets active item if primary key is not sent.
+          params: id === null ? null : { [SubnetMeta.PK]: id },
         },
       }),
       reducer: () => {

--- a/ui/src/app/store/vlan/slice.ts
+++ b/ui/src/app/store/vlan/slice.ts
@@ -68,7 +68,8 @@ const vlanSlice = createSlice({
           method: "set_active",
         },
         payload: {
-          params: { [VLANMeta.PK]: id },
+          // Server unsets active item if primary key is not sent.
+          params: id === null ? null : { [VLANMeta.PK]: id },
         },
       }),
       reducer: () => {

--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -1,5 +1,23 @@
+import type { Fabric, FabricMeta } from "app/store/fabric/types";
+import type { Space, SpaceMeta } from "app/store/space/types";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import { argPath } from "app/utils";
+
 const urls = {
   index: "/networks", // ?by = 'fabric' | 'space'
+  fabric: {
+    index: argPath<{ id: Fabric[FabricMeta.PK] }>("/fabric/:id"),
+  },
+  space: {
+    index: argPath<{ id: Space[SpaceMeta.PK] }>("/space/:id"),
+  },
+  subnet: {
+    index: argPath<{ id: Subnet[SubnetMeta.PK] }>("/subnet/:id"),
+  },
+  vlan: {
+    index: argPath<{ id: VLAN[VLANMeta.PK] }>("/vlan/:id"),
+  },
 };
 
 export default urls;

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import FabricDetails from "./FabricDetails";
+
+import { actions as fabricActions } from "app/store/fabric";
+import subnetsURLs from "app/subnets/urls";
+import {
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches actions to get and set fabric as active on mount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.fabric.index(null, true)}
+          component={() => <FabricDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [fabricActions.get(1), fabricActions.setActive(1)];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("dispatches actions to unset active fabric and clean up on unmount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  const { unmount } = render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.fabric.index(null, true)}
+          component={() => <FabricDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  unmount();
+
+  const expectedActions = [
+    fabricActions.setActive(null),
+    fabricActions.cleanup(),
+  ];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) =>
+          actualAction.type === expectedAction.type &&
+          // Check payload to differentiate "set" and "unset" active actions
+          actualAction.payload?.params === expectedAction.payload?.params
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the fabric does not exist", () => {
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.fabric.index(null, true)}
+          component={() => <FabricDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText("Fabric not found")).toBeInTheDocument();
+});
+
+it("shows a spinner if the fabric has not loaded yet", () => {
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [],
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.fabric.index(null, true)}
+          component={() => <FabricDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByTestId("section-header-title-spinner")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import FabricDetailsHeader from "./FabricDetailsHeader";
+
+import ModelNotFound from "app/base/components/ModelNotFound";
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import { useGetURLId } from "app/base/hooks/urls";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import { FabricMeta } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
+import subnetURLs from "app/subnets/urls";
+import { isId } from "app/utils";
+
+const FabricDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(FabricMeta.PK);
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, id)
+  );
+  const fabricsLoading = useSelector(fabricSelectors.loading);
+  const isValidID = isId(id);
+
+  useEffect(() => {
+    if (isValidID) {
+      dispatch(fabricActions.get(id));
+      dispatch(fabricActions.setActive(id));
+    }
+
+    const unsetActiveFabricAndCleanup = () => {
+      dispatch(fabricActions.setActive(null));
+      dispatch(fabricActions.cleanup());
+    };
+    return unsetActiveFabricAndCleanup;
+  }, [dispatch, id, isValidID]);
+
+  if (!fabric) {
+    const fabricNotFound = !isValidID || !fabricsLoading;
+
+    if (fabricNotFound) {
+      return (
+        <ModelNotFound id={id} linkURL={subnetURLs.index} modelName="fabric" />
+      );
+    }
+    return <Section header={<SectionHeader loading />} />;
+  }
+
+  return <Section header={<FabricDetailsHeader fabric={fabric} />} />;
+};
+
+export default FabricDetails;

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+
+import FabricDetailsHeader from "./FabricDetailsHeader";
+
+import { fabric as fabricFactory } from "testing/factories";
+
+it("shows the fabric name as the section title", () => {
+  const fabric = fabricFactory({ id: 1, name: "fabric-1" });
+  render(<FabricDetailsHeader fabric={fabric} />);
+
+  expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+    "fabric-1"
+  );
+});

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
@@ -1,0 +1,12 @@
+import SectionHeader from "app/base/components/SectionHeader";
+import type { Fabric } from "app/store/fabric/types";
+
+type Props = {
+  fabric: Fabric;
+};
+
+const FabricDetailsHeader = ({ fabric }: Props): JSX.Element => {
+  return <SectionHeader title={fabric.name} />;
+};
+
+export default FabricDetailsHeader;

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/index.ts
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricDetailsHeader";

--- a/ui/src/app/subnets/views/FabricDetails/index.ts
+++ b/ui/src/app/subnets/views/FabricDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricDetails";

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SpaceDetails from "./SpaceDetails";
+
+import { actions as spaceActions } from "app/store/space";
+import subnetsURLs from "app/subnets/urls";
+import {
+  spaceState as spaceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches actions to get and set space as active on mount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index(null, true)}
+          component={() => <SpaceDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [spaceActions.get(1), spaceActions.setActive(1)];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("dispatches actions to unset active space and clean up on unmount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  const { unmount } = render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index(null, true)}
+          component={() => <SpaceDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  unmount();
+
+  const expectedActions = [
+    spaceActions.setActive(null),
+    spaceActions.cleanup(),
+  ];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) =>
+          actualAction.type === expectedAction.type &&
+          // Check payload to differentiate "set" and "unset" active actions
+          actualAction.payload?.params === expectedAction.payload?.params
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the space does not exist", () => {
+  const state = rootStateFactory({
+    space: spaceStateFactory({
+      items: [],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index(null, true)}
+          component={() => <SpaceDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText("Space not found")).toBeInTheDocument();
+});
+
+it("shows a spinner if the space has not loaded yet", () => {
+  const state = rootStateFactory({
+    space: spaceStateFactory({
+      items: [],
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index(null, true)}
+          component={() => <SpaceDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByTestId("section-header-title-spinner")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import SpaceDetailsHeader from "./SpaceDetailsHeader";
+
+import ModelNotFound from "app/base/components/ModelNotFound";
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import { useGetURLId } from "app/base/hooks/urls";
+import type { RootState } from "app/store/root/types";
+import { actions as spaceActions } from "app/store/space";
+import spaceSelectors from "app/store/space/selectors";
+import { SpaceMeta } from "app/store/space/types";
+import subnetURLs from "app/subnets/urls";
+import { isId } from "app/utils";
+
+const SpaceDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(SpaceMeta.PK);
+  const space = useSelector((state: RootState) =>
+    spaceSelectors.getById(state, id)
+  );
+  const spacesLoading = useSelector(spaceSelectors.loading);
+  const isValidID = isId(id);
+
+  useEffect(() => {
+    if (isValidID) {
+      dispatch(spaceActions.get(id));
+      dispatch(spaceActions.setActive(id));
+    }
+
+    const unsetActiveSpaceAndCleanup = () => {
+      dispatch(spaceActions.setActive(null));
+      dispatch(spaceActions.cleanup());
+    };
+    return unsetActiveSpaceAndCleanup;
+  }, [dispatch, id, isValidID]);
+
+  if (!space) {
+    const spaceNotFound = !isValidID || !spacesLoading;
+
+    if (spaceNotFound) {
+      return (
+        <ModelNotFound id={id} linkURL={subnetURLs.index} modelName="space" />
+      );
+    }
+    return <Section header={<SectionHeader loading />} />;
+  }
+
+  return <Section header={<SpaceDetailsHeader space={space} />} />;
+};
+
+export default SpaceDetails;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+
+import SpaceDetailsHeader from "./SpaceDetailsHeader";
+
+import { space as spaceFactory } from "testing/factories";
+
+it("shows the space name as the section title", () => {
+  const space = spaceFactory({ id: 1, name: "space-1" });
+  render(<SpaceDetailsHeader space={space} />);
+
+  expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+    "space-1"
+  );
+});

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.tsx
@@ -1,0 +1,12 @@
+import SectionHeader from "app/base/components/SectionHeader";
+import type { Space } from "app/store/space/types";
+
+type Props = {
+  space: Space;
+};
+
+const SpaceDetailsHeader = ({ space }: Props): JSX.Element => {
+  return <SectionHeader title={space.name} />;
+};
+
+export default SpaceDetailsHeader;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/index.ts
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceDetailsHeader";

--- a/ui/src/app/subnets/views/SpaceDetails/index.ts
+++ b/ui/src/app/subnets/views/SpaceDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceDetails";

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SubnetDetails from "./SubnetDetails";
+
+import { actions as subnetActions } from "app/store/subnet";
+import subnetsURLs from "app/subnets/urls";
+import {
+  subnetState as subnetStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches actions to get and set subnet as active on mount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.subnet.index(null, true)}
+          component={() => <SubnetDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [subnetActions.get(1), subnetActions.setActive(1)];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("dispatches actions to unset active subnet and clean up on unmount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  const { unmount } = render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.subnet.index(null, true)}
+          component={() => <SubnetDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  unmount();
+
+  const expectedActions = [
+    subnetActions.setActive(null),
+    subnetActions.cleanup(),
+  ];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) =>
+          actualAction.type === expectedAction.type &&
+          // Check payload to differentiate "set" and "unset" active actions
+          actualAction.payload?.params === expectedAction.payload?.params
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the subnet does not exist", () => {
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({
+      items: [],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.subnet.index(null, true)}
+          component={() => <SubnetDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText("Subnet not found")).toBeInTheDocument();
+});
+
+it("shows a spinner if the subnet has not loaded yet", () => {
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({
+      items: [],
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.subnet.index(null, true)}
+          component={() => <SubnetDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByTestId("section-header-title-spinner")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import SubnetDetailsHeader from "./SubnetDetailsHeader";
+
+import ModelNotFound from "app/base/components/ModelNotFound";
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import { useGetURLId } from "app/base/hooks/urls";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import { SubnetMeta } from "app/store/subnet/types";
+import subnetURLs from "app/subnets/urls";
+import { isId } from "app/utils";
+
+const SubnetDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(SubnetMeta.PK);
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, id)
+  );
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+  const isValidID = isId(id);
+
+  useEffect(() => {
+    if (isValidID) {
+      dispatch(subnetActions.get(id));
+      dispatch(subnetActions.setActive(id));
+    }
+
+    const unsetActiveSubnetAndCleanup = () => {
+      dispatch(subnetActions.setActive(null));
+      dispatch(subnetActions.cleanup());
+    };
+    return unsetActiveSubnetAndCleanup;
+  }, [dispatch, id, isValidID]);
+
+  if (!subnet) {
+    const subnetNotFound = !isValidID || !subnetsLoading;
+
+    if (subnetNotFound) {
+      return (
+        <ModelNotFound id={id} linkURL={subnetURLs.index} modelName="subnet" />
+      );
+    }
+    return <Section header={<SectionHeader loading />} />;
+  }
+
+  return <Section header={<SubnetDetailsHeader subnet={subnet} />} />;
+};
+
+export default SubnetDetails;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+
+import SubnetDetailsHeader from "./SubnetDetailsHeader";
+
+import { subnet as subnetFactory } from "testing/factories";
+
+it("shows the subnet name as the section title", () => {
+  const subnet = subnetFactory({ id: 1, name: "subnet-1" });
+  render(<SubnetDetailsHeader subnet={subnet} />);
+
+  expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+    "subnet-1"
+  );
+});

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
@@ -1,0 +1,12 @@
+import SectionHeader from "app/base/components/SectionHeader";
+import type { Subnet } from "app/store/subnet/types";
+
+type Props = {
+  subnet: Subnet;
+};
+
+const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
+  return <SectionHeader title={subnet.name} />;
+};
+
+export default SubnetDetailsHeader;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetDetailsHeader";

--- a/ui/src/app/subnets/views/SubnetDetails/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetDetails";

--- a/ui/src/app/subnets/views/Subnets.tsx
+++ b/ui/src/app/subnets/views/Subnets.tsx
@@ -2,12 +2,36 @@ import { Route, Switch } from "react-router-dom";
 
 import NotFound from "app/base/views/NotFound";
 import subnetsURLs from "app/subnets/urls";
+import FabricDetails from "app/subnets/views/FabricDetails";
+import SpaceDetails from "app/subnets/views/SpaceDetails";
+import SubnetDetails from "app/subnets/views/SubnetDetails";
 import SubnetsList from "app/subnets/views/SubnetsList";
+import VLANDetails from "app/subnets/views/VLANDetails";
 
 const Routes = (): JSX.Element => {
   return (
     <Switch>
       <Route exact path={subnetsURLs.index} component={SubnetsList} />
+      <Route
+        exact
+        path={subnetsURLs.fabric.index(null, true)}
+        component={FabricDetails}
+      />
+      <Route
+        exact
+        path={subnetsURLs.space.index(null, true)}
+        component={SpaceDetails}
+      />
+      <Route
+        exact
+        path={subnetsURLs.subnet.index(null, true)}
+        component={SubnetDetails}
+      />
+      <Route
+        exact
+        path={subnetsURLs.vlan.index(null, true)}
+        component={VLANDetails}
+      />
       <Route path="*" component={NotFound} />
     </Switch>
   );

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import VLANDetails from "./VLANDetails";
+
+import { actions as vlanActions } from "app/store/vlan";
+import subnetsURLs from "app/subnets/urls";
+import {
+  vlanState as vlanStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches actions to get and set vlan as active on mount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.vlan.index(null, true)}
+          component={() => <VLANDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [vlanActions.get(1), vlanActions.setActive(1)];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("dispatches actions to unset active vlan and clean up on unmount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  const { unmount } = render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.vlan.index(null, true)}
+          component={() => <VLANDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  unmount();
+
+  const expectedActions = [vlanActions.setActive(null), vlanActions.cleanup()];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) =>
+          actualAction.type === expectedAction.type &&
+          // Check payload to differentiate "set" and "unset" active actions
+          actualAction.payload?.params === expectedAction.payload?.params
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the vlan does not exist", () => {
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({
+      items: [],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.vlan.index(null, true)}
+          component={() => <VLANDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText("VLAN not found")).toBeInTheDocument();
+});
+
+it("shows a spinner if the vlan has not loaded yet", () => {
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({
+      items: [],
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.vlan.index(null, true)}
+          component={() => <VLANDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByTestId("section-header-title-spinner")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import VLANDetailsHeader from "./VLANDetailsHeader";
+
+import ModelNotFound from "app/base/components/ModelNotFound";
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import { useGetURLId } from "app/base/hooks/urls";
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import { VLANMeta } from "app/store/vlan/types";
+import subnetURLs from "app/subnets/urls";
+import { isId } from "app/utils";
+
+const VLANDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(VLANMeta.PK);
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, id)
+  );
+  const vlansLoading = useSelector(vlanSelectors.loading);
+  const isValidID = isId(id);
+
+  useEffect(() => {
+    if (isValidID) {
+      dispatch(vlanActions.get(id));
+      dispatch(vlanActions.setActive(id));
+    }
+
+    const unsetActiveVLANAndCleanup = () => {
+      dispatch(vlanActions.setActive(null));
+      dispatch(vlanActions.cleanup());
+    };
+    return unsetActiveVLANAndCleanup;
+  }, [dispatch, id, isValidID]);
+
+  if (!vlan) {
+    const vlanNotFound = !isValidID || !vlansLoading;
+
+    if (vlanNotFound) {
+      return (
+        <ModelNotFound id={id} linkURL={subnetURLs.index} modelName="VLAN" />
+      );
+    }
+    return <Section header={<SectionHeader loading />} />;
+  }
+
+  return <Section header={<VLANDetailsHeader vlan={vlan} />} />;
+};
+
+export default VLANDetails;

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+
+import VLANDetailsHeader from "./VLANDetailsHeader";
+
+import { vlan as vlanFactory } from "testing/factories";
+
+it("shows the vlan name as the section title", () => {
+  const vlan = vlanFactory({ id: 1, name: "vlan-1" });
+  render(<VLANDetailsHeader vlan={vlan} />);
+
+  expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+    "vlan-1"
+  );
+});

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -1,0 +1,12 @@
+import SectionHeader from "app/base/components/SectionHeader";
+import type { VLAN } from "app/store/vlan/types";
+
+type Props = {
+  vlan: VLAN;
+};
+
+const VLANDetailsHeader = ({ vlan }: Props): JSX.Element => {
+  return <SectionHeader title={vlan.name} />;
+};
+
+export default VLANDetailsHeader;

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VLANDetailsHeader";

--- a/ui/src/app/subnets/views/VLANDetails/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VLANDetails";


### PR DESCRIPTION
## Done

- Set up basic components for fabric + space + subnet + VLAN details, which all just basically show the name and an error if the thing can't be found.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that navigating to `/MAAS/r/fabric/<FABRIC_ID>` renders the fabric name in the header if that fabric exists
- Check that navigating to `/MAAS/r/fabric/<NON_EXISTENT_ID>` shows a "Not found" message
- Do the same for each of spaces, subnets and VLANs

## Fixes

Fixes canonical-web-and-design/app-tribe#634
