### PR TITLE
add formik-devtools-extension

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -106,6 +106,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
+    "formik-devtools-extension": "0.1.7",
     "jest-fetch-mock": "3.0.3",
     "jest-websocket-mock": "2.2.1",
     "mock-socket": "9.1.0",

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { Form, Notification } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import { withFormikDevtools } from "formik-devtools-extension";
 import { useDispatch } from "react-redux";
 import { Redirect } from "react-router";
 
@@ -87,9 +88,12 @@ const FormikFormContent = <V, E = null>({
   submitDisabled,
   ...buttonsProps
 }: Props<V, E>): JSX.Element => {
+  const formikContext = useFormikContext<V>();
+  if (process.env.NODE_ENV === "development") {
+    withFormikDevtools(formikContext);
+  }
   const dispatch = useDispatch();
   const onSuccessCalled = useRef(false);
-  const formikContext = useFormikContext<V>();
   const { handleSubmit, initialValues, resetForm, values } = formikContext;
   const formDisabled = useFormikFormDisabled<V>({
     allowAllEmpty,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8493,6 +8493,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formik-devtools-extension@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/formik-devtools-extension/-/formik-devtools-extension-0.1.7.tgz#1ae9ce28c7e15ad3f2638337d31d5396720d808c"
+  integrity sha512-vHLgA8M/Norz+PuPtctmYcwpL4Xn2LSWpmrP5rPWg2Wlz2LGDJAzpled5/Q5Hz81Ij7z/DioODJ3FXVkHClSKw==
+
 formik@2.2.9:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"


### PR DESCRIPTION
## Done

- add formik-devtools-extension https://www.npmjs.com/package/formik-devtools-extension
- it can make easier to debug issues with forms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Install the extension using instructions here: https://www.npmjs.com/package/formik-devtools-extension
- open formik devtools via chrome/firefox developer tools
- Go to `/MAAS/r/networks?by=fabric`
- select "Add VLAN"
- verify formik state updates appear in the extension

## Screenshots
<img src="https://user-images.githubusercontent.com/7452681/149994353-3cc81820-a61f-4cea-8bf3-badd87976dcb.png" width="450" />


## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
