### PR TITLE
fix(ui): fix filtering nodes by tag

### DIFF
--- a/ui/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
+++ b/ui/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
@@ -53,13 +53,16 @@ describe("FilterAccordion", () => {
   it("can mark an item as active", () => {
     const wrapper = mount(
       <FilterAccordion
-        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
+        filtersToString={FilterMachines.filtersToString}
         filterString="pool:(=pool1)"
+        getCurrentFilters={FilterMachines.getCurrentFilters}
         getValue={getValue}
+        isFilterActive={FilterMachines.isFilterActive}
         items={items}
         onUpdateFilterString={() => null}
+        toggleFilter={FilterMachines.toggleFilter}
       />
     );
     // Open the menu:
@@ -73,13 +76,16 @@ describe("FilterAccordion", () => {
     const onUpdateFilterString = jest.fn();
     const wrapper = mount(
       <FilterAccordion
-        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
+        filtersToString={FilterMachines.filtersToString}
         filterString=""
+        getCurrentFilters={FilterMachines.getCurrentFilters}
         getValue={getValue}
+        isFilterActive={FilterMachines.isFilterActive}
         items={items}
         onUpdateFilterString={onUpdateFilterString}
+        toggleFilter={FilterMachines.toggleFilter}
       />
     );
     // Open the menu:
@@ -92,13 +98,16 @@ describe("FilterAccordion", () => {
     delete items[0].pxe_mac;
     const wrapper = mount(
       <FilterAccordion
-        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
+        filtersToString={FilterMachines.filtersToString}
         filterString=""
+        getCurrentFilters={FilterMachines.getCurrentFilters}
         getValue={getValue}
+        isFilterActive={FilterMachines.isFilterActive}
         items={items}
         onUpdateFilterString={() => null}
+        toggleFilter={FilterMachines.toggleFilter}
       />
     );
     // Open the menu:
@@ -110,13 +119,16 @@ describe("FilterAccordion", () => {
     items[0].link_speeds = [];
     const wrapper = mount(
       <FilterAccordion
-        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
+        filtersToString={FilterMachines.filtersToString}
         filterString=""
+        getCurrentFilters={FilterMachines.getCurrentFilters}
         getValue={getValue}
+        isFilterActive={FilterMachines.isFilterActive}
         items={items}
         onUpdateFilterString={() => null}
+        toggleFilter={FilterMachines.toggleFilter}
       />
     );
     // Open the menu:

--- a/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
+++ b/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
@@ -24,14 +24,17 @@ type FilterSections = Map<FilterKey, FilterValues>;
 
 export type Props<I, PK extends keyof I> = {
   disabled?: boolean;
-  filterItems: FilterItems<I, PK>;
   filterNames: Map<FilterKey, string>;
   filterOrder: FilterKey[];
+  filtersToString: FilterItems<I, PK>["filtersToString"];
   filterString?: string;
+  getCurrentFilters: FilterItems<I, PK>["getCurrentFilters"];
   getValue: (item: I, filter: FilterKey) => FilterValue | FilterValue[] | null;
   getValueDisplay?: (filter: FilterKey, value: FilterValue) => ReactNode;
+  isFilterActive: FilterItems<I, PK>["isFilterActive"];
   items: I[];
   onUpdateFilterString: (filterString: string) => void;
+  toggleFilter: FilterItems<I, PK>["toggleFilter"];
 };
 
 // An accordion section.
@@ -98,16 +101,19 @@ const sortByFilterKey = (
 
 const FilterAccordion = <I, PK extends keyof I>({
   disabled,
-  filterItems,
   filterNames,
   filterOrder,
+  filtersToString,
   filterString,
+  getCurrentFilters,
   getValue,
   getValueDisplay,
+  isFilterActive,
   items,
   onUpdateFilterString,
+  toggleFilter,
 }: Props<I, PK>): JSX.Element => {
-  const currentFilters = filterItems.getCurrentFilters(filterString);
+  const currentFilters = getCurrentFilters(filterString);
   const [expandedSection, setExpandedSection] = useState();
   const sections = useMemo(() => {
     const filterOptions = getFilters<I, PK>(items, filterOrder, getValue);
@@ -127,7 +133,7 @@ const FilterAccordion = <I, PK extends keyof I>({
                     className={classNames(
                       "u-align-text--left u-no-margin--bottom filter-accordion__item is-dense",
                       {
-                        "is-active": filterItems.isFilterActive(
+                        "is-active": isFilterActive(
                           currentFilters,
                           filter,
                           filterValue,
@@ -137,15 +143,13 @@ const FilterAccordion = <I, PK extends keyof I>({
                     )}
                     data-testid={`filter-${filter}`}
                     onClick={() => {
-                      const newFilters = filterItems.toggleFilter(
+                      const newFilters = toggleFilter(
                         currentFilters,
                         filter,
                         filterValue,
                         true
                       );
-                      onUpdateFilterString(
-                        filterItems.filtersToString(newFilters)
-                      );
+                      onUpdateFilterString(filtersToString(newFilters));
                     }}
                   >
                     {getValueDisplay
@@ -163,13 +167,15 @@ const FilterAccordion = <I, PK extends keyof I>({
     }, []);
   }, [
     currentFilters,
-    filterItems,
     filterNames,
     filterOrder,
+    filtersToString,
     getValue,
     getValueDisplay,
+    isFilterActive,
     items,
     onUpdateFilterString,
+    toggleFilter,
   ]);
 
   return (

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.tsx
@@ -14,6 +14,7 @@ import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
 import { FilterControllers } from "app/store/controller/utils";
 import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
 
 const ControllerList = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -37,6 +38,7 @@ const ControllerList = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(controllerActions.fetch());
+    dispatch(tagActions.fetch());
   }, [dispatch]);
 
   // Update the URL when filters are changed.

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.tsx
@@ -31,13 +31,16 @@ const DiscoveriesFilterAccordion = ({
   return (
     <FilterAccordion
       disabled={!loaded}
-      filterItems={FilterDiscoveries}
       filterNames={filterNames}
       filterOrder={filterOrder}
+      filtersToString={FilterDiscoveries.filtersToString}
       filterString={searchText}
+      getCurrentFilters={FilterDiscoveries.getCurrentFilters}
       getValue={getDiscoveryValue}
+      isFilterActive={FilterDiscoveries.isFilterActive}
       items={discoveries}
       onUpdateFilterString={setSearchText}
+      toggleFilter={FilterDiscoveries.toggleFilter}
     />
   );
 };

--- a/ui/src/app/devices/views/DeviceList/DeviceListControls/DeviceFilterAccordion/DeviceFilterAccordion.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListControls/DeviceFilterAccordion/DeviceFilterAccordion.test.tsx
@@ -10,6 +10,8 @@ import {
   device as deviceFactory,
   deviceState as deviceStateFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -19,8 +21,11 @@ describe("DeviceFilterAccordion", () => {
   beforeEach(() => {
     state = rootStateFactory({
       device: deviceStateFactory({
-        items: [deviceFactory()],
+        items: [deviceFactory({ tags: [1] })],
         loaded: true,
+      }),
+      tag: tagStateFactory({
+        items: [tagFactory({ id: 1, name: "echidna" })],
       }),
     });
   });
@@ -39,5 +44,23 @@ describe("DeviceFilterAccordion", () => {
     );
 
     expect(wrapper.find("FilterAccordion").prop("disabled")).toBe(true);
+  });
+
+  it("displays tags", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/devices", key: "testKey" }]}
+        >
+          <DeviceFilterAccordion searchText="" setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find("[data-testid='filter-tags']").last().text()).toBe(
+      "echidna (1)"
+    );
   });
 });

--- a/ui/src/app/devices/views/DeviceList/DeviceListControls/DeviceFilterAccordion/DeviceFilterAccordion.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListControls/DeviceFilterAccordion/DeviceFilterAccordion.tsx
@@ -1,8 +1,12 @@
-import { useSelector } from "react-redux";
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
 
 import FilterAccordion from "app/base/components/FilterAccordion";
 import deviceSelectors from "app/store/device/selectors";
 import { FilterDevices, getDeviceValue } from "app/store/device/utils";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
 
 type Props = {
   searchText: string;
@@ -33,19 +37,28 @@ const DeviceFilterAccordion = ({
   searchText,
   setSearchText,
 }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const devices = useSelector(deviceSelectors.all);
   const devicesLoaded = useSelector(deviceSelectors.loaded);
+  const tags = useSelector(tagSelectors.all);
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
 
   return (
     <FilterAccordion
       disabled={!devicesLoaded}
-      filterItems={FilterDevices}
       filterNames={filterNames}
       filterOrder={filterOrder}
+      filtersToString={FilterDevices.filtersToString}
       filterString={searchText}
-      getValue={getDeviceValue}
+      getCurrentFilters={FilterDevices.getCurrentFilters}
+      getValue={(device, filter) => getDeviceValue(device, filter, { tags })}
+      isFilterActive={FilterDevices.isFilterActive}
       items={devices}
       onUpdateFilterString={setSearchText}
+      toggleFilter={FilterDevices.toggleFilter}
     />
   );
 };

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
+
 import { Spinner, Strip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
 import LXDHostToolbar from "../LXDHostToolbar";
@@ -13,6 +15,7 @@ import type { KVMSetHeaderContent } from "app/kvm/types";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
 import type { VMCluster } from "app/store/vmcluster/types";
 
 type Props = {
@@ -32,6 +35,7 @@ const LXDHostVMs = ({
   setSearchFilter,
   setHeaderContent,
 }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, hostId)
   );
@@ -44,6 +48,10 @@ const LXDHostVMs = ({
     false
   );
   const isInCluster = !!clusterId || clusterId === 0;
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
 
   if (pod) {
     return (

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Strip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 
@@ -12,6 +12,7 @@ import { useWindowTitle } from "app/base/hooks";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
@@ -24,6 +25,7 @@ const LXDClusterHosts = ({
   clusterId,
   setHeaderContent,
 }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const cluster = useSelector((state: RootState) =>
     vmClusterSelectors.getById(state, clusterId)
   );
@@ -33,6 +35,10 @@ const LXDClusterHosts = ({
     podSelectors.searchInCluster(state, clusterId, searchFilter)
   );
   useWindowTitle(`${cluster?.name || "LXD cluster"} KVM hosts`);
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
 
   return (
     <>

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
+
 import { Strip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
@@ -11,6 +13,7 @@ import { KVMHeaderViews } from "app/kvm/constants";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import kvmURLs from "app/kvm/urls";
 import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
 import type { VMCluster } from "app/store/vmcluster/types";
 
@@ -27,6 +30,7 @@ const LXDClusterVMs = ({
   setHeaderContent,
   setSearchFilter,
 }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
   const cluster = useSelector((state: RootState) =>
     vmClusterSelectors.getById(state, clusterId)
   );
@@ -34,6 +38,10 @@ const LXDClusterVMs = ({
     vmClusterSelectors.getFilteredVMs(state, clusterId, searchFilter)
   );
   useWindowTitle(`${cluster?.name || "Cluster"} virtual machines`);
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
 
   if (!cluster) {
     return null;

--- a/ui/src/app/machines/views/MachineList/MachineList.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.tsx
@@ -12,6 +12,7 @@ import type { SetSearchFilter } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
 import { formatErrors } from "app/utils";
 
 type Props = {
@@ -43,6 +44,10 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
 
   useEffect(
     () => () => {

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
@@ -10,6 +10,8 @@ import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -29,6 +31,7 @@ describe("MachinesFilterAccordion", () => {
             workload_annotations: {
               type: "production",
             },
+            tags: [1],
             zone: {
               id: 1,
               name: "zone1",
@@ -36,6 +39,9 @@ describe("MachinesFilterAccordion", () => {
           }),
         ],
         loaded: true,
+      }),
+      tag: tagStateFactory({
+        items: [tagFactory({ id: 1, name: "echidna" })],
       }),
     });
   });
@@ -121,5 +127,23 @@ describe("MachinesFilterAccordion", () => {
       .last()
       .simulate("click");
     expect(setSearchText).toHaveBeenCalledWith("");
+  });
+
+  it("displays tags", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachinesFilterAccordion searchText="" setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find("[data-testid='filter-tags']").last().text()).toBe(
+      "echidna (1)"
+    );
   });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -1,8 +1,12 @@
-import { useSelector } from "react-redux";
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
 
 import FilterAccordion from "app/base/components/FilterAccordion";
 import machineSelectors from "app/store/machine/selectors";
 import { FilterMachines, getMachineValue } from "app/store/machine/utils";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
 import { formatSpeedUnits } from "app/utils";
 import type { FilterValue } from "app/utils/search/filter-handlers";
 
@@ -61,20 +65,29 @@ const MachinesFilterAccordion = ({
   searchText,
   setSearchText,
 }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
+  const tags = useSelector(tagSelectors.all);
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
 
   return (
     <FilterAccordion
       disabled={!machinesLoaded}
-      filterItems={FilterMachines}
       filterNames={filterNames}
       filterOrder={filterOrder}
+      filtersToString={FilterMachines.filtersToString}
       filterString={searchText}
-      getValue={getMachineValue}
+      getCurrentFilters={FilterMachines.getCurrentFilters}
+      getValue={(machine, filter) => getMachineValue(machine, filter, { tags })}
       getValueDisplay={getValueDisplay}
+      isFilterActive={FilterMachines.isFilterActive}
       items={machines}
       onUpdateFilterString={setSearchText}
+      toggleFilter={FilterMachines.toggleFilter}
     />
   );
 };

--- a/ui/src/app/store/controller/selectors.test.ts
+++ b/ui/src/app/store/controller/selectors.test.ts
@@ -10,6 +10,8 @@ import {
   controllerStatuses as controllerStatusesFactory,
   service as serviceFactory,
   serviceState as serviceStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 describe("controller selectors", () => {
@@ -154,5 +156,18 @@ describe("controller selectors", () => {
     expect(controller.servicesForController(state, "abc123")).toStrictEqual(
       services
     );
+  });
+
+  it("can search tags", () => {
+    const items = [controllerFactory({ tags: [1] }), controllerFactory()];
+    const state = rootStateFactory({
+      controller: controllerStateFactory({
+        items,
+      }),
+      tag: tagStateFactory({
+        items: [tagFactory({ id: 1, name: "echidna" })],
+      }),
+    });
+    expect(controller.search(state, "echidna", [])).toStrictEqual([items[0]]);
   });
 });

--- a/ui/src/app/store/controller/selectors.ts
+++ b/ui/src/app/store/controller/selectors.ts
@@ -15,6 +15,7 @@ import type {
   ControllerStatuses,
 } from "app/store/controller/types";
 import serviceSelectors from "app/store/service/selectors";
+import tagSelectors from "app/store/tag/selectors";
 import { generateBaseSelectors } from "app/store/utils";
 
 const defaultSelectors = generateBaseSelectors<
@@ -234,6 +235,7 @@ const selected = createSelector(
 const search = createSelector(
   [
     defaultSelectors.all,
+    tagSelectors.all,
     (
       _state: RootState,
       terms: string | null,
@@ -243,11 +245,11 @@ const search = createSelector(
       selectedIDs,
     }),
   ],
-  (items: Controller[], { selectedIDs, terms }) => {
+  (items: Controller[], tags, { selectedIDs, terms }) => {
     if (!terms) {
       return items;
     }
-    return FilterControllers.filterItems(items, terms, selectedIDs);
+    return FilterControllers.filterItems(items, terms, selectedIDs, { tags });
   }
 );
 

--- a/ui/src/app/store/controller/utils/search.test.ts
+++ b/ui/src/app/store/controller/utils/search.test.ts
@@ -1,7 +1,10 @@
 import { FilterControllers, getControllerValue } from "./search";
 
 import type { Filters } from "app/utils/search/filter-handlers";
-import { controller as controllerFactory } from "testing/factories";
+import {
+  controller as controllerFactory,
+  tag as tagFactory,
+} from "testing/factories";
 
 describe("search", () => {
   describe("getControllerValue", () => {
@@ -20,8 +23,24 @@ describe("search", () => {
     });
 
     it("can get an attribute that is an array directly from the controller", () => {
+      const controller = controllerFactory({ permissions: ["edit", "read"] });
+      expect(getControllerValue(controller, "permissions")).toStrictEqual([
+        "edit",
+        "read",
+      ]);
+    });
+
+    it("can get tags", () => {
+      const tags = [
+        tagFactory({ id: 1, name: "tag1" }),
+        tagFactory({ id: 2, name: "tag2" }),
+        tagFactory({ id: 3, name: "tag3" }),
+      ];
       const controller = controllerFactory({ tags: [1, 2] });
-      expect(getControllerValue(controller, "tags")).toStrictEqual([1, 2]);
+      expect(getControllerValue(controller, "tags", { tags })).toStrictEqual([
+        "tag1",
+        "tag2",
+      ]);
     });
   });
 

--- a/ui/src/app/store/device/selectors.test.ts
+++ b/ui/src/app/store/device/selectors.test.ts
@@ -12,6 +12,8 @@ import {
   deviceStatus as deviceStatusFactory,
   deviceStatuses as deviceStatusesFactory,
   networkLink as networkLinkFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 describe("device selectors", () => {
@@ -229,34 +231,43 @@ describe("device selectors", () => {
           deviceFactory({
             hostname: "baz",
             owner: "robert",
+            tags: [1],
           }),
         ],
+      }),
+      tag: tagStateFactory({
+        items: [tagFactory({ id: 1, name: "echidna" })],
       }),
     });
 
     // Get all devices with "foo" in any of the properties.
-    let results = device.search(state, "foo");
+    let results = device.search(state, "foo", []);
     expect(results.length).toEqual(3);
     expect(results[0].hostname).toEqual("foo");
     expect(results[1].owner).toEqual("foodie");
     expect(results[2].hostname).toEqual("foobar");
 
     // Get all devices with "bar" in the hostname.
-    results = device.search(state, "hostname:bar");
+    results = device.search(state, "hostname:bar", []);
     expect(results.length).toEqual(2);
     expect(results[0].hostname).toEqual("bar");
     expect(results[1].hostname).toEqual("foobar");
 
     // Get all devices with "rob" as the owner.
-    results = device.search(state, "owner:=rob");
+    results = device.search(state, "owner:=rob", []);
     expect(results.length).toEqual(1);
     expect(results[0].owner).toEqual("rob");
 
     // Get all devices without "baz" in any of the properties.
-    results = device.search(state, "!baz");
+    results = device.search(state, "!baz", []);
     expect(results.length).toEqual(2);
     expect(results[0].hostname).toEqual("foo");
     expect(results[1].hostname).toEqual("bar");
+
+    // Get all devices without "baz" in any of the properties.
+    results = device.search(state, "echidna", []);
+    expect(results.length).toEqual(1);
+    expect(results[0].hostname).toEqual("baz");
   });
 
   it("can get an interface by id", () => {

--- a/ui/src/app/store/device/selectors.ts
+++ b/ui/src/app/store/device/selectors.ts
@@ -11,6 +11,7 @@ import type {
   DeviceNetworkInterface,
 } from "app/store/device/types";
 import { FilterDevices, isDeviceDetails } from "app/store/device/utils";
+import tagSelectors from "app/store/tag/selectors";
 import {
   generateBaseSelectors,
   getInterfaceById as getInterfaceByIdUtil,
@@ -192,6 +193,7 @@ const selected = createSelector(
 const search = createSelector(
   [
     defaultSelectors.all,
+    tagSelectors.all,
     (
       _state: RootState,
       terms: string | null,
@@ -201,11 +203,11 @@ const search = createSelector(
       selectedIDs,
     }),
   ],
-  (items: Device[], { selectedIDs, terms }) => {
+  (items: Device[], tags, { selectedIDs, terms }) => {
     if (!terms) {
       return items;
     }
-    return FilterDevices.filterItems(items, terms, selectedIDs);
+    return FilterDevices.filterItems(items, terms, selectedIDs, { tags });
   }
 );
 

--- a/ui/src/app/store/device/utils/search.test.ts
+++ b/ui/src/app/store/device/utils/search.test.ts
@@ -1,7 +1,7 @@
 import { FilterDevices, getDeviceValue } from "./search";
 
 import type { Filters } from "app/utils/search/filter-handlers";
-import { device as deviceFactory } from "testing/factories";
+import { device as deviceFactory, tag as tagFactory } from "testing/factories";
 
 describe("search", () => {
   describe("getDeviceValue", () => {
@@ -16,8 +16,24 @@ describe("search", () => {
     });
 
     it("can get an attribute that is an array directly from the device", () => {
+      const device = deviceFactory({ fabrics: ["fabric-0", "fabric-1"] });
+      expect(getDeviceValue(device, "fabrics")).toStrictEqual([
+        "fabric-0",
+        "fabric-1",
+      ]);
+    });
+
+    it("can get tags", () => {
+      const tags = [
+        tagFactory({ id: 1, name: "tag1" }),
+        tagFactory({ id: 2, name: "tag2" }),
+        tagFactory({ id: 3, name: "tag3" }),
+      ];
       const device = deviceFactory({ tags: [1, 2] });
-      expect(getDeviceValue(device, "tags")).toStrictEqual([1, 2]);
+      expect(getDeviceValue(device, "tags", { tags })).toStrictEqual([
+        "tag1",
+        "tag2",
+      ]);
     });
   });
 

--- a/ui/src/app/store/device/utils/search.ts
+++ b/ui/src/app/store/device/utils/search.ts
@@ -1,6 +1,8 @@
 import { DeviceMeta } from "app/store/device/types";
 import type { Device } from "app/store/device/types";
 import { getIpAssignmentDisplay } from "app/store/device/utils";
+import type { Tag } from "app/store/tag/types/base";
+import { getTagNamesForIds } from "app/store/tag/utils";
 import type { FilterValue } from "app/utils/search/filter-handlers";
 import {
   isFilterValue,
@@ -8,8 +10,15 @@ import {
 } from "app/utils/search/filter-handlers";
 import FilterItems from "app/utils/search/filter-items";
 
+type ExtraData = {
+  tags: Tag[];
+};
+
 type SearchMappings = {
-  [x: string]: (device: Device) => FilterValue | FilterValue[] | null;
+  [x: string]: (
+    device: Device,
+    extraData?: ExtraData
+  ) => FilterValue | FilterValue[] | null;
 };
 
 // Helpers that convert the pseudo field on the device to an actual value.
@@ -17,17 +26,20 @@ const searchMappings: SearchMappings = {
   domain: (device: Device) => device.domain.name,
   ip_assignment: (device: Device) =>
     getIpAssignmentDisplay(device.ip_assignment),
+  tags: (device, extraData) =>
+    extraData?.tags ? getTagNamesForIds(device.tags, extraData.tags) : [],
   zone: (device: Device) => device.zone.name,
 };
 
 export const getDeviceValue = (
   device: Device,
-  filter: string
+  filter: string,
+  extraData?: ExtraData
 ): FilterValue | FilterValue[] | null => {
   const mapFunc = filter in searchMappings ? searchMappings[filter] : null;
   let value: FilterValue | FilterValue[] | null = null;
   if (mapFunc) {
-    value = mapFunc(device);
+    value = mapFunc(device, extraData);
   } else if (device.hasOwnProperty(filter)) {
     const deviceValue = device[filter as keyof Device];
     // Only return values that are valid for filters, all other values should
@@ -39,7 +51,7 @@ export const getDeviceValue = (
   return value;
 };
 
-export const FilterDevices = new FilterItems<Device, DeviceMeta.PK>(
+export const FilterDevices = new FilterItems<Device, DeviceMeta.PK, ExtraData>(
   DeviceMeta.PK,
   getDeviceValue
 );

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -12,6 +12,8 @@ import {
   machineStatus as machineStatusFactory,
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 describe("machine selectors", () => {
@@ -390,7 +392,7 @@ describe("machine selectors", () => {
         items,
       }),
     });
-    expect(machine.search(state, "abc")).toStrictEqual([items[0]]);
+    expect(machine.search(state, "abc", [])).toStrictEqual([items[0]]);
   });
 
   it("can search items starting with a number", () => {
@@ -400,7 +402,20 @@ describe("machine selectors", () => {
         items,
       }),
     });
-    expect(machine.search(state, "1abc")).toStrictEqual([items[0]]);
+    expect(machine.search(state, "1abc", [])).toStrictEqual([items[0]]);
+  });
+
+  it("can search tags", () => {
+    const items = [machineFactory({ tags: [1] }), machineFactory()];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items,
+      }),
+      tag: tagStateFactory({
+        items: [tagFactory({ id: 1, name: "echidna" })],
+      }),
+    });
+    expect(machine.search(state, "echidna", [])).toStrictEqual([items[0]]);
   });
 
   it("can get an interface by id", () => {

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -11,6 +11,7 @@ import type {
 } from "app/store/machine/types";
 import { FilterMachines, isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
+import tagSelectors from "app/store/tag/selectors";
 import type { NetworkInterface } from "app/store/types/node";
 import {
   generateBaseSelectors,
@@ -116,6 +117,7 @@ const getStatusForMachine = createSelector(
 const search = createSelector(
   [
     defaultSelectors.all,
+    tagSelectors.all,
     (
       _state: RootState,
       terms: string | null,
@@ -125,11 +127,11 @@ const search = createSelector(
       selectedIDs,
     }),
   ],
-  (items: Machine[], { terms, selectedIDs }) => {
+  (items: Machine[], tags, { terms, selectedIDs }) => {
     if (!terms) {
       return items;
     }
-    return FilterMachines.filterItems(items, terms, selectedIDs);
+    return FilterMachines.filterItems(items, terms, selectedIDs, { tags });
   }
 );
 

--- a/ui/src/app/store/machine/utils/search.test.ts
+++ b/ui/src/app/store/machine/utils/search.test.ts
@@ -1,7 +1,10 @@
 import { FilterMachines, getMachineValue } from "./search";
 
 import type { Filters } from "app/utils/search/filter-handlers";
-import { machine as machineFactory } from "testing/factories";
+import {
+  machine as machineFactory,
+  tag as tagFactory,
+} from "testing/factories";
 
 describe("search", () => {
   describe("getMachineValue", () => {
@@ -25,6 +28,21 @@ describe("search", () => {
         workload_annotations: { type: "production" },
       });
       expect(getMachineValue(machine, "workload-type")).toBe("production");
+    });
+
+    it("can get tags", () => {
+      const tags = [
+        tagFactory({ id: 1, name: "tag1" }),
+        tagFactory({ id: 2, name: "tag2" }),
+        tagFactory({ id: 3, name: "tag3" }),
+      ];
+      const machine = machineFactory({
+        tags: [1, 2],
+      });
+      expect(getMachineValue(machine, "tags", { tags })).toStrictEqual([
+        "tag1",
+        "tag2",
+      ]);
     });
   });
 

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -9,6 +9,7 @@ import { PodType } from "app/store/pod/constants";
 import type { LxdServerGroup, Pod, PodState } from "app/store/pod/types";
 import { PodMeta } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import tagSelectors from "app/store/tag/selectors";
 import type { Host } from "app/store/types/host";
 import { generateBaseSelectors } from "app/store/utils";
 import type { VMCluster, VMClusterMeta } from "app/store/vmcluster/types";
@@ -206,17 +207,18 @@ const getVMs = createSelector(
  */
 const filteredVMs = createSelector(
   [
+    tagSelectors.all,
     (state: RootState, podId: Pod[PodMeta.PK], terms: string) => ({
       terms,
       selectedIDs: machine.selectedIDs(state),
       vms: getVMs(state, podId),
     }),
   ],
-  ({ terms, selectedIDs, vms }) => {
+  (tags, { terms, selectedIDs, vms }) => {
     if (!terms) {
       return vms;
     }
-    return FilterMachines.filterItems(vms, terms, selectedIDs);
+    return FilterMachines.filterItems(vms, terms, selectedIDs, { tags });
   }
 );
 

--- a/ui/src/app/store/tag/utils.test.ts
+++ b/ui/src/app/store/tag/utils.test.ts
@@ -1,0 +1,27 @@
+import { getTagNamesForIds, getTagsDisplay } from "./utils";
+
+import { tag as tagFactory } from "testing/factories";
+
+describe("tag utils", () => {
+  describe("getTagsDisplay", () => {
+    it("can get tags for display", () => {
+      const tags = [tagFactory({ name: "tag1" }), tagFactory({ name: "tag2" })];
+      expect(getTagsDisplay(tags)).toBe("tag1, tag2");
+    });
+
+    it("handles no tags", () => {
+      expect(getTagsDisplay([])).toBe("-");
+    });
+  });
+
+  describe("getTagNamesForIds", () => {
+    it("can map tag ids to names", () => {
+      const tags = [
+        tagFactory({ id: 1, name: "tag1" }),
+        tagFactory({ id: 2, name: "tag2" }),
+        tagFactory({ id: 3, name: "tag3" }),
+      ];
+      expect(getTagNamesForIds([1, 3], tags)).toStrictEqual(["tag1", "tag3"]);
+    });
+  });
+});

--- a/ui/src/app/store/tag/utils.ts
+++ b/ui/src/app/store/tag/utils.ts
@@ -1,4 +1,4 @@
-import type { Tag } from "app/store/tag/types";
+import type { Tag, TagMeta } from "app/store/tag/types";
 
 export const getTagsDisplay = (tags: Tag[]): string => {
   if (tags.length === 0) {
@@ -9,3 +9,15 @@ export const getTagsDisplay = (tags: Tag[]): string => {
     .sort((a, b) => a.localeCompare(b))
     .join(", ");
 };
+
+export const getTagNamesForIds = (
+  ids: Tag[TagMeta.PK][],
+  tags: Tag[]
+): Tag["name"][] =>
+  ids.reduce<Tag["name"][]>((tagNames, tagId) => {
+    const tag = tags.find(({ id }) => id === tagId);
+    if (tag) {
+      tagNames.push(tag.name);
+    }
+    return tagNames;
+  }, []);

--- a/ui/src/app/store/vmcluster/selectors.ts
+++ b/ui/src/app/store/vmcluster/selectors.ts
@@ -8,6 +8,7 @@ import type { VMClusterState, VMCluster, VMClusterStatuses } from "./types";
 import machineSelectors from "app/store/machine/selectors";
 import { FilterMachines } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
+import tagSelectors from "app/store/tag/selectors";
 
 const defaultSelectors = generateBaseSelectors<
   VMClusterState,
@@ -97,6 +98,7 @@ const getVMs = createSelector(
  */
 const getFilteredVMs = createSelector(
   [
+    tagSelectors.all,
     (
       state: RootState,
       clusterId: VMCluster[VMClusterMeta.PK],
@@ -107,11 +109,11 @@ const getFilteredVMs = createSelector(
       terms,
     }),
   ],
-  ({ clusterVMs, selectedIDs, terms }) => {
+  (tags, { clusterVMs, selectedIDs, terms }) => {
     if (!terms) {
       return clusterVMs;
     }
-    return FilterMachines.filterItems(clusterVMs, terms, selectedIDs);
+    return FilterMachines.filterItems(clusterVMs, terms, selectedIDs, { tags });
   }
 );
 

--- a/ui/src/app/utils/search/filter-items.test.ts
+++ b/ui/src/app/utils/search/filter-items.test.ts
@@ -3,9 +3,13 @@ import FilterItems from "./filter-items";
 import type { Machine } from "app/store/machine/types";
 import { MachineMeta } from "app/store/machine/types";
 import { getMachineValue } from "app/store/machine/utils";
+import type { ExtraData } from "app/store/machine/utils/search";
 import { PowerState } from "app/store/types/enum";
 import { NodeStatus } from "app/store/types/node";
-import { machine as machineFactory } from "testing/factories";
+import {
+  machine as machineFactory,
+  tag as tagFactory,
+} from "testing/factories";
 
 describe("FilterItems", () => {
   // If a scenario is not provided `result`, `nodes` or `selected` then the
@@ -16,13 +20,11 @@ describe("FilterItems", () => {
     machineFactory({ hostname: "other" }),
   ];
   const DEFAULT_SELECTED: Machine["system_id"][] = [];
-  // TODO: Fix filtering nodes by tag.
-  // https://github.com/canonical-web-and-design/maas-ui/issues/3514
   // These are common nodes to prevent duplication:
-  // const tagNodes = [
-  //   machineFactory({ tags: ["first", "second"] }),
-  //   machineFactory({ tags: ["second", "third"] }),
-  // ];
+  const tagNodes = [
+    machineFactory({ tags: [1, 2] }),
+    machineFactory({ tags: [2, 3] }),
+  ];
 
   // The `result` parameter should be an array of indexes that get mapped to
   // the `nodes` array.
@@ -304,176 +306,174 @@ describe("FilterItems", () => {
         }),
       ],
     },
-    // TODO: Fix filtering nodes by tag.
-    // https://github.com/canonical-web-and-design/maas-ui/issues/3514
-    // {
-    //   description: "matches a tag",
-    //   filter: "tags:first",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a negated tag",
-    //   filter: "tags:!third",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a negated tag with parens",
-    //   filter: "tags:(!third)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a negated tag with the parens negated",
-    //   filter: "tags:!(third)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a double negated tag",
-    //   filter: "tags:!!first",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a double negated tag with parens",
-    //   filter: "tags:(!!first)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a tag with the parens double negated",
-    //   filter: "tags:!!(first)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a negated tag with the parens double negated",
-    //   filter: "tags:!!(!first)",
-    //   nodes: tagNodes,
-    //   result: [1],
-    // },
-    // {
-    //   description:
-    //     "matches a double negated tag with the parens double negated",
-    //   filter: "tags:!!(!!first)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a double negated tag with in and outside negated",
-    //   filter: "tags:!(!first)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches a direct and a negated tag",
-    //   filter: "tags:(first,!third)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches an exact direct and a negated tag",
-    //   filter: "tags:(=first,!third)",
-    //   nodes: tagNodes,
-    // },
-    // {
-    //   description: "matches two negated tags",
-    //   filter: "tags:(!second,!third)",
-    //   nodes: [
-    //     machineFactory({ tags: ["first", "second"] }),
-    //     machineFactory({ tags: ["second", "third"] }),
-    //     machineFactory({ tags: ["fourth", "fifth"] }),
-    //   ],
-    //   result: [2],
-    // },
-    // {
-    //   description: "matches tags and free search",
-    //   filter: "fourth tags:(!second,!first)",
-    //   nodes: [
-    //     machineFactory({ tags: ["first", "second"] }),
-    //     machineFactory({ tags: ["second", "third"] }),
-    //     machineFactory({ tags: ["fourth", "fifth"] }),
-    //   ],
-    //   result: [2],
-    // },
-    // {
-    //   description: "matches tags and attribute",
-    //   filter: "status:New tags:(!second,!first)",
-    //   nodes: [
-    //     machineFactory({ status: NodeStatus.NEW, tags: ["first", "second"] }),
-    //     machineFactory({
-    //       status: NodeStatus.FAILED_DEPLOYMENT,
-    //       tags: ["second", "third"],
-    //     }),
-    //     machineFactory({ status: NodeStatus.NEW, tags: ["fourth", "fifth"] }),
-    //   ],
-    //   result: [2],
-    // },
-    // {
-    //   description: "matches tags and negated attribute",
-    //   filter: "status:!New tags:(!fourth,!first)",
-    //   nodes: [
-    //     machineFactory({ status: NodeStatus.NEW, tags: ["first", "second"] }),
-    //     machineFactory({ status: NodeStatus.NEW, tags: ["sixth", "second"] }),
-    //     machineFactory({
-    //       status: NodeStatus.FAILED_DEPLOYMENT,
-    //       tags: ["second", "third"],
-    //     }),
-    //     machineFactory({ status: NodeStatus.NEW, tags: ["fourth", "fifth"] }),
-    //   ],
-    //   result: [2],
-    // },
-    // {
-    //   description: "matches tags, negated attribute and free search",
-    //   filter: "status:!New tags:(!fourth,!first) name",
-    //   nodes: [
-    //     machineFactory({
-    //       hostname: "name1",
-    //       status: NodeStatus.NEW,
-    //       tags: ["first", "second"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name2",
-    //       status: NodeStatus.NEW,
-    //       tags: ["sixth", "second"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name3",
-    //       status: NodeStatus.FAILED_DEPLOYMENT,
-    //       tags: ["second", "third"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name4",
-    //       status: NodeStatus.NEW,
-    //       tags: ["fourth", "fifth"],
-    //     }),
-    //   ],
-    //   result: [2],
-    // },
-    // {
-    //   description: "matches tags, negated attribute and negated free search",
-    //   filter: "status:!New tags:(!fourth,!first) !name5",
-    //   nodes: [
-    //     machineFactory({
-    //       hostname: "name1",
-    //       status: NodeStatus.NEW,
-    //       tags: ["first", "second"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name2",
-    //       status: NodeStatus.NEW,
-    //       tags: ["sixth", "second"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name3",
-    //       status: NodeStatus.FAILED_DEPLOYMENT,
-    //       tags: ["second", "third"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name4",
-    //       status: NodeStatus.NEW,
-    //       tags: ["fourth", "fifth"],
-    //     }),
-    //     machineFactory({
-    //       hostname: "name5",
-    //       status: NodeStatus.NEW,
-    //       tags: ["seventh", "eighth"],
-    //     }),
-    //   ],
-    //   result: [2],
-    // },
+    {
+      description: "matches a tag",
+      filter: "tags:first",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a negated tag",
+      filter: "tags:!third",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a negated tag with parens",
+      filter: "tags:(!third)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a negated tag with the parens negated",
+      filter: "tags:!(third)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a double negated tag",
+      filter: "tags:!!first",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a double negated tag with parens",
+      filter: "tags:(!!first)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a tag with the parens double negated",
+      filter: "tags:!!(first)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a negated tag with the parens double negated",
+      filter: "tags:!!(!first)",
+      nodes: tagNodes,
+      result: [1],
+    },
+    {
+      description:
+        "matches a double negated tag with the parens double negated",
+      filter: "tags:!!(!!first)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a double negated tag with in and outside negated",
+      filter: "tags:!(!first)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches a direct and a negated tag",
+      filter: "tags:(first,!third)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches an exact direct and a negated tag",
+      filter: "tags:(=first,!third)",
+      nodes: tagNodes,
+    },
+    {
+      description: "matches two negated tags",
+      filter: "tags:(!second,!third)",
+      nodes: [
+        machineFactory({ tags: [1, 2] }),
+        machineFactory({ tags: [2, 3] }),
+        machineFactory({ tags: [4, 5] }),
+      ],
+      result: [2],
+    },
+    {
+      description: "matches tags and free search",
+      filter: "fourth tags:(!second,!first)",
+      nodes: [
+        machineFactory({ tags: [1, 2] }),
+        machineFactory({ tags: [2, 3] }),
+        machineFactory({ tags: [4, 5] }),
+      ],
+      result: [2],
+    },
+    {
+      description: "matches tags and attribute",
+      filter: "status:New tags:(!second,!first)",
+      nodes: [
+        machineFactory({ status: NodeStatus.NEW, tags: [1, 2] }),
+        machineFactory({
+          status: NodeStatus.FAILED_DEPLOYMENT,
+          tags: [2, 3],
+        }),
+        machineFactory({ status: NodeStatus.NEW, tags: [4, 5] }),
+      ],
+      result: [2],
+    },
+    {
+      description: "matches tags and negated attribute",
+      filter: "status:!New tags:(!fourth,!first)",
+      nodes: [
+        machineFactory({ status: NodeStatus.NEW, tags: [1, 2] }),
+        machineFactory({ status: NodeStatus.NEW, tags: [6, 2] }),
+        machineFactory({
+          status: NodeStatus.FAILED_DEPLOYMENT,
+          tags: [2, 3],
+        }),
+        machineFactory({ status: NodeStatus.NEW, tags: [4, 5] }),
+      ],
+      result: [2],
+    },
+    {
+      description: "matches tags, negated attribute and free search",
+      filter: "status:!New tags:(!fourth,!first) name",
+      nodes: [
+        machineFactory({
+          hostname: "name1",
+          status: NodeStatus.NEW,
+          tags: [1, 2],
+        }),
+        machineFactory({
+          hostname: "name2",
+          status: NodeStatus.NEW,
+          tags: [6, 2],
+        }),
+        machineFactory({
+          hostname: "name3",
+          status: NodeStatus.FAILED_DEPLOYMENT,
+          tags: [2, 3],
+        }),
+        machineFactory({
+          hostname: "name4",
+          status: NodeStatus.NEW,
+          tags: [4, 5],
+        }),
+      ],
+      result: [2],
+    },
+    {
+      description: "matches tags, negated attribute and negated free search",
+      filter: "status:!New tags:(!fourth,!first) !name5",
+      nodes: [
+        machineFactory({
+          hostname: "name1",
+          status: NodeStatus.NEW,
+          tags: [1, 2],
+        }),
+        machineFactory({
+          hostname: "name2",
+          status: NodeStatus.NEW,
+          tags: [6, 2],
+        }),
+        machineFactory({
+          hostname: "name3",
+          status: NodeStatus.FAILED_DEPLOYMENT,
+          tags: [2, 3],
+        }),
+        machineFactory({
+          hostname: "name4",
+          status: NodeStatus.NEW,
+          tags: [4, 5],
+        }),
+        machineFactory({
+          hostname: "name5",
+          status: NodeStatus.NEW,
+          tags: [7, 8],
+        }),
+      ],
+      result: [2],
+    },
     {
       description: "matches any values",
       filter: "status:Ne,Dep",
@@ -545,14 +545,26 @@ describe("FilterItems", () => {
       selected = DEFAULT_SELECTED,
     }) => {
       it(`${description}: ${filter}`, () => {
-        const FilterMachines = new FilterItems<Machine, MachineMeta.PK>(
+        const FilterMachines = new FilterItems<
+          Machine,
           MachineMeta.PK,
-          getMachineValue,
-          [{ filter: "workload_annotations", prefix: "workload" }]
-        );
-        expect(FilterMachines.filterItems(nodes, filter, selected)).toEqual(
-          result.map((index) => nodes[index])
-        );
+          ExtraData
+        >(MachineMeta.PK, getMachineValue, [
+          { filter: "workload_annotations", prefix: "workload" },
+        ]);
+        const tags = [
+          tagFactory({ id: 1, name: "first" }),
+          tagFactory({ id: 2, name: "second" }),
+          tagFactory({ id: 3, name: "third" }),
+          tagFactory({ id: 4, name: "fourth" }),
+          tagFactory({ id: 5, name: "fifth" }),
+          tagFactory({ id: 6, name: "sixth" }),
+          tagFactory({ id: 7, name: "seventh" }),
+          tagFactory({ id: 8, name: "eighth" }),
+        ];
+        expect(
+          FilterMachines.filterItems(nodes, filter, selected, { tags })
+        ).toEqual(result.map((index) => nodes[index]));
       });
     }
   );

--- a/ui/src/app/utils/search/filter-items.ts
+++ b/ui/src/app/utils/search/filter-items.ts
@@ -1,18 +1,23 @@
 import FilterHandlers from "./filter-handlers";
 import type { Filters, FilterValue, PrefixedFilter } from "./filter-handlers";
 
-export type GetValue<I> = (
+export type GetValue<I, D = void> = (
   item: I,
-  filter: string
+  filter: string,
+  extraData?: D
 ) => FilterValue | FilterValue[] | null;
 
-export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
-  getValue: GetValue<I>;
+export default class FilterItems<
+  I,
+  PK extends keyof I,
+  D = void
+> extends FilterHandlers {
+  getValue: GetValue<I, D>;
   primaryKey: PK;
 
   constructor(
     primaryKey: PK,
-    getValue: GetValue<I>,
+    getValue: GetValue<I, D>,
     prefixedFilters?: PrefixedFilter[]
   ) {
     super(prefixedFilters);
@@ -74,7 +79,8 @@ export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
     filteredItems: I[],
     attr: keyof Filters,
     terms: FilterValue[],
-    selectedIDs: I[PK][]
+    selectedIDs: I[PK][],
+    extraData?: D
   ): I[] =>
     filteredItems.filter((item) => {
       let matched = false;
@@ -98,7 +104,11 @@ export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
           }
           return false;
         }
-        const itemAttribute = this.getValue(item, filterAttribute.toString());
+        const itemAttribute = this.getValue(
+          item,
+          filterAttribute.toString(),
+          extraData
+        );
         if (!itemAttribute && itemAttribute !== 0) {
           // Unable to get value for this node. So skip it.
           return false;
@@ -135,7 +145,8 @@ export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
   filterItems = (
     nodes: I[],
     search: string,
-    selectedIDs: I[PK][] = []
+    selectedIDs: I[PK][] = [],
+    extraData?: D
   ): I[] => {
     let filteredItems = nodes;
     if (
@@ -164,7 +175,8 @@ export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
             filteredItems,
             attr,
             [term],
-            selectedIDs
+            selectedIDs,
+            extraData
           );
         });
       } else {
@@ -172,7 +184,8 @@ export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
           filteredItems,
           attr,
           terms,
-          selectedIDs
+          selectedIDs,
+          extraData
         );
       }
     });


### PR DESCRIPTION
## Done

- Update the node filters to handle tag ids.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list and filter dropdown and click on a filter.
- The machine list should update to show the correct machines.
- Repeat the same in the device list.
- Go to a controller config tab and click on a tag.
- You should get taken to the controller list which should be filtered by the tag.

## Fixes

Fixes: #3514.