### PR TITLE
feat(ui): add types and utils for detailed subnets and VLANs

### DIFF
--- a/ui/src/app/store/subnet/types/base.ts
+++ b/ui/src/app/store/subnet/types/base.ts
@@ -1,8 +1,13 @@
-import type { SubnetMeta } from "./enum";
+import type { IPAddressType, SubnetMeta } from "./enum";
 
 import type { APIError } from "app/base/types";
+import type { Domain } from "app/store/domain/types";
+import type { Architecture } from "app/store/general/types";
+import type { Pod } from "app/store/pod/types";
 import type { Model } from "app/store/types/model";
+import type { NetworkInterface, Node, NodeType } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
+import type { User } from "app/store/user/types";
 import type { VLAN } from "app/store/vlan/types";
 
 export type SubnetStatisticsRange = {
@@ -28,13 +33,49 @@ export type SubnetStatistics = {
   usage: number;
 };
 
-export type Subnet = Model & {
+export type SubnetBMCNode = {
+  hostname: Node["hostname"];
+  system_id: Node["system_id"];
+};
+
+export type SubnetBMC = Model & {
+  nodes: SubnetBMCNode[];
+  power_type: Pod["type"];
+};
+
+export type SubnetDNSRecord = Model & {
+  domain: Domain["name"];
+  name: string;
+};
+
+export type SubnetIPNodeSummary = {
+  fqdn: Node["fqdn"];
+  hostname: Node["hostname"];
+  is_container: boolean;
+  node_type: NodeType;
+  system_id: Node["system_id"];
+  via?: NetworkInterface["name"];
+};
+
+export type SubnetIP = {
+  alloc_type: IPAddressType;
+  bmcs?: SubnetBMC[];
+  created: string;
+  dns_records?: SubnetDNSRecord[];
+  ip: string;
+  node_summary?: SubnetIPNodeSummary;
+  updated: string;
+  user?: User["username"];
+};
+
+export type BaseSubnet = Model & {
   active_discovery: boolean;
   allow_dns: boolean;
   allow_proxy: boolean;
   cidr: string;
   created: string;
   description: string;
+  disabled_boot_architectures: Architecture[];
   dns_servers: string;
   gateway_ip: string | null;
   managed: boolean;
@@ -46,6 +87,12 @@ export type Subnet = Model & {
   version: number;
   vlan: VLAN["id"];
 };
+
+export type SubnetDetails = BaseSubnet & {
+  ip_addresses: SubnetIP[];
+};
+
+export type Subnet = BaseSubnet | SubnetDetails;
 
 export type SubnetState = GenericState<Subnet, APIError> & {
   active: Subnet[SubnetMeta.PK] | null;

--- a/ui/src/app/store/subnet/types/enum.ts
+++ b/ui/src/app/store/subnet/types/enum.ts
@@ -1,3 +1,11 @@
+export enum IPAddressType {
+  AUTO = 0,
+  STICKY = 1,
+  USER_RESERVED = 4,
+  DHCP = 5,
+  DISCOVERED = 6,
+}
+
 export enum SubnetMeta {
   MODEL = "subnet",
   PK = "id",

--- a/ui/src/app/store/subnet/types/index.ts
+++ b/ui/src/app/store/subnet/types/index.ts
@@ -1,10 +1,17 @@
 export type { CreateParams, UpdateParams } from "./actions";
 
 export type {
+  BaseSubnet,
   Subnet,
+  SubnetBMC,
+  SubnetBMCNode,
+  SubnetDetails,
+  SubnetDNSRecord,
+  SubnetIP,
+  SubnetIPNodeSummary,
   SubnetState,
   SubnetStatistics,
   SubnetStatisticsRange,
 } from "./base";
 
-export { SubnetMeta } from "./enum";
+export { IPAddressType, SubnetMeta } from "./enum";

--- a/ui/src/app/store/subnet/utils.test.ts
+++ b/ui/src/app/store/subnet/utils.test.ts
@@ -1,6 +1,9 @@
-import { getSubnetDisplay } from "./utils";
+import { getSubnetDisplay, isSubnetDetails } from "./utils";
 
-import { subnet as subnetFactory } from "testing/factories";
+import {
+  subnet as subnetFactory,
+  subnetDetails as subnetDetailsFactory,
+} from "testing/factories";
 
 describe("subnet utils", () => {
   describe("getSubnetDisplay", function () {
@@ -21,6 +24,20 @@ describe("subnet utils", () => {
     it("can return the short name instead of cidr + name", function () {
       const subnet = subnetFactory({ cidr: "cidr-name", name: "subnet-name" });
       expect(getSubnetDisplay(subnet, true)).toBe("cidr-name");
+    });
+  });
+
+  describe("isSubnetDetails", () => {
+    it("handles the null case", () => {
+      expect(isSubnetDetails()).toBe(false);
+      expect(isSubnetDetails(null)).toBe(false);
+    });
+
+    it("correctly returns whether a subnet is the detailed type", () => {
+      const subnet = subnetFactory();
+      const subnetDetails = subnetDetailsFactory();
+      expect(isSubnetDetails(subnet)).toBe(false);
+      expect(isSubnetDetails(subnetDetails)).toBe(true);
     });
   });
 });

--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -1,4 +1,4 @@
-import type { Subnet } from "app/store/subnet/types";
+import type { Subnet, SubnetDetails } from "app/store/subnet/types";
 
 /**
  * Get the Subnet display text.
@@ -17,3 +17,12 @@ export const getSubnetDisplay = (
     return subnet.cidr;
   }
 };
+
+/**
+ * Returns whether a subnet is of type SubnetDetails.
+ * @param subnet - The subnet to check.
+ * @returns Whether the subnet is of type SubnetDetails.
+ */
+export const isSubnetDetails = (
+  subnet?: Subnet | null
+): subnet is SubnetDetails => !!subnet && "ip_addresses" in subnet;

--- a/ui/src/app/store/vlan/types/base.ts
+++ b/ui/src/app/store/vlan/types/base.ts
@@ -2,10 +2,12 @@ import type { VLANMeta, VlanVid } from "./enum";
 
 import type { APIError } from "app/base/types";
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
+import type { Space, SpaceMeta } from "app/store/space/types";
 import type { Model } from "app/store/types/model";
+import type { Node } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
 
-export type VLAN = Model & {
+export type BaseVLAN = Model & {
   created: string;
   description: string;
   dhcp_on: boolean;
@@ -21,6 +23,13 @@ export type VLAN = Model & {
   updated: string;
   vid: VlanVid.UNTAGGED | number;
 };
+
+export type VLANDetails = BaseVLAN & {
+  node_ids: Node["id"][];
+  space_ids: Space[SpaceMeta.PK][];
+};
+
+export type VLAN = BaseVLAN | VLANDetails;
 
 export type VLANState = GenericState<VLAN, APIError> & {
   active: VLAN[VLANMeta.PK] | null;

--- a/ui/src/app/store/vlan/types/index.ts
+++ b/ui/src/app/store/vlan/types/index.ts
@@ -1,5 +1,5 @@
 export type { CreateParams, UpdateParams } from "./actions";
 
-export type { VLAN, VLANState } from "./base";
+export type { BaseVLAN, VLAN, VLANDetails, VLANState } from "./base";
 
 export { VLANMeta, VlanVid } from "./enum";

--- a/ui/src/app/store/vlan/utils.test.ts
+++ b/ui/src/app/store/vlan/utils.test.ts
@@ -1,9 +1,15 @@
-import { getDHCPStatus, getFullVLANName, getVLANDisplay } from "./utils";
+import {
+  getDHCPStatus,
+  getFullVLANName,
+  getVLANDisplay,
+  isVLANDetails,
+} from "./utils";
 
 import { VlanVid } from "app/store/vlan/types";
 import {
   fabric as fabricFactory,
   vlan as vlanFactory,
+  vlanDetails as vlanDetailsFactory,
 } from "testing/factories";
 
 describe("vlan utils", () => {
@@ -89,6 +95,20 @@ describe("vlan utils", () => {
       expect(getDHCPStatus(vlans[0], vlans, fabrics, true)).toEqual(
         "Relayed via fabric-1.101 (test-vlan)"
       );
+    });
+  });
+
+  describe("isVLANDetails", () => {
+    it("handles the null case", () => {
+      expect(isVLANDetails()).toBe(false);
+      expect(isVLANDetails(null)).toBe(false);
+    });
+
+    it("correctly returns whether a subnet is the detailed type", () => {
+      const vlan = vlanFactory();
+      const vlanDetails = vlanDetailsFactory();
+      expect(isVLANDetails(vlan)).toBe(false);
+      expect(isVLANDetails(vlanDetails)).toBe(true);
     });
   });
 });

--- a/ui/src/app/store/vlan/utils.ts
+++ b/ui/src/app/store/vlan/utils.ts
@@ -1,6 +1,6 @@
 import type { Fabric } from "app/store/fabric/types";
 import { getFabricDisplay } from "app/store/fabric/utils";
-import type { VLAN } from "app/store/vlan/types";
+import type { VLAN, VLANDetails } from "app/store/vlan/types";
 import { VlanVid } from "app/store/vlan/types";
 
 /**
@@ -75,3 +75,11 @@ export const getDHCPStatus = (
   }
   return "No DHCP";
 };
+
+/**
+ * Returns whether a VLAN is of type VLANDetails.
+ * @param vlan - The VLAN to check.
+ * @returns Whether the VLAN is of type VLANDetails.
+ */
+export const isVLANDetails = (vlan?: VLAN | null): vlan is VLANDetails =>
+  !!vlan && "space_ids" in vlan;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react";
 
 import SubnetDetailsHeader from "./SubnetDetailsHeader";
 
-import { subnet as subnetFactory } from "testing/factories";
+import {
+  subnet as subnetFactory,
+  subnetDetails as subnetDetailsFactory,
+} from "testing/factories";
 
 it("shows the subnet name as the section title", () => {
   const subnet = subnetFactory({ id: 1, name: "subnet-1" });
@@ -11,4 +14,20 @@ it("shows the subnet name as the section title", () => {
   expect(screen.getByTestId("section-header-title")).toHaveTextContent(
     "subnet-1"
   );
+});
+
+it("shows a spinner subtitle if the subnet is loading details", () => {
+  const subnet = subnetFactory({ id: 1, name: "subnet-1" });
+  render(<SubnetDetailsHeader subnet={subnet} />);
+
+  expect(
+    screen.queryByTestId("section-header-subtitle-spinner")
+  ).toBeInTheDocument();
+});
+
+it("does not show a spinner subtitle if the subnet is detailed", () => {
+  const subnet = subnetDetailsFactory({ id: 1, name: "subnet-1" });
+  render(<SubnetDetailsHeader subnet={subnet} />);
+
+  expect(screen.queryByTestId("section-header-subtitle-spinner")).toBeNull();
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
@@ -1,12 +1,18 @@
 import SectionHeader from "app/base/components/SectionHeader";
 import type { Subnet } from "app/store/subnet/types";
+import { isSubnetDetails } from "app/store/subnet/utils";
 
 type Props = {
   subnet: Subnet;
 };
 
 const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
-  return <SectionHeader title={subnet.name} />;
+  return (
+    <SectionHeader
+      subtitleLoading={!isSubnetDetails(subnet)}
+      title={subnet.name}
+    />
+  );
 };
 
 export default SubnetDetailsHeader;

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react";
 
 import VLANDetailsHeader from "./VLANDetailsHeader";
 
-import { vlan as vlanFactory } from "testing/factories";
+import {
+  vlan as vlanFactory,
+  vlanDetails as vlanDetailsFactory,
+} from "testing/factories";
 
 it("shows the vlan name as the section title", () => {
   const vlan = vlanFactory({ id: 1, name: "vlan-1" });
@@ -11,4 +14,20 @@ it("shows the vlan name as the section title", () => {
   expect(screen.getByTestId("section-header-title")).toHaveTextContent(
     "vlan-1"
   );
+});
+
+it("shows a spinner subtitle if the vlan is loading details", () => {
+  const vlan = vlanFactory({ id: 1, name: "vlan-1" });
+  render(<VLANDetailsHeader vlan={vlan} />);
+
+  expect(
+    screen.queryByTestId("section-header-subtitle-spinner")
+  ).toBeInTheDocument();
+});
+
+it("does not show a spinner subtitle if the vlan is detailed", () => {
+  const vlan = vlanDetailsFactory({ id: 1, name: "vlan-1" });
+  render(<VLANDetailsHeader vlan={vlan} />);
+
+  expect(screen.queryByTestId("section-header-subtitle-spinner")).toBeNull();
 });

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -1,12 +1,15 @@
 import SectionHeader from "app/base/components/SectionHeader";
 import type { VLAN } from "app/store/vlan/types";
+import { isVLANDetails } from "app/store/vlan/utils";
 
 type Props = {
   vlan: VLAN;
 };
 
 const VLANDetailsHeader = ({ vlan }: Props): JSX.Element => {
-  return <SectionHeader title={vlan.name} />;
+  return (
+    <SectionHeader subtitleLoading={!isVLANDetails(vlan)} title={vlan.name} />
+  );
 };
 
 export default VLANDetailsHeader;

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -162,11 +162,21 @@ export { service } from "./service";
 export { space } from "./space";
 export { sshKey } from "./sshkey";
 export { sslKey } from "./sslkey";
-export { subnet, subnetStatistics, subnetStatisticsRange } from "./subnet";
+export {
+  subnet,
+  subnetBMC,
+  subnetBMCNode,
+  subnetDNSRecord,
+  subnetDetails,
+  subnetIP,
+  subnetIPNodeSummary,
+  subnetStatistics,
+  subnetStatisticsRange,
+} from "./subnet";
 export { tag } from "./tag";
 export { token } from "./token";
 export { user, userEventError, userStatuses } from "./user";
-export { vlan } from "./vlan";
+export { vlan, vlanDetails } from "./vlan";
 export {
   virtualMachine,
   vmCluster,

--- a/ui/src/testing/factories/subnet.ts
+++ b/ui/src/testing/factories/subnet.ts
@@ -2,12 +2,21 @@ import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
+import { PodType } from "app/store/pod/constants";
+import { IPAddressType } from "app/store/subnet/types";
 import type {
-  Subnet,
+  BaseSubnet,
+  SubnetBMC,
+  SubnetBMCNode,
+  SubnetDetails,
+  SubnetDNSRecord,
+  SubnetIP,
+  SubnetIPNodeSummary,
   SubnetStatistics,
   SubnetStatisticsRange,
 } from "app/store/subnet/types";
 import type { Model } from "app/store/types/model";
+import { NodeType } from "app/store/types/node";
 
 export const subnetStatisticsRange = define<SubnetStatisticsRange>({
   end: "172.16.2.1",
@@ -32,13 +41,44 @@ export const subnetStatistics = define<SubnetStatistics>({
   usage: random,
 });
 
-export const subnet = extend<Model, Subnet>(model, {
+export const subnetBMCNode = define<SubnetBMCNode>({
+  hostname: "bmc-node",
+  system_id: () => random().toString(),
+});
+
+export const subnetBMC = extend<Model, SubnetBMC>(model, {
+  nodes: () => [],
+  power_type: PodType.LXD,
+});
+
+export const subnetDNSRecord = extend<Model, SubnetDNSRecord>(model, {
+  domain: "dns-domain",
+  name: "dns-name",
+});
+
+export const subnetIPNodeSummary = define<SubnetIPNodeSummary>({
+  fqdn: "subnet-node-fqdn",
+  hostname: "subnet-node-hostname",
+  is_container: false,
+  node_type: NodeType.MACHINE,
+  system_id: () => random().toString(),
+});
+
+export const subnetIP = define<SubnetIP>({
+  alloc_type: IPAddressType.AUTO,
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  ip: "192.168.1.1",
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+});
+
+export const subnet = extend<Model, BaseSubnet>(model, {
   active_discovery: false,
   allow_dns: false,
   allow_proxy: false,
   cidr: "172.16.1.0/24",
   created: "Wed, 08 Jul. 2020 05:35:4",
   description: "test description",
+  disabled_boot_architectures: () => [],
   dns_servers: "fd89:8724:81f1:5512:557f:99c3:6967:8d63",
   gateway_ip: null,
   managed: false,
@@ -49,4 +89,8 @@ export const subnet = extend<Model, Subnet>(model, {
   updated: "Wed, 08 Jul. 2020 05:35:4",
   version: random,
   vlan: random,
+});
+
+export const subnetDetails = extend<BaseSubnet, SubnetDetails>(subnet, {
+  ip_addresses: () => [],
 });

--- a/ui/src/testing/factories/vlan.ts
+++ b/ui/src/testing/factories/vlan.ts
@@ -3,9 +3,9 @@ import { extend, random } from "cooky-cutter";
 import { model } from "./model";
 
 import type { Model } from "app/store/types/model";
-import type { VLAN } from "app/store/vlan/types";
+import type { BaseVLAN, VLANDetails } from "app/store/vlan/types";
 
-export const vlan = extend<Model, VLAN>(model, {
+export const vlan = extend<Model, BaseVLAN>(model, {
   created: "Thu, 13 Feb. 2020 14:56:05",
   description: "a vlan",
   dhcp_on: false,
@@ -20,4 +20,9 @@ export const vlan = extend<Model, VLAN>(model, {
   space: random,
   updated: "Thu, 04 Jun. 2020 02:45:47",
   vid: random,
+});
+
+export const vlanDetails = extend<BaseVLAN, VLANDetails>(vlan, {
+  node_ids: () => [],
+  space_ids: () => [],
 });


### PR DESCRIPTION
## Done

- Added types and utils for subnet and VLAN details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes canonical-web-and-design/app-tribe#638
