### PR TITLE
fix(ui): fix route rerenders

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -35,11 +35,11 @@ const Routes = (): JSX.Element => (
     <Route
       exact
       path={baseURLs.index}
-      component={() => <Redirect to={machineURLs.machines.index} />}
+      render={() => <Redirect to={machineURLs.machines.index} />}
     />
     <Route
       path={introURLs.index}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Intro />
         </ErrorBoundary>
@@ -47,7 +47,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={prefsURLs.prefs}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Preferences />
         </ErrorBoundary>
@@ -55,7 +55,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={controllersURLs.controllers.index}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Controllers />
         </ErrorBoundary>
@@ -66,7 +66,7 @@ const Routes = (): JSX.Element => (
         <Route
           key={path}
           path={path}
-          component={() => (
+          render={() => (
             <ErrorBoundary>
               <Devices />
             </ErrorBoundary>
@@ -79,7 +79,7 @@ const Routes = (): JSX.Element => (
         exact
         key={path}
         path={path}
-        component={() => (
+        render={() => (
           <ErrorBoundary>
             <Domains />
           </ErrorBoundary>
@@ -88,7 +88,7 @@ const Routes = (): JSX.Element => (
     ))}
     <Route
       path={imagesURLs.index}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Images />
         </ErrorBoundary>
@@ -96,7 +96,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={kvmURLs.kvm}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <KVM />
         </ErrorBoundary>
@@ -104,7 +104,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={machineURLs.machines.index}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Machines />
         </ErrorBoundary>
@@ -112,7 +112,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={machineURLs.machine.index(null, true)}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <MachineDetails />
         </ErrorBoundary>
@@ -120,7 +120,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={poolsURLs.pools}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Machines />
         </ErrorBoundary>
@@ -128,7 +128,7 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={settingsURLs.index}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Settings />
         </ErrorBoundary>
@@ -145,7 +145,7 @@ const Routes = (): JSX.Element => (
         exact
         key={path}
         path={path}
-        component={() => (
+        render={() => (
           <ErrorBoundary>
             <Subnets />
           </ErrorBoundary>
@@ -157,7 +157,7 @@ const Routes = (): JSX.Element => (
         exact
         key={path}
         path={path}
-        component={() => (
+        render={() => (
           <ErrorBoundary>
             <Zones />
           </ErrorBoundary>
@@ -166,13 +166,13 @@ const Routes = (): JSX.Element => (
     ))}
     <Route
       path={dashboardURLs.index}
-      component={() => (
+      render={() => (
         <ErrorBoundary>
           <Dashboard />
         </ErrorBoundary>
       )}
     />
-    <Route path="*" component={() => <NotFound includeSection />} />
+    <Route path="*" render={() => <NotFound includeSection />} />
   </Switch>
 );
 

--- a/ui/src/app/base/components/SideNav/SideNav.test.tsx
+++ b/ui/src/app/base/components/SideNav/SideNav.test.tsx
@@ -38,9 +38,7 @@ describe("SideNav", () => {
         initialIndex={0}
       >
         <Route
-          component={(props: RouteProps) => (
-            <SideNav {...props} items={items} />
-          )}
+          render={(props: RouteProps) => <SideNav {...props} items={items} />}
           path="/settings"
         />
       </MemoryRouter>
@@ -55,9 +53,7 @@ describe("SideNav", () => {
         initialIndex={0}
       >
         <Route
-          component={(props: RouteProps) => (
-            <SideNav {...props} items={items} />
-          )}
+          render={(props: RouteProps) => <SideNav {...props} items={items} />}
           path="/settings"
         />
       </MemoryRouter>

--- a/ui/src/app/base/hooks/urls.test.tsx
+++ b/ui/src/app/base/hooks/urls.test.tsx
@@ -17,7 +17,7 @@ const generateWrapper =
     (
       <Provider store={mockStore(rootStateFactory())}>
         <MemoryRouter initialEntries={[{ pathname }]}>
-          <Route exact path={route} component={() => <>{children}</>} />
+          <Route exact path={route} render={() => <>{children}</>} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -58,7 +58,7 @@ describe("ControllerList", () => {
           ]}
         >
           <ControllerList />
-          <Route path="*" component={() => <FetchRoute />} />
+          <Route path="*" render={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -11,9 +11,9 @@ const Controllers = (): JSX.Element => {
       <Route
         exact
         path={controllersURLs.controllers.index}
-        component={() => <ControllerList />}
+        render={() => <ControllerList />}
       />
-      <Route path="*" component={() => <NotFound />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/dashboard/views/Dashboard.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.tsx
@@ -38,14 +38,14 @@ const Dashboard = (): JSX.Element => {
         <Route
           exact
           path={dashboardURLs.index}
-          component={() => <DiscoveriesList />}
+          render={() => <DiscoveriesList />}
         />
         <Route
           exact
           path={dashboardURLs.configuration}
-          component={() => <DashboardConfigurationForm />}
+          render={() => <DashboardConfigurationForm />}
         />
-        <Route path="*" component={() => <NotFound />} />
+        <Route path="*" render={() => <NotFound />} />
       </Switch>
     </Section>
   );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
@@ -42,7 +42,7 @@ describe("DeviceDetails", () => {
           <Route
             exact
             path={deviceURLs.device.index(null, true)}
-            component={() => <DeviceDetails />}
+            render={() => <DeviceDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -74,7 +74,7 @@ describe("DeviceDetails", () => {
           <Route
             exact
             path={deviceURLs.device.index(null, true)}
-            component={() => <DeviceDetails />}
+            render={() => <DeviceDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -112,7 +112,7 @@ describe("DeviceDetails", () => {
           <Route
             exact
             path={deviceURLs.device.index(null, true)}
-            component={() => <DeviceDetails />}
+            render={() => <DeviceDetails />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -70,17 +70,17 @@ const DeviceDetails = (): JSX.Element => {
           <Route
             exact
             path={deviceURLs.device.summary(null, true)}
-            component={() => <DeviceSummary systemId={id} />}
+            render={() => <DeviceSummary systemId={id} />}
           />
           <Route
             exact
             path={deviceURLs.device.network(null, true)}
-            component={() => <DeviceNetwork systemId={id} />}
+            render={() => <DeviceNetwork systemId={id} />}
           />
           <Route
             exact
             path={deviceURLs.device.configuration(null, true)}
-            component={() => <DeviceConfiguration systemId={id} />}
+            render={() => <DeviceConfiguration systemId={id} />}
           />
           <Redirect
             from={deviceURLs.device.index(null, true)}

--- a/ui/src/app/devices/views/DeviceList/DeviceList.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.test.tsx
@@ -52,7 +52,7 @@ describe("DeviceList", () => {
           ]}
         >
           <DeviceList />
-          <Route path="*" component={() => <FetchRoute />} />
+          <Route path="*" render={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/Devices.tsx
+++ b/ui/src/app/devices/views/Devices.tsx
@@ -12,7 +12,7 @@ const Devices = (): JSX.Element => {
       <Route
         exact
         path={devicesURLs.devices.index}
-        component={() => <DeviceList />}
+        render={() => <DeviceList />}
       />
       {[
         devicesURLs.device.configuration(null, true),
@@ -20,14 +20,9 @@ const Devices = (): JSX.Element => {
         devicesURLs.device.network(null, true),
         devicesURLs.device.summary(null, true),
       ].map((path) => (
-        <Route
-          exact
-          key={path}
-          path={path}
-          component={() => <DeviceDetails />}
-        />
+        <Route exact key={path} path={path} render={() => <DeviceDetails />} />
       ))}
-      <Route path="*" component={() => <NotFound />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
@@ -26,7 +26,7 @@ describe("DomainDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
         >
-          <Route exact path="/domain/:id" component={() => <DomainDetails />} />
+          <Route exact path="/domain/:id" render={() => <DomainDetails />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/domains/views/Domains.tsx
+++ b/ui/src/app/domains/views/Domains.tsx
@@ -9,17 +9,13 @@ import domainsURLs from "app/domains/urls";
 const Domains = (): JSX.Element => {
   return (
     <Switch>
-      <Route
-        exact
-        path={domainsURLs.domains}
-        component={() => <DomainsList />}
-      />
+      <Route exact path={domainsURLs.domains} render={() => <DomainsList />} />
       <Route
         exact
         path={domainsURLs.details(null, true)}
-        component={() => <DomainDetails />}
+        render={() => <DomainDetails />}
       />
-      <Route path="*" component={() => <NotFound />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/domains/views/DomainsList/DomainsList.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsList.tsx
@@ -28,7 +28,7 @@ const DomainsList = (): JSX.Element => {
         <Route
           exact
           path={domainsURLs.domains}
-          component={() => <>{domains.length > 0 && <DomainsTable />}</>}
+          render={() => <>{domains.length > 0 && <DomainsTable />}</>}
         />
       </Switch>
     </Section>

--- a/ui/src/app/images/views/Images.tsx
+++ b/ui/src/app/images/views/Images.tsx
@@ -7,8 +7,8 @@ import ImageList from "app/images/views/ImageList";
 const Images = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={imagesURLs.index} component={() => <ImageList />} />
-      <Route path="*" component={() => <NotFound />} />
+      <Route exact path={imagesURLs.index} render={() => <ImageList />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -53,15 +53,15 @@ const Intro = (): JSX.Element => {
   }
   return (
     <Switch>
-      <Route exact path={introURLs.index} component={() => <MaasIntro />} />
-      <Route exact path={introURLs.images} component={() => <ImagesIntro />} />
+      <Route exact path={introURLs.index} render={() => <MaasIntro />} />
+      <Route exact path={introURLs.images} render={() => <ImagesIntro />} />
       <Route
         exact
         path={introURLs.success}
-        component={() => <MaasIntroSuccess />}
+        render={() => <MaasIntroSuccess />}
       />
-      <Route exact path={introURLs.user} component={() => <UserIntro />} />
-      <Route path="*" component={() => <NotFound />} />
+      <Route exact path={introURLs.user} render={() => <UserIntro />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -12,7 +12,7 @@ const KVM = (): JSX.Element => {
   return (
     <Switch>
       {[kvmURLs.kvm, kvmURLs.lxd.index, kvmURLs.virsh.index].map((path) => (
-        <Route exact key={path} path={path} component={() => <KVMList />} />
+        <Route exact key={path} path={path} render={() => <KVMList />} />
       ))}
       {[
         kvmURLs.lxd.cluster.index(null, true),
@@ -28,7 +28,7 @@ const KVM = (): JSX.Element => {
           exact
           key={path}
           path={path}
-          component={() => <LXDClusterDetails />}
+          render={() => <LXDClusterDetails />}
         />
       ))}
       {[
@@ -41,7 +41,7 @@ const KVM = (): JSX.Element => {
           exact
           key={path}
           path={path}
-          component={() => <LXDSingleDetails />}
+          render={() => <LXDSingleDetails />}
         />
       ))}
       {[
@@ -49,14 +49,9 @@ const KVM = (): JSX.Element => {
         kvmURLs.virsh.details.edit(null, true),
         kvmURLs.virsh.details.resources(null, true),
       ].map((path) => (
-        <Route
-          exact
-          key={path}
-          path={path}
-          component={() => <VirshDetails />}
-        />
+        <Route exact key={path} path={path} render={() => <VirshDetails />} />
       ))}
-      <Route path="*" component={() => <NotFound />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -37,7 +37,7 @@ describe("LXDClusterDetails", () => {
           <Route
             exact
             path={kvmURLs.lxd.cluster.index(null, true)}
-            component={() => <LXDClusterDetails />}
+            render={() => <LXDClusterDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -73,7 +73,7 @@ describe("LXDClusterDetails", () => {
           <Route
             exact
             path={kvmURLs.lxd.cluster.vms.host(null, true)}
-            component={() => <LXDClusterDetails />}
+            render={() => <LXDClusterDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -101,7 +101,7 @@ describe("LXDClusterDetails", () => {
           <Route
             exact
             path={kvmURLs.lxd.cluster.vms.host(null, true)}
-            component={() => <LXDClusterDetails />}
+            render={() => <LXDClusterDetails />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -112,7 +112,7 @@ const LXDClusterDetails = (): JSX.Element => {
         <Route
           exact
           path={kvmURLs.lxd.cluster.hosts(null, true)}
-          component={() => (
+          render={() => (
             <LXDClusterHosts
               clusterId={clusterId}
               setHeaderContent={setHeaderContent}
@@ -122,7 +122,7 @@ const LXDClusterDetails = (): JSX.Element => {
         <Route
           exact
           path={kvmURLs.lxd.cluster.vms.index(null, true)}
-          component={() => (
+          render={() => (
             <LXDClusterVMs
               clusterId={clusterId}
               searchFilter={searchFilter}
@@ -134,12 +134,12 @@ const LXDClusterDetails = (): JSX.Element => {
         <Route
           exact
           path={kvmURLs.lxd.cluster.resources(null, true)}
-          component={() => <LXDClusterResources clusterId={clusterId} />}
+          render={() => <LXDClusterResources clusterId={clusterId} />}
         />
         <Route
           exact
           path={kvmURLs.lxd.cluster.edit(null, true)}
-          component={() => (
+          render={() => (
             <LXDClusterSettings
               clusterId={clusterId}
               setHeaderContent={setHeaderContent}
@@ -149,7 +149,7 @@ const LXDClusterDetails = (): JSX.Element => {
         <Route
           exact
           path={kvmURLs.lxd.cluster.vms.host(null, true)}
-          component={() => (
+          render={() => (
             <>
               {hostId !== null && (
                 <LXDClusterHostVMs
@@ -166,7 +166,7 @@ const LXDClusterDetails = (): JSX.Element => {
         <Route
           exact
           path={kvmURLs.lxd.cluster.host.edit(null, true)}
-          component={() => (
+          render={() => (
             <>
               {hostId !== null && (
                 <LXDClusterHostSettings clusterId={clusterId} hostId={hostId} />

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -64,7 +64,7 @@ describe("LXDSingleDetails", () => {
           <Route
             exact
             path={kvmURLs.lxd.single.vms(null, true)}
-            component={() => <LXDSingleDetails />}
+            render={() => <LXDSingleDetails />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -76,7 +76,7 @@ const LXDSingleDetails = (): JSX.Element => {
           <Route
             exact
             path={kvmURLs.lxd.single.vms(null, true)}
-            component={() => (
+            render={() => (
               <LXDSingleVMs
                 id={id}
                 searchFilter={searchFilter}
@@ -88,12 +88,12 @@ const LXDSingleDetails = (): JSX.Element => {
           <Route
             exact
             path={kvmURLs.lxd.single.resources(null, true)}
-            component={() => <LXDSingleResources id={id} />}
+            render={() => <LXDSingleResources id={id} />}
           />
           <Route
             exact
             path={kvmURLs.lxd.single.edit(null, true)}
-            component={() => (
+            render={() => (
               <LXDSingleSettings id={id} setHeaderContent={setHeaderContent} />
             )}
           />

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
@@ -57,12 +57,12 @@ const VirshDetails = (): JSX.Element => {
           <Route
             exact
             path={kvmURLs.virsh.details.resources(null, true)}
-            component={() => <VirshResources id={id} />}
+            render={() => <VirshResources id={id} />}
           />
           <Route
             exact
             path={kvmURLs.virsh.details.edit(null, true)}
-            component={() => <VirshSettings id={id} />}
+            render={() => <VirshSettings id={id} />}
           />
           <Redirect
             from={kvmURLs.virsh.details.index(null, true)}

--- a/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
@@ -74,10 +74,7 @@ describe("MachineCommissioning", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route
-            path="/machine/:id"
-            component={() => <MachineCommissioning />}
-          />
+          <Route path="/machine/:id" render={() => <MachineCommissioning />} />
         </MemoryRouter>
       </Provider>
     );
@@ -97,10 +94,7 @@ describe("MachineCommissioning", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route
-            path="/machine/:id"
-            component={() => <MachineCommissioning />}
-          />
+          <Route path="/machine/:id" render={() => <MachineCommissioning />} />
         </MemoryRouter>
       </Provider>
     );
@@ -148,10 +142,7 @@ describe("MachineCommissioning", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route
-            path="/machine/:id"
-            component={() => <MachineCommissioning />}
-          />
+          <Route path="/machine/:id" render={() => <MachineCommissioning />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -41,11 +41,7 @@ describe("MachineDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/machine/:id"
-            component={() => <MachineDetails />}
-          />
+          <Route exact path="/machine/:id" render={() => <MachineDetails />} />
         </MemoryRouter>
       </Provider>
     );
@@ -90,11 +86,7 @@ describe("MachineDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/machine/:id"
-            component={() => <MachineDetails />}
-          />
+          <Route exact path="/machine/:id" render={() => <MachineDetails />} />
         </MemoryRouter>
       </Provider>
     );
@@ -112,7 +104,7 @@ describe("MachineDetails", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <Link to="/machine/abc123/commissioning" />
-          <Route path="/machine/:id" component={() => <MachineDetails />} />
+          <Route path="/machine/:id" render={() => <MachineDetails />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -86,7 +86,7 @@ const MachineDetails = (): JSX.Element => {
           <Route
             exact
             path={machineURLs.machine.summary(null, true)}
-            component={() => (
+            render={() => (
               <>
                 <SummaryNotifications id={id} />
                 <MachineSummary setHeaderContent={setHeaderContent} />
@@ -96,12 +96,12 @@ const MachineDetails = (): JSX.Element => {
           <Route
             exact
             path={machineURLs.machine.instances(null, true)}
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
           <Route
             exact
             path={machineURLs.machine.network(null, true)}
-            component={() => (
+            render={() => (
               <>
                 <NetworkNotifications id={id} />
                 <MachineNetwork id={id} setHeaderContent={setHeaderContent} />
@@ -111,7 +111,7 @@ const MachineDetails = (): JSX.Element => {
           <Route
             exact
             path={machineURLs.machine.storage(null, true)}
-            component={() => (
+            render={() => (
               <>
                 <StorageNotifications id={id} />
                 <MachineStorage />
@@ -121,59 +121,57 @@ const MachineDetails = (): JSX.Element => {
           <Route
             exact
             path={machineURLs.machine.pciDevices(null, true)}
-            component={() => (
+            render={() => (
               <MachinePCIDevices setHeaderContent={setHeaderContent} />
             )}
           />
           <Route
             exact
             path={machineURLs.machine.usbDevices(null, true)}
-            component={() => (
+            render={() => (
               <MachineUSBDevices setHeaderContent={setHeaderContent} />
             )}
           />
           <Route
             exact
             path={machineURLs.machine.commissioning.index(null, true)}
-            component={() => <MachineComissioning />}
+            render={() => <MachineComissioning />}
           />
           <Route
             exact
             path={machineURLs.machine.commissioning.scriptResult(null, true)}
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
           <Route
             exact
             path={machineURLs.machine.testing.index(null, true)}
-            component={() => <MachineTests />}
+            render={() => <MachineTests />}
           />
           <Route
             exact
             path={machineURLs.machine.testing.scriptResult(null, true)}
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
           <Route
             path={machineURLs.machine.logs.index(null, true)}
-            component={() => <MachineLogs systemId={id} />}
+            render={() => <MachineLogs systemId={id} />}
           />
           <Route
             exact
             path={machineURLs.machine.events(null, true)}
-            component={() => (
+            render={() => (
               <Redirect to={machineURLs.machine.logs.events(null, true)} />
             )}
           />
           <Route
             exact
             path={machineURLs.machine.configuration(null, true)}
-            component={() => <MachineConfiguration />}
+            render={() => <MachineConfiguration />}
           />
           <Route
             exact
             path={machineURLs.machine.index(null, true)}
-            component={() => (
-              <Redirect to={machineURLs.machine.summary({ id })} />
-            )}
+            render={() => <Redirect to={machineURLs.machine.summary({ id })} />}
           />
         </Switch>
       )}

--- a/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
@@ -59,7 +59,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>
@@ -81,7 +81,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>
@@ -123,7 +123,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>
@@ -164,7 +164,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>
@@ -221,7 +221,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>
@@ -261,7 +261,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>
@@ -316,7 +316,7 @@ describe("MachineInstances", () => {
           <Route
             exact
             path="/machine/:id/instances"
-            component={() => <MachineInstances />}
+            render={() => <MachineInstances />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -57,7 +57,7 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
       <Route
         exact
         path={machineURLs.machine.logs.installationOutput(null, true)}
-        component={() => <InstallationOutput systemId={systemId} />}
+        render={() => <InstallationOutput systemId={systemId} />}
       />
       {[
         machineURLs.machine.logs.index(null, true),
@@ -67,7 +67,7 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
           exact
           key={path}
           path={path}
-          component={() => <EventLogs systemId={systemId} />}
+          render={() => <EventLogs systemId={systemId} />}
         />
       ))}
     </>

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
@@ -35,7 +35,7 @@ describe("MachinePCIDevices", () => {
           <Route
             exact
             path="/machine/:id/pci-devices"
-            component={() => <MachinePCIDevices setHeaderContent={jest.fn()} />}
+            render={() => <MachinePCIDevices setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -68,7 +68,7 @@ describe("MachineStorage", () => {
           <Route
             exact
             path="/machine/:id/storage"
-            component={() => <MachineStorage />}
+            render={() => <MachineStorage />}
           />
         </MemoryRouter>
       </Provider>
@@ -109,7 +109,7 @@ describe("MachineStorage", () => {
           <Route
             exact
             path="/machine/:id/storage"
-            component={() => <MachineStorage />}
+            render={() => <MachineStorage />}
           />
         </MemoryRouter>
       </Provider>
@@ -149,7 +149,7 @@ describe("MachineStorage", () => {
           <Route
             exact
             path="/machine/:id/storage"
-            component={() => <MachineStorage />}
+            render={() => <MachineStorage />}
           />
         </MemoryRouter>
       </Provider>
@@ -180,7 +180,7 @@ describe("MachineStorage", () => {
           <Route
             exact
             path="/machine/:id/storage"
-            component={() => <MachineStorage />}
+            render={() => <MachineStorage />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -72,7 +72,7 @@ describe("MachineSummary", () => {
           <Route
             exact
             path="/machine/:id/summary"
-            component={() => <MachineSummary setHeaderContent={jest.fn()} />}
+            render={() => <MachineSummary setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -98,7 +98,7 @@ describe("MachineSummary", () => {
           <Route
             exact
             path="/machine/:id/summary"
-            component={() => <MachineSummary setHeaderContent={jest.fn()} />}
+            render={() => <MachineSummary setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>
@@ -121,7 +121,7 @@ describe("MachineSummary", () => {
           <Route
             exact
             path="/machine/:id/summary"
-            component={() => <MachineSummary setHeaderContent={jest.fn()} />}
+            render={() => <MachineSummary setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -78,7 +78,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -124,7 +124,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -162,7 +162,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -198,7 +198,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -216,7 +216,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -236,7 +236,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );
@@ -284,7 +284,7 @@ describe("MachineTests", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route path="/machine/:id" component={() => <MachineTests />} />
+          <Route path="/machine/:id" render={() => <MachineTests />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
@@ -61,7 +61,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -77,7 +77,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -96,7 +96,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -128,7 +128,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -157,7 +157,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -185,7 +185,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>
@@ -225,7 +225,7 @@ describe("MachineTestDetails", () => {
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
           <Route
             path="/machine/:id/testing/:scriptResultId/details"
-            component={() => <MachineTestsDetails />}
+            render={() => <MachineTestsDetails />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
@@ -35,7 +35,7 @@ describe("MachineUSBDevices", () => {
           <Route
             exact
             path="/machine/:id/usb-devices"
-            component={() => <MachineUSBDevices setHeaderContent={jest.fn()} />}
+            render={() => <MachineUSBDevices setHeaderContent={jest.fn()} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/Machines.test.tsx
+++ b/ui/src/app/machines/views/Machines.test.tsx
@@ -200,7 +200,7 @@ describe("Machines", () => {
           ]}
         >
           <Machines />
-          <Route path="*" component={() => <FetchRoute />} />
+          <Route path="*" render={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/Machines.tsx
+++ b/ui/src/app/machines/views/Machines.tsx
@@ -74,7 +74,7 @@ const Machines = (): JSX.Element => {
         <Route
           exact
           path={machineURLs.machines.index}
-          component={() => (
+          render={() => (
             <MachineList
               headerFormOpen={!!headerContent}
               searchFilter={searchFilter}
@@ -82,14 +82,14 @@ const Machines = (): JSX.Element => {
             />
           )}
         />
-        <Route exact path={poolsURLs.pools} component={() => <Pools />} />
-        <Route exact path={poolsURLs.add} component={() => <PoolAdd />} />
+        <Route exact path={poolsURLs.pools} render={() => <Pools />} />
+        <Route exact path={poolsURLs.add} render={() => <PoolAdd />} />
         <Route
           exact
           path={poolsURLs.edit(null, true)}
-          component={() => <PoolEdit />}
+          render={() => <PoolEdit />}
         />
-        <Route path="*" component={() => <NotFound />} />
+        <Route path="*" render={() => <NotFound />} />
       </Switch>
     </Section>
   );

--- a/ui/src/app/preferences/components/Nav/Nav.test.tsx
+++ b/ui/src/app/preferences/components/Nav/Nav.test.tsx
@@ -10,7 +10,7 @@ describe("Nav", () => {
         initialEntries={[{ pathname: "/prefs", key: "testKey" }]}
         initialIndex={0}
       >
-        <Route component={() => <Nav />} path="/prefs" />
+        <Route render={() => <Nav />} path="/prefs" />
       </MemoryRouter>
     );
     expect(wrapper.find("SideNav").exists()).toBe(true);

--- a/ui/src/app/preferences/components/Routes/Routes.tsx
+++ b/ui/src/app/preferences/components/Routes/Routes.tsx
@@ -15,19 +15,19 @@ const Routes = (): JSX.Element => {
   return (
     <Switch>
       <Redirect exact from={prefsURLs.prefs} to={prefsURLs.details} />
-      <Route exact path={prefsURLs.details} component={Details} />
-      <Route exact path={prefsURLs.apiKeys.index} component={APIKeyList} />
-      <Route exact path={prefsURLs.apiKeys.add} component={APIKeyAdd} />
+      <Route exact path={prefsURLs.details} render={Details} />
+      <Route exact path={prefsURLs.apiKeys.index} render={APIKeyList} />
+      <Route exact path={prefsURLs.apiKeys.add} render={APIKeyAdd} />
       <Route
         exact
         path={prefsURLs.apiKeys.edit(null, true)}
-        component={APIKeyEdit}
+        render={APIKeyEdit}
       />
-      <Route exact path={prefsURLs.sshKeys.index} component={SSHKeyList} />
-      <Route exact path={prefsURLs.sshKeys.add} component={AddSSHKey} />
-      <Route exact path={prefsURLs.sslKeys.index} component={SSLKeyList} />
-      <Route exact path={prefsURLs.sslKeys.add} component={AddSSLKey} />
-      <Route path="*" component={NotFound} />
+      <Route exact path={prefsURLs.sshKeys.index} render={SSHKeyList} />
+      <Route exact path={prefsURLs.sshKeys.add} render={AddSSHKey} />
+      <Route exact path={prefsURLs.sslKeys.index} render={SSLKeyList} />
+      <Route exact path={prefsURLs.sslKeys.add} render={AddSSLKey} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
@@ -78,7 +78,7 @@ describe("APIKeyEdit", () => {
           <Route
             exact
             path="/account/prefs/api-keys/:id/edit"
-            component={() => <APIKeyEdit />}
+            render={() => <APIKeyEdit />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/settings/components/Nav/Nav.test.tsx
+++ b/ui/src/app/settings/components/Nav/Nav.test.tsx
@@ -10,7 +10,7 @@ describe("Nav", () => {
         initialEntries={[{ pathname: "/settings", key: "testKey" }]}
         initialIndex={0}
       >
-        <Route component={() => <Nav />} path="/settings" />
+        <Route render={() => <Nav />} path="/settings" />
       </MemoryRouter>
     );
     expect(wrapper.find("SideNav").exists()).toBe(true);

--- a/ui/src/app/settings/components/Routes/Routes.tsx
+++ b/ui/src/app/settings/components/Routes/Routes.tsx
@@ -33,26 +33,18 @@ import UsersList from "app/settings/views/Users/UsersList";
 const Routes = (): JSX.Element => {
   return (
     <Switch>
-      <Route
-        exact
-        path={settingsURLs.configuration.general}
-        component={General}
-      />
+      <Route exact path={settingsURLs.configuration.general} render={General} />
       <Route
         exact
         path={settingsURLs.configuration.commissioning}
-        component={Commissioning}
+        render={Commissioning}
       />
       <Route
         exact
         path={settingsURLs.configuration.kernelParameters}
-        component={KernelParameters}
+        render={KernelParameters}
       />
-      <Route
-        exact
-        path={settingsURLs.configuration.deploy}
-        component={Deploy}
-      />
+      <Route exact path={settingsURLs.configuration.deploy} render={Deploy} />
       <Redirect
         exact
         from={settingsURLs.index}
@@ -62,37 +54,33 @@ const Routes = (): JSX.Element => {
         from={settingsURLs.configuration.index}
         to={settingsURLs.configuration.general}
       />
-      <Route exact path={settingsURLs.users.index} component={UsersList} />
-      <Route exact path={settingsURLs.users.add} component={UserAdd} />
+      <Route exact path={settingsURLs.users.index} render={UsersList} />
+      <Route exact path={settingsURLs.users.add} render={UserAdd} />
       <Route
         exact
         path={settingsURLs.users.edit(null, true)}
-        component={UserEdit}
+        render={UserEdit}
       />
       <Route
         exact
         path={settingsURLs.licenseKeys.index}
-        component={LicenseKeyList}
+        render={LicenseKeyList}
       />
-      <Route
-        exact
-        path={settingsURLs.licenseKeys.add}
-        component={LicenseKeyAdd}
-      />
+      <Route exact path={settingsURLs.licenseKeys.add} render={LicenseKeyAdd} />
       <Route
         exact
         path={settingsURLs.licenseKeys.edit(null, true)}
-        component={LicenseKeyEdit}
+        render={LicenseKeyEdit}
       />
-      <Route exact path={settingsURLs.storage} component={StorageForm} />
-      <Route exact path={settingsURLs.network.proxy} component={ProxyForm} />
-      <Route exact path={settingsURLs.network.dns} component={DnsForm} />
-      <Route exact path={settingsURLs.network.ntp} component={NtpForm} />
-      <Route exact path={settingsURLs.network.syslog} component={SyslogForm} />
+      <Route exact path={settingsURLs.storage} render={StorageForm} />
+      <Route exact path={settingsURLs.network.proxy} render={ProxyForm} />
+      <Route exact path={settingsURLs.network.dns} render={DnsForm} />
+      <Route exact path={settingsURLs.network.ntp} render={NtpForm} />
+      <Route exact path={settingsURLs.network.syslog} render={SyslogForm} />
       <Route
         exact
         path={settingsURLs.network.networkDiscovery}
-        component={NetworkDiscoveryForm}
+        render={NetworkDiscoveryForm}
       />
       <Redirect
         exact
@@ -102,53 +90,53 @@ const Routes = (): JSX.Element => {
       <Route
         exact
         path={settingsURLs.scripts.commissioning.index}
-        component={() => <ScriptsList type="commissioning" />}
+        render={() => <ScriptsList type="commissioning" />}
       />
       <Route
         exact
         path={settingsURLs.scripts.commissioning.upload}
-        component={() => <ScriptsUpload type="commissioning" />}
+        render={() => <ScriptsUpload type="commissioning" />}
       />
       <Route
         exact
         path={settingsURLs.scripts.testing.index}
-        component={() => <ScriptsList type="testing" />}
+        render={() => <ScriptsList type="testing" />}
       />
       <Route
         exact
         path={settingsURLs.scripts.testing.upload}
-        component={() => <ScriptsUpload type="testing" />}
+        render={() => <ScriptsUpload type="testing" />}
       />
-      <Route exact path={settingsURLs.dhcp.index} component={DhcpList} />
-      <Route exact path={settingsURLs.dhcp.add} component={DhcpAdd} />
+      <Route exact path={settingsURLs.dhcp.index} render={DhcpList} />
+      <Route exact path={settingsURLs.dhcp.add} render={DhcpAdd} />
       <Route
         exact
         path={settingsURLs.dhcp.edit(null, true)}
-        component={DhcpEdit}
+        render={DhcpEdit}
       />
       <Route
         exact
         path={settingsURLs.repositories.index}
-        component={RepositoriesList}
+        render={RepositoriesList}
       />
       <Route
         exact
         path={settingsURLs.repositories.add(null, true)}
-        component={RepositoryAdd}
+        render={RepositoryAdd}
       />
       <Route
         exact
         path={settingsURLs.repositories.edit(null, true)}
-        component={RepositoryEdit}
+        render={RepositoryEdit}
       />
-      <Route exact path={settingsURLs.images.windows} component={Windows} />
-      <Route exact path={settingsURLs.images.vmware} component={VMWare} />
+      <Route exact path={settingsURLs.images.windows} render={Windows} />
+      <Route exact path={settingsURLs.images.vmware} render={VMWare} />
       <Route
         exact
         path={settingsURLs.images.ubuntu}
-        component={ThirdPartyDrivers}
+        render={ThirdPartyDrivers}
       />
-      <Route path="*" component={NotFound} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
@@ -79,7 +79,7 @@ describe("DhcpEdit", () => {
           <Route
             exact
             path="/settings/dhcp/:id/edit"
-            component={() => <DhcpEdit />}
+            render={() => <DhcpEdit />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
@@ -112,7 +112,7 @@ describe("LicenseKeyEdit", () => {
           <Route
             exact
             path="/settings/license-keys/:osystem/:distro_series/edit"
-            component={() => <LicenseKeyEdit />}
+            render={() => <LicenseKeyEdit />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
@@ -36,7 +36,7 @@ describe("RepositoryAdd", () => {
           <Route
             exact
             path="/settings/repositories/add/:type"
-            component={() => <RepositoryAdd />}
+            render={() => <RepositoryAdd />}
           />
         </MemoryRouter>
       </Provider>
@@ -61,7 +61,7 @@ describe("RepositoryAdd", () => {
           <Route
             exact
             path="/settings/repositories/add/:type"
-            component={() => <RepositoryAdd />}
+            render={() => <RepositoryAdd />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
@@ -80,7 +80,7 @@ describe("RepositoryEdit", () => {
           <Route
             exact
             path="/settings/repositories/edit/:type/:id"
-            component={() => <RepositoryEdit />}
+            render={() => <RepositoryEdit />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
@@ -238,7 +238,7 @@ describe("ScriptsUpload", () => {
           ]}
         >
           <ScriptsUpload type="commissioning" />
-          <Route path="*" component={() => <FetchRoute />} />
+          <Route path="*" render={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );
@@ -259,7 +259,7 @@ describe("ScriptsUpload", () => {
           initialEntries={[{ pathname: "/settings/scripts/testing/upload" }]}
         >
           <ScriptsUpload type="testing" />
-          <Route path="*" component={() => <FetchRoute />} />
+          <Route path="*" render={() => <FetchRoute />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
+++ b/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
@@ -92,7 +92,7 @@ describe("UserEdit", () => {
           <Route
             exact
             path="/settings/users/:id/edit"
-            component={() => <UserEdit />}
+            render={() => <UserEdit />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/subnets/views/Subnets.tsx
+++ b/ui/src/app/subnets/views/Subnets.tsx
@@ -11,28 +11,28 @@ import VLANDetails from "app/subnets/views/VLANDetails";
 const Routes = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={subnetsURLs.index} component={SubnetsList} />
+      <Route exact path={subnetsURLs.index} render={SubnetsList} />
       <Route
         exact
         path={subnetsURLs.fabric.index(null, true)}
-        component={FabricDetails}
+        render={FabricDetails}
       />
       <Route
         exact
         path={subnetsURLs.space.index(null, true)}
-        component={SpaceDetails}
+        render={SpaceDetails}
       />
       <Route
         exact
         path={subnetsURLs.subnet.index(null, true)}
-        component={SubnetDetails}
+        render={SubnetDetails}
       />
       <Route
         exact
         path={subnetsURLs.vlan.index(null, true)}
-        component={VLANDetails}
+        render={VLANDetails}
       />
-      <Route path="*" component={NotFound} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -51,7 +51,7 @@ describe("ZoneDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
         >
-          <Route exact path="/zone/:id" component={() => <ZoneDetails />} />
+          <Route exact path="/zone/:id" render={() => <ZoneDetails />} />
         </MemoryRouter>
       </Provider>
     );
@@ -73,7 +73,7 @@ describe("ZoneDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
         >
-          <Route exact path="/zone/:id" component={() => <ZoneDetails />} />
+          <Route exact path="/zone/:id" render={() => <ZoneDetails />} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
@@ -58,7 +58,7 @@ describe("ZoneDetailsHeader", () => {
           <Route
             exact
             path="/zone/:id"
-            component={() => <ZoneDetailsHeader id={1} />}
+            render={() => <ZoneDetailsHeader id={1} />}
           />
         </MemoryRouter>
       </Provider>
@@ -79,7 +79,7 @@ describe("ZoneDetailsHeader", () => {
           <Route
             exact
             path="/zone/:id"
-            component={() => <ZoneDetailsHeader id={3} />}
+            render={() => <ZoneDetailsHeader id={3} />}
           />
         </MemoryRouter>
       </Provider>
@@ -100,7 +100,7 @@ describe("ZoneDetailsHeader", () => {
           <Route
             exact
             path="/zone/:id"
-            component={() => <ZoneDetailsHeader id={2} />}
+            render={() => <ZoneDetailsHeader id={2} />}
           />
         </MemoryRouter>
       </Provider>
@@ -119,7 +119,7 @@ describe("ZoneDetailsHeader", () => {
           <Route
             exact
             path="/zone/:id"
-            component={() => <ZoneDetailsHeader id={1} />}
+            render={() => <ZoneDetailsHeader id={1} />}
           />
         </MemoryRouter>
       </Provider>
@@ -145,7 +145,7 @@ describe("ZoneDetailsHeader", () => {
           <Route
             exact
             path="/zone/:id"
-            component={() => <ZoneDetailsHeader id={2} />}
+            render={() => <ZoneDetailsHeader id={2} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/zones/views/Zones.tsx
+++ b/ui/src/app/zones/views/Zones.tsx
@@ -8,13 +8,13 @@ import ZonesList from "app/zones/views/ZonesList";
 const Zones = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={zonesURLs.index} component={() => <ZonesList />} />
+      <Route exact path={zonesURLs.index} render={() => <ZonesList />} />
       <Route
         exact
         path={zonesURLs.details(null, true)}
-        component={() => <ZoneDetails />}
+        render={() => <ZoneDetails />}
       />
-      <Route path="*" component={() => <NotFound />} />
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };


### PR DESCRIPTION
## Done

- Fix rerenders on all state changes due to using the [Route component prop](https://v5.reactrouter.com/web/api/Route/component). The relevant part of the docs being: `That means if you provide an inline function to the component prop, you would create a new component every render. This results in the existing component unmounting and the new component mounting instead of just updating the existing component.`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Tick some machines.
- Use the take action menu to open a form in the header. It should appear.

## Fixes

Fixes: #3533.