### PR TITLE
fix(ui): fix tag names in the vms table and clone form

### DIFF
--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -11,6 +11,8 @@ import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -316,5 +318,38 @@ describe("VMsTable", () => {
     );
 
     expect(wrapper.find("[data-testid='host-column']").exists()).toBe(false);
+  });
+
+  it("displays tag names", () => {
+    const vms = [machineFactory({ tags: [1, 2] })];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: vms,
+      }),
+      tag: tagStateFactory({
+        items: [
+          tagFactory({ id: 1, name: "tag1" }),
+          tagFactory({ id: 2, name: "tag2" }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable
+            currentPage={1}
+            getResources={getResources}
+            searchFilter=""
+            vms={vms}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("DoubleRow[data-testid='pool-col']").at(0).prop("secondary")
+    ).toBe("tag1, tag2");
   });
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -1,15 +1,25 @@
 import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import SourceMachineSelect from "./SourceMachineSelect";
 
 import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
+
+const mockStore = configureStore();
 
 describe("SourceMachineSelect", () => {
   let machines: Machine[];
+  let state: RootState;
 
   beforeEach(() => {
     machines = [
@@ -26,27 +36,47 @@ describe("SourceMachineSelect", () => {
         tags: [13],
       }),
     ];
+    state = rootStateFactory({
+      tag: tagStateFactory({
+        items: [
+          tagFactory({ id: 12, name: "tagA" }),
+          tagFactory({ id: 13, name: "tagB" }),
+        ],
+      }),
+    });
   });
 
   it("shows a spinner while data is loading", () => {
+    const store = mockStore(state);
     const wrapper = mount(
-      <SourceMachineSelect
-        loadingData
-        machines={machines}
-        onMachineClick={jest.fn()}
-      />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect
+            loadingData
+            machines={machines}
+            onMachineClick={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     expect(wrapper.find("[data-testid='loading-spinner']").exists()).toBe(true);
   });
 
   it("shows an error if no machines are available to select", () => {
-    const wrapper = mount(
-      <SourceMachineSelect
-        machines={[machineFactory()]}
-        onMachineClick={jest.fn()}
-      />
+    const store = mockStore(state);
+    const Proxy = ({ machines }: { machines: Machine[] }) => (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
     );
+    const wrapper = mount(<Proxy machines={[machineFactory()]} />);
     expect(wrapper.find("[data-testid='no-source-machines']").exists()).toBe(
       false
     );
@@ -58,8 +88,15 @@ describe("SourceMachineSelect", () => {
   });
 
   it("can filter machines by hostname, system_id and/or tags", () => {
+    const store = mockStore(state);
     const wrapper = mount(
-      <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
     );
 
     // Filter by "first" which matches the hostname of the first machine
@@ -84,10 +121,10 @@ describe("SourceMachineSelect", () => {
       true
     );
 
-    // Filter by "1" which matches the tags of the first and second machine
+    // Filter by "tag" which matches the tags of the first and second machine
     wrapper
       .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "1" } });
+      .simulate("change", { target: { value: "tag" } });
     expect(wrapper.find("[data-testid='source-machine-first']").exists()).toBe(
       true
     );
@@ -97,8 +134,15 @@ describe("SourceMachineSelect", () => {
   });
 
   it("highlights the substring that matches the search text", () => {
+    const store = mockStore(state);
     const wrapper = mount(
-      <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
     );
 
     // Filter by "fir" which matches part of the hostname of the first machine
@@ -116,11 +160,19 @@ describe("SourceMachineSelect", () => {
 
   it("runs onMachineClick function on row click", () => {
     const onMachineClick = jest.fn();
+
+    const store = mockStore(state);
     const wrapper = mount(
-      <SourceMachineSelect
-        machines={machines}
-        onMachineClick={onMachineClick}
-      />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect
+            machines={machines}
+            onMachineClick={onMachineClick}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     wrapper.find("[data-testid='source-machine-row']").at(0).simulate("click");
@@ -129,12 +181,20 @@ describe("SourceMachineSelect", () => {
 
   it("shows the machine's details when selected", () => {
     const selectedMachine = machineDetailsFactory();
+
+    const store = mockStore(state);
     const wrapper = mount(
-      <SourceMachineSelect
-        machines={machines}
-        onMachineClick={jest.fn()}
-        selectedMachine={selectedMachine}
-      />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect
+            machines={machines}
+            onMachineClick={jest.fn()}
+            selectedMachine={selectedMachine}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     expect(wrapper.find("SourceMachineDetails").exists()).toBe(true);
@@ -143,17 +203,45 @@ describe("SourceMachineSelect", () => {
   it("clears the selected machine on search input change", () => {
     const selectedMachine = machineDetailsFactory();
     const onMachineClick = jest.fn();
+
+    const store = mockStore(state);
     const wrapper = mount(
-      <SourceMachineSelect
-        machines={machines}
-        onMachineClick={onMachineClick}
-        selectedMachine={selectedMachine}
-      />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect
+            machines={machines}
+            onMachineClick={onMachineClick}
+            selectedMachine={selectedMachine}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     wrapper
       .find("[data-testid='source-machine-searchbox'] input")
       .simulate("change", { target: { value: "" } });
     expect(onMachineClick).toHaveBeenCalledWith(null);
+  });
+
+  it("displays tag names", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Filter by "first" which matches the hostname of the first machine
+    wrapper
+      .find("[data-testid='source-machine-searchbox'] input")
+      .simulate("change", { target: { value: "first" } });
+    expect(wrapper.find("[data-testid='source-machine-tagA']").exists()).toBe(
+      true
+    );
   });
 });


### PR DESCRIPTION
## Done

- Update the cluster vms table and clone form source select to display tag names instead of id.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the vms tab for a LXD cluster. There should be tag names, not ids.
- Go to the machine list and tick some machines and open the clone form.
- The list of machines should display tags not tag ids.

## Fixes

Fixes: canonical-web-and-design/app-tribe#639.