### PR TITLE
feat(ui): add more scaffolding components for network details pages

### DIFF
--- a/ui/src/app/base/hooks/index.ts
+++ b/ui/src/app/base/hooks/index.ts
@@ -16,3 +16,4 @@ export {
 export { useIsAllNetworkingDisabled } from "./node-networking";
 export { useTableSort } from "./tables";
 export type { TableSort } from "./tables";
+export { useGetURLId } from "./urls";

--- a/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
+++ b/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const DHCPSnippets = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">DHCP snippets</h2>
+  </Strip>
+);
+
+export default DHCPSnippets;

--- a/ui/src/app/subnets/components/DHCPSnippets/index.ts
+++ b/ui/src/app/subnets/components/DHCPSnippets/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DHCPSnippets";

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const ReservedRanges = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Reserved ranges</h2>
+  </Strip>
+);
+
+export default ReservedRanges;

--- a/ui/src/app/subnets/components/ReservedRanges/index.ts
+++ b/ui/src/app/subnets/components/ReservedRanges/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReservedRanges";

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
@@ -3,11 +3,13 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import FabricDetailsHeader from "./FabricDetailsHeader";
+import FabricSummary from "./FabricSummary";
+import FabricVLANs from "./FabricVLANs";
 
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
-import { useGetURLId } from "app/base/hooks/urls";
+import { useGetURLId, useWindowTitle } from "app/base/hooks";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import { FabricMeta } from "app/store/fabric/types";
@@ -23,6 +25,7 @@ const FabricDetails = (): JSX.Element => {
   );
   const fabricsLoading = useSelector(fabricSelectors.loading);
   const isValidID = isId(id);
+  useWindowTitle(`${fabric?.name || "Fabric"} details`);
 
   useEffect(() => {
     if (isValidID) {
@@ -48,7 +51,12 @@ const FabricDetails = (): JSX.Element => {
     return <Section header={<SectionHeader loading />} />;
   }
 
-  return <Section header={<FabricDetailsHeader fabric={fabric} />} />;
+  return (
+    <Section header={<FabricDetailsHeader fabric={fabric} />}>
+      <FabricSummary />
+      <FabricVLANs />
+    </Section>
+  );
 };
 
 export default FabricDetails;

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const FabricSummary = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Fabric summary</h2>
+  </Strip>
+);
+
+export default FabricSummary;

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/index.ts
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricSummary";

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const FabricVLANs = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">VLANs on this fabric</h2>
+  </Strip>
+);
+
+export default FabricVLANs;

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/index.ts
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricVLANs";

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
@@ -3,11 +3,13 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import SpaceDetailsHeader from "./SpaceDetailsHeader";
+import SpaceSubnets from "./SpaceSubnets";
+import SpaceSummary from "./SpaceSummary";
 
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
-import { useGetURLId } from "app/base/hooks/urls";
+import { useGetURLId, useWindowTitle } from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as spaceActions } from "app/store/space";
 import spaceSelectors from "app/store/space/selectors";
@@ -23,6 +25,7 @@ const SpaceDetails = (): JSX.Element => {
   );
   const spacesLoading = useSelector(spaceSelectors.loading);
   const isValidID = isId(id);
+  useWindowTitle(`${space?.name || "Space"} details`);
 
   useEffect(() => {
     if (isValidID) {
@@ -48,7 +51,12 @@ const SpaceDetails = (): JSX.Element => {
     return <Section header={<SectionHeader loading />} />;
   }
 
-  return <Section header={<SpaceDetailsHeader space={space} />} />;
+  return (
+    <Section header={<SpaceDetailsHeader space={space} />}>
+      <SpaceSummary />
+      <SpaceSubnets />
+    </Section>
+  );
 };
 
 export default SpaceDetails;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const SpaceSubnets = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Subnets on this space</h2>
+  </Strip>
+);
+
+export default SpaceSubnets;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/index.ts
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceSubnets";

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const SpaceSummary = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Space summary</h2>
+  </Strip>
+);
+
+export default SpaceSummary;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/index.ts
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceSummary";

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const StaticRoutes = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Static routes</h2>
+  </Strip>
+);
+
+export default StaticRoutes;

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StaticRoutes";

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -2,16 +2,22 @@ import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 
+import StaticRoutes from "./StaticRoutes";
 import SubnetDetailsHeader from "./SubnetDetailsHeader";
+import SubnetSummary from "./SubnetSummary";
+import UsedIPs from "./UsedIPs";
+import Utilisation from "./Utilisation";
 
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
-import { useGetURLId } from "app/base/hooks/urls";
+import { useGetURLId, useWindowTitle } from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import { SubnetMeta } from "app/store/subnet/types";
+import DHCPSnippets from "app/subnets/components/DHCPSnippets";
+import ReservedRanges from "app/subnets/components/ReservedRanges";
 import subnetURLs from "app/subnets/urls";
 import { isId } from "app/utils";
 
@@ -23,6 +29,7 @@ const SubnetDetails = (): JSX.Element => {
   );
   const subnetsLoading = useSelector(subnetSelectors.loading);
   const isValidID = isId(id);
+  useWindowTitle(`${subnet?.name || "Subnet"} details`);
 
   useEffect(() => {
     if (isValidID) {
@@ -48,7 +55,16 @@ const SubnetDetails = (): JSX.Element => {
     return <Section header={<SectionHeader loading />} />;
   }
 
-  return <Section header={<SubnetDetailsHeader subnet={subnet} />} />;
+  return (
+    <Section header={<SubnetDetailsHeader subnet={subnet} />}>
+      <SubnetSummary />
+      <Utilisation />
+      <StaticRoutes />
+      <ReservedRanges />
+      <DHCPSnippets />
+      <UsedIPs />
+    </Section>
+  );
 };
 
 export default SubnetDetails;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const SubnetSummary = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Subnet summary</h2>
+  </Strip>
+);
+
+export default SubnetSummary;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetSummary";

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const SubnetUsedIPs = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Used IP addresses</h2>
+  </Strip>
+);
+
+export default SubnetUsedIPs;

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetUsedIPs";

--- a/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const SubnetUtilisation = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Utilisation</h2>
+  </Strip>
+);
+
+export default SubnetUtilisation;

--- a/ui/src/app/subnets/views/SubnetDetails/Utilisation/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/Utilisation/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetUtilisation";

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const DHCPStatus = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">DHCP</h2>
+  </Strip>
+);
+
+export default DHCPStatus;

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DHCPStatus";

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -2,16 +2,21 @@ import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 
+import DHCPStatus from "./DHCPStatus";
 import VLANDetailsHeader from "./VLANDetailsHeader";
+import VLANSubnets from "./VLANSubnets";
+import VLANSummary from "./VLANSummary";
 
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
-import { useGetURLId } from "app/base/hooks/urls";
+import { useGetURLId, useWindowTitle } from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import { VLANMeta } from "app/store/vlan/types";
+import DHCPSnippets from "app/subnets/components/DHCPSnippets";
+import ReservedRanges from "app/subnets/components/ReservedRanges";
 import subnetURLs from "app/subnets/urls";
 import { isId } from "app/utils";
 
@@ -23,6 +28,7 @@ const VLANDetails = (): JSX.Element => {
   );
   const vlansLoading = useSelector(vlanSelectors.loading);
   const isValidID = isId(id);
+  useWindowTitle(`${vlan?.name || "VLAN"} details`);
 
   useEffect(() => {
     if (isValidID) {
@@ -48,7 +54,15 @@ const VLANDetails = (): JSX.Element => {
     return <Section header={<SectionHeader loading />} />;
   }
 
-  return <Section header={<VLANDetailsHeader vlan={vlan} />} />;
+  return (
+    <Section header={<VLANDetailsHeader vlan={vlan} />}>
+      <VLANSummary />
+      <DHCPStatus />
+      <ReservedRanges />
+      <VLANSubnets />
+      <DHCPSnippets />
+    </Section>
+  );
 };
 
 export default VLANDetails;

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const VLANSubnets = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">Subnets on this VLAN</h2>
+  </Strip>
+);
+
+export default VLANSubnets;

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VLANSubnets";

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -1,0 +1,9 @@
+import { Strip } from "@canonical/react-components";
+
+const VLANSummary = (): JSX.Element => (
+  <Strip shallow>
+    <h2 className="p-heading--4">VLAN summary</h2>
+  </Strip>
+);
+
+export default VLANSummary;

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VLANSummary";


### PR DESCRIPTION
## Done

- Added a bunch of basic component files and folders for the network details pages. This should hopefully minimise any uncertainties around folder structure and boring stuff like that during the sprint.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React details page for a fabric, VLAN, subnet and space
- Check that there is a header for each section just like with the legacy versions.

## Fixes

Fixes canonical-web-and-design/app-tribe#678
