### PR TITLE
feat(ui): add staticroute slice and selectors

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.ts.snap
+++ b/ui/src/__snapshots__/root-reducer.test.ts.snap
@@ -301,6 +301,14 @@ Object {
     "saved": false,
     "saving": false,
   },
+  "staticroute": Object {
+    "errors": null,
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
   "status": Object {
     "authenticated": false,
     "authenticating": false,

--- a/ui/src/app/store/root/types.ts
+++ b/ui/src/app/store/root/types.ts
@@ -57,6 +57,10 @@ import type { ServiceState, ServiceMeta } from "app/store/service/types";
 import type { SpaceState, SpaceMeta } from "app/store/space/types";
 import type { SSHKeyState, SSHKeyMeta } from "app/store/sshkey/types";
 import type { SSLKeyState, SSLKeyMeta } from "app/store/sslkey/types";
+import type {
+  StaticRouteState,
+  StaticRouteMeta,
+} from "app/store/staticroute/types";
 import type { StatusState, StatusMeta } from "app/store/status/types";
 import type { SubnetState, SubnetMeta } from "app/store/subnet/types";
 import type { TagState, TagMeta } from "app/store/tag/types";
@@ -92,6 +96,7 @@ export type RootState = {
   [SpaceMeta.MODEL]: SpaceState;
   [SSHKeyMeta.MODEL]: SSHKeyState;
   [SSLKeyMeta.MODEL]: SSLKeyState;
+  [StaticRouteMeta.MODEL]: StaticRouteState;
   [StatusMeta.MODEL]: StatusState;
   [SubnetMeta.MODEL]: SubnetState;
   [TagMeta.MODEL]: TagState;

--- a/ui/src/app/store/staticroute/action.test.ts
+++ b/ui/src/app/store/staticroute/action.test.ts
@@ -1,0 +1,74 @@
+import { actions } from "./slice";
+
+it("can create an action for fetching static routes", () => {
+  expect(actions.fetch()).toEqual({
+    type: "staticroute/fetch",
+    meta: {
+      model: "staticroute",
+      method: "list",
+    },
+    payload: null,
+  });
+});
+
+it("can create an action for creating a static route", () => {
+  expect(
+    actions.create({
+      destination: 123,
+      gateway_ip: "192.168.1.1",
+      metric: 0,
+      source: 456,
+    })
+  ).toEqual({
+    type: "staticroute/create",
+    meta: {
+      model: "staticroute",
+      method: "create",
+    },
+    payload: {
+      params: {
+        destination: 123,
+        gateway_ip: "192.168.1.1",
+        metric: 0,
+        source: 456,
+      },
+    },
+  });
+});
+
+it("can create an action for deleting a static route", () => {
+  expect(actions.delete(1)).toEqual({
+    type: "staticroute/delete",
+    meta: {
+      model: "staticroute",
+      method: "delete",
+    },
+    payload: {
+      params: {
+        id: 1,
+      },
+    },
+  });
+});
+
+it("can create an action for updating a static route", () => {
+  expect(actions.update({ id: 1, source: 456 })).toEqual({
+    type: "staticroute/update",
+    meta: {
+      model: "staticroute",
+      method: "update",
+    },
+    payload: {
+      params: {
+        id: 1,
+        source: 456,
+      },
+    },
+  });
+});
+
+it("can clean up", () => {
+  expect(actions.cleanup()).toEqual({
+    type: "staticroute/cleanup",
+  });
+});

--- a/ui/src/app/store/staticroute/index.ts
+++ b/ui/src/app/store/staticroute/index.ts
@@ -1,0 +1,1 @@
+export { default, actions } from "./slice";

--- a/ui/src/app/store/staticroute/reducers.test.ts
+++ b/ui/src/app/store/staticroute/reducers.test.ts
@@ -1,0 +1,171 @@
+import reducers, { actions } from "./slice";
+
+import {
+  staticRoute as staticRouteFactory,
+  staticRouteState as staticRouteStateFactory,
+} from "testing/factories";
+
+it("should return the initial state", () => {
+  expect(reducers(undefined, { type: "" })).toEqual(
+    staticRouteStateFactory({
+      errors: null,
+      loading: false,
+      loaded: false,
+      items: [],
+      saved: false,
+      saving: false,
+    })
+  );
+});
+
+it("should correctly reduce cleanup", () => {
+  const initialState = staticRouteStateFactory({
+    errors: { key: "Key already exists" },
+    saved: true,
+    saving: true,
+  });
+  expect(reducers(initialState, actions.cleanup())).toEqual(
+    staticRouteStateFactory({
+      errors: null,
+      saved: false,
+      saving: false,
+    })
+  );
+});
+
+describe("fetch reducers", () => {
+  it("should correctly reduce fetchStart", () => {
+    const initialState = staticRouteStateFactory({ loading: false });
+    expect(reducers(initialState, actions.fetchStart())).toEqual(
+      staticRouteStateFactory({
+        loading: true,
+      })
+    );
+  });
+
+  it("should correctly reduce fetchSuccess", () => {
+    const initialState = staticRouteStateFactory({
+      loading: true,
+      loaded: false,
+      items: [],
+    });
+    const items = [staticRouteFactory(), staticRouteFactory()];
+    expect(reducers(initialState, actions.fetchSuccess(items))).toEqual(
+      staticRouteStateFactory({
+        loading: false,
+        loaded: true,
+        items,
+      })
+    );
+  });
+
+  it("should correctly reduce fetchError", () => {
+    const initialState = staticRouteStateFactory({
+      errors: null,
+      loading: true,
+    });
+    expect(
+      reducers(initialState, actions.fetchError("Unable to list static routes"))
+    ).toEqual(
+      staticRouteStateFactory({
+        errors: "Unable to list static routes",
+        loading: false,
+      })
+    );
+  });
+});
+
+describe("create reducers", () => {
+  it("should correctly reduce createStart", () => {
+    const initialState = staticRouteStateFactory({ saving: false });
+    expect(reducers(initialState, actions.createStart())).toEqual(
+      staticRouteStateFactory({
+        saving: true,
+      })
+    );
+  });
+
+  it("should correctly reduce createError", () => {
+    const initialState = staticRouteStateFactory({ saving: true });
+    expect(
+      reducers(initialState, actions.createError({ key: "Key already exists" }))
+    ).toEqual(
+      staticRouteStateFactory({
+        errors: { key: "Key already exists" },
+        saving: false,
+      })
+    );
+  });
+
+  it("should correctly reduce createSuccess", () => {
+    const initialState = staticRouteStateFactory({
+      saved: false,
+      saving: true,
+    });
+    expect(reducers(initialState, actions.createSuccess())).toEqual(
+      staticRouteStateFactory({
+        saved: true,
+        saving: false,
+      })
+    );
+  });
+
+  it("should correctly reduce createNotify", () => {
+    const items = [staticRouteFactory(), staticRouteFactory()];
+    const initialState = staticRouteStateFactory({ items: [items[0]] });
+    expect(reducers(initialState, actions.createNotify(items[1]))).toEqual(
+      staticRouteStateFactory({
+        items,
+      })
+    );
+  });
+});
+
+describe("delete reducers", () => {
+  it("should correctly reduce deleteStart", () => {
+    const initialState = staticRouteStateFactory({
+      saved: true,
+      saving: false,
+    });
+    expect(reducers(initialState, actions.deleteStart())).toEqual(
+      staticRouteStateFactory({
+        saved: false,
+        saving: true,
+      })
+    );
+  });
+
+  it("should correctly reduce deleteError", () => {
+    const initialState = staticRouteStateFactory({
+      errors: null,
+      saving: true,
+    });
+    expect(
+      reducers(initialState, actions.deleteError("Could not delete"))
+    ).toEqual(
+      staticRouteStateFactory({
+        errors: "Could not delete",
+        saving: false,
+      })
+    );
+  });
+
+  it("should correctly reduce deleteSuccess", () => {
+    const initialState = staticRouteStateFactory({ saved: false });
+    expect(reducers(initialState, actions.deleteSuccess())).toEqual(
+      staticRouteStateFactory({
+        saved: true,
+      })
+    );
+  });
+
+  it("should correctly reduce deleteNotify", () => {
+    const items = [staticRouteFactory(), staticRouteFactory()];
+    const initialState = staticRouteStateFactory({ items });
+    expect(reducers(initialState, actions.deleteNotify(items[0].id))).toEqual(
+      staticRouteStateFactory({
+        items: [items[1]],
+      })
+    );
+  });
+});

--- a/ui/src/app/store/staticroute/selectors.test.ts
+++ b/ui/src/app/store/staticroute/selectors.test.ts
@@ -1,0 +1,74 @@
+import staticRoute from "./selectors";
+
+import {
+  rootState as rootStateFactory,
+  staticRoute as staticRouteFactory,
+  staticRouteState as staticRouteStateFactory,
+} from "testing/factories";
+
+describe("all", () => {
+  it("returns list of all static routes", () => {
+    const items = [staticRouteFactory(), staticRouteFactory()];
+    const state = rootStateFactory({
+      staticroute: staticRouteStateFactory({
+        items,
+      }),
+    });
+    expect(staticRoute.all(state)).toStrictEqual(items);
+  });
+});
+
+describe("loading", () => {
+  it("returns staticroute loading state", () => {
+    const state = rootStateFactory({
+      staticroute: staticRouteStateFactory({
+        loading: false,
+      }),
+    });
+    expect(staticRoute.loading(state)).toStrictEqual(false);
+  });
+});
+
+describe("loaded", () => {
+  it("returns staticroute loaded state", () => {
+    const state = rootStateFactory({
+      staticroute: staticRouteStateFactory({
+        loaded: true,
+      }),
+    });
+    expect(staticRoute.loaded(state)).toStrictEqual(true);
+  });
+});
+
+describe("errors", () => {
+  it("returns staticroute error state", () => {
+    const state = rootStateFactory({
+      staticroute: staticRouteStateFactory({
+        errors: "Unable to list static routes.",
+      }),
+    });
+    expect(staticRoute.errors(state)).toEqual("Unable to list static routes.");
+  });
+});
+
+describe("saving", () => {
+  it("returns staticroute saving state", () => {
+    const state = rootStateFactory({
+      staticroute: staticRouteStateFactory({
+        saving: true,
+      }),
+    });
+    expect(staticRoute.saving(state)).toStrictEqual(true);
+  });
+});
+
+describe("saved", () => {
+  it("returns staticroute saved state", () => {
+    const state = rootStateFactory({
+      staticroute: staticRouteStateFactory({
+        saved: true,
+      }),
+    });
+    expect(staticRoute.saved(state)).toStrictEqual(true);
+  });
+});

--- a/ui/src/app/store/staticroute/selectors.ts
+++ b/ui/src/app/store/staticroute/selectors.ts
@@ -1,0 +1,14 @@
+import { StaticRouteMeta } from "app/store/staticroute/types";
+import type {
+  StaticRoute,
+  StaticRouteState,
+} from "app/store/staticroute/types";
+import { generateBaseSelectors } from "app/store/utils";
+
+const selectors = generateBaseSelectors<
+  StaticRouteState,
+  StaticRoute,
+  StaticRouteMeta.PK
+>(StaticRouteMeta.MODEL, StaticRouteMeta.PK);
+
+export default selectors;

--- a/ui/src/app/store/staticroute/slice.ts
+++ b/ui/src/app/store/staticroute/slice.ts
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+import { StaticRouteMeta } from "./types";
+import type { CreateParams, StaticRouteState, UpdateParams } from "./types";
+
+import {
+  generateCommonReducers,
+  genericInitialState,
+} from "app/store/utils/slice";
+
+const staticRouteSlice = createSlice({
+  name: StaticRouteMeta.MODEL,
+  initialState: genericInitialState as StaticRouteState,
+  reducers: generateCommonReducers<
+    StaticRouteState,
+    StaticRouteMeta.PK,
+    CreateParams,
+    UpdateParams
+  >(StaticRouteMeta.MODEL, StaticRouteMeta.PK),
+});
+
+export const { actions } = staticRouteSlice;
+
+export default staticRouteSlice.reducer;

--- a/ui/src/app/store/staticroute/types/actions.ts
+++ b/ui/src/app/store/staticroute/types/actions.ts
@@ -1,0 +1,13 @@
+import type { StaticRoute } from "./base";
+import type { StaticRouteMeta } from "./enum";
+
+export type CreateParams = {
+  destination: StaticRoute["destination"];
+  gateway_ip: StaticRoute["gateway_ip"];
+  metric?: StaticRoute["metric"];
+  source: StaticRoute["source"];
+};
+
+export type UpdateParams = Partial<CreateParams> & {
+  [StaticRouteMeta.PK]: StaticRoute[StaticRouteMeta.PK];
+};

--- a/ui/src/app/store/staticroute/types/base.ts
+++ b/ui/src/app/store/staticroute/types/base.ts
@@ -1,0 +1,15 @@
+import type { APIError } from "app/base/types";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
+export type StaticRoute = Model & {
+  created: string;
+  destination: Subnet[SubnetMeta.PK];
+  gateway_ip: string;
+  metric: number;
+  source: Subnet[SubnetMeta.PK];
+  updated: string;
+};
+
+export type StaticRouteState = GenericState<StaticRoute, APIError>;

--- a/ui/src/app/store/staticroute/types/enum.ts
+++ b/ui/src/app/store/staticroute/types/enum.ts
@@ -1,0 +1,4 @@
+export enum StaticRouteMeta {
+  MODEL = "staticroute",
+  PK = "id",
+}

--- a/ui/src/app/store/staticroute/types/index.ts
+++ b/ui/src/app/store/staticroute/types/index.ts
@@ -1,0 +1,5 @@
+export type { CreateParams, UpdateParams } from "./actions";
+
+export type { StaticRoute, StaticRouteState } from "./base";
+
+export { StaticRouteMeta } from "./enum";

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import SubnetDetails from "./SubnetDetails";
 
+import { actions as staticRouteActions } from "app/store/staticroute";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetsURLs from "app/subnets/urls";
 import {
@@ -14,7 +15,7 @@ import {
 
 const mockStore = configureStore();
 
-it("dispatches actions to get and set subnet as active on mount", () => {
+it("dispatches actions to fetch necessary data and set subnet as active on mount", () => {
   const state = rootStateFactory();
   const store = mockStore(state);
   render(
@@ -31,7 +32,11 @@ it("dispatches actions to get and set subnet as active on mount", () => {
     </Provider>
   );
 
-  const expectedActions = [subnetActions.get(1), subnetActions.setActive(1)];
+  const expectedActions = [
+    subnetActions.get(1),
+    subnetActions.setActive(1),
+    staticRouteActions.fetch(),
+  ];
   const actualActions = store.getActions();
   expectedActions.forEach((expectedAction) => {
     expect(

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -13,6 +13,7 @@ import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
 import { useGetURLId, useWindowTitle } from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
+import { actions as staticRouteActions } from "app/store/staticroute";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import { SubnetMeta } from "app/store/subnet/types";
@@ -35,6 +36,7 @@ const SubnetDetails = (): JSX.Element => {
     if (isValidID) {
       dispatch(subnetActions.get(id));
       dispatch(subnetActions.setActive(id));
+      dispatch(staticRouteActions.fetch());
     }
 
     const unsetActiveSubnetAndCleanup = () => {

--- a/ui/src/root-reducer.ts
+++ b/ui/src/root-reducer.ts
@@ -30,6 +30,7 @@ import service from "app/store/service";
 import space from "app/store/space";
 import sshkey from "app/store/sshkey";
 import sslkey from "app/store/sslkey";
+import staticroute from "app/store/staticroute";
 import status from "app/store/status";
 import type { StatusState } from "app/store/status/types";
 import subnet from "app/store/subnet";
@@ -70,6 +71,7 @@ const createAppReducer = (routerReducer: Reducer<RouterState, AnyAction>) =>
     space,
     sshkey,
     sslkey,
+    staticroute,
     status,
     subnet,
     tag,

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -51,6 +51,7 @@ export {
   spaceState,
   sshKeyState,
   sslKeyState,
+  staticRouteState,
   statusState,
   subnetEventError,
   subnetState,
@@ -168,6 +169,7 @@ export { service } from "./service";
 export { space } from "./space";
 export { sshKey } from "./sshkey";
 export { sslKey } from "./sslkey";
+export { staticRoute } from "./staticroute";
 export {
   subnet,
   subnetBMC,

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -69,6 +69,7 @@ import type { ServiceState } from "app/store/service/types";
 import type { SpaceState } from "app/store/space/types";
 import type { SSHKeyState } from "app/store/sshkey/types";
 import type { SSLKeyState } from "app/store/sslkey/types";
+import type { StaticRouteState } from "app/store/staticroute/types";
 import type { StatusState } from "app/store/status/types";
 import { DEFAULT_STATUSES as DEFAULT_SUBNET_STATUSES } from "app/store/subnet/slice";
 import type {
@@ -261,6 +262,11 @@ export const sshKeyState = define<SSHKeyState>({
 });
 
 export const sslKeyState = define<SSLKeyState>({
+  ...defaultState,
+  errors: null,
+});
+
+export const staticRouteState = define<StaticRouteState>({
   ...defaultState,
   errors: null,
 });
@@ -519,6 +525,7 @@ export const rootState = define<RootState>({
   space: spaceState,
   sshkey: sshKeyState,
   sslkey: sslKeyState,
+  staticroute: staticRouteState,
   status: statusState,
   subnet: subnetState,
   tag: tagState,

--- a/ui/src/testing/factories/staticroute.ts
+++ b/ui/src/testing/factories/staticroute.ts
@@ -1,0 +1,15 @@
+import { extend } from "cooky-cutter";
+
+import { model } from "./model";
+
+import type { StaticRoute } from "app/store/staticroute/types";
+import type { Model } from "app/store/types/model";
+
+export const staticRoute = extend<Model, StaticRoute>(model, {
+  created: "Fri, 25 Jun. 2021 04:27:12",
+  destination: 456,
+  gateway_ip: "192.168.1.1",
+  metric: 0,
+  source: 123,
+  updated: "Fri, 25 Jun. 2021 04:27:12",
+});


### PR DESCRIPTION
## Done

- Added the `staticroute` model to the React app including slice, selectors and types

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet's details page in React (e.g. `/MAAS/r/subnet/18`)
- Open Redux DevTools and check that static routes are fetched and added to state

## Fixes

Fixes canonical-web-and-design/app-tribe#679