### PR TITLE
refactor: subnets table view

### DIFF
--- a/integration/cypress/integration/legacy/subnets.spec.ts
+++ b/integration/cypress/integration/legacy/subnets.spec.ts
@@ -25,35 +25,4 @@ context("Subnets", () => {
       );
     });
   });
-
-  it("displays the main networking view correctly", () => {
-    const expectedHeaders = [
-      "Fabric",
-      "VLAN",
-      "DHCP",
-      "Subnet",
-      "Available IPs",
-      "Space",
-    ];
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
-      expectedHeaders.forEach((name) => {
-        cy.findByRole("columnheader", { name }).should("exist");
-      });
-    });
-  });
-
-  it("allows filtering by 'fabrics' or 'spaces' via the 'Group by' drop-down", () => {
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
-      cy.findAllByRole("columnheader").first().should("have.text", "Fabric");
-    });
-    cy.findByRole("combobox", { name: "Group by" })
-      .within(() => {
-        cy.findByRole("option", { selected: true }).contains("Fabrics");
-        cy.findByRole("option", { name: "Spaces" }).should("exist");
-      })
-      .select("Spaces");
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
-      cy.findAllByRole("columnheader").first().should("have.text", "Space");
-    });
-  });
 });

--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -1,47 +1,141 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
-import { generateId } from "../utils";
+import { generateId, generateVid } from "../utils";
 
 context("Subnets - Add", () => {
   beforeEach(() => {
     cy.login();
     cy.visit(generateNewURL("/networks?by=fabric"));
+    cy.viewport("macbook-11");
   });
 
-  ["Space", "Fabric"].forEach((type) => {
-    it(`displays an error when trying to add a ${type} with a name that already exists`, () => {
-      const name = `cypress-${generateId()}`;
+  const openAddForm = (name: string) => {
+    cy.findByRole("button", { name: "Add" }).click();
+    cy.findByRole("button", { name }).click();
+  };
 
-      const completeForm = () => {
-        cy.findByRole("button", { name: "Add" }).click();
-        cy.findByRole("button", { name: type }).click();
-        cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
-        cy.findByRole("button", { name: `Add ${type}` }).click();
-      };
+  const submitForm = (formName: string) => {
+    cy.findByRole("button", { name: `Add ${formName}` }).click();
+  };
 
-      completeForm();
-      completeForm();
+  const completeAddVlanForm = (
+    vid: string,
+    name: string,
+    fabricName?: string,
+    spaceName?: string
+  ) => {
+    openAddForm("VLAN");
+    cy.findByRole("textbox", { name: "VID" }).type(vid);
+    cy.findByRole("combobox", { name: "Fabric" }).select(fabricName || 1);
+    cy.findByRole("combobox", { name: "Space" }).select(spaceName || 1);
+    cy.findByRole("textbox", { name: "Name" }).type(name);
+    cy.findByRole("button", { name: "Add VLAN" }).click();
+  };
 
-      cy.findByText(/this Name already exists/).should("be.visible");
+  const completeAddSubnetForm = (
+    subnetName: string,
+    cidr: string,
+    fabric: string,
+    vid: string,
+    vlan: string
+  ) => {
+    openAddForm("Subnet");
+    cy.findByRole("textbox", { name: "CIDR" }).type(cidr);
+    cy.findByRole("textbox", { name: "Name" }).type(subnetName);
+    cy.findByRole("combobox", { name: "Fabric" }).select(fabric);
+    cy.findByRole("combobox", { name: "VLAN" }).select(`${vid} (${vlan})`);
+    cy.findByRole("button", { name: "Add Subnet" }).click();
+  };
+
+  const completeForm = (formName: string, name: string) => {
+    openAddForm(formName);
+    cy.findByRole("textbox", { name: "Name (optional)" }).type(name);
+    submitForm(formName);
+  };
+
+  it(`displays a newly added Fabric in the subnets table`, () => {
+    const name = `cypress-${generateId()}`;
+    completeForm("Fabric", name);
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findByRole("row", { name }).within(() =>
+        cy.findByRole("link", { name }).should("be.visible")
+      );
     });
   });
 
+  it("displays a newly added VLAN in the subnets table", () => {
+    const vid = generateVid();
+    const name = `cypress-${vid}`;
+    completeAddVlanForm(vid, name);
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findByRole("link", { name: `${vid} (${name})` }).should("be.visible");
+    });
+  });
+
+  it("Groups items added to the same fabric correctly", () => {
+    const fabricName = `cy-fabric-${generateId()}`;
+    const spaceName = `cy-space-${generateId()}`;
+    const vid = generateVid();
+    const vlanName = `cy-vlan-${vid}`;
+    const cidr = "192.168.122.18";
+    const subnetName = `cy-subnet-${generateId()}`;
+
+    completeForm("Fabric", fabricName);
+    completeForm("Space", spaceName);
+    completeAddVlanForm(vid, vlanName, fabricName, spaceName);
+    completeAddSubnetForm(subnetName, cidr, fabricName, vid, vlanName);
+
+    cy.findAllByRole("row", { name: fabricName }).should("have.length", 2);
+
+    cy.findAllByRole("row", { name: fabricName })
+      .first()
+      .within(() => {
+        cy.findByRole("rowheader").within(() =>
+          cy.findByText(fabricName).should("be.visible")
+        );
+      });
+
+    cy.findAllByRole("row", { name: fabricName })
+      .eq(1)
+      .within(() => {
+        cy.findByRole("rowheader").within(() =>
+          cy.findByText(fabricName).should("not.be.visible")
+        );
+        cy.findByRole("column", { name: "VLAN" }).should(
+          "have.text",
+          `${vid} (${vlanName})`
+        );
+        cy.findByRole("column", { name: "Subnet" }).should(
+          "include.text",
+          `(${subnetName})`
+        );
+        cy.findByRole("column", { name: "Space" }).should(
+          "have.text",
+          spaceName
+        );
+      });
+  });
+
   it("displays an error when trying to add a VLAN with a VID that already exists", () => {
-    const VID = `${Math.floor(Math.random() * 100)}`;
-
-    const completeForm = () => {
-      cy.findByRole("button", { name: "Add" }).click();
-      cy.findByRole("button", { name: "VLAN" }).click();
-      cy.findByRole("textbox", { name: "VID" }).type(VID);
-      cy.findByRole("combobox", { name: "Fabric" }).select(1);
-      cy.findByRole("combobox", { name: "Space" }).select(1);
-      cy.findByRole("button", { name: "Add VLAN" }).click();
-    };
-
-    completeForm();
-    completeForm();
-
+    const vid = generateVid();
+    const name = `cypress-${vid}`;
+    completeAddVlanForm(vid, name);
+    completeAddVlanForm(vid, name);
     cy.findByText(
       /A VLAN with the specified VID already exists in the destination fabric./
     ).should("exist");
+  });
+
+  it(`displays an error when trying to add a Fabric with a name that already exists`, () => {
+    const name = `cypress-${generateId()}`;
+    completeForm("Fabric", name);
+    completeForm("Fabric", name);
+    cy.findByText(/this Name already exists/).should("be.visible");
+  });
+
+  it(`displays an error when trying to add a Space with a name that already exists`, () => {
+    const name = `cypress-${generateId()}`;
+    completeForm("Space", name);
+    completeForm("Space", name);
+    cy.findByText(/this Name already exists/).should("be.visible");
   });
 });

--- a/integration/cypress/integration/subnets/subnets.spec.ts
+++ b/integration/cypress/integration/subnets/subnets.spec.ts
@@ -1,0 +1,59 @@
+import { generateNewURL } from "@maas-ui/maas-ui-shared";
+
+context("Subnets", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateNewURL("/networks?by=fabric"));
+    cy.viewport("macbook-11");
+  });
+
+  it("renders the correct heading", () => {
+    cy.findByRole("heading", { level: 1 }).contains("Subnets");
+  });
+
+  it("displays the main networking view correctly", () => {
+    const expectedHeaders = [
+      "Fabric",
+      "VLAN",
+      "DHCP",
+      "Subnet",
+      "Available IPs",
+      "Space",
+    ];
+
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      expectedHeaders.forEach((name) => {
+        cy.findByRole("columnheader", { name }).should("exist");
+      });
+    });
+  });
+
+  it("updates the URL to default grouping if no group paramater has been set", () => {
+    cy.visit(generateNewURL("/networks"));
+
+    cy.findByRole("combobox", { name: "Group by" }).within(() => {
+      cy.findByRole("option", { selected: true }).contains("Fabric");
+    });
+
+    cy.url().should("include", generateNewURL("/networks?by=fabric"));
+  });
+
+  it("allows grouping by fabric and space", () => {
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findAllByRole("columnheader").first().should("have.text", "Fabric");
+    });
+
+    cy.findByRole("combobox", { name: "Group by" }).within(() => {
+      cy.findByRole("option", { selected: true }).contains("Fabric");
+      cy.findByRole("option", { selected: false }).contains("Space");
+    });
+
+    cy.findByRole("combobox", { name: "Group by" }).select("Space");
+
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findAllByRole("columnheader").first().should("have.text", "Space");
+    });
+
+    cy.url().should("include", generateNewURL("/networks?by=space"));
+  });
+});

--- a/integration/cypress/integration/utils.ts
+++ b/integration/cypress/integration/utils.ts
@@ -14,3 +14,4 @@ export const generateMac = () =>
 
 export const generateEmail = () => `${nanoid()}@example.com`;
 export const generateId = () => nanoid();
+export const generateVid = () => `${Math.floor(Math.random() * 1000)}`;

--- a/ui/package.json
+++ b/ui/package.json
@@ -89,6 +89,7 @@
     "@types/path-parse": "1.0.19",
     "@typescript-eslint/eslint-plugin": "5.10.0",
     "@typescript-eslint/parser": "5.10.0",
+    "@welldone-software/why-did-you-render": "6.2.3",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
     "babel-eslint": "10.1.0",
     "babel-plugin-macros": "3.1.0",

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -37,6 +37,7 @@ const FormikForm = <V, E = null>({
   submitAppearance,
   submitDisabled,
   submitLabel,
+  "aria-label": ariaLabel,
   ...formikProps
 }: Props<V, E>): JSX.Element => {
   return (
@@ -44,6 +45,7 @@ const FormikForm = <V, E = null>({
       <FormikFormContent<V, E>
         allowAllEmpty={allowAllEmpty}
         allowUnchanged={allowUnchanged}
+        aria-label={ariaLabel}
         buttonsAlign={buttonsAlign}
         buttonsBordered={buttonsBordered}
         buttonsClassName={buttonsClassName}

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -39,7 +39,7 @@ export type Props<V, E> = {
   savedRedirect?: string | null;
   saving?: boolean;
   submitDisabled?: boolean;
-} & AriaAttributes &
+} & Pick<AriaAttributes, "aria-label"> &
   FormikFormButtonsProps<V>;
 
 const generateNonFieldError = <V, E = null>(

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { ReactNode } from "react";
+import type { ReactNode, AriaAttributes } from "react";
 
 import { Form, Notification } from "@canonical/react-components";
 import { useFormikContext } from "formik";
@@ -39,7 +39,8 @@ export type Props<V, E> = {
   savedRedirect?: string | null;
   saving?: boolean;
   submitDisabled?: boolean;
-} & FormikFormButtonsProps<V>;
+} & AriaAttributes &
+  FormikFormButtonsProps<V>;
 
 const generateNonFieldError = <V, E = null>(
   values: V,
@@ -86,6 +87,7 @@ const FormikFormContent = <V, E = null>({
   savedRedirect,
   saving,
   submitDisabled,
+  "aria-label": ariaLabel,
   ...buttonsProps
 }: Props<V, E>): JSX.Element => {
   const formikContext = useFormikContext<V>();
@@ -156,7 +158,12 @@ const FormikFormContent = <V, E = null>({
   }
 
   return (
-    <Form className={className} inline={inline} onSubmit={handleSubmit}>
+    <Form
+      className={className}
+      inline={inline}
+      onSubmit={handleSubmit}
+      aria-label={ariaLabel}
+    >
       {!!nonFieldError && (
         <Notification severity="negative" title="Error:">
           {nonFieldError}

--- a/ui/src/app/base/hooks/urls.ts
+++ b/ui/src/app/base/hooks/urls.ts
@@ -1,4 +1,6 @@
-import { useParams } from "react-router";
+import { useMemo } from "react";
+
+import { useParams, useLocation } from "react-router";
 
 import { parseNumberId } from "app/utils";
 
@@ -27,3 +29,9 @@ export function useGetURLId<P extends RouteParams, K extends keyof P>(
   }
   return parseNumberId(id);
 }
+
+export const useQuery = (): URLSearchParams => {
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
+};

--- a/ui/src/app/store/fabric/utils.ts
+++ b/ui/src/app/store/fabric/utils.ts
@@ -17,3 +17,14 @@ export const getFabricDisplay = (
     return `fabric-${fabric.id}`;
   }
 };
+
+/**
+ * Get a fabric with a given id
+ * @param fabrics - The fabrics to check.
+ * @param fabricId - Fabric id
+ * @returns fabric with a given id
+ */
+export const getFabricById = (
+  fabrics: Fabric[],
+  fabricId: Fabric["id"]
+): Fabric | null => fabrics.find((fabric) => fabric?.id === fabricId) || null;

--- a/ui/src/app/store/space/utils.ts
+++ b/ui/src/app/store/space/utils.ts
@@ -1,0 +1,11 @@
+import type { Space } from "./types";
+
+export const getSpaceDisplay = (space?: Space | null): string =>
+  space?.name || "No space";
+
+export const getSpaceById = (
+  spaces: Space[],
+  spaceId: Space["id"] | null
+): Space | undefined => {
+  return spaces.find((space) => space?.id === spaceId);
+};

--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -42,6 +42,12 @@ export const getAvailableIPs = (subnet: Subnet | null | undefined): string => {
   }
 };
 
+/**
+ * Get Subnets for a given VLAN id
+ * @param subnets - Subnets.
+ * @param vlanId - VLAN id.
+ * @return Subnets for a given VLAN id
+ */
 export const getSubnetsInVLAN = (
   subnets: Subnet[],
   vlanId: VLAN["id"]

--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -1,4 +1,6 @@
+import type { Space } from "app/store/space/types";
 import type { Subnet, SubnetDetails } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
 
 /**
  * Get the Subnet display text.
@@ -26,3 +28,32 @@ export const getSubnetDisplay = (
 export const isSubnetDetails = (
   subnet?: Subnet | null
 ): subnet is SubnetDetails => !!subnet && "ip_addresses" in subnet;
+
+/**
+ * Get the Subnet available IPs.
+ * @param subnet - A subnet.
+ * @return Subnet's available IPs string, e.g. "100%"
+ */
+export const getAvailableIPs = (subnet: Subnet | null | undefined): string => {
+  if (!subnet) {
+    return "Unconfigured";
+  } else {
+    return `${subnet?.statistics?.available_string}`;
+  }
+};
+
+export const getSubnetsInVLAN = (
+  subnets: Subnet[],
+  vlanId: VLAN["id"]
+): Subnet[] => subnets.filter((subnet) => subnet.vlan === vlanId);
+
+/**
+ * Get subnets in a given space
+ * @param subnets - The subnets to check.
+ * @param spaceId - Space id
+ * @returns subnets in a given space.
+ */
+export const getSubnetsInSpace = (
+  subnets: Subnet[],
+  spaceId: Space["id"]
+): Subnet[] => subnets.filter((subnet) => subnet.space === spaceId);

--- a/ui/src/app/store/vlan/utils.ts
+++ b/ui/src/app/store/vlan/utils.ts
@@ -83,3 +83,22 @@ export const getDHCPStatus = (
  */
 export const isVLANDetails = (vlan?: VLAN | null): vlan is VLANDetails =>
   !!vlan && "space_ids" in vlan;
+
+/**
+ * Returns VLANs for a given fabric id.
+ * @param vlans - The available vlans.
+ * @param fabricId - A fabric id.
+ * @returns Whether the VLAN is of type VLANDetails.
+ */
+export const getVLANsInFabric = (
+  vlans: VLAN[],
+  fabricId: Fabric["id"]
+): VLAN[] => vlans.filter((vlan) => vlan.fabric === fabricId);
+
+/**
+ * @param vlans - The available vlans.
+ * @param vlanId - A VLAN id.
+ * @returns VLAN with a given id.
+ */
+export const getVlanById = (vlans: VLAN[], vlanId: VLAN["id"]): VLAN | null =>
+  vlans.find((vlan) => vlan?.id === vlanId) || null;

--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -1,8 +1,10 @@
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
+
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import type { Space, SpaceMeta } from "app/store/space/types";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
-import { argPath } from "app/utils";
+import { argPath, isId } from "app/utils";
 
 const urls = {
   index: "/networks", // ?by = 'fabric' | 'space'
@@ -20,4 +22,14 @@ const urls = {
   },
 };
 
+const getFabricLink = (id?: Fabric["id"]): string | null =>
+  isId(id) ? generateLegacyURL(`/fabric/${id}`) : null;
+const getSpaceLink = (id?: Space["id"]): string | null =>
+  isId(id) ? generateLegacyURL(`/space/${id}`) : null;
+const getVLANLink = (id?: VLAN["id"]): string | null =>
+  isId(id) ? generateLegacyURL(`/vlan/${id}`) : null;
+const getSubnetLink = (id?: Subnet["id"]): string | null =>
+  isId(id) ? generateLegacyURL(`/subnet/${id}`) : null;
+
 export default urls;
+export { getFabricLink, getSpaceLink, getVLANLink, getSubnetLink };

--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -1,4 +1,4 @@
-import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
+import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import type { Space, SpaceMeta } from "app/store/space/types";
@@ -23,13 +23,13 @@ const urls = {
 };
 
 const getFabricLink = (id?: Fabric["id"]): string | null =>
-  isId(id) ? generateLegacyURL(`/fabric/${id}`) : null;
+  isId(id) ? generateNewURL(`/fabric/${id}`) : null;
 const getSpaceLink = (id?: Space["id"]): string | null =>
-  isId(id) ? generateLegacyURL(`/space/${id}`) : null;
+  isId(id) ? generateNewURL(`/space/${id}`) : null;
 const getVLANLink = (id?: VLAN["id"]): string | null =>
-  isId(id) ? generateLegacyURL(`/vlan/${id}`) : null;
+  isId(id) ? generateNewURL(`/vlan/${id}`) : null;
 const getSubnetLink = (id?: Subnet["id"]): string | null =>
-  isId(id) ? generateLegacyURL(`/subnet/${id}`) : null;
+  isId(id) ? generateNewURL(`/subnet/${id}`) : null;
 
 export default urls;
 export { getFabricLink, getSpaceLink, getVLANLink, getSubnetLink };

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -23,6 +23,7 @@ const AddFabric = ({
 
   return (
     <FormikForm<AddFabricValues>
+      aria-label="Add fabric"
       buttonsBordered={false}
       allowAllEmpty
       initialValues={{ name: "" }}

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -23,6 +23,7 @@ const AddSpace = ({
 
   return (
     <FormikForm<AddSpaceValues>
+      aria-label="Add space"
       buttonsBordered={false}
       allowAllEmpty
       initialValues={{ name: "" }}

--- a/ui/src/app/subnets/views/FormActions/components/AddSubnet.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSubnet.tsx
@@ -119,6 +119,7 @@ const AddSubnet = ({
 
   return (
     <FormikForm<AddSubnetValues>
+      aria-label="Add subnet"
       validationSchema={addSubnetSchema}
       buttonsBordered={false}
       allowAllEmpty

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -57,6 +57,7 @@ const AddVlan = ({
 
   return (
     <FormikForm<AddVlanValues>
+      aria-label="Add VLAN"
       validationSchema={vlanSchema}
       buttonsBordered={false}
       initialValues={{

--- a/ui/src/app/subnets/views/Subnets.tsx
+++ b/ui/src/app/subnets/views/Subnets.tsx
@@ -5,7 +5,7 @@ import subnetsURLs from "app/subnets/urls";
 import FabricDetails from "app/subnets/views/FabricDetails";
 import SpaceDetails from "app/subnets/views/SpaceDetails";
 import SubnetDetails from "app/subnets/views/SubnetDetails";
-import SubnetsList from "app/subnets/views/SubnetsList";
+import SubnetsList from "app/subnets/views/SubnetsList/SubnetsList";
 import VLANDetails from "app/subnets/views/VLANDetails";
 
 const Subnets = (): JSX.Element => {

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import SubnetsControls from "./SubnetsControls";
+
+it("renders select element correctly", () => {
+  render(<SubnetsControls groupBy="fabric" setGroupBy={jest.fn()} />);
+  expect(screen.getByRole("combobox", { name: "Group by" })).toBeVisible();
+});
+
+it("displays additional information for group by on press", () => {
+  render(<SubnetsControls groupBy="fabric" setGroupBy={jest.fn()} />);
+  expect(
+    screen.queryByTestId("subnets-groupby-help-text")
+  ).not.toBeInTheDocument();
+  userEvent.click(screen.getByRole("button", { name: "more about group by" }));
+  expect(screen.getByTestId("subnets-groupby-help-text")).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+import { Row, Col, Button, Select } from "@canonical/react-components";
+
+import type {
+  GroupByKey,
+  SubnetGroupByProps,
+} from "app/subnets/views/SubnetsList/SubnetsTable/types";
+
+const SubnetsControls = ({
+  groupBy,
+  setGroupBy,
+}: SubnetGroupByProps): JSX.Element => {
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
+
+  return (
+    <Row>
+      <Col size={3}>
+        <Select
+          aria-label="Group by"
+          label={
+            <>
+              Group by{" "}
+              <Button
+                aria-label="more about group by"
+                appearance="base"
+                dense
+                hasIcon
+                onClick={() => setIsInfoOpen(!isInfoOpen)}
+              >
+                <i className="p-icon--question"></i>
+              </Button>
+            </>
+          }
+          name="groupBy"
+          value={groupBy}
+          onChange={(event) => {
+            setGroupBy(event.target.value as GroupByKey);
+          }}
+          options={[
+            {
+              label: "Fabric",
+              value: "fabric",
+            },
+            {
+              label: "Space",
+              value: "space",
+            },
+          ]}
+        />
+        {isInfoOpen ? (
+          <div data-testId="subnets-groupby-help-text">
+            <p className="p-form-help-text">
+              <strong>Fabric</strong> is a set of consistent interconnected
+              VLANs that are capable of mutual communication.
+            </p>
+            <p className="p-form-help-text">
+              <strong>Space</strong> is a grouping of networks (VLANs and their
+              subnets) that are able to mutually communicate with each other.
+            </p>
+            <p className="p-form-help-text">
+              Subnets within a space do not need to belong to the same fabric.
+            </p>
+          </div>
+        ) : null}
+      </Col>
+    </Row>
+  );
+};
+
+export default SubnetsControls;

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsControls/index.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsControls/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetsControls";

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -1,15 +1,41 @@
-import React from "react";
+import React, { useEffect, useCallback } from "react";
 
 import { ContextualMenu } from "@canonical/react-components";
+import { useHistory } from "react-router";
+
+import SubnetsTable from "./SubnetsTable";
+import type { GroupByKey } from "./SubnetsTable/types";
 
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
+import { useWindowTitle } from "app/base/hooks";
+import { useQuery } from "app/base/hooks/urls";
 import { SubnetForms } from "app/subnets/enum";
 import type { SubnetForm } from "app/subnets/types";
 import FormActions from "app/subnets/views/FormActions";
 
 const SubnetsList = (): JSX.Element => {
+  useWindowTitle("Subnets");
   const [activeForm, setActiveForm] = React.useState<SubnetForm | null>(null);
+  const query = useQuery();
+  const history = useHistory();
+  const groupBy = query.get("by");
+  const setGroupBy = useCallback(
+    (group: GroupByKey) =>
+      history.replace({
+        pathname: "/networks",
+        search: `?by=${group}`,
+      }),
+    [history]
+  );
+
+  const hasValidGroupBy = groupBy && ["fabric", "space"].includes(groupBy);
+
+  useEffect(() => {
+    if (!hasValidGroupBy) {
+      setGroupBy("fabric");
+    }
+  }, [groupBy, setGroupBy, hasValidGroupBy]);
 
   return (
     <Section
@@ -45,7 +71,11 @@ const SubnetsList = (): JSX.Element => {
           />
         </>
       }
-    ></Section>
+    >
+      {hasValidGroupBy ? (
+        <SubnetsTable groupBy={groupBy as GroupByKey} setGroupBy={setGroupBy} />
+      ) : null}
+    </Section>
   );
 };
 

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
@@ -1,0 +1,102 @@
+import { memo } from "react";
+
+import { Table, TableRow } from "@canonical/react-components";
+
+import { getRowPropsAreEqual } from "../utils";
+
+import {
+  TableHeader,
+  TableCell,
+} from "app/subnets/views/SubnetsList/SubnetsTable/components";
+import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
+
+export const FabricRow = memo(
+  ({ columns }: SubnetsTableRow): JSX.Element => (
+    <TableRow aria-label={columns.fabric.label || undefined}>
+      <TableCell
+        role="rowheader"
+        className="subnets-table__cell--fabric"
+        aria-label="Fabric"
+        cellData={columns.fabric}
+      >
+        {columns.fabric.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--vlan"
+        aria-label="VLAN"
+        cellData={columns.vlan}
+      >
+        {columns.vlan.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--dhcp"
+        aria-label="DHCP"
+        cellData={columns.dhcp}
+      >
+        {columns.dhcp.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--subnet"
+        aria-label="Subnet"
+        cellData={columns.subnet}
+      >
+        {columns.subnet.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--ips"
+        aria-label="IPs"
+        cellData={columns.ips}
+      >
+        {columns.ips.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--space u-align--right"
+        aria-label="Space"
+        cellData={columns.space}
+      >
+        {columns.space.label}
+      </TableCell>
+    </TableRow>
+  ),
+  getRowPropsAreEqual
+);
+
+const FabricTable = ({ rows }: { rows: SubnetsTableRow[] }): JSX.Element => {
+  return (
+    <Table role="table" className="subnets-table" aria-label="Subnets">
+      <thead>
+        <tr>
+          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
+          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
+          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
+          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
+          <TableHeader
+            label="Available IPs"
+            className="subnets-table__cell--ips"
+          />
+          <TableHeader
+            label="Space"
+            className="subnets-table__cell--space u-align--right"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => {
+          return (
+            <FabricRow
+              key={`${row.sortData?.fabricId}-${row.sortData?.vlanId}-${i}`}
+              {...row}
+            />
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+};
+
+export default FabricTable;

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/index.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricTable";

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
@@ -1,0 +1,116 @@
+import { memo, useState } from "react";
+
+import { Table, TableRow, Button } from "@canonical/react-components";
+
+import { getRowPropsAreEqual } from "../utils";
+
+import {
+  TableHeader,
+  TableCell,
+} from "app/subnets/views/SubnetsList/SubnetsTable/components";
+import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
+
+export const SpaceRow = memo(({ columns }: SubnetsTableRow): JSX.Element => {
+  const [isWarningOpen, setIsWarningOpen] = useState(false);
+  return (
+    <TableRow aria-label={columns.space.label || undefined}>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--space"
+        aria-label="Space"
+        cellData={columns.space}
+      >
+        {columns.space.label === "No space" ? (
+          <Button
+            appearance="base"
+            dense
+            hasIcon
+            aria-label="No space - press to see more information"
+            onClick={() => setIsWarningOpen(!isWarningOpen)}
+          >
+            <i className="p-icon--warning"></i> <span>No space</span>
+          </Button>
+        ) : (
+          columns.space.label
+        )}
+        {isWarningOpen ? (
+          <div>
+            MAAS integrations require a space in order to determine the purpose
+            of a network. Define a space for each subnet by selecting the space
+            on the VLAN details page.
+          </div>
+        ) : null}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--vlan"
+        aria-label="VLAN"
+        cellData={columns.vlan}
+      >
+        {columns.vlan.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--dhcp"
+        aria-label="DHCP"
+        cellData={columns.dhcp}
+      >
+        {columns.dhcp.label}
+      </TableCell>
+      <TableCell
+        role="rowheader"
+        className="subnets-table__cell--fabric"
+        aria-label="Fabric"
+        cellData={columns.fabric}
+      >
+        {columns.fabric.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--subnet"
+        aria-label="Subnet"
+        cellData={columns.subnet}
+      >
+        {columns.subnet.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--ips u-align--right"
+        aria-label="IPs"
+        cellData={columns.ips}
+      >
+        {columns.ips.label}
+      </TableCell>
+    </TableRow>
+  );
+}, getRowPropsAreEqual);
+
+const SpaceTable = ({ rows }: { rows: SubnetsTableRow[] }): JSX.Element => {
+  return (
+    <Table role="table" className="subnets-table" aria-label="Subnets">
+      <thead>
+        <tr>
+          <TableHeader label="Space" className="subnets-table__cell--space" />
+          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
+          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
+          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
+          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
+          <TableHeader
+            label="Available IPs"
+            className="subnets-table__cell--ips u-align--right"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <SpaceRow
+            key={`${row.sortData?.spaceName}-${row.sortData?.vlanId}-${i}`}
+            {...row}
+          />
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+export default SpaceTable;

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/index.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceTable";

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
@@ -1,86 +1,9 @@
-import { Table } from "@canonical/react-components";
-
+import FabricTable from "./FabricTable";
+import SpaceTable from "./SpaceTable";
 import { useSubnetsTable } from "./hooks";
 
 import SubnetsControls from "app/subnets/views/SubnetsList/SubnetsControls";
-import {
-  TableHeader,
-  FabricRow,
-  SpaceRow,
-} from "app/subnets/views/SubnetsList/SubnetsTable/components";
-import type {
-  SubnetsTableRow,
-  SubnetGroupByProps,
-} from "app/subnets/views/SubnetsList/SubnetsTable/types";
-
-const FabricTable = ({
-  rows,
-}: {
-  rows: SubnetsTableRow[] | null;
-}): JSX.Element => {
-  return (
-    <Table role="table" className="subnets-table" aria-label="Subnets">
-      <thead>
-        <tr>
-          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
-          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
-          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
-          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
-          <TableHeader
-            label="Available IPs"
-            className="subnets-table__cell--ips"
-          />
-          <TableHeader
-            label="Space"
-            className="subnets-table__cell--space u-align--right"
-          />
-        </tr>
-      </thead>
-      <tbody>
-        {rows?.map((row, i) => {
-          return (
-            <FabricRow
-              key={`${row.sortData?.fabricId}-${row.sortData?.vlanId}-${i}`}
-              {...row}
-            />
-          );
-        })}
-      </tbody>
-    </Table>
-  );
-};
-
-const SpaceTable = ({
-  rows,
-}: {
-  rows: SubnetsTableRow[] | null;
-}): JSX.Element => {
-  return (
-    <Table role="table" className="subnets-table" aria-label="Subnets">
-      <thead>
-        <tr>
-          <TableHeader label="Space" className="subnets-table__cell--space" />
-          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
-          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
-          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
-          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
-          <TableHeader
-            label="Available IPs"
-            className="subnets-table__cell--ips u-align--right"
-          />
-        </tr>
-      </thead>
-      <tbody>
-        {rows?.map((row, i) => (
-          <SpaceRow
-            key={`${row.sortData?.spaceName}-${row.sortData?.vlanId}-${i}`}
-            {...row}
-          />
-        ))}
-      </tbody>
-    </Table>
-  );
-};
+import type { SubnetGroupByProps } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
 const SubnetsTable = ({
   groupBy,

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
@@ -1,0 +1,104 @@
+import { Table } from "@canonical/react-components";
+
+import { useSubnetsTable } from "./hooks";
+
+import SubnetsControls from "app/subnets/views/SubnetsList/SubnetsControls";
+import {
+  TableHeader,
+  FabricRow,
+  SpaceRow,
+} from "app/subnets/views/SubnetsList/SubnetsTable/components";
+import type {
+  SubnetsTableRow,
+  SubnetGroupByProps,
+} from "app/subnets/views/SubnetsList/SubnetsTable/types";
+
+const FabricTable = ({
+  rows,
+}: {
+  rows: SubnetsTableRow[] | null;
+}): JSX.Element => {
+  return (
+    <Table role="table" className="subnets-table" aria-label="Subnets">
+      <thead>
+        <tr>
+          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
+          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
+          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
+          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
+          <TableHeader
+            label="Available IPs"
+            className="subnets-table__cell--ips"
+          />
+          <TableHeader
+            label="Space"
+            className="subnets-table__cell--space u-align--right"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        {rows?.map((row, i) => {
+          return (
+            <FabricRow
+              key={`${row.sortData?.fabricId}-${row.sortData?.vlanId}-${i}`}
+              {...row}
+            />
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+};
+
+const SpaceTable = ({
+  rows,
+}: {
+  rows: SubnetsTableRow[] | null;
+}): JSX.Element => {
+  return (
+    <Table role="table" className="subnets-table" aria-label="Subnets">
+      <thead>
+        <tr>
+          <TableHeader label="Space" className="subnets-table__cell--space" />
+          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
+          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
+          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
+          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
+          <TableHeader
+            label="Available IPs"
+            className="subnets-table__cell--ips u-align--right"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        {rows?.map((row, i) => (
+          <SpaceRow
+            key={`${row.sortData?.spaceName}-${row.sortData?.vlanId}-${i}`}
+            {...row}
+          />
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+const SubnetsTable = ({
+  groupBy,
+  setGroupBy,
+}: SubnetGroupByProps): JSX.Element | null => {
+  const { rows } = useSubnetsTable(groupBy);
+
+  return (
+    <>
+      <SubnetsControls groupBy={groupBy} setGroupBy={setGroupBy} />
+
+      {groupBy === "fabric" ? (
+        <FabricTable rows={rows} />
+      ) : (
+        <SpaceTable rows={rows} />
+      )}
+    </>
+  );
+};
+
+export default SubnetsTable;

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -1,0 +1,191 @@
+import { memo, useState } from "react";
+
+import {
+  TableRow as TableRowComponent,
+  TableHeader as TableHeaderComponent,
+  TableCell as TableCellComponent,
+  Button,
+} from "@canonical/react-components";
+import type {
+  TableHeaderProps,
+  TableCellProps,
+} from "@canonical/react-components";
+
+import type { SubnetsTableRow, SubnetsTableColumn } from "./types";
+import { getRowPropsAreEqual } from "./utils";
+
+export const TableHeader = ({
+  label,
+  ...props
+}: TableHeaderProps & {
+  label: string;
+}): JSX.Element => (
+  <TableHeaderComponent {...props}>{label}</TableHeaderComponent>
+);
+
+const TableCell = ({
+  cellData,
+  children,
+  className,
+  ...props
+}: TableCellProps & {
+  cellData: SubnetsTableColumn;
+}): JSX.Element => (
+  <TableCellComponent
+    className={`${className} ${
+      cellData.isVisuallyHidden ? "u-no-border--top" : ""
+    }`}
+    {...props}
+  >
+    <span
+      className={
+        cellData.isVisuallyHidden ? "subnets-table__visually-hidden" : ""
+      }
+    >
+      {cellData.href ? <a href={cellData.href}>{children}</a> : children}
+    </span>
+  </TableCellComponent>
+);
+
+export const FabricRow = memo(
+  ({ columns }: SubnetsTableRow): JSX.Element => (
+    <TableRowComponent
+      aria-label={columns.fabric.label || undefined}
+      style={{
+        transition: "opacity 250ms",
+        opacity: 1,
+      }}
+    >
+      <TableCell
+        role="rowheader"
+        className="subnets-table__cell--fabric"
+        aria-label="Fabric"
+        cellData={columns.fabric}
+      >
+        {columns.fabric.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--vlan"
+        aria-label="VLAN"
+        cellData={columns.vlan}
+      >
+        {columns.vlan.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--dhcp"
+        aria-label="DHCP"
+        cellData={columns.dhcp}
+      >
+        {columns.dhcp.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--subnet"
+        aria-label="Subnet"
+        cellData={columns.subnet}
+      >
+        {columns.subnet.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--ips"
+        aria-label="IPs"
+        cellData={columns.ips}
+      >
+        {columns.ips.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--space u-align--right"
+        aria-label="Space"
+        cellData={columns.space}
+      >
+        {columns.space.label}
+      </TableCell>
+    </TableRowComponent>
+  ),
+  getRowPropsAreEqual
+);
+
+export const SpaceRow = memo(({ columns }: SubnetsTableRow): JSX.Element => {
+  const [isWarningOpen, setIsWarningOpen] = useState(false);
+  return (
+    <TableRowComponent
+      aria-label={columns.fabric.label || undefined}
+      style={{
+        transition: "opacity 250ms",
+        opacity: 1,
+      }}
+    >
+      <TableCell
+        role="column"
+        className="subnets-table__cell--space"
+        aria-label="Space"
+        cellData={columns.space}
+      >
+        {columns.space.label === "No space" ? (
+          <Button
+            appearance="base"
+            dense
+            hasIcon
+            aria-label="No space - press to see more information"
+            onClick={() => setIsWarningOpen(!isWarningOpen)}
+          >
+            <i className="p-icon--warning"></i> <span>No space</span>
+          </Button>
+        ) : (
+          columns.space.label
+        )}
+        {isWarningOpen ? (
+          <div>
+            MAAS integrations require a space in order to determine the purpose
+            of a network. Define a space for each subnet by selecting the space
+            on the VLAN details page.
+          </div>
+        ) : null}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--vlan"
+        aria-label="VLAN"
+        cellData={columns.vlan}
+      >
+        {columns.vlan.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--dhcp"
+        aria-label="DHCP"
+        cellData={columns.dhcp}
+      >
+        {columns.dhcp.label}
+      </TableCell>
+      <TableCell
+        role="rowheader"
+        className="subnets-table__cell--fabric"
+        aria-label="Fabric"
+        cellData={columns.fabric}
+      >
+        {columns.fabric.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--subnet"
+        aria-label="Subnet"
+        cellData={columns.subnet}
+      >
+        {columns.subnet.label}
+      </TableCell>
+      <TableCell
+        role="column"
+        className="subnets-table__cell--ips u-align--right"
+        aria-label="IPs"
+        cellData={columns.ips}
+      >
+        {columns.ips.label}
+      </TableCell>
+    </TableRowComponent>
+  );
+}, getRowPropsAreEqual);

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -1,18 +1,13 @@
-import { memo, useState } from "react";
-
-import {
-  TableRow as TableRowComponent,
-  TableHeader as TableHeaderComponent,
-  TableCell as TableCellComponent,
-  Button,
-} from "@canonical/react-components";
 import type {
-  TableHeaderProps,
   TableCellProps,
+  TableHeaderProps,
+} from "@canonical/react-components";
+import {
+  TableCell as TableCellComponent,
+  TableHeader as TableHeaderComponent,
 } from "@canonical/react-components";
 
-import type { SubnetsTableRow, SubnetsTableColumn } from "./types";
-import { getRowPropsAreEqual } from "./utils";
+import type { SubnetsTableColumn } from "./types";
 
 export const TableHeader = ({
   label,
@@ -23,7 +18,7 @@ export const TableHeader = ({
   <TableHeaderComponent {...props}>{label}</TableHeaderComponent>
 );
 
-const TableCell = ({
+export const TableCell = ({
   cellData,
   children,
   className,
@@ -46,146 +41,3 @@ const TableCell = ({
     </span>
   </TableCellComponent>
 );
-
-export const FabricRow = memo(
-  ({ columns }: SubnetsTableRow): JSX.Element => (
-    <TableRowComponent
-      aria-label={columns.fabric.label || undefined}
-      style={{
-        transition: "opacity 250ms",
-        opacity: 1,
-      }}
-    >
-      <TableCell
-        role="rowheader"
-        className="subnets-table__cell--fabric"
-        aria-label="Fabric"
-        cellData={columns.fabric}
-      >
-        {columns.fabric.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--vlan"
-        aria-label="VLAN"
-        cellData={columns.vlan}
-      >
-        {columns.vlan.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--dhcp"
-        aria-label="DHCP"
-        cellData={columns.dhcp}
-      >
-        {columns.dhcp.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--subnet"
-        aria-label="Subnet"
-        cellData={columns.subnet}
-      >
-        {columns.subnet.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--ips"
-        aria-label="IPs"
-        cellData={columns.ips}
-      >
-        {columns.ips.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--space u-align--right"
-        aria-label="Space"
-        cellData={columns.space}
-      >
-        {columns.space.label}
-      </TableCell>
-    </TableRowComponent>
-  ),
-  getRowPropsAreEqual
-);
-
-export const SpaceRow = memo(({ columns }: SubnetsTableRow): JSX.Element => {
-  const [isWarningOpen, setIsWarningOpen] = useState(false);
-  return (
-    <TableRowComponent
-      aria-label={columns.fabric.label || undefined}
-      style={{
-        transition: "opacity 250ms",
-        opacity: 1,
-      }}
-    >
-      <TableCell
-        role="column"
-        className="subnets-table__cell--space"
-        aria-label="Space"
-        cellData={columns.space}
-      >
-        {columns.space.label === "No space" ? (
-          <Button
-            appearance="base"
-            dense
-            hasIcon
-            aria-label="No space - press to see more information"
-            onClick={() => setIsWarningOpen(!isWarningOpen)}
-          >
-            <i className="p-icon--warning"></i> <span>No space</span>
-          </Button>
-        ) : (
-          columns.space.label
-        )}
-        {isWarningOpen ? (
-          <div>
-            MAAS integrations require a space in order to determine the purpose
-            of a network. Define a space for each subnet by selecting the space
-            on the VLAN details page.
-          </div>
-        ) : null}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--vlan"
-        aria-label="VLAN"
-        cellData={columns.vlan}
-      >
-        {columns.vlan.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--dhcp"
-        aria-label="DHCP"
-        cellData={columns.dhcp}
-      >
-        {columns.dhcp.label}
-      </TableCell>
-      <TableCell
-        role="rowheader"
-        className="subnets-table__cell--fabric"
-        aria-label="Fabric"
-        cellData={columns.fabric}
-      >
-        {columns.fabric.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--subnet"
-        aria-label="Subnet"
-        cellData={columns.subnet}
-      >
-        {columns.subnet.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--ips u-align--right"
-        aria-label="IPs"
-        cellData={columns.ips}
-      >
-        {columns.ips.label}
-      </TableCell>
-    </TableRowComponent>
-  );
-}, getRowPropsAreEqual);

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/hooks.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/hooks.ts
@@ -17,7 +17,7 @@ import vlanSelectors from "app/store/vlan/selectors";
 export const useSubnetsTable = (
   groupBy: GroupByKey = "fabric"
 ): {
-  rows: SubnetsTableRow[] | null;
+  rows: SubnetsTableRow[];
 } => {
   const dispatch = useDispatch();
   const fabrics = useSelector(fabricSelectors.all);
@@ -30,7 +30,7 @@ export const useSubnetsTable = (
   const spacesLoaded = useSelector(spaceSelectors.loaded);
   const loaded = fabricsLoaded && vlansLoaded && subnetsLoaded && spacesLoaded;
 
-  const [rows, setRows] = useState<SubnetsTableRow[] | null>(null);
+  const [rows, setRows] = useState<SubnetsTableRow[]>([]);
 
   useEffect(() => {
     if (!fabricsLoaded) dispatch(fabricActions.fetch());

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/hooks.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/hooks.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import type { SubnetsTableRow, GroupByKey } from "./types";
+import { getTableData } from "./utils";
+
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import { actions as spaceActions } from "app/store/space";
+import spaceSelectors from "app/store/space/selectors";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+export const useSubnetsTable = (
+  groupBy: GroupByKey = "fabric"
+): {
+  rows: SubnetsTableRow[] | null;
+} => {
+  const dispatch = useDispatch();
+  const fabrics = useSelector(fabricSelectors.all);
+  const fabricsLoaded = useSelector(fabricSelectors.loaded);
+  const vlans = useSelector(vlanSelectors.all);
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+  const subnets = useSelector(subnetSelectors.all);
+  const spaces = useSelector(spaceSelectors.all);
+  const spacesLoaded = useSelector(spaceSelectors.loaded);
+  const loaded = fabricsLoaded && vlansLoaded && subnetsLoaded && spacesLoaded;
+
+  const [rows, setRows] = useState<SubnetsTableRow[] | null>(null);
+
+  useEffect(() => {
+    if (!fabricsLoaded) dispatch(fabricActions.fetch());
+    if (!vlansLoaded) dispatch(vlanActions.fetch());
+    if (!subnetsLoaded) dispatch(subnetActions.fetch());
+    if (!spacesLoaded) dispatch(spaceActions.fetch());
+  }, [dispatch, fabricsLoaded, vlansLoaded, subnetsLoaded, spacesLoaded]);
+
+  useEffect(() => {
+    if (loaded) {
+      setRows(getTableData({ fabrics, vlans, subnets, spaces }, groupBy));
+    }
+  }, [loaded, fabrics, vlans, subnets, spaces, setRows, groupBy]);
+
+  return { rows };
+};

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/index.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetsTable";

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/types.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/types.ts
@@ -1,0 +1,54 @@
+import type { Fabric } from "app/store/fabric/types";
+import type { Space } from "app/store/space/types";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
+
+export type GroupByKey = "fabric" | "space";
+
+export type SubnetsTableData = {
+  fabrics: Fabric[];
+  vlans: VLAN[];
+  subnets: Subnet[];
+  spaces: Space[];
+};
+
+export type SubnetsTableColumn = {
+  isVisuallyHidden: boolean;
+  label: string | null;
+  href: string | null;
+};
+
+type SortKey = number | string;
+
+export type SortData = {
+  fabricId: SortKey;
+  fabricName: SortKey;
+  vlanId: SortKey;
+  spaceName: SortKey;
+  cidr: SortKey;
+};
+
+export type SubnetGroupByProps = {
+  groupBy: GroupByKey;
+  setGroupBy: (group: GroupByKey) => void;
+};
+
+export type SortDataKey =
+  | "fabricId"
+  | "fabricName"
+  | "vlanId"
+  | "spaceName"
+  | "cidr";
+
+export type SubnetsTableRow = {
+  columns: {
+    fabric: SubnetsTableColumn;
+    vlan: SubnetsTableColumn;
+    dhcp: SubnetsTableColumn;
+    subnet: SubnetsTableColumn;
+    ips: SubnetsTableColumn;
+    space: SubnetsTableColumn;
+  };
+  sortData: SortData;
+  children?: React.ReactChildren[];
+};

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
@@ -1,0 +1,61 @@
+import { getTableData } from "./utils";
+
+import {
+  fabric as fabricFactory,
+  vlan as vlanFactory,
+  subnet as subnetFactory,
+  space as spaceFactory,
+} from "testing/factories";
+
+test("getTableData generates correct sortData for fabric", () => {
+  const fabrics = [fabricFactory({ id: 1, vlan_ids: [1] })];
+  const vlans = [vlanFactory({ id: 1, fabric: 1 })];
+  const subnets = [subnetFactory({ vlan: 1, cidr: "172.16.1.0/24" })];
+  const spaces = [spaceFactory({ vlan_ids: [1] })];
+  expect(
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[0].sortData
+  ).toEqual({
+    cidr: "172.16.1.0/24",
+    fabricId: 1,
+    fabricName: "test-fabric",
+    spaceName: "no space",
+    vlanId: 1,
+  });
+});
+
+test("getTableData returns grouped fabrics in a correct format", () => {
+  const fabrics = [
+    fabricFactory({ id: 1, vlan_ids: [1] }),
+    fabricFactory({ id: 2 }),
+  ];
+  const vlans = [vlanFactory({ fabric: 1 }), vlanFactory({ fabric: 1 })];
+  const subnets = [subnetFactory(), subnetFactory()];
+  const spaces = [spaceFactory()];
+
+  expect(
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[0]?.columns
+      .fabric
+  ).toStrictEqual({
+    href: "/MAAS/l/fabric/1",
+    isVisuallyHidden: false,
+    label: "test-fabric",
+  });
+
+  expect(
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[1]?.columns
+      .fabric
+  ).toStrictEqual({
+    href: "/MAAS/l/fabric/1",
+    isVisuallyHidden: true,
+    label: "test-fabric",
+  });
+
+  expect(
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[2]?.columns
+      .fabric
+  ).toStrictEqual({
+    href: "/MAAS/l/fabric/2",
+    isVisuallyHidden: false,
+    label: "test-fabric",
+  });
+});

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
@@ -36,7 +36,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[0]?.columns
       .fabric
   ).toStrictEqual({
-    href: "/MAAS/l/fabric/1",
+    href: "/MAAS/r/fabric/1",
     isVisuallyHidden: false,
     label: "test-fabric",
   });
@@ -45,7 +45,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[1]?.columns
       .fabric
   ).toStrictEqual({
-    href: "/MAAS/l/fabric/1",
+    href: "/MAAS/r/fabric/1",
     isVisuallyHidden: true,
     label: "test-fabric",
   });
@@ -54,7 +54,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[2]?.columns
       .fabric
   ).toStrictEqual({
-    href: "/MAAS/l/fabric/2",
+    href: "/MAAS/r/fabric/2",
     isVisuallyHidden: false,
     label: "test-fabric",
   });

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.tsx
@@ -1,0 +1,213 @@
+import type {
+  SubnetsTableRow,
+  SubnetsTableData,
+  GroupByKey,
+  SortData,
+} from "./types";
+
+import type { Fabric } from "app/store/fabric/types";
+import { getFabricById, getFabricDisplay } from "app/store/fabric/utils";
+import type { Space } from "app/store/space/types";
+import { getSpaceDisplay, getSpaceById } from "app/store/space/utils";
+import type { Subnet } from "app/store/subnet/types";
+import {
+  getAvailableIPs,
+  getSubnetDisplay,
+  getSubnetsInSpace,
+  getSubnetsInVLAN,
+} from "app/store/subnet/utils";
+import type { VLAN } from "app/store/vlan/types";
+import {
+  getDHCPStatus,
+  getVlanById,
+  getVLANDisplay,
+  getVLANsInFabric,
+} from "app/store/vlan/utils";
+import {
+  getFabricLink,
+  getSpaceLink,
+  getSubnetLink,
+  getVLANLink,
+} from "app/subnets/urls";
+import { simpleSortByKey } from "app/utils";
+
+export const getRowPropsAreEqual = (
+  prevProps: SubnetsTableRow,
+  nextProps: SubnetsTableRow
+): boolean => {
+  return (
+    prevProps.columns.fabric.label === nextProps.columns.fabric.label &&
+    prevProps.columns.vlan.label === nextProps.columns.vlan.label &&
+    prevProps.columns.vlan.href === nextProps.columns.vlan.href &&
+    prevProps.columns.dhcp.label === nextProps.columns.dhcp.label &&
+    prevProps.columns.subnet.label === nextProps.columns.subnet.label &&
+    prevProps.columns.subnet.href === nextProps.columns.subnet.href &&
+    prevProps.columns.ips.label === nextProps.columns.ips.label &&
+    prevProps.columns.space.label === nextProps.columns.space.label &&
+    prevProps.columns.space.href === nextProps.columns.space.href &&
+    prevProps.columns.space.isVisuallyHidden ===
+      nextProps.columns.space.isVisuallyHidden &&
+    prevProps.columns.vlan.isVisuallyHidden ===
+      nextProps.columns.vlan.isVisuallyHidden &&
+    prevProps.columns.fabric.isVisuallyHidden ===
+      nextProps.columns.fabric.isVisuallyHidden
+  );
+};
+
+const sortBySortKey =
+  (key: keyof SortData, { reverse } = { reverse: false }) =>
+  (a: SubnetsTableRow, b: SubnetsTableRow): number => {
+    if (a.sortData[key] > b.sortData[key]) return reverse ? -1 : 1;
+    if (a.sortData[key] < b.sortData[key]) return reverse ? 1 : -1;
+    return 0;
+  };
+
+const getColumn = (label: string | null, href?: string | null) => ({
+  label,
+  href: href ? href : null,
+  isVisuallyHidden: false,
+});
+
+const markRepeatedFabricRows = (rows: SubnetsTableRow[]): SubnetsTableRow[] => {
+  rows.forEach((row, index) => {
+    const previousRow: SubnetsTableRow = rows[index - 1];
+
+    if (row.columns && index > 0) {
+      if (row.sortData?.fabricId === previousRow?.sortData?.fabricId) {
+        row.columns.fabric = { ...row.columns.fabric, isVisuallyHidden: true };
+      }
+      if (row.sortData?.vlanId === previousRow?.sortData?.vlanId) {
+        row.columns.vlan = { ...row.columns.vlan, isVisuallyHidden: true };
+      }
+    }
+  });
+
+  return rows;
+};
+
+const markRepeatedSpaceRows = (rows: SubnetsTableRow[]): SubnetsTableRow[] => {
+  rows.forEach((row, index) => {
+    const previousRow: SubnetsTableRow = rows[index - 1];
+
+    if (row.columns.space?.label === previousRow?.columns.space?.label) {
+      row.columns.space = { ...row.columns.space, isVisuallyHidden: true };
+    }
+  });
+
+  return rows;
+};
+
+const getRowData = ({
+  fabric,
+  vlan,
+  subnet,
+  space,
+  data,
+}: {
+  fabric?: Fabric;
+  vlan?: VLAN;
+  subnet?: Subnet;
+  space?: Space;
+  data?: SubnetsTableData;
+}): SubnetsTableRow => {
+  return {
+    columns: {
+      fabric: getColumn(getFabricDisplay(fabric), getFabricLink(fabric?.id)),
+      vlan: getColumn(
+        getVLANDisplay(vlan),
+        vlan?.id ? getVLANLink(vlan?.id) : null
+      ),
+      dhcp: getColumn(
+        data ? getDHCPStatus(vlan, data.vlans, data.fabrics, true) : null
+      ),
+      subnet: getColumn(
+        subnet?.id ? getSubnetDisplay(subnet) : null,
+        subnet?.id ? getSubnetLink(subnet?.id) : null
+      ),
+      ips: getColumn(subnet ? getAvailableIPs(subnet) : null),
+      space: getColumn(getSpaceDisplay(space), getSpaceLink(space?.id)),
+    },
+    sortData: {
+      fabricId: fabric?.id || "",
+      fabricName: getFabricDisplay(fabric)?.toLowerCase() || "",
+      vlanId: vlan?.id || "",
+
+      spaceName: getSpaceDisplay(space)?.toLowerCase() || "",
+      cidr: subnet?.cidr || "",
+    },
+  };
+};
+
+const getOrphanVLANs = (data: SubnetsTableData): SubnetsTableRow[] => {
+  const rows: SubnetsTableRow[] = [];
+  const subnets = [...data.subnets].filter((subnet) => subnet.space === null);
+  subnets.forEach((subnet) => {
+    const vlan = getVlanById(data.vlans, subnet.vlan) as VLAN;
+    const fabric = getFabricById(data.fabrics, vlan.fabric) as Fabric;
+    rows.push(getRowData({ fabric, vlan, subnet, space: undefined, data }));
+  });
+
+  return markRepeatedSpaceRows(rows.sort(sortBySortKey("cidr")));
+};
+
+const getBySpaces = (data: SubnetsTableData): SubnetsTableRow[] => {
+  const rows: SubnetsTableRow[] = [];
+
+  if (data.spaces.length > 0) {
+    data.spaces.forEach((space) => {
+      const subnets = getSubnetsInSpace(data.subnets, space.id);
+
+      if (subnets.length < 1) {
+        rows.push(getRowData({ space, data }));
+      }
+      subnets.forEach((subnet) => {
+        const vlan = getVlanById(data.vlans, subnet.vlan) as VLAN;
+        const fabric = getFabricById(data.fabrics, vlan.fabric) as Fabric;
+        rows.push(getRowData({ fabric, vlan, subnet, space, data }));
+      });
+    });
+  }
+
+  return markRepeatedSpaceRows(rows.sort(sortBySortKey("spaceName")));
+};
+
+const getByFabric = (data: SubnetsTableData): SubnetsTableRow[] => {
+  const rows: SubnetsTableRow[] = [];
+
+  data.fabrics.forEach((fabric) => {
+    const fabricHasVLANs = fabric.vlan_ids.length > 0;
+    if (!fabricHasVLANs) {
+      rows.push(getRowData({ fabric }));
+    } else {
+      const vlansInFabric = getVLANsInFabric(data.vlans, fabric.id).sort(
+        simpleSortByKey("vid")
+      );
+      vlansInFabric.forEach((vlan) => {
+        const subnetsInVLAN = getSubnetsInVLAN(data.subnets, vlan.id);
+        const vlanHasSubnets = subnetsInVLAN.length > 0;
+        if (!vlanHasSubnets) {
+          const space = getSpaceById(data.spaces, vlan.space);
+          rows.push(getRowData({ fabric, vlan, space, data }));
+        } else {
+          subnetsInVLAN.forEach((subnet) => {
+            const space = getSpaceById(data.spaces, subnet.space);
+            rows.push(getRowData({ fabric, vlan, subnet, space, data }));
+          });
+        }
+      });
+    }
+  });
+
+  return markRepeatedFabricRows(rows.sort(sortBySortKey("fabricName")));
+};
+
+export const getTableData = (
+  data: SubnetsTableData,
+  filterBy: GroupByKey
+): SubnetsTableRow[] => {
+  if (filterBy === "fabric") {
+    return getByFabric(data);
+  } else {
+    return [...getBySpaces(data), ...getOrphanVLANs(data)];
+  }
+};

--- a/ui/src/app/subnets/views/SubnetsList/_index.scss
+++ b/ui/src/app/subnets/views/SubnetsList/_index.scss
@@ -1,0 +1,56 @@
+.subnets-table {
+  tr:not(:first-child) {
+    border-top: 0 !important;
+  }
+  tbody tr:not(:first-child) td {
+    border-top: 1px solid $color-mid-light;
+  }
+
+  tbody {
+    tr:hover,
+    tr:focus {
+      background-color: $color-x-light;
+    }
+  }
+
+  td {
+    padding-top: $spv-inner--x-small;
+    padding-bottom: $spv-inner--x-small;
+  }
+
+  .subnets-table__cell--fabric {
+    width: 13%;
+  }
+
+  .subnets-table__cell--space {
+    width: 14%;
+  }
+
+  .subnets-table__cell--vlan {
+    width: 13%;
+  }
+
+  .subnets-table__cell--subnet {
+    width: 28%;
+  }
+
+  .subnets-table__cell--ips {
+    width: 12%;
+  }
+
+  .subnets-table__cell--dhcp {
+    width: 20%;
+  }
+}
+
+@media (min-width: 773px) {
+  .subnets-table__visually-hidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}

--- a/ui/src/app/subnets/views/SubnetsList/index.ts
+++ b/ui/src/app/subnets/views/SubnetsList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetsList";

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -31,6 +31,10 @@
     display: flex;
   }
 
+  .u-block {
+    display: block !important;
+  }
+
   .u-flex--align-baseline {
     align-items: baseline;
     display: flex;
@@ -168,5 +172,19 @@
   .u-text--default-size {
     font-size: map-get($base-font-sizes, base);
     font-weight: $font-weight-regular-text;
+  }
+
+  .u-no-border--top {
+    border-top: 0 !important;
+  }
+
+  .u-visually-hidden:not(:focus):not(:active) {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
   }
 }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -230,6 +230,9 @@
 @include OverviewCard;
 @include SourceMachineSelect;
 
+// subnets
+@import "~app/subnets/views/SubnetsList";
+
 // preferences
 @import "~app/preferences/views/APIKeys/APIKeyList";
 @import "~app/preferences/views/SSLKeys/AddSSLKey";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4207,6 +4207,13 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
   integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
 
+"@welldone-software/why-did-you-render@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-6.2.3.tgz#cdd5e27cf25b7e767c1c0b0e8808f67d3f6be833"
+  integrity sha512-FQgi90jvC9uw2aALlonJfqaWOvU5UUBBVvdAnS2iryXwCc4YJkKsPJY5Y/LzaND3OIyk8XGUn1vTRn6hcem28Q==
+  dependencies:
+    lodash "^4"
+
 "@wojtekmaj/enzyme-adapter-react-17@0.6.6":
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.6.tgz#2ee3d4956caea4de05e372e5d9f39b31becffe6a"
@@ -11441,7 +11448,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
+"lodash@>=3.5 <5", lodash@^4, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Done

- refactor: subnets table view

### Note:
- additional improvements will be investigated as part of https://github.com/canonical-web-and-design/app-tribe/issues/681
  - data model and implementation for table rows groups could use some work, followed the structure in legacy implementation for now (adding `isVisuallyHidden` key to each subsequent item in the group)
  - I made some work into UI performance  (only a single row re-renders on update, instead of the entire table) but this needs to be investigated further - we need to make sure this works with a very large dataset (e.g. few thousands of entries)
  - implementation could be refactored to be closer to how machines list (e.g. search pattern in `machine/utils/search.ts`)


## Screenshots
### No space warning toggle
![image](https://user-images.githubusercontent.com/7452681/150681837-5823f61d-3fb2-46cd-a04b-a42153c7e1c6.png)

![image](https://user-images.githubusercontent.com/7452681/150681841-3ea52056-1db4-4743-ab49-73ffe6126b5e.png)
_Using a button toggle instead of tooltip for better accessibility_


### Group by more information toggle
![image](https://user-images.githubusercontent.com/7452681/150821652-7a2a3ce8-4b1e-4b6e-bb01-eaef31d9f090.png)
_Collapsed_

![image](https://user-images.githubusercontent.com/7452681/150821633-6bdfa7bf-4097-4296-a990-3fe055e912a8.png)
_Expanded_




## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `MAAS/r/networks?by=fabric` and try breaking the table by adding different items / changing the view from/to group by fabric/space

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
