### PR TITLE
feat(ui): add tags view

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -27,6 +27,7 @@ import settingsURLs from "app/settings/urls";
 import Settings from "app/settings/views/Settings";
 import subnetsURLs from "app/subnets/urls";
 import Subnets from "app/subnets/views/Subnets";
+import tagURLs from "app/tags/urls";
 import zonesURLs from "app/zones/urls";
 import Zones from "app/zones/views/Zones";
 
@@ -120,6 +121,14 @@ const Routes = (): JSX.Element => (
     />
     <Route
       path={poolsURLs.pools}
+      render={() => (
+        <ErrorBoundary>
+          <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={tagURLs.tags.index}
       render={() => (
         <ErrorBoundary>
           <Machines />

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -17,6 +17,8 @@ import {
   resourcePool as resourcePoolFactory,
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
@@ -63,6 +65,10 @@ describe("MachineListHeader", () => {
           resourcePoolFactory({ id: 0, name: "default" }),
           resourcePoolFactory({ id: 1, name: "other" }),
         ],
+      }),
+      tag: tagStateFactory({
+        loaded: true,
+        items: [tagFactory(), tagFactory()],
       }),
       zone: zoneStateFactory({
         loaded: true,
@@ -111,9 +117,10 @@ describe("MachineListHeader", () => {
     );
   });
 
-  it("displays machine and resource pool counts if loaded", () => {
+  it("displays machine, resource pool and tag counts if loaded", () => {
     state.machine.loaded = true;
     state.resourcepool.loaded = true;
+    state.tag.loaded = true;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -131,6 +138,7 @@ describe("MachineListHeader", () => {
     const tabs = wrapper.find('[data-testid="section-header-tabs"]');
     expect(tabs.find("Link").at(0).text()).toBe("2 Machines");
     expect(tabs.find("Link").at(1).text()).toBe("2 Resource pools");
+    expect(tabs.find("Link").at(2).text()).toBe("2 Tags");
   });
 
   it("displays a selected machine filter button if some machines have been selected", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -24,6 +24,9 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import tagURLs from "app/tags/urls";
 
 type Props = {
   headerContent: MachineHeaderContent | null;
@@ -42,10 +45,12 @@ export const MachineListHeader = ({
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const resourcePools = useSelector(resourcePoolSelectors.all);
   const selectedMachines = useSelector(machineSelectors.selected);
+  const tags = useSelector(tagSelectors.all);
 
   useEffect(() => {
     dispatch(machineActions.fetch());
     dispatch(resourcePoolActions.fetch());
+    dispatch(tagActions.fetch());
   }, [dispatch]);
 
   useEffect(() => {
@@ -122,6 +127,12 @@ export const MachineListHeader = ({
           component: Link,
           label: `${pluralize("Resource pool", resourcePools.length, true)}`,
           to: poolsURLs.pools,
+        },
+        {
+          active: location.pathname.startsWith(tagURLs.tags.index),
+          component: Link,
+          label: `${pluralize("Tag", tags.length, true)}`,
+          to: tagURLs.tags.index,
         },
       ]}
       title={getHeaderTitle("Machines", headerContent)}

--- a/ui/src/app/machines/views/Machines.test.tsx
+++ b/ui/src/app/machines/views/Machines.test.tsx
@@ -14,6 +14,7 @@ import machineURLs from "app/machines/urls";
 import poolsURLs from "app/pools/urls";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
+import tagURLs from "app/tags/urls";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -104,6 +105,10 @@ describe("Machines", () => {
     {
       component: "PoolEdit",
       path: poolsURLs.edit({ id: 1 }),
+    },
+    {
+      component: "Tags",
+      path: tagURLs.tags.index,
     },
     {
       component: "NotFound",

--- a/ui/src/app/machines/views/Machines.tsx
+++ b/ui/src/app/machines/views/Machines.tsx
@@ -15,6 +15,8 @@ import PoolAdd from "app/pools/views/PoolAdd";
 import PoolEdit from "app/pools/views/PoolEdit";
 import Pools from "app/pools/views/Pools";
 import { FilterMachines } from "app/store/machine/utils";
+import tagURLs from "app/tags/urls";
+import Tags from "app/tags/views/Tags";
 
 const Machines = (): JSX.Element => {
   const history = useHistory();
@@ -89,6 +91,7 @@ const Machines = (): JSX.Element => {
           path={poolsURLs.edit(null, true)}
           render={() => <PoolEdit />}
         />
+        <Route exact path={tagURLs.tags.index} render={() => <Tags />} />
         <Route path="*" render={() => <NotFound />} />
       </Switch>
     </Section>

--- a/ui/src/app/tags/urls.ts
+++ b/ui/src/app/tags/urls.ts
@@ -1,0 +1,7 @@
+const urls = {
+  tags: {
+    index: "/tags",
+  },
+};
+
+export default urls;

--- a/ui/src/app/tags/views/Tags.test.tsx
+++ b/ui/src/app/tags/views/Tags.test.tsx
@@ -1,0 +1,40 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import Tags from "./Tags";
+
+import type { RootState } from "app/store/root/types";
+import {
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("Tags", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      tag: tagStateFactory({
+        loaded: true,
+        items: [tagFactory(), tagFactory()],
+      }),
+    });
+  });
+
+  it("displays a loading component if pools are loading", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+          <Tags />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.text().includes("Tags")).toBe(true);
+  });
+});

--- a/ui/src/app/tags/views/Tags.tsx
+++ b/ui/src/app/tags/views/Tags.tsx
@@ -1,0 +1,8 @@
+import { useWindowTitle } from "app/base/hooks";
+
+const Tags = (): JSX.Element => {
+  useWindowTitle("Tags");
+  return <>Tags</>;
+};
+
+export default Tags;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,6 +4906,20 @@ babel-extract-comments@^1.0.0:
   dependencies:
     babylon "^6.18.0"
 
+babel-jest@26.6.3, babel-jest@^26.6.0, babel-jest@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
+  integrity sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==
+  dependencies:
+    "@jest/transform" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/babel__core" "^7.1.7"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^26.6.2"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    slash "^3.0.0"
+
 babel-jest@27.4.6, babel-jest@^27.4.6:
   version "27.4.6"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.6.tgz#4d024e69e241cdf4f396e453a07100f44f7ce314"
@@ -4916,20 +4930,6 @@ babel-jest@27.4.6, babel-jest@^27.4.6:
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
     babel-preset-jest "^27.4.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    slash "^3.0.0"
-
-babel-jest@^26.6.0, babel-jest@^26.6.3:
-  version "26.6.3"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
-  integrity sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==
-  dependencies:
-    "@jest/transform" "^26.6.2"
-    "@jest/types" "^26.6.2"
-    "@types/babel__core" "^7.1.7"
-    babel-plugin-istanbul "^6.0.0"
-    babel-preset-jest "^26.6.2"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
     slash "^3.0.0"
@@ -10212,7 +10212,7 @@ jest-circus@^27.4.6:
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
-jest-cli@^26.6.0:
+jest-cli@^26.6.0, jest-cli@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
   integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
@@ -11030,6 +11030,15 @@ jest@26.6.0:
     "@jest/core" "^26.6.0"
     import-local "^3.0.2"
     jest-cli "^26.6.0"
+
+jest@26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
+  integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  dependencies:
+    "@jest/core" "^26.6.3"
+    import-local "^3.0.2"
+    jest-cli "^26.6.3"
 
 jest@27.4.7:
   version "27.4.7"


### PR DESCRIPTION




## Done

- Set up the basic tags view.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list.
- There should be a new tab that shows the number of tags.
- Clicking on the tab should show the tags content (just "Tags" for now).

## Fixes

Fixes: canonical-web-and-design/app-tribe#680.