### PR TITLE
refactor: build subnets space summary

### DIFF
--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -9,6 +9,7 @@ import { actions as spaceActions } from "app/store/space";
 import subnetsURLs from "app/subnets/urls";
 import {
   spaceState as spaceStateFactory,
+  space as spaceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -128,4 +129,38 @@ it("shows a spinner if the space has not loaded yet", () => {
   expect(
     screen.getByTestId("section-header-title-spinner")
   ).toBeInTheDocument();
+});
+
+it("displays space details", async () => {
+  const space = spaceFactory({
+    id: 1,
+    name: "space1",
+    description: "space 1 description",
+  });
+  const state = rootStateFactory({
+    space: spaceStateFactory({
+      items: [space],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index(null, true)}
+          component={() => <SpaceDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const spaceSummary = await waitFor(() =>
+    screen.getByRole("region", { name: "Space summary" })
+  );
+  expect(within(spaceSummary).getByText(space.name)).toBeInTheDocument();
+  expect(within(spaceSummary).getByText(space.description)).toBeInTheDocument();
 });

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
@@ -53,7 +53,7 @@ const SpaceDetails = (): JSX.Element => {
 
   return (
     <Section header={<SpaceDetailsHeader space={space} />}>
-      <SpaceSummary />
+      <SpaceSummary name={space.name} description={space.description} />
       <SpaceSubnets />
     </Section>
   );

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, within } from "@testing-library/react";
+
+import SpaceSummary from "./SpaceSummary";
+
+it("displays space name and description", () => {
+  render(
+    <SpaceSummary
+      name="outer"
+      description="The cold, dark, emptiness of space."
+    />
+  );
+  const spaceSummary = screen.getByRole("region", { name: "Space summary" });
+
+  expect(within(spaceSummary).getByText("outer")).toBeInTheDocument();
+  expect(
+    within(spaceSummary).getByText("The cold, dark, emptiness of space.")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
@@ -1,9 +1,23 @@
 import { Strip } from "@canonical/react-components";
+import { nanoid } from "nanoid";
 
-const SpaceSummary = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Space summary</h2>
-  </Strip>
-);
+import Definition from "app/base/components/Definition";
+import type { Space } from "app/store/space/types";
+
+const SpaceSummary = ({
+  name,
+  description,
+}: Pick<Space, "name" | "description">): JSX.Element => {
+  const id = nanoid();
+  return (
+    <Strip shallow element="section" aria-labelledby={id}>
+      <h2 id={id} className="p-heading--4">
+        Space summary
+      </h2>
+      <Definition label="Name">{name}</Definition>
+      <Definition label="Description">{description}</Definition>
+    </Strip>
+  );
+};
 
 export default SpaceSummary;


### PR DESCRIPTION
## Done

- build subnets space summary in React

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/151162475-85572326-9fad-4870-80f2-15c59f97fae9.png)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to space details page, e.g. `/MAAS/r/space/1` and verify information within space summary is displayed correctly

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
