### PR TITLE
test: remove redundant cypress test

### DIFF
--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://0.0.0.0:8400",
+  "defaultCommandTimeout": "6000",
   "env": {
     "username": "admin",
     "password": "test",

--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -62,15 +62,6 @@ context("Subnets - Add", () => {
     });
   });
 
-  it("displays a newly added VLAN in the subnets table", () => {
-    const vid = generateVid();
-    const name = `cypress-${vid}`;
-    completeAddVlanForm(vid, name);
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
-      cy.findByRole("link", { name: `${vid} (${name})` }).should("be.visible");
-    });
-  });
-
   it("Groups items added to the same fabric correctly", () => {
     const fabricName = `cy-fabric-${generateId()}`;
     const spaceName = `cy-space-${generateId()}`;


### PR DESCRIPTION
## Done

- remove redundant cypress test (already testing if a newly added VLAN is displayed the subnets table in the [next test](https://github.com/canonical-web-and-design/maas-ui/blob/f6eef046fd51d08f2c07ff85366daeded0e43a46/integration/cypress/integration/subnets/add.spec.ts#L94-L97))
- increase default command timeout from 4 seconds to 6 seconds to reduce flakiness

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
