### PR TITLE
fix(ui): handle non-json bootresource responses

### DIFF
--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -333,28 +333,6 @@ describe("websocket sagas", () => {
     );
   });
 
-  it("can handle a WebSocket JSON response message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
-    expect(saga.next().value).toEqual(take(socketChannel));
-    expect(
-      saga.next({
-        data: JSON.stringify({ request_id: 99, result: '{"this_is": "JSON"}' }),
-      }).value
-    ).toEqual(call([socketClient, socketClient.getRequest], 99));
-    saga.next({
-      meta: { jsonResponse: true },
-      type: "test/action",
-      payload: { id: 808 },
-    });
-    expect(saga.next(false).value).toEqual(
-      put({
-        meta: { item: { id: 808 } },
-        type: "test/actionSuccess",
-        payload: { this_is: "JSON" },
-      })
-    );
-  });
-
   it("can handle a batch response", () => {
     const saga = handleMessage(socketChannel, socketClient);
     saga.next();

--- a/ui/src/app/base/sagas/websockets.ts
+++ b/ui/src/app/base/sagas/websockets.ts
@@ -473,14 +473,6 @@ export function* handleMessage(
             // If this uses the file context then don't dispatch the response
             // payload.
             result = null;
-          } else if (action.meta?.jsonResponse) {
-            try {
-              if (typeof response.result === "string") {
-                result = JSON.parse(response.result);
-              }
-            } catch {
-              error = "Error parsing API response";
-            }
           } else {
             result = response.result;
           }

--- a/ui/src/app/store/bootresource/actions.test.ts
+++ b/ui/src/app/store/bootresource/actions.test.ts
@@ -26,7 +26,6 @@ describe("bootresource actions", () => {
     ).toEqual({
       type: "bootresource/fetch",
       meta: {
-        jsonResponse: true,
         model: "bootresource",
         method: "fetch",
       },
@@ -45,7 +44,6 @@ describe("bootresource actions", () => {
     expect(actions.poll({ continuous: true })).toEqual({
       type: "bootresource/poll",
       meta: {
-        jsonResponse: true,
         model: "bootresource",
         method: "poll",
         poll: true,
@@ -58,7 +56,6 @@ describe("bootresource actions", () => {
     expect(actions.poll({ continuous: false })).toEqual({
       type: "bootresource/poll",
       meta: {
-        jsonResponse: true,
         model: "bootresource",
         method: "poll",
         poll: false,

--- a/ui/src/app/store/bootresource/slice.ts
+++ b/ui/src/app/store/bootresource/slice.ts
@@ -76,8 +76,6 @@ const bootResourceSlice = createSlice({
     fetch: {
       prepare: (params: FetchParams) => ({
         meta: {
-          // The data returned by the API is JSON for this endpoint.
-          jsonResponse: true,
           model: BootResourceMeta.MODEL,
           method: "fetch",
         },
@@ -112,8 +110,6 @@ const bootResourceSlice = createSlice({
     poll: {
       prepare: ({ continuous = true }) => ({
         meta: {
-          // The data returned by the API is JSON for this endpoint.
-          jsonResponse: true,
           model: BootResourceMeta.MODEL,
           method: "poll",
           poll: continuous,

--- a/ui/src/websocket-client.ts
+++ b/ui/src/websocket-client.ts
@@ -72,8 +72,6 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     dispatchMultiple?: boolean;
     // A key to be used to identify a file in the file context.
     fileContextKey?: string;
-    // Whether the response contains JSON that needs to be parsed.
-    jsonResponse?: boolean;
     // The endpoint method e.g. "list".
     method: string;
     // The endpoint model e.g. "machine".


### PR DESCRIPTION
## Done

- Update fetch and poll for bootresource to handle non-json responses.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click Images in the header.
- Check that the page loads and shows a list of images and there are no errors in the console.

## Fixes

Fixes: #3554.

## Launchpad issue

https://bugs.launchpad.net/maas/+bug/1959183