### PR TITLE
fix(ui): fix subnets table routes

### DIFF
--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -1,5 +1,3 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
-
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import type { Space, SpaceMeta } from "app/store/space/types";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
@@ -23,13 +21,13 @@ const urls = {
 };
 
 const getFabricLink = (id?: Fabric["id"]): string | null =>
-  isId(id) ? generateNewURL(`/fabric/${id}`) : null;
+  isId(id) ? urls.fabric.index({ id }) : null;
 const getSpaceLink = (id?: Space["id"]): string | null =>
-  isId(id) ? generateNewURL(`/space/${id}`) : null;
+  isId(id) ? urls.space.index({ id }) : null;
 const getVLANLink = (id?: VLAN["id"]): string | null =>
-  isId(id) ? generateNewURL(`/vlan/${id}`) : null;
+  isId(id) ? urls.vlan.index({ id }) : null;
 const getSubnetLink = (id?: Subnet["id"]): string | null =>
-  isId(id) ? generateNewURL(`/subnet/${id}`) : null;
+  isId(id) ? urls.subnet.index({ id }) : null;
 
 export default urls;
 export { getFabricLink, getSpaceLink, getVLANLink, getSubnetLink };

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -6,6 +6,7 @@ import {
   TableCell as TableCellComponent,
   TableHeader as TableHeaderComponent,
 } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 
 import type { SubnetsTableColumn } from "./types";
 
@@ -37,7 +38,7 @@ export const TableCell = ({
         cellData.isVisuallyHidden ? "subnets-table__visually-hidden" : ""
       }
     >
-      {cellData.href ? <a href={cellData.href}>{children}</a> : children}
+      {cellData.href ? <Link to={cellData.href}>{children}</Link> : children}
     </span>
   </TableCellComponent>
 );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
@@ -36,7 +36,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[0]?.columns
       .fabric
   ).toStrictEqual({
-    href: "/MAAS/r/fabric/1",
+    href: "/fabric/1",
     isVisuallyHidden: false,
     label: "test-fabric",
   });
@@ -45,7 +45,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[1]?.columns
       .fabric
   ).toStrictEqual({
-    href: "/MAAS/r/fabric/1",
+    href: "/fabric/1",
     isVisuallyHidden: true,
     label: "test-fabric",
   });
@@ -54,7 +54,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[2]?.columns
       .fabric
   ).toStrictEqual({
-    href: "/MAAS/r/fabric/2",
+    href: "/fabric/2",
     isVisuallyHidden: false,
     label: "test-fabric",
   });


### PR DESCRIPTION
## Done

- Use react-router `Link` component for subnets table routes to prevent app reload

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/MAAS/r/networks`
- Click on a few links for a fabric/VLAN/space/subnet
- Check that the app does not reload
