### PR TITLE
feat(ui): display the VLAN title and delete button

### DIFF
--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -26,6 +26,7 @@ const VLANDetails = (): JSX.Element => {
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
+
   const vlansLoading = useSelector(vlanSelectors.loading);
   const isValidID = isId(id);
   useWindowTitle(`${vlan?.name || "VLAN"} details`);
@@ -55,7 +56,7 @@ const VLANDetails = (): JSX.Element => {
   }
 
   return (
-    <Section header={<VLANDetailsHeader vlan={vlan} />}>
+    <Section header={<VLANDetailsHeader id={id} />}>
       <VLANSummary />
       <DHCPStatus />
       <ReservedRanges />

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -125,9 +125,6 @@ describe("VLANDetailsHeader", () => {
   });
 
   it("shows the delete button when the user is an admin and the vlan is not the default", () => {
-    // state.fabric.items = [
-    //   fabricFactory({ id: 2, name: "fabric1", default_vlan_id: vlan.id }),
-    // ];
     state.user = userStateFactory({
       auth: authStateFactory({
         user: userFactory({ is_superuser: true }),

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -1,33 +1,183 @@
 import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import VLANDetailsHeader from "./VLANDetailsHeader";
 
+import type { RootState } from "app/store/root/types";
+import type { VLAN } from "app/store/vlan/types";
+import { VlanVid } from "app/store/vlan/types";
 import {
+  authState as authStateFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
   vlan as vlanFactory,
   vlanDetails as vlanDetailsFactory,
+  vlanState as vlanStateFactory,
 } from "testing/factories";
 
-it("shows the vlan name as the section title", () => {
-  const vlan = vlanFactory({ id: 1, name: "vlan-1" });
-  render(<VLANDetailsHeader vlan={vlan} />);
+const mockStore = configureStore();
 
-  expect(screen.getByTestId("section-header-title")).toHaveTextContent(
-    "vlan-1"
-  );
-});
+describe("VLANDetailsHeader", () => {
+  let state: RootState;
+  let vlan: VLAN;
 
-it("shows a spinner subtitle if the vlan is loading details", () => {
-  const vlan = vlanFactory({ id: 1, name: "vlan-1" });
-  render(<VLANDetailsHeader vlan={vlan} />);
+  beforeEach(() => {
+    vlan = vlanDetailsFactory({ fabric: 2 });
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        items: [fabricFactory({ id: 2, name: "fabric1" })],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+      }),
+    });
+  });
 
-  expect(
-    screen.queryByTestId("section-header-subtitle-spinner")
-  ).toBeInTheDocument();
-});
+  it("shows the title when the vlan has a name", () => {
+    vlan = vlanDetailsFactory({ name: "vlan-1", fabric: 2 });
+    state.vlan.items = [vlan];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+      "vlan-1 in fabric1"
+    );
+  });
 
-it("does not show a spinner subtitle if the vlan is detailed", () => {
-  const vlan = vlanDetailsFactory({ id: 1, name: "vlan-1" });
-  render(<VLANDetailsHeader vlan={vlan} />);
+  it("shows the title when it is the default for the fabric", () => {
+    vlan = vlanDetailsFactory({
+      fabric: 2,
+      name: undefined,
+      vid: VlanVid.UNTAGGED,
+    });
+    state.vlan.items = [vlan];
+    state.fabric.items = [
+      fabricFactory({ id: 2, name: "fabric1", default_vlan_id: vlan.id }),
+    ];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+      "Default VLAN in fabric1"
+    );
+  });
 
-  expect(screen.queryByTestId("section-header-subtitle-spinner")).toBeNull();
+  it("shows the title when it is not the default for the fabric", () => {
+    vlan = vlanDetailsFactory({ fabric: 2, name: undefined, vid: 3 });
+    state.vlan.items = [vlan];
+    state.fabric.items = [
+      fabricFactory({ id: 2, name: "fabric1", default_vlan_id: 99 }),
+    ];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+      "VLAN 3 in fabric1"
+    );
+  });
+
+  it("shows a spinner subtitle if the vlan is loading details", () => {
+    vlan = vlanFactory({ name: "vlan-1" });
+    state.vlan.items = [vlan];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      screen.queryByTestId("section-header-subtitle-spinner")
+    ).toBeInTheDocument();
+  });
+
+  it("does not show a spinner subtitle if the vlan is detailed", () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.queryByTestId("section-header-subtitle-spinner")).toBeNull();
+  });
+
+  it("shows the delete button when the user is an admin and the vlan is not the default", () => {
+    // state.fabric.items = [
+    //   fabricFactory({ id: 2, name: "fabric1", default_vlan_id: vlan.id }),
+    // ];
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ is_superuser: true }),
+      }),
+    });
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.queryByTestId("delete-vlan")).toBeInTheDocument();
+  });
+
+  it("does not show the delete button if the user is not an admin", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ is_superuser: false }),
+      }),
+    });
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.queryByTestId("delete-vlan")).toBeNull();
+  });
+
+  it("does not show the delete button if the vlan is the default", () => {
+    state.fabric.items = [
+      fabricFactory({ id: 2, name: "fabric1", default_vlan_id: vlan.id }),
+    ];
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ is_superuser: true }),
+      }),
+    });
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
+          <VLANDetailsHeader id={vlan.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.queryByTestId("delete-vlan")).toBeNull();
+  });
 });

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -1,14 +1,74 @@
+import { useEffect } from "react";
+
+import { Button } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
 import SectionHeader from "app/base/components/SectionHeader";
-import type { VLAN } from "app/store/vlan/types";
+import authSelectors from "app/store/auth/selectors";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import { VlanVid } from "app/store/vlan/types";
 import { isVLANDetails } from "app/store/vlan/utils";
+import { isId } from "app/utils";
 
 type Props = {
-  vlan: VLAN;
+  id?: VLAN[VLANMeta.PK] | null;
 };
 
-const VLANDetailsHeader = ({ vlan }: Props): JSX.Element => {
+const generateTitle = (
+  vlan?: VLAN | null,
+  fabric?: Fabric | null
+): string | null => {
+  if (!vlan || !fabric) {
+    return null;
+  }
+  let title: string;
+  if (vlan.name) {
+    title = vlan.name;
+  } else if (vlan.vid === VlanVid.UNTAGGED) {
+    title = "Default VLAN";
+  } else {
+    title = `VLAN ${vlan.vid}`;
+  }
+  return `${title} in ${fabric.name}`;
+};
+
+const VLANDetailsHeader = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, id)
+  );
+  const fabricId = vlan?.fabric;
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, fabricId)
+  );
+  const isAdmin = useSelector(authSelectors.isAdmin);
+  const isFabricDefault = fabric && vlan && fabric.default_vlan_id === vlan.id;
+  const buttons = [];
+  if (isAdmin && !isFabricDefault) {
+    buttons.push(
+      <Button data-testid="delete-vlan" key="delete-vlan">
+        Delete VLAN
+      </Button>
+    );
+  }
+
+  useEffect(() => {
+    if (isId(fabricId)) {
+      dispatch(fabricActions.get(fabricId));
+    }
+  }, [dispatch, fabricId]);
+
   return (
-    <SectionHeader subtitleLoading={!isVLANDetails(vlan)} title={vlan.name} />
+    <SectionHeader
+      buttons={buttons}
+      subtitleLoading={!isVLANDetails(vlan)}
+      title={generateTitle(vlan, fabric)}
+    />
   );
 };
 


### PR DESCRIPTION
## Done

- Add the VLAN title and delete button.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React version of VLAN details, you should see a title.
- Go to a VLAN that is the default for a fabric, you should not see a delete button.
- Go to a VLAN that is not the default for a fabric, you should see a delete button.
- Log in as a non admin and go to a VLAN that is not the default for a fabric, you should not see a delete button.

## Fixes

Fixes: canonical-web-and-design/app-tribe#715.