### PR TITLE
feat(ui): add a form to delete a VLAN

### DIFF
--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
@@ -1,0 +1,54 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import VLANDeleteForm from "./VLANDeleteForm";
+
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import {
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { submitFormikForm } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("VLANDeleteForm", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      vlan: vlanStateFactory({
+        items: [vlanFactory({ id: 1 })],
+      }),
+    });
+  });
+
+  it("calls closeForm on cancel click", () => {
+    const closeForm = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <VLANDeleteForm id={1} closeForm={closeForm} />
+      </Provider>
+    );
+    wrapper.find("button[data-testid='cancel-action']").simulate("click");
+    expect(closeForm).toHaveBeenCalled();
+  });
+
+  it("can delete a VLAN", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <VLANDeleteForm id={1} closeForm={jest.fn()} />
+      </Provider>
+    );
+    submitFormikForm(wrapper);
+    const deleteAction = vlanActions.delete(1);
+    expect(
+      store.getActions().find((action) => action.type === deleteAction.type)
+    ).toStrictEqual(deleteAction);
+  });
+});

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+
+import { Icon } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikForm from "app/base/components/FormikForm";
+import type { EmptyObject } from "app/base/types";
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import subnetURLs from "app/subnets/urls";
+
+type Props = {
+  closeForm: () => void;
+  id?: VLAN[VLANMeta.PK] | null;
+};
+
+const VLANDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, id)
+  );
+  const errors = useSelector(vlanSelectors.errors);
+  const saved = useSelector(vlanSelectors.saved);
+  const saving = useSelector(vlanSelectors.saving);
+  const cleanup = useCallback(() => vlanActions.cleanup(), []);
+
+  if (!id || !vlan) {
+    return null;
+  }
+
+  return (
+    <FormikForm<EmptyObject>
+      buttonsBordered={false}
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{}}
+      onCancel={closeForm}
+      onSubmit={() => {
+        dispatch(cleanup());
+        dispatch(vlanActions.delete(id));
+      }}
+      savedRedirect={subnetURLs.index}
+      saved={saved}
+      saving={saving}
+      submitAppearance="negative"
+      submitLabel="Delete vlan"
+    >
+      <p
+        className="u-no-margin--bottom u-no-max-width"
+        data-testid="delete-message"
+      >
+        <Icon name="warning" className="is-inline" />
+        Are you sure you want to delete this VLAN?
+      </p>
+    </FormikForm>
+  );
+};
+
+export default VLANDeleteForm;

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
@@ -10,6 +10,7 @@ import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
 import subnetURLs from "app/subnets/urls";
+import { isId } from "app/utils";
 
 type Props = {
   closeForm: () => void;
@@ -26,7 +27,7 @@ const VLANDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
   const saving = useSelector(vlanSelectors.saving);
   const cleanup = useCallback(() => vlanActions.cleanup(), []);
 
-  if (!id || !vlan) {
+  if (!isId(id) || !vlan) {
     return null;
   }
 

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VLANDeleteForm";

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -1,5 +1,9 @@
+import { useState } from "react";
+
 import { Button } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+
+import VLANDeleteForm from "./VLANDeleteForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import authSelectors from "app/store/auth/selectors";
@@ -14,6 +18,10 @@ import { isVLANDetails } from "app/store/vlan/utils";
 type Props = {
   id?: VLAN[VLANMeta.PK] | null;
 };
+
+enum HeaderForms {
+  Delete,
+}
 
 const generateTitle = (
   vlan?: VLAN | null,
@@ -42,21 +50,38 @@ const VLANDetailsHeader = ({ id }: Props): JSX.Element => {
     fabricSelectors.getById(state, fabricId)
   );
   const isAdmin = useSelector(authSelectors.isAdmin);
+  const [formOpen, setFormOpen] = useState<HeaderForms | null>(null);
   const isFabricDefault = fabric && vlan && fabric.default_vlan_id === vlan.id;
   const buttons = [];
   if (isAdmin && !isFabricDefault) {
     buttons.push(
-      <Button data-testid="delete-vlan" key="delete-vlan">
+      <Button
+        data-testid="delete-vlan"
+        key="delete-vlan"
+        onClick={() => setFormOpen(HeaderForms.Delete)}
+      >
         Delete VLAN
       </Button>
     );
   }
+  const closeForm = () => {
+    setFormOpen(null);
+  };
 
   return (
     <SectionHeader
       buttons={buttons}
       subtitleLoading={!isVLANDetails(vlan)}
       title={generateTitle(vlan, fabric)}
+      headerContent={
+        formOpen === null ? null : (
+          <>
+            {formOpen === HeaderForms.Delete && (
+              <VLANDeleteForm closeForm={closeForm} id={id} />
+            )}
+          </>
+        )
+      }
     />
   );
 };


### PR DESCRIPTION
## Done

- Add a form to the VLAN details header to delete the VLAN.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the react VLAN details for a VLAN that is not the default (you might need to add a new VLAN).
- In the header click "Delete VLAN" and then confirm.
- The VLAN should get deleted.

## Fixes

Fixes: canonical-web-and-design/app-tribe#665.