### PR TITLE
feat(ui): add helper components for rendering network model links

### DIFF
--- a/ui/src/app/base/components/FabricLink/FabricLink.test.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import FabricLink from "./FabricLink";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders a spinner if fabrics are loading", () => {
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [], loading: true }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByLabelText("Loading fabrics")).toBeInTheDocument();
+});
+
+it("handles when a fabric does not exist", () => {
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [], loading: false }),
+  });
+  const store = mockStore(state);
+  const { container } = render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+it("renders a link if fabrics have loaded and it exists", () => {
+  const fabric = fabricFactory();
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [fabric], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricLink id={fabric.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    subnetsURLs.fabric.index({ id: fabric.id })
+  );
+});

--- a/ui/src/app/base/components/FabricLink/FabricLink.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.tsx
@@ -1,0 +1,41 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric, FabricMeta } from "app/store/fabric/types";
+import { getFabricDisplay } from "app/store/fabric/utils";
+import type { RootState } from "app/store/root/types";
+import subnetsURLs from "app/subnets/urls";
+
+type Props = {
+  id?: Fabric[FabricMeta.PK] | null;
+};
+
+const FabricLink = ({ id }: Props): JSX.Element => {
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, id)
+  );
+  const fabricsLoading = useSelector(fabricSelectors.loading);
+  const fabricDisplay = getFabricDisplay(fabric);
+
+  if (fabricsLoading) {
+    // TODO: Put aria-label directly on Spinner component when issue is fixed.
+    // https://github.com/canonical-web-and-design/react-components/issues/651
+    return (
+      <span aria-label="Loading fabrics">
+        <Spinner />
+      </span>
+    );
+  }
+  if (!fabric) {
+    return <>{fabricDisplay}</>;
+  }
+  return (
+    <Link to={subnetsURLs.fabric.index({ id: fabric.id })}>
+      {fabricDisplay}
+    </Link>
+  );
+};
+
+export default FabricLink;

--- a/ui/src/app/base/components/FabricLink/index.ts
+++ b/ui/src/app/base/components/FabricLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricLink";

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.test.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SpaceLink from "./SpaceLink";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  rootState as rootStateFactory,
+  space as spaceFactory,
+  spaceState as spaceStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders a spinner if spaces are loading", () => {
+  const state = rootStateFactory({
+    space: spaceStateFactory({ items: [], loading: true }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SpaceLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByLabelText("Loading spaces")).toBeInTheDocument();
+});
+
+it("handles when a space does not exist", () => {
+  const state = rootStateFactory({
+    space: spaceStateFactory({ items: [], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SpaceLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.queryByRole("link")).toBeNull();
+  expect(screen.getByText("No space")).toBeInTheDocument();
+});
+
+it("renders a link if spaces have loaded and it exists", () => {
+  const space = spaceFactory();
+  const state = rootStateFactory({
+    space: spaceStateFactory({ items: [space], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SpaceLink id={space.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    subnetsURLs.space.index({ id: space.id })
+  );
+});

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
@@ -1,0 +1,39 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import type { RootState } from "app/store/root/types";
+import spaceSelectors from "app/store/space/selectors";
+import type { Space, SpaceMeta } from "app/store/space/types";
+import { getSpaceDisplay } from "app/store/space/utils";
+import subnetsURLs from "app/subnets/urls";
+
+type Props = {
+  id?: Space[SpaceMeta.PK] | null;
+};
+
+const SpaceLink = ({ id }: Props): JSX.Element => {
+  const space = useSelector((state: RootState) =>
+    spaceSelectors.getById(state, id)
+  );
+  const spacesLoading = useSelector(spaceSelectors.loading);
+  const spaceDisplay = getSpaceDisplay(space);
+
+  if (spacesLoading) {
+    // TODO: Put aria-label directly on Spinner component when issue is fixed.
+    // https://github.com/canonical-web-and-design/react-components/issues/651
+    return (
+      <span aria-label="Loading spaces">
+        <Spinner />
+      </span>
+    );
+  }
+  if (!space) {
+    return <>{spaceDisplay}</>;
+  }
+  return (
+    <Link to={subnetsURLs.space.index({ id: space.id })}>{spaceDisplay}</Link>
+  );
+};
+
+export default SpaceLink;

--- a/ui/src/app/base/components/SpaceLink/index.ts
+++ b/ui/src/app/base/components/SpaceLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpaceLink";

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.test.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SubnetLink from "./SubnetLink";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders a spinner if subnets are loading", () => {
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [], loading: true }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SubnetLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByLabelText("Loading subnets")).toBeInTheDocument();
+});
+
+it("handles when a subnet does not exist", () => {
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SubnetLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.queryByRole("link")).toBeNull();
+  expect(screen.getByText("Unconfigured")).toBeInTheDocument();
+});
+
+it("renders a link if subnets have loaded and it exists", () => {
+  const subnet = subnetFactory();
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [subnet], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SubnetLink id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    subnetsURLs.subnet.index({ id: subnet.id })
+  );
+});

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
@@ -1,0 +1,41 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import type { RootState } from "app/store/root/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import { getSubnetDisplay } from "app/store/subnet/utils";
+import subnetsURLs from "app/subnets/urls";
+
+type Props = {
+  id?: Subnet[SubnetMeta.PK] | null;
+};
+
+const SubnetLink = ({ id }: Props): JSX.Element => {
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, id)
+  );
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+  const subnetDisplay = getSubnetDisplay(subnet);
+
+  if (subnetsLoading) {
+    // TODO: Put aria-label directly on Spinner component when issue is fixed.
+    // https://github.com/canonical-web-and-design/react-components/issues/651
+    return (
+      <span aria-label="Loading subnets">
+        <Spinner />
+      </span>
+    );
+  }
+  if (!subnet) {
+    return <>{subnetDisplay}</>;
+  }
+  return (
+    <Link to={subnetsURLs.subnet.index({ id: subnet.id })}>
+      {subnetDisplay}
+    </Link>
+  );
+};
+
+export default SubnetLink;

--- a/ui/src/app/base/components/SubnetLink/index.ts
+++ b/ui/src/app/base/components/SubnetLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetLink";

--- a/ui/src/app/base/components/VLANLink/VLANLink.test.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import VLANLink from "./VLANLink";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  rootState as rootStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders a spinner if vlans are loading", () => {
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [], loading: true }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <VLANLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByLabelText("Loading VLANs")).toBeInTheDocument();
+});
+
+it("handles when a VLAN does not exist", () => {
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [], loading: false }),
+  });
+  const store = mockStore(state);
+  const { container } = render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <VLANLink id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+it("renders a link if vlans have loaded and it exists", () => {
+  const vlan = vlanFactory();
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [vlan], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <VLANLink id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    subnetsURLs.vlan.index({ id: vlan.id })
+  );
+});

--- a/ui/src/app/base/components/VLANLink/VLANLink.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.tsx
@@ -1,0 +1,39 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import type { RootState } from "app/store/root/types";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import { getVLANDisplay } from "app/store/vlan/utils";
+import subnetsURLs from "app/subnets/urls";
+
+type Props = {
+  id?: VLAN[VLANMeta.PK] | null;
+};
+
+const VLANLink = ({ id }: Props): JSX.Element => {
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, id)
+  );
+  const vlansLoading = useSelector(vlanSelectors.loading);
+  const vlanDisplay = getVLANDisplay(vlan);
+
+  if (vlansLoading) {
+    // TODO: Put aria-label directly on Spinner component when issue is fixed.
+    // https://github.com/canonical-web-and-design/react-components/issues/651
+    return (
+      <span aria-label="Loading VLANs">
+        <Spinner />
+      </span>
+    );
+  }
+  if (!vlan) {
+    return <>{vlanDisplay}</>;
+  }
+  return (
+    <Link to={subnetsURLs.vlan.index({ id: vlan.id })}>{vlanDisplay}</Link>
+  );
+};
+
+export default VLANLink;

--- a/ui/src/app/base/components/VLANLink/index.ts
+++ b/ui/src/app/base/components/VLANLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VLANLink";

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -10,19 +10,15 @@ import {
 } from "@canonical/react-components";
 import { nanoid } from "nanoid";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";
+import FabricLink from "app/base/components/FabricLink";
+import SpaceLink from "app/base/components/SpaceLink";
 import controllerSelectors from "app/store/controller/selectors";
-import fabricSelectors from "app/store/fabric/selectors";
-import { getFabricDisplay } from "app/store/fabric/utils";
 import type { RootState } from "app/store/root/types";
-import spaceSelectors from "app/store/space/selectors";
-import { getSpaceDisplay } from "app/store/space/utils";
 import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
-import subnetsURLs from "app/subnets/urls";
 import { breakLines } from "app/utils";
 
 type Props = {
@@ -51,21 +47,10 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
     controllerSelectors.getByIDs(state, getRackIDs(vlan))
   );
   const controllersLoading = useSelector(controllerSelectors.loading);
-  const fabric = useSelector((state: RootState) =>
-    fabricSelectors.getById(state, vlan?.fabric)
-  );
-  const fabricsLoading = useSelector(fabricSelectors.loading);
-  const space = useSelector((state: RootState) =>
-    spaceSelectors.getById(state, vlan?.space)
-  );
-  const spacesLoading = useSelector(spaceSelectors.loading);
 
   if (!vlan) {
     return null;
   }
-
-  const fabricDisplay = getFabricDisplay(fabric);
-  const spaceDisplay = getSpaceDisplay(space);
   return (
     <Strip aria-labelledby={sectionID.current} element="section" shallow>
       <h2 className="p-heading--4" id={sectionID.current}>
@@ -80,32 +65,10 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
         </Col>
         <Col size={6}>
           <Definition label="Space">
-            {spacesLoading ? (
-              <Spinner />
-            ) : space ? (
-              <Link
-                data-testid="space-link"
-                to={subnetsURLs.space.index({ id: space.id })}
-              >
-                {spaceDisplay}
-              </Link>
-            ) : (
-              spaceDisplay
-            )}
+            <SpaceLink id={vlan.space} />
           </Definition>
           <Definition label="Fabric">
-            {fabricsLoading ? (
-              <Spinner />
-            ) : fabric ? (
-              <Link
-                data-testid="fabric-link"
-                to={subnetsURLs.fabric.index({ id: fabric.id })}
-              >
-                {fabricDisplay}
-              </Link>
-            ) : (
-              fabricDisplay
-            )}
+            <FabricLink id={vlan.fabric} />
           </Definition>
           <Definition
             label={


### PR DESCRIPTION
## Done

- Built helper components for each of fabric, space, subnet and VLANs that simply, given an ID:
  - returns a spinner if that model type is loading
  - handles when a model with that ID does not exist
  - returns a link to the React details page of that model instance

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React details page of a VLAN and check that the fabric and space links still render as before 

## Fixes

Fixes canonical-web-and-design/app-tribe#717
