### PR TITLE
feat(ui): add DHCP snippets table to subnet and vlan details

### DIFF
--- a/ui/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -112,12 +112,14 @@ describe("DHCPTable", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("TableRow").length).toBe(2);
     expect(
-      wrapper.find("[data-testid='snippet-applies-to']").at(0).text()
+      wrapper.find("TableCell[data-testid='snippet-applies-to']").length
+    ).toBe(2);
+    expect(
+      wrapper.find("TableCell[data-testid='snippet-applies-to']").at(0).text()
     ).toBe("subnet-name1");
     expect(
-      wrapper.find("[data-testid='snippet-applies-to']").at(1).text()
+      wrapper.find("TableCell[data-testid='snippet-applies-to']").at(1).text()
     ).toBe("subnet-name2");
   });
 

--- a/ui/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -15,6 +15,7 @@ import {
   machineEvent as machineEventFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
+  subnet as subnetFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -58,7 +59,7 @@ describe("DHCPTable", () => {
         >
           <DHCPTable
             node={state.machine.items[0]}
-            nodeType={MachineMeta.MODEL}
+            modelName={MachineMeta.MODEL}
           />
         </MemoryRouter>
       </Provider>
@@ -83,12 +84,41 @@ describe("DHCPTable", () => {
         >
           <DHCPTable
             node={state.machine.items[0]}
-            nodeType={MachineMeta.MODEL}
+            modelName={MachineMeta.MODEL}
           />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("TableRow").length).toBe(3);
+  });
+
+  it("shows snippets for subnets", () => {
+    const subnets = [
+      subnetFactory({ name: "subnet-name1" }),
+      subnetFactory({ name: "subnet-name2" }),
+    ];
+    state.dhcpsnippet.items = [
+      dhcpSnippetFactory({ subnet: subnets[0].id }),
+      dhcpSnippetFactory(),
+      dhcpSnippetFactory({ subnet: subnets[1].id }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DHCPTable subnets={subnets} modelName={MachineMeta.MODEL} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("TableRow").length).toBe(2);
+    expect(
+      wrapper.find("[data-testid='snippet-applies-to']").at(0).text()
+    ).toBe("subnet-name1");
+    expect(
+      wrapper.find("[data-testid='snippet-applies-to']").at(1).text()
+    ).toBe("subnet-name2");
   });
 
   it("can show a form to edit a snippet", () => {
@@ -108,7 +138,7 @@ describe("DHCPTable", () => {
         >
           <DHCPTable
             node={state.machine.items[0]}
-            nodeType={MachineMeta.MODEL}
+            modelName={MachineMeta.MODEL}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -47,7 +47,7 @@ const DeviceNetwork = ({ systemId }: Props): JSX.Element => {
           />
         )}
         dhcpTable={() => (
-          <DHCPTable node={device} nodeType={DeviceMeta.MODEL} />
+          <DHCPTable node={device} modelName={DeviceMeta.MODEL} />
         )}
         expandedForm={(expanded, setExpanded) => {
           if (expanded?.content === ExpandedState.EDIT) {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -54,7 +54,7 @@ const MachineNetwork = ({ id, setHeaderContent }: Props): JSX.Element => {
           <AddInterface close={() => setExpanded(null)} systemId={id} />
         )}
         dhcpTable={() => (
-          <DHCPTable node={machine} nodeType={MachineMeta.MODEL} />
+          <DHCPTable node={machine} modelName={MachineMeta.MODEL} />
         )}
         expandedForm={(expanded, setExpanded) => {
           if (expanded?.content === ExpandedState.EDIT) {

--- a/ui/src/app/store/dhcpsnippet/selectors.test.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.test.ts
@@ -122,4 +122,21 @@ describe("dhcpsnippet selectors", () => {
       items[2],
     ]);
   });
+
+  it("can get dhcp snippets for subnets", () => {
+    const items = [
+      dhcpSnippetFactory({ id: 707, subnet: 1 }),
+      dhcpSnippetFactory({ id: 808, subnet: 2 }),
+      dhcpSnippetFactory({ id: 909, subnet: 3 }),
+    ];
+    const state = rootStateFactory({
+      dhcpsnippet: dhcpSnippetStateFactory({
+        items,
+      }),
+    });
+    expect(dhcpsnippet.getBySubnets(state, [1, 3])).toStrictEqual([
+      items[0],
+      items[2],
+    ]);
+  });
 });

--- a/ui/src/app/store/dhcpsnippet/selectors.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.ts
@@ -26,7 +26,7 @@ const defaultSelectors = generateBaseSelectors<
 const getByNode = createSelector(
   [
     defaultSelectors.all,
-    (_state: RootState, node: DHCPSnippet["node"] | null) => node,
+    (_state: RootState, node: DHCPSnippet["node"] | null | undefined) => node,
   ],
   (snippets: DHCPSnippet[], node) => {
     if (!node) {
@@ -36,9 +36,30 @@ const getByNode = createSelector(
   }
 );
 
+/**
+ * Finds snippets for a subnet.
+ * @param state - The redux state.
+ * @param systemId - A subnet's id.
+ * @returns Snippets for a subnet.
+ */
+const getBySubnets = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, subnets: DHCPSnippet["subnet"][] | null | undefined) =>
+      subnets,
+  ],
+  (snippets: DHCPSnippet[], subnets) => {
+    if (!subnets) {
+      return [];
+    }
+    return snippets.filter((snippet) => subnets.includes(snippet.subnet));
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
   getByNode,
+  getBySubnets,
 };
 
 export default selectors;

--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -49,6 +49,23 @@ describe("subnet selectors", () => {
     expect(subnet.getById(state, 909)).toStrictEqual(items[1]);
   });
 
+  it("can get multiple subnets by id", () => {
+    const items = [
+      subnetFactory({ id: 707 }),
+      subnetFactory({ id: 808 }),
+      subnetFactory({ id: 909 }),
+    ];
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items,
+      }),
+    });
+    expect(subnet.getByIds(state, [707, 909])).toStrictEqual([
+      items[0],
+      items[2],
+    ]);
+  });
+
   it("can get a subnet by cidr", () => {
     const items = [
       subnetFactory({ cidr: "cidr0" }),
@@ -75,6 +92,20 @@ describe("subnet selectors", () => {
       }),
     });
     expect(subnet.getByPod(state, pod)).toStrictEqual([subnets[0], subnets[1]]);
+  });
+
+  it("can get subnets that are available to a given pod", () => {
+    const subnets = [
+      subnetFactory({ vlan: 1 }),
+      subnetFactory({ vlan: 2 }),
+      subnetFactory({ vlan: 1 }),
+    ];
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: subnets,
+      }),
+    });
+    expect(subnet.getByVLAN(state, 1)).toStrictEqual([subnets[0], subnets[2]]);
   });
 
   it("can get PXE-enabled subnets that are available to a given pod", () => {

--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -94,7 +94,7 @@ describe("subnet selectors", () => {
     expect(subnet.getByPod(state, pod)).toStrictEqual([subnets[0], subnets[1]]);
   });
 
-  it("can get subnets that are available to a given pod", () => {
+  it("can get subnets for a VLAN", () => {
     const subnets = [
       subnetFactory({ vlan: 1 }),
       subnetFactory({ vlan: 2 }),

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -45,6 +45,22 @@ const active = createSelector(
 );
 
 /**
+ * Get subnets for a given VLAN.
+ * @param {RootState} state - The redux state.
+ * @param {Pod} VLANId - The id of the VLAN.
+ * @returns {Subnet[]} Subnets for a VLAN.
+ */
+const getByIds = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, ids: Subnet[SubnetMeta.PK][]) => ids,
+  ],
+  (subnets, ids) => {
+    return subnets.filter(({ id }) => ids.includes(id));
+  }
+);
+
+/**
  * Get subnets for a given cidr.
  * @param state - The redux state.
  * @param cidr - The cidr to filter by.
@@ -78,6 +94,25 @@ const getByPod = createSelector(
     return subnets.filter((subnet) =>
       pod.attached_vlans?.includes(subnet.vlan)
     );
+  }
+);
+
+/**
+ * Get subnets for a given VLAN.
+ * @param {RootState} state - The redux state.
+ * @param {Pod} VLANId - The id of the VLAN.
+ * @returns {Subnet[]} Subnets for a VLAN.
+ */
+const getByVLAN = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, VLANId: Subnet["vlan"] | null) => VLANId,
+  ],
+  (subnets, VLANId) => {
+    if (!isId(VLANId)) {
+      return [];
+    }
+    return subnets.filter(({ vlan }) => vlan === VLANId);
   }
 );
 
@@ -201,7 +236,9 @@ const selectors = {
   eventErrors,
   eventErrorsForSubnets,
   getByCIDR,
+  getByIds,
   getByPod,
+  getByVLAN,
   getPxeEnabledByPod,
   getStatusForSubnet,
   scanning,

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -45,10 +45,10 @@ const active = createSelector(
 );
 
 /**
- * Get subnets for a given VLAN.
+ * Get subnets for given ids.
  * @param {RootState} state - The redux state.
- * @param {Pod} VLANId - The id of the VLAN.
- * @returns {Subnet[]} Subnets for a VLAN.
+ * @param {Pod} ids - A list of subnet ids
+ * @returns {Subnet[]} The subnets for the given ids.
  */
 const getByIds = createSelector(
   [

--- a/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
+++ b/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
@@ -1,0 +1,85 @@
+import { render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DHCPSnippets from "./DHCPSnippets";
+
+import type { Props as DHCPTableProps } from "app/base/components/DHCPTable/DHCPTable";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetsURLs from "app/subnets/urls";
+import {
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+const mockDHCPTable = jest.fn();
+jest.mock("app/base/components/DHCPTable", () => (props: DHCPTableProps) => {
+  mockDHCPTable(props);
+  return null;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("dispatches actions to fetch necessary data and set subnet as active on mount", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <DHCPSnippets modelName="subnet" subnetIds={[1, 2]} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [subnetActions.fetch()];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the subnet does not exist", () => {
+  const subnets = [subnetFactory(), subnetFactory(), subnetFactory()];
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({
+      items: subnets,
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.subnet.index(null, true)}
+          component={() => (
+            <DHCPSnippets
+              modelName="subnet"
+              subnetIds={[subnets[0].id, subnets[2].id]}
+            />
+          )}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(mockDHCPTable).toHaveBeenCalledWith(
+    expect.objectContaining({
+      subnets: [subnets[0], subnets[2]],
+      modelName: "subnet",
+    })
+  );
+});

--- a/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
+++ b/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it("dispatches actions to fetch necessary data and set subnet as active on mount", () => {
+it("dispatches an action to fetch the subnets on mount", () => {
   const state = rootStateFactory();
   const store = mockStore(state);
   render(
@@ -49,7 +49,7 @@ it("dispatches actions to fetch necessary data and set subnet as active on mount
   });
 });
 
-it("displays a message if the subnet does not exist", () => {
+it("selects the correct subnets to display in the table", () => {
   const subnets = [subnetFactory(), subnetFactory(), subnetFactory()];
   const state = rootStateFactory({
     subnet: subnetStateFactory({

--- a/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
+++ b/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
@@ -1,9 +1,40 @@
-import { Strip } from "@canonical/react-components";
+import { useEffect, useRef } from "react";
 
-const DHCPSnippets = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">DHCP snippets</h2>
-  </Strip>
-);
+import { Strip } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+import { useDispatch, useSelector } from "react-redux";
+
+import DHCPTable from "app/base/components/DHCPTable";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+
+type Props = {
+  modelName: string;
+  subnetIds: Subnet[SubnetMeta.PK][];
+};
+
+const DHCPSnippets = ({ modelName, subnetIds }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const sectionID = useRef(nanoid());
+  const subnets = useSelector((state: RootState) =>
+    subnetSelectors.getByIds(state, subnetIds)
+  );
+
+  useEffect(() => {
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Strip aria-labelledby={sectionID.current} element="section" shallow>
+      <DHCPTable
+        headerId={sectionID.current}
+        subnets={subnets}
+        modelName={modelName}
+      />
+    </Strip>
+  );
+};
 
 export default DHCPSnippets;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -63,7 +63,10 @@ const SubnetDetails = (): JSX.Element => {
       <Utilisation />
       <StaticRoutes />
       <ReservedRanges />
-      <DHCPSnippets />
+      <DHCPSnippets
+        subnetIds={isId(id) ? [id] : []}
+        modelName={SubnetMeta.MODEL}
+      />
       <UsedIPs />
     </Section>
   );

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -15,6 +15,8 @@ import { actions as controllerActions } from "app/store/controller";
 import { actions as fabricActions } from "app/store/fabric";
 import type { RootState } from "app/store/root/types";
 import { actions as spaceActions } from "app/store/space";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import { VLANMeta } from "app/store/vlan/types";
@@ -30,6 +32,10 @@ const VLANDetails = (): JSX.Element => {
     vlanSelectors.getById(state, id)
   );
   const vlansLoading = useSelector(vlanSelectors.loading);
+  const subnets = useSelector((state: RootState) =>
+    subnetSelectors.getByVLAN(state, id)
+  );
+
   useWindowTitle(`${vlan?.name || "VLAN"} details`);
   const fabricId = vlan?.fabric;
   const spaceId = vlan?.space;
@@ -39,6 +45,7 @@ const VLANDetails = (): JSX.Element => {
       dispatch(vlanActions.get(id));
       dispatch(vlanActions.setActive(id));
       dispatch(controllerActions.fetch());
+      dispatch(subnetActions.fetch());
     }
 
     const unsetActiveVLANAndCleanup = () => {
@@ -77,7 +84,10 @@ const VLANDetails = (): JSX.Element => {
       <DHCPStatus />
       <ReservedRanges />
       <VLANSubnets />
-      <DHCPSnippets />
+      <DHCPSnippets
+        subnetIds={subnets.map(({ id }) => id)}
+        modelName={VLANMeta.MODEL}
+      />
     </Section>
   );
 };


### PR DESCRIPTION
## Done

- Update the DHCP snippet table to handle subnets.
- Add the DHCP snippets table to subnet and vlan details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Settings -> DHCP snippets.
- Add a DHCP snippet to a subnet.
- Go to the React subnet details for that subnet. You should see a table with the DHCP snippet you added.
- Go to the subnet's VLAN details. You should see a table with the DHCP snippet you added.

## Fixes

Fixes: canonical-web-and-design/app-tribe#672.
Fixes: canonical-web-and-design/app-tribe#716.
Fixes: canonical-web-and-design/app-tribe#673.