### PR TITLE
feat(ui): build Subnets in this VLAN table

### DIFF
--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -87,7 +87,7 @@ const VLANDetails = (): JSX.Element => {
       <VLANSummary id={id} />
       <DHCPStatus />
       <ReservedRanges />
-      <VLANSubnets />
+      <VLANSubnets id={id} />
       <DHCPSnippets
         subnetIds={subnets.map(({ id }) => id)}
         modelName={VLANMeta.MODEL}

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import VLANSubnets from "./VLANSubnets";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  subnetStatistics as subnetStatisticsFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders correct details", () => {
+  const vlan = vlanFactory({ id: 5005 });
+  const subnet = subnetFactory({
+    allow_dns: true,
+    allow_proxy: false,
+    managed: true,
+    statistics: subnetStatisticsFactory({ usage_string: "25%" }),
+    vlan: vlan.id,
+  });
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [subnet] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <VLANSubnets id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const vlanSubnetsTable = within(
+    screen.getByRole("region", {
+      name: "Subnets on this VLAN",
+    })
+  ).getByRole("grid");
+
+  expect(within(vlanSubnetsTable).getByRole("link")).toHaveAttribute(
+    "href",
+    subnetsURLs.subnet.index({ id: subnet.id })
+  );
+  expect(within(vlanSubnetsTable).getByLabelText("Usage").textContent).toBe(
+    subnet.statistics.usage_string
+  );
+  expect(
+    within(vlanSubnetsTable).getByLabelText("Managed allocation").textContent
+  ).toBe("Yes");
+  expect(
+    within(vlanSubnetsTable).getByLabelText("Proxy access").textContent
+  ).toBe("No");
+  expect(
+    within(vlanSubnetsTable).getByLabelText("Allows DNS resolution").textContent
+  ).toBe("Yes");
+});

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.tsx
@@ -1,9 +1,132 @@
-import { Strip } from "@canonical/react-components";
+import { useRef } from "react";
 
-const VLANSubnets = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Subnets on this VLAN</h2>
-  </Strip>
-);
+import { Icon, MainTable, Spinner, Strip } from "@canonical/react-components";
+import { nanoid } from "nanoid";
+import { useSelector } from "react-redux";
+
+import SubnetLink from "app/base/components/SubnetLink";
+import type { RootState } from "app/store/root/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+
+type Props = {
+  id: VLAN[VLANMeta.PK] | null;
+};
+
+const VLANSubnets = ({ id }: Props): JSX.Element | null => {
+  const sectionID = useRef(nanoid());
+  const subnets = useSelector((state: RootState) =>
+    subnetSelectors.getByVLAN(state, id)
+  );
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+
+  return (
+    <Strip aria-labelledby={sectionID.current} element="section" shallow>
+      <h2 className="p-heading--4" id={sectionID.current}>
+        Subnets on this VLAN
+      </h2>
+      <MainTable
+        className="vlan-subnets"
+        defaultSort="cidr"
+        defaultSortDirection="ascending"
+        emptyStateMsg={
+          subnetsLoading ? (
+            <Spinner text="Loading..." />
+          ) : (
+            "There are no subnets on this VLAN"
+          )
+        }
+        headers={[
+          {
+            className: "subnet-col",
+            content: "Subnet",
+            sortKey: "cidr",
+          },
+          {
+            className: "usage-col",
+            content: "Usage",
+            sortKey: "usage",
+          },
+          {
+            className: "managed-col u-align--center",
+            content: "Managed allocation",
+            sortKey: "managed",
+          },
+          {
+            className: "proxy-col u-align--center",
+            content: "Proxy access",
+            sortKey: "allow_proxy",
+          },
+          {
+            className: "dns-col u-align--center",
+            content: "Allows DNS resolution",
+            sortKey: "allow_dns",
+          },
+        ]}
+        responsive
+        rows={subnets.map((subnet) => {
+          const {
+            allow_dns,
+            allow_proxy,
+            cidr,
+            id,
+            managed,
+            statistics: { usage, usage_string },
+          } = subnet;
+
+          return {
+            columns: [
+              {
+                "aria-label": "Subnet",
+                className: "subnet-col",
+                content: <SubnetLink id={id} />,
+              },
+              {
+                "aria-label": "Usage",
+                className: "used-col",
+                content: usage_string,
+              },
+              {
+                "aria-label": "Managed allocation",
+                className: "managed-col u-align--center",
+                content: (
+                  <Icon name={managed ? "tick" : "close"}>
+                    {managed ? "Yes" : "No"}
+                  </Icon>
+                ),
+              },
+              {
+                "aria-label": "Proxy access",
+                className: "proxy-col u-align--center",
+                content: (
+                  <Icon name={allow_proxy ? "tick" : "close"}>
+                    {allow_proxy ? "Yes" : "No"}
+                  </Icon>
+                ),
+              },
+              {
+                "aria-label": "Allows DNS resolution",
+                className: "dns-col u-align--center",
+                content: (
+                  <Icon name={allow_dns ? "tick" : "close"}>
+                    {allow_dns ? "Yes" : "No"}
+                  </Icon>
+                ),
+              },
+            ],
+            sortData: {
+              allow_dns,
+              allow_proxy,
+              cidr,
+              managed,
+              usage,
+            },
+          };
+        })}
+        sortable
+      />
+    </Strip>
+  );
+};
 
 export default VLANSubnets;

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/_index.scss
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/_index.scss
@@ -1,0 +1,23 @@
+@mixin VLANSubnets {
+  .vlan-subnets {
+    .subnet-col {
+      width: 30%;
+    }
+
+    .usage-col {
+      width: 10%;
+    }
+
+    .managed-col {
+      width: 20%;
+    }
+
+    .proxy-col {
+      width: 20%;
+    }
+
+    .dns-col {
+      width: 20%;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -230,9 +230,6 @@
 @include OverviewCard;
 @include SourceMachineSelect;
 
-// subnets
-@import "~app/subnets/views/SubnetsList";
-
 // preferences
 @import "~app/preferences/views/APIKeys/APIKeyList";
 @import "~app/preferences/views/SSLKeys/AddSSLKey";
@@ -258,6 +255,11 @@
 @include ScriptsList;
 @include ScriptsUpload;
 @include UsersList;
+
+// subnets
+@import "~app/subnets/views/SubnetsList";
+@import "~app/subnets/views/VLANDetails/VLANSubnets";
+@include VLANSubnets;
 
 #maas-ui {
   background-color: $color-light;


### PR DESCRIPTION
## Done

- Built Subnets on this VLAN table in VLAN details page
  - I've updated it a bit by removing the "Space" column since it's a VLAN-specific piece of data (i.e. every subnet in the table will be in the same space, so its inclusion is redundant). In its place I've added a few columns of extra data.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React details page of a VLAN and check that there is a table for subnets in that VLAN
- Check that the data is correct as per the legacy details pages for those subnets
- Check that sorting works correctly

## Fixes

Fixes canonical-web-and-design/app-tribe#671

## Screenshot
![2022-02-01_16-33](https://user-images.githubusercontent.com/25733845/151923294-a98e3573-81ec-410d-8739-c1b4c921ba03.png)

