### PR TITLE
fix(ui): close the dhcp form on success

### DIFF
--- a/ui/src/app/base/components/DhcpForm/DhcpForm.tsx
+++ b/ui/src/app/base/components/DhcpForm/DhcpForm.tsx
@@ -67,7 +67,7 @@ export const DhcpForm = ({
   );
 
   useAddMessage(
-    saved,
+    saved && !errors,
     dhcpsnippetActions.cleanup,
     `${savingDhcp} ${editing ? "updated" : "added"} successfully.`,
     () => setSaving(null)
@@ -139,8 +139,8 @@ export const DhcpForm = ({
           dispatch(dhcpsnippetActions.create(params));
         }
         setSaving(params.name);
-        onSave && onSave();
       }}
+      onSuccess={() => onSave && onSave()}
       saving={saving}
       saved={saved}
       submitLabel="Save snippet"


### PR DESCRIPTION
## Done

- Fix the DHCP snippet form to only close if the create/update action was successful.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a DHCP snippet in settings and target it to a subnet (it'll need to be a real one).
- Go to the subnet details page and the DHCP snippets table should show the snippet you created.
- Click the edit button and change the subnet to another subnet that isn't real.
- Click save and the form should stay open and an error should appear.
- Change the subnet to a real subnet (such as the one for the page you're viewing).
- Click save and the form should close.

## Fixes

Fixes: #3568.