### PR TITLE
refactor: button to delete fabric

### DIFF
--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
@@ -1,14 +1,87 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory } from "history";
+import { Provider } from "react-redux";
+import { Router, Route } from "react-router";
+import configureStore from "redux-mock-store";
 
 import FabricDetailsHeader from "./FabricDetailsHeader";
 
-import { fabric as fabricFactory } from "testing/factories";
+import { actions as fabricActions } from "app/store/fabric";
+import subnetsURLs from "app/subnets/urls";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const renderTestCase = (
+  fabric = fabricFactory({
+    id: 1,
+    name: "fabric1",
+    description: "fabric 1 description",
+  })
+) => {
+  const history = createMemoryHistory({
+    initialEntries: [{ pathname: subnetsURLs.fabric.index({ id: fabric.id }) }],
+  });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [fabric],
+      loading: false,
+    }),
+  });
+  const store = configureStore()(state);
+  return {
+    history,
+    store,
+    ...render(
+      <Provider store={store}>
+        <Router history={history}>
+          <Route
+            exact
+            path={subnetsURLs.fabric.index({ id: fabric.id })}
+            component={() => <FabricDetailsHeader fabric={fabric} />}
+          />
+        </Router>
+      </Provider>
+    ),
+  };
+};
 
 it("shows the fabric name as the section title", () => {
-  const fabric = fabricFactory({ id: 1, name: "fabric-1" });
-  render(<FabricDetailsHeader fabric={fabric} />);
+  renderTestCase(fabricFactory({ id: 1, name: "fabric-1" }));
 
   expect(screen.getByTestId("section-header-title")).toHaveTextContent(
     "fabric-1"
   );
+});
+
+it("displays a delete confirmation before delete", () => {
+  renderTestCase(
+    fabricFactory({
+      id: 1,
+      name: "fabric-1",
+      description: "fabric 1 description",
+    })
+  );
+  userEvent.click(screen.getByRole("button", { name: "Delete fabric" }));
+  expect(
+    screen.getByText("Are you sure you want to delete fabric-1 fabric?")
+  ).toBeInTheDocument();
+});
+
+it("deletes the fabric when confirmed", () => {
+  const { store } = renderTestCase(fabricFactory({ id: 1, name: "fabric-1" }));
+  userEvent.click(screen.getByRole("button", { name: "Delete fabric" }));
+  userEvent.click(screen.getByRole("button", { name: "Yes, delete fabric" }));
+  const expectedActions = [fabricActions.delete(1)];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
 });

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
@@ -1,12 +1,80 @@
+import { useState } from "react";
+
+import {
+  Button,
+  Col,
+  ActionButton,
+  Strip,
+  Row,
+} from "@canonical/react-components";
+import { useSelector, useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
+
 import SectionHeader from "app/base/components/SectionHeader";
+import { useCycled } from "app/base/hooks";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
 import type { Fabric } from "app/store/fabric/types";
+import urls from "app/subnets/urls";
 
 type Props = {
   fabric: Fabric;
 };
 
 const FabricDetailsHeader = ({ fabric }: Props): JSX.Element => {
-  return <SectionHeader title={fabric.name} />;
+  const [showConfirm, setShowConfirm] = useState(false);
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const saving = useSelector(fabricSelectors.saving);
+  const saved = useSelector(fabricSelectors.saved);
+
+  const deleteFabric = () => {
+    dispatch(fabricActions.delete(fabric.id));
+  };
+
+  useCycled(saved, () => {
+    if (saved) {
+      history.replace(urls.indexBy({ by: "fabric" }));
+    }
+  });
+
+  return (
+    <SectionHeader
+      title={fabric.name}
+      buttons={[
+        <Button
+          appearance="neutral"
+          disabled={showConfirm}
+          onClick={() => setShowConfirm(true)}
+        >
+          Delete fabric
+        </Button>,
+      ]}
+      headerContent={
+        showConfirm ? (
+          <Strip shallow element="section">
+            <Row>
+              <Col size={8}>
+                <p>Are you sure you want to delete {fabric.name} fabric?</p>
+              </Col>
+              <Col size={4} className="u-align--right">
+                <ActionButton
+                  appearance="negative"
+                  onClick={deleteFabric}
+                  disabled={saving}
+                >
+                  Yes, delete fabric
+                </ActionButton>
+                <Button onClick={() => setShowConfirm(false)} disabled={saving}>
+                  No, cancel
+                </Button>
+              </Col>
+            </Row>
+          </Strip>
+        ) : null
+      }
+    />
+  );
 };
 
 export default FabricDetailsHeader;


### PR DESCRIPTION
## Done

- Add button and confirmation panel to delete a fabric.

![image](https://user-images.githubusercontent.com/20623084/151946226-28382339-a2d8-436a-a042-d7e63c4142fc.png)
![image](https://user-images.githubusercontent.com/20623084/151946269-7b87d0c8-2184-4a22-9f7f-c088070c4ec0.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `MAAS/r/networks?by=fabric`
- Create a test fabric and delete it
- Make sure it works as expected.

## Fixes

Fixes https://github.com/canonical-web-and-design/app-tribe/issues/642

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
