### PR TITLE
add VisuallyHidden and useId utils

### DIFF
--- a/ui/src/app/base/components/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/ui/src/app/base/components/VisuallyHidden/VisuallyHidden.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from "@testing-library/react";
+
+import VisuallyHidden from "./VisuallyHidden";
+
+it("renders children correctly", () => {
+  render(<VisuallyHidden>test content</VisuallyHidden>);
+  expect(screen.getByText("test content")).toBeInTheDocument();
+});

--- a/ui/src/app/base/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/ui/src/app/base/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const VisuallyHidden = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element => <div className="u-visually-hidden">{children}</div>;
+
+export default VisuallyHidden;

--- a/ui/src/app/base/components/VisuallyHidden/_index.scss
+++ b/ui/src/app/base/components/VisuallyHidden/_index.scss
@@ -1,0 +1,11 @@
+@mixin VisuallyHidden {
+  .u-visually-hidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}

--- a/ui/src/app/base/components/VisuallyHidden/index.ts
+++ b/ui/src/app/base/components/VisuallyHidden/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VisuallyHidden";

--- a/ui/src/app/base/hooks/base.test.tsx
+++ b/ui/src/app/base/hooks/base.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks";
 import TestRenderer from "react-test-renderer";
 
-import { useCycled, useProcessing, useScrollOnRender } from "./base";
+import { useCycled, useId, useProcessing, useScrollOnRender } from "./base";
 
 const { act } = TestRenderer;
 
@@ -216,6 +216,15 @@ describe("hooks", () => {
       expect(onComplete).not.toHaveBeenCalled();
       expect(onError).toHaveBeenCalled();
       expect(result.current).toBe(false);
+    });
+  });
+
+  describe("getId", () => {
+    it("generates the id on first render", () => {
+      const { result, rerender } = renderHook(() => useId());
+      const previousResult = result;
+      rerender();
+      expect(result).toEqual(previousResult);
     });
   });
 });

--- a/ui/src/app/base/hooks/base.ts
+++ b/ui/src/app/base/hooks/base.ts
@@ -162,7 +162,4 @@ export const useScrollOnRender = <T extends HTMLElement>(): ((
  * Get a random ID string
  * @returns non-secure random ID string
  */
-export const useId = (): string => {
-  const [id] = useState(() => nanoid());
-  return id;
-};
+export const useId = (): string => useRef(nanoid()).current;

--- a/ui/src/app/base/hooks/base.ts
+++ b/ui/src/app/base/hooks/base.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { NotificationSeverity } from "@canonical/react-components";
 import type { NotificationProps } from "@canonical/react-components";
-import { nanoid } from "nanoid";
+import { nanoid } from "nanoid/non-secure";
 import { useDispatch, useSelector } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
@@ -159,6 +159,10 @@ export const useScrollOnRender = <T extends HTMLElement>(): ((
 };
 
 /**
- * Get a unique ID for a DOM element
+ * Get a random ID string
+ * @returns non-secure random ID string
  */
-export const useId = (): string => useRef(nanoid()).current;
+export const useId = (): string => {
+  const [id] = useState(() => nanoid());
+  return id;
+};

--- a/ui/src/app/base/hooks/base.ts
+++ b/ui/src/app/base/hooks/base.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { NotificationSeverity } from "@canonical/react-components";
 import type { NotificationProps } from "@canonical/react-components";
+import { nanoid } from "nanoid";
 import { useDispatch, useSelector } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
@@ -156,3 +157,8 @@ export const useScrollOnRender = <T extends HTMLElement>(): ((
   }, []);
   return onRenderRef;
 };
+
+/**
+ * Get a unique ID for a DOM element
+ */
+export const useId = (): string => useRef(nanoid()).current;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
@@ -1,14 +1,14 @@
 import { Strip } from "@canonical/react-components";
-import { nanoid } from "nanoid";
 
 import Definition from "app/base/components/Definition";
+import { useId } from "app/base/hooks/base";
 import type { Space } from "app/store/space/types";
 
 const SpaceSummary = ({
   name,
   description,
 }: Pick<Space, "name" | "description">): JSX.Element => {
-  const id = nanoid();
+  const id = useId();
   return (
     <Strip shallow element="section" aria-labelledby={id}>
       <h2 id={id} className="p-heading--4">

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 import {
   Col,
   Icon,
@@ -8,13 +6,13 @@ import {
   Strip,
   Tooltip,
 } from "@canonical/react-components";
-import { nanoid } from "nanoid";
 import { useSelector } from "react-redux";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";
 import FabricLink from "app/base/components/FabricLink";
 import SpaceLink from "app/base/components/SpaceLink";
+import { useId } from "app/base/hooks/base";
 import controllerSelectors from "app/store/controller/selectors";
 import type { RootState } from "app/store/root/types";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -39,7 +37,7 @@ const getRackIDs = (vlan: VLAN | null) => {
 };
 
 const VLANSummary = ({ id }: Props): JSX.Element | null => {
-  const sectionID = useRef(nanoid());
+  const sectionID = useId();
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
@@ -52,8 +50,8 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
     return null;
   }
   return (
-    <Strip aria-labelledby={sectionID.current} element="section" shallow>
-      <h2 className="p-heading--4" id={sectionID.current}>
+    <Strip aria-labelledby={sectionID} element="section" shallow>
+      <h2 className="p-heading--4" id={sectionID}>
         VLAN summary
       </h2>
       <Row>


### PR DESCRIPTION
## Done

- add `VisuallyHidden` component (Visually Hidden is used when an element needs to be available to assistive technology, but otherwise hidden)
- add `useId` hook

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
