### PR TITLE
feat(ui): add reusable titled component to subnets

### DIFF
--- a/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -4,6 +4,8 @@ import { List, MainTable, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import TitledSection from "../TitledSection";
+
 import EditDHCP from "./EditDHCP";
 
 import TableActions from "app/base/components/TableActions";
@@ -17,7 +19,7 @@ import type { Node } from "app/store/types/node";
 import { isId } from "app/utils";
 
 type BaseProps = {
-  headerId?: string;
+  className?: string;
   modelName: string;
   node?: Node;
   subnets?: Subnet[];
@@ -103,7 +105,7 @@ const generateRows = (
   });
 
 const DHCPTable = ({
-  headerId,
+  className,
   node,
   subnets,
   modelName,
@@ -125,10 +127,7 @@ const DHCPTable = ({
   }, [dispatch]);
 
   return (
-    <>
-      <h2 className="p-heading--four" id={headerId}>
-        DHCP snippets
-      </h2>
+    <TitledSection className={className} title="DHCP snippets">
       {node || subnets?.length ? (
         <>
           <MainTable
@@ -196,7 +195,7 @@ const DHCPTable = ({
           />
         </>
       ) : null}
-    </>
+    </TitledSection>
   );
 };
 

--- a/ui/src/app/base/components/TitledSection/TitledSection.test.tsx
+++ b/ui/src/app/base/components/TitledSection/TitledSection.test.tsx
@@ -21,3 +21,20 @@ it("sets the labelledby ids", () => {
     sectionId
   );
 });
+
+it("can display buttons", () => {
+  render(
+    <TitledSection
+      buttons={
+        <>
+          <button>Button</button>
+          <button>Button</button>
+        </>
+      }
+      title="echidna says"
+    >
+      G'day
+    </TitledSection>
+  );
+  expect(screen.getAllByRole("button").length).toBe(2);
+});

--- a/ui/src/app/base/components/TitledSection/TitledSection.test.tsx
+++ b/ui/src/app/base/components/TitledSection/TitledSection.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, within } from "@testing-library/react";
+
+import TitledSection from "./TitledSection";
+
+it("displays the provided title and content", () => {
+  const title = "echidna says";
+  const content = "G'day";
+  render(<TitledSection title={title}>{content}</TitledSection>);
+  expect(screen.getByText(content)).toBeInTheDocument();
+  expect(
+    within(screen.getByRole("heading")).getByText(title)
+  ).toBeInTheDocument();
+});
+
+it("sets the labelledby ids", () => {
+  render(<TitledSection title="echidna says">G'day</TitledSection>);
+  const sectionId = screen.getByRole("heading").id;
+  expect(sectionId).toBeTruthy();
+  expect(screen.getByTestId("titled-section")).toHaveAttribute(
+    "aria-labelledby",
+    sectionId
+  );
+});

--- a/ui/src/app/base/components/TitledSection/TitledSection.tsx
+++ b/ui/src/app/base/components/TitledSection/TitledSection.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+import { Strip } from "@canonical/react-components";
+import type { PropsWithSpread, StripProps } from "@canonical/react-components";
+
+import { useId } from "app/base/hooks/base";
+
+type Props = PropsWithSpread<
+  {
+    children?: ReactNode;
+    title: ReactNode;
+  },
+  StripProps
+>;
+
+const TitledSection = ({ children, title, ...props }: Props): JSX.Element => {
+  const id = useId();
+  return (
+    <Strip
+      shallow
+      element="section"
+      aria-labelledby={id}
+      data-testid="titled-section"
+      {...props}
+    >
+      <h2 id={id} className="p-heading--4">
+        {title}
+      </h2>
+      {children}
+    </Strip>
+  );
+};
+
+export default TitledSection;

--- a/ui/src/app/base/components/TitledSection/TitledSection.tsx
+++ b/ui/src/app/base/components/TitledSection/TitledSection.tsx
@@ -7,14 +7,25 @@ import { useId } from "app/base/hooks/base";
 
 type Props = PropsWithSpread<
   {
+    buttons?: ReactNode;
     children?: ReactNode;
     title: ReactNode;
   },
   StripProps
 >;
 
-const TitledSection = ({ children, title, ...props }: Props): JSX.Element => {
+const TitledSection = ({
+  buttons,
+  children,
+  title,
+  ...props
+}: Props): JSX.Element => {
   const id = useId();
+  const titleElement = (
+    <h2 id={id} className="p-heading--4">
+      {title}
+    </h2>
+  );
   return (
     <Strip
       shallow
@@ -23,9 +34,14 @@ const TitledSection = ({ children, title, ...props }: Props): JSX.Element => {
       data-testid="titled-section"
       {...props}
     >
-      <h2 id={id} className="p-heading--4">
-        {title}
-      </h2>
+      {buttons ? (
+        <div className="u-flex--between">
+          {titleElement}
+          <div>{buttons}</div>
+        </div>
+      ) : (
+        titleElement
+      )}
       {children}
     </Strip>
   );

--- a/ui/src/app/base/components/TitledSection/index.ts
+++ b/ui/src/app/base/components/TitledSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TitledSection";

--- a/ui/src/app/base/hooks/base.test.tsx
+++ b/ui/src/app/base/hooks/base.test.tsx
@@ -222,9 +222,10 @@ describe("hooks", () => {
   describe("getId", () => {
     it("generates the id on first render", () => {
       const { result, rerender } = renderHook(() => useId());
+      expect(result.current).toBeTruthy();
       const previousResult = result;
       rerender();
-      expect(result).toEqual(previousResult);
+      expect(result.current).toEqual(previousResult.current);
     });
   });
 });

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.tsx
@@ -47,7 +47,11 @@ const DeviceNetwork = ({ systemId }: Props): JSX.Element => {
           />
         )}
         dhcpTable={() => (
-          <DHCPTable node={device} modelName={DeviceMeta.MODEL} />
+          <DHCPTable
+            className="u-no-padding--top"
+            node={device}
+            modelName={DeviceMeta.MODEL}
+          />
         )}
         expandedForm={(expanded, setExpanded) => {
           if (expanded?.content === ExpandedState.EDIT) {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -54,7 +54,11 @@ const MachineNetwork = ({ id, setHeaderContent }: Props): JSX.Element => {
           <AddInterface close={() => setExpanded(null)} systemId={id} />
         )}
         dhcpTable={() => (
-          <DHCPTable node={machine} modelName={MachineMeta.MODEL} />
+          <DHCPTable
+            className="u-no-padding--top"
+            node={machine}
+            modelName={MachineMeta.MODEL}
+          />
         )}
         expandedForm={(expanded, setExpanded) => {
           if (expanded?.content === ExpandedState.EDIT) {

--- a/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
+++ b/ui/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
-import { Strip } from "@canonical/react-components";
-import { nanoid } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "react-redux";
 
 import DHCPTable from "app/base/components/DHCPTable";
@@ -17,7 +15,6 @@ type Props = {
 
 const DHCPSnippets = ({ modelName, subnetIds }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const sectionID = useRef(nanoid());
   const subnets = useSelector((state: RootState) =>
     subnetSelectors.getByIds(state, subnetIds)
   );
@@ -26,15 +23,7 @@ const DHCPSnippets = ({ modelName, subnetIds }: Props): JSX.Element => {
     dispatch(subnetActions.fetch());
   }, [dispatch]);
 
-  return (
-    <Strip aria-labelledby={sectionID.current} element="section" shallow>
-      <DHCPTable
-        headerId={sectionID.current}
-        subnets={subnets}
-        modelName={modelName}
-      />
-    </Strip>
-  );
+  return <DHCPTable subnets={subnets} modelName={modelName} />;
 };
 
 export default DHCPSnippets;

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -1,9 +1,7 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
 const ReservedRanges = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Reserved ranges</h2>
-  </Strip>
+  <TitledSection title="Reserved ranges" />
 );
 
 export default ReservedRanges;

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 
-import { Spinner, Strip } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";
+import TitledSection from "app/base/components/TitledSection";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Fabric } from "app/store/fabric/types";
@@ -26,8 +27,7 @@ const FabricSummary = ({ fabric }: { fabric: Fabric }): JSX.Element => {
   }, [dispatch, vlansLoaded, controllersLoaded]);
 
   return (
-    <Strip shallow>
-      <h2 className="p-heading--4">Fabric summary</h2>
+    <TitledSection title="Fabric summary">
       <Definition label="Name" description={fabric.name} />
       <Definition label="Rack controllers">
         {!controllersLoaded || !vlansLoaded ? (
@@ -41,7 +41,7 @@ const FabricSummary = ({ fabric }: { fabric: Fabric }): JSX.Element => {
         )}
       </Definition>
       <Definition label="Description" description={fabric.description} />
-    </Strip>
+    </TitledSection>
   );
 };
 

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
@@ -1,9 +1,7 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
 const FabricVLANs = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">VLANs on this fabric</h2>
-  </Strip>
+  <TitledSection title="VLANs on this fabric" />
 );
 
 export default FabricVLANs;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
@@ -1,9 +1,7 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
 const SpaceSubnets = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Subnets on this space</h2>
-  </Strip>
+  <TitledSection title="Subnets on this space" />
 );
 
 export default SpaceSubnets;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
@@ -1,22 +1,16 @@
-import { Strip } from "@canonical/react-components";
-
 import Definition from "app/base/components/Definition";
-import { useId } from "app/base/hooks/base";
+import TitledSection from "app/base/components/TitledSection";
 import type { Space } from "app/store/space/types";
 
 const SpaceSummary = ({
   name,
   description,
 }: Pick<Space, "name" | "description">): JSX.Element => {
-  const id = useId();
   return (
-    <Strip shallow element="section" aria-labelledby={id}>
-      <h2 id={id} className="p-heading--4">
-        Space summary
-      </h2>
+    <TitledSection title="Space summary">
       <Definition label="Name">{name}</Definition>
       <Definition label="Description">{description}</Definition>
-    </Strip>
+    </TitledSection>
   );
 };
 

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -1,9 +1,5 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
-const StaticRoutes = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Static routes</h2>
-  </Strip>
-);
+const StaticRoutes = (): JSX.Element => <TitledSection title="Static routes" />;
 
 export default StaticRoutes;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -1,9 +1,7 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
 const SubnetSummary = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Subnet summary</h2>
-  </Strip>
+  <TitledSection title="Subnet summary" />
 );
 
 export default SubnetSummary;

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
@@ -1,9 +1,7 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
 const SubnetUsedIPs = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Used IP addresses</h2>
-  </Strip>
+  <TitledSection title="Used IP addresses" />
 );
 
 export default SubnetUsedIPs;

--- a/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
@@ -1,9 +1,7 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
 const SubnetUtilisation = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">Utilisation</h2>
-  </Strip>
+  <TitledSection title="Utilisation" />
 );
 
 export default SubnetUtilisation;

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -1,9 +1,5 @@
-import { Strip } from "@canonical/react-components";
+import TitledSection from "app/base/components/TitledSection";
 
-const DHCPStatus = (): JSX.Element => (
-  <Strip shallow>
-    <h2 className="p-heading--4">DHCP</h2>
-  </Strip>
-);
+const DHCPStatus = (): JSX.Element => <TitledSection title="DHCP" />;
 
 export default DHCPStatus;

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.tsx
@@ -1,10 +1,8 @@
-import { useRef } from "react";
-
-import { Icon, MainTable, Spinner, Strip } from "@canonical/react-components";
-import { nanoid } from "nanoid";
+import { Icon, MainTable, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import SubnetLink from "app/base/components/SubnetLink";
+import TitledSection from "app/base/components/TitledSection";
 import type { RootState } from "app/store/root/types";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
@@ -14,17 +12,13 @@ type Props = {
 };
 
 const VLANSubnets = ({ id }: Props): JSX.Element | null => {
-  const sectionID = useRef(nanoid());
   const subnets = useSelector((state: RootState) =>
     subnetSelectors.getByVLAN(state, id)
   );
   const subnetsLoading = useSelector(subnetSelectors.loading);
 
   return (
-    <Strip aria-labelledby={sectionID.current} element="section" shallow>
-      <h2 className="p-heading--4" id={sectionID.current}>
-        Subnets on this VLAN
-      </h2>
+    <TitledSection title="Subnets on this VLAN">
       <MainTable
         className="vlan-subnets"
         defaultSort="cidr"
@@ -125,7 +119,7 @@ const VLANSubnets = ({ id }: Props): JSX.Element | null => {
         })}
         sortable
       />
-    </Strip>
+    </TitledSection>
   );
 };
 

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -1,18 +1,11 @@
-import {
-  Col,
-  Icon,
-  Row,
-  Spinner,
-  Strip,
-  Tooltip,
-} from "@canonical/react-components";
+import { Col, Icon, Row, Spinner, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";
 import FabricLink from "app/base/components/FabricLink";
 import SpaceLink from "app/base/components/SpaceLink";
-import { useId } from "app/base/hooks/base";
+import TitledSection from "app/base/components/TitledSection";
 import controllerSelectors from "app/store/controller/selectors";
 import type { RootState } from "app/store/root/types";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -37,7 +30,6 @@ const getRackIDs = (vlan: VLAN | null) => {
 };
 
 const VLANSummary = ({ id }: Props): JSX.Element | null => {
-  const sectionID = useId();
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
@@ -50,10 +42,7 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
     return null;
   }
   return (
-    <Strip aria-labelledby={sectionID} element="section" shallow>
-      <h2 className="p-heading--4" id={sectionID}>
-        VLAN summary
-      </h2>
+    <TitledSection title="VLAN summary">
       <Row>
         <Col size={6}>
           <Definition label="VID" description={`${vlan.vid}`} />
@@ -95,7 +84,7 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
           </Definition>
         </Col>
       </Row>
-    </Strip>
+    </TitledSection>
   );
 };
 


### PR DESCRIPTION
## Done

- Add a reusable titled section component.
- Updated subnet views to use the new component.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to details pages for the react subnets models.
- You should see the section titles as before.

## Fixes

Fixes: canonical-web-and-design/app-tribe#718.