### PR TITLE
fix(ui): update delete fabric form

### DIFF
--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -1,6 +1,8 @@
 import subnet from "./selectors";
 
 import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
   podDetails as podDetailsFactory,
   rootState as rootStateFactory,
   subnet as subnetFactory,
@@ -106,6 +108,25 @@ describe("subnet selectors", () => {
       }),
     });
     expect(subnet.getByVLAN(state, 1)).toStrictEqual([subnets[0], subnets[2]]);
+  });
+
+  it("can get subnets for a fabric", () => {
+    const subnets = [
+      subnetFactory({ vlan: 1 }),
+      subnetFactory({ vlan: 2 }),
+      subnetFactory({ vlan: 3 }),
+    ];
+    const fabric = fabricFactory({ id: 101, vlan_ids: [1, 3] });
+    const state = rootStateFactory({
+      fabric: fabricStateFactory({ items: [fabric] }),
+      subnet: subnetStateFactory({
+        items: subnets,
+      }),
+    });
+    expect(subnet.getByFabric(state, 101)).toStrictEqual([
+      subnets[0],
+      subnets[2],
+    ]);
   });
 
   it("can get PXE-enabled subnets that are available to a given pod", () => {

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
+import fabricSelectors from "app/store/fabric/selectors";
 import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import { SubnetMeta } from "app/store/subnet/types";
@@ -113,6 +114,22 @@ const getByVLAN = createSelector(
       return [];
     }
     return subnets.filter(({ vlan }) => vlan === VLANId);
+  }
+);
+
+/**
+ * Get subnets in a given fabric.
+ * @param state - The redux state.
+ * @param fabricId - The id of the fabric.
+ * @returns Subnets in a fabric.
+ */
+const getByFabric = createSelector(
+  [defaultSelectors.all, fabricSelectors.getById],
+  (subnets, fabric) => {
+    if (!fabric) {
+      return [];
+    }
+    return subnets.filter((subnet) => fabric.vlan_ids.includes(subnet.vlan));
   }
 );
 
@@ -236,6 +253,7 @@ const selectors = {
   eventErrors,
   eventErrorsForSubnets,
   getByCIDR,
+  getByFabric,
   getByIds,
   getByPod,
   getByVLAN,

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import FabricDetails from "./FabricDetails";
 
 import { actions as fabricActions } from "app/store/fabric";
+import { actions as subnetActions } from "app/store/subnet";
 import subnetsURLs from "app/subnets/urls";
 import {
   fabricState as fabricStateFactory,
@@ -14,7 +15,7 @@ import {
 
 const mockStore = configureStore();
 
-it("dispatches actions to get and set fabric as active on mount", () => {
+it("dispatches actions to fetch necessary data and set fabric as active on mount", () => {
   const state = rootStateFactory();
   const store = mockStore(state);
   render(
@@ -31,7 +32,11 @@ it("dispatches actions to get and set fabric as active on mount", () => {
     </Provider>
   );
 
-  const expectedActions = [fabricActions.get(1), fabricActions.setActive(1)];
+  const expectedActions = [
+    fabricActions.get(1),
+    fabricActions.setActive(1),
+    subnetActions.fetch(),
+  ];
   const actualActions = store.getActions();
   expectedActions.forEach((expectedAction) => {
     expect(

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
@@ -14,6 +14,7 @@ import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import { FabricMeta } from "app/store/fabric/types";
 import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
 import subnetURLs from "app/subnets/urls";
 import { isId } from "app/utils";
 
@@ -31,6 +32,7 @@ const FabricDetails = (): JSX.Element => {
     if (isValidID) {
       dispatch(fabricActions.get(id));
       dispatch(fabricActions.setActive(id));
+      dispatch(subnetActions.fetch());
     }
 
     const unsetActiveFabricAndCleanup = () => {

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import configureStore from "redux-mock-store";
+
+import FabricDeleteForm from "./FabricDeleteForm";
+
+import { actions as fabricActions } from "app/store/fabric";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("does not allow deletion if the fabric is the default fabric", () => {
+  const fabric = fabricFactory({ id: 0 });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [fabric],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(
+      "This fabric cannot be deleted because it is the default fabric for this MAAS."
+    )
+  ).toBeInTheDocument();
+});
+
+it("does not allow deletion if the fabric has subnets attached", () => {
+  const subnet = subnetFactory({ vlan: 101 });
+  const fabric = fabricFactory({ id: 1, vlan_ids: [subnet.vlan] });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [fabric],
+    }),
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(
+      "This fabric cannot be deleted because it has subnets attached. Remove all subnets from the VLANs on this fabric to allow deletion."
+    )
+  ).toBeInTheDocument();
+});
+
+it(`displays a delete confirmation if the fabric is not the default and has no
+    subnets attached`, () => {
+  const fabric = fabricFactory({ id: 1 });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [fabric] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByText("Are you sure you want to delete this fabric?")
+  ).toBeInTheDocument();
+});
+
+it("deletes the fabric when confirmed", async () => {
+  const fabric = fabricFactory({ id: 1 });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [fabric] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  userEvent.click(screen.getByRole("button", { name: "Delete fabric" }));
+
+  const expectedActions = [fabricActions.delete(fabric.id)];
+  const actualActions = store.getActions();
+  await waitFor(() =>
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        actualActions.find(
+          (actualAction) => actualAction.type === expectedAction.type
+        )
+      ).toStrictEqual(expectedAction);
+    })
+  );
+});

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+
+import { Notification } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikForm from "app/base/components/FormikForm";
+import type { EmptyObject } from "app/base/types";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric, FabricMeta } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import subnetURLs from "app/subnets/urls";
+import { isId } from "app/utils";
+
+type Props = {
+  closeForm: () => void;
+  id?: Fabric[FabricMeta.PK] | null;
+};
+
+const FabricDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, id)
+  );
+  const subnetsInFabric = useSelector((state: RootState) =>
+    subnetSelectors.getByFabric(state, id)
+  );
+  const errors = useSelector(fabricSelectors.errors);
+  const saved = useSelector(fabricSelectors.saved);
+  const saving = useSelector(fabricSelectors.saving);
+  const cleanup = useCallback(() => fabricActions.cleanup(), []);
+
+  if (!isId(id) || !fabric) {
+    return null;
+  }
+
+  const fabricIsDefault = fabric.id === 0;
+  const hasSubnets = subnetsInFabric.length > 0;
+  let warning: ReactNode;
+  if (fabricIsDefault) {
+    warning = (
+      <Notification borderless inline severity="negative">
+        This fabric cannot be deleted because it is the default fabric for this
+        MAAS.
+      </Notification>
+    );
+  } else if (hasSubnets) {
+    warning = (
+      <Notification borderless inline severity="negative">
+        This fabric cannot be deleted because it has subnets attached. Remove
+        all subnets from the VLANs on this fabric to allow deletion.
+      </Notification>
+    );
+  } else {
+    warning = (
+      <Notification borderless inline severity="caution">
+        Are you sure you want to delete this fabric?
+      </Notification>
+    );
+  }
+  return (
+    <FormikForm<EmptyObject>
+      buttonsBordered={false}
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{}}
+      onCancel={closeForm}
+      onSubmit={() => {
+        dispatch(cleanup());
+        dispatch(fabricActions.delete(id));
+      }}
+      savedRedirect={subnetURLs.indexBy({ by: "fabric" })}
+      saved={saved}
+      saving={saving}
+      submitAppearance="negative"
+      submitDisabled={fabricIsDefault || hasSubnets}
+      submitLabel="Delete fabric"
+    >
+      {warning}
+    </FormikForm>
+  );
+};
+
+export default FabricDeleteForm;

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/index.ts
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FabricDeleteForm";

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
@@ -1,87 +1,67 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
-import { Router, Route } from "react-router";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricDetailsHeader from "./FabricDetailsHeader";
 
-import { actions as fabricActions } from "app/store/fabric";
-import subnetsURLs from "app/subnets/urls";
+import type { Fabric } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
 import {
+  authState as authStateFactory,
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
 } from "testing/factories";
 
-const renderTestCase = (
-  fabric = fabricFactory({
-    id: 1,
-    name: "fabric1",
-    description: "fabric 1 description",
-  })
-) => {
-  const history = createMemoryHistory({
-    initialEntries: [{ pathname: subnetsURLs.fabric.index({ id: fabric.id }) }],
-  });
-  const state = rootStateFactory({
+const mockStore = configureStore();
+let state: RootState;
+let fabric: Fabric;
+beforeEach(() => {
+  fabric = fabricFactory({ id: 1, name: "fabric1" });
+  state = rootStateFactory({
     fabric: fabricStateFactory({
       items: [fabric],
-      loading: false,
     }),
   });
-  const store = configureStore()(state);
-  return {
-    history,
-    store,
-    ...render(
-      <Provider store={store}>
-        <Router history={history}>
-          <Route
-            exact
-            path={subnetsURLs.fabric.index({ id: fabric.id })}
-            component={() => <FabricDetailsHeader fabric={fabric} />}
-          />
-        </Router>
-      </Provider>
-    ),
-  };
-};
-
-it("shows the fabric name as the section title", () => {
-  renderTestCase(fabricFactory({ id: 1, name: "fabric-1" }));
-
-  expect(screen.getByTestId("section-header-title")).toHaveTextContent(
-    "fabric-1"
-  );
 });
 
-it("displays a delete confirmation before delete", () => {
-  renderTestCase(
-    fabricFactory({
-      id: 1,
-      name: "fabric-1",
-      description: "fabric 1 description",
-    })
+it("shows the delete button when the user is an admin", () => {
+  state.user = userStateFactory({
+    auth: authStateFactory({
+      user: userFactory({ is_superuser: true }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/fabric/1" }]}>
+        <FabricDetailsHeader fabric={fabric} />
+      </MemoryRouter>
+    </Provider>
   );
-  userEvent.click(screen.getByRole("button", { name: "Delete fabric" }));
+
   expect(
-    screen.getByText("Are you sure you want to delete fabric-1 fabric?")
+    screen.getByRole("button", { name: "Delete fabric" })
   ).toBeInTheDocument();
 });
 
-it("deletes the fabric when confirmed", () => {
-  const { store } = renderTestCase(fabricFactory({ id: 1, name: "fabric-1" }));
-  userEvent.click(screen.getByRole("button", { name: "Delete fabric" }));
-  userEvent.click(screen.getByRole("button", { name: "Yes, delete fabric" }));
-  const expectedActions = [fabricActions.delete(1)];
-  const actualActions = store.getActions();
-  expectedActions.forEach((expectedAction) => {
-    expect(
-      actualActions.find(
-        (actualAction) => actualAction.type === expectedAction.type
-      )
-    ).toStrictEqual(expectedAction);
+it("does not show the delete button if the user is not an admin", () => {
+  state.user = userStateFactory({
+    auth: authStateFactory({
+      user: userFactory({ is_superuser: false }),
+    }),
   });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/fabric/1" }]}>
+        <FabricDetailsHeader fabric={fabric} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.queryByRole("button", { name: "Delete fabric" })).toBeNull();
 });

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
@@ -1,76 +1,43 @@
 import { useState } from "react";
 
-import {
-  Button,
-  Col,
-  ActionButton,
-  Strip,
-  Row,
-} from "@canonical/react-components";
-import { useSelector, useDispatch } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { Button } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import FabricDeleteForm from "./FabricDeleteForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
-import { useCycled } from "app/base/hooks";
-import { actions as fabricActions } from "app/store/fabric";
-import fabricSelectors from "app/store/fabric/selectors";
+import authSelectors from "app/store/auth/selectors";
 import type { Fabric } from "app/store/fabric/types";
-import urls from "app/subnets/urls";
 
 type Props = {
   fabric: Fabric;
 };
 
 const FabricDetailsHeader = ({ fabric }: Props): JSX.Element => {
-  const [showConfirm, setShowConfirm] = useState(false);
-  const dispatch = useDispatch();
-  const history = useHistory();
-  const saving = useSelector(fabricSelectors.saving);
-  const saved = useSelector(fabricSelectors.saved);
-
-  const deleteFabric = () => {
-    dispatch(fabricActions.delete(fabric.id));
-  };
-
-  useCycled(saved, () => {
-    if (saved) {
-      history.replace(urls.indexBy({ by: "fabric" }));
-    }
-  });
+  const isAdmin = useSelector(authSelectors.isAdmin);
+  const [showDeleteForm, setShowDeleteForm] = useState(false);
 
   return (
     <SectionHeader
       title={fabric.name}
-      buttons={[
-        <Button
-          appearance="neutral"
-          disabled={showConfirm}
-          onClick={() => setShowConfirm(true)}
-        >
-          Delete fabric
-        </Button>,
-      ]}
+      buttons={
+        isAdmin
+          ? [
+              <Button
+                appearance="neutral"
+                onClick={() => setShowDeleteForm(true)}
+              >
+                Delete fabric
+              </Button>,
+            ]
+          : null
+      }
       headerContent={
-        showConfirm ? (
-          <Strip shallow element="section">
-            <Row>
-              <Col size={8}>
-                <p>Are you sure you want to delete {fabric.name} fabric?</p>
-              </Col>
-              <Col size={4} className="u-align--right">
-                <ActionButton
-                  appearance="negative"
-                  onClick={deleteFabric}
-                  disabled={saving}
-                >
-                  Yes, delete fabric
-                </ActionButton>
-                <Button onClick={() => setShowConfirm(false)} disabled={saving}>
-                  No, cancel
-                </Button>
-              </Col>
-            </Row>
-          </Strip>
+        showDeleteForm ? (
+          <FabricDeleteForm
+            closeForm={() => setShowDeleteForm(false)}
+            id={fabric.id}
+          />
         ) : null
       }
     />

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
@@ -1,10 +1,12 @@
 import { useCallback } from "react";
 
-import { Icon } from "@canonical/react-components";
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
+import FabricLink from "app/base/components/FabricLink";
 import FormikForm from "app/base/components/FormikForm";
 import type { EmptyObject } from "app/base/types";
+import fabricSelectors from "app/store/fabric/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -22,15 +24,19 @@ const VLANDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, vlan?.fabric)
+  );
   const errors = useSelector(vlanSelectors.errors);
   const saved = useSelector(vlanSelectors.saved);
   const saving = useSelector(vlanSelectors.saving);
   const cleanup = useCallback(() => vlanActions.cleanup(), []);
 
-  if (!isId(id) || !vlan) {
+  if (!isId(id) || !vlan || !fabric) {
     return null;
   }
 
+  const isDefaultVLAN = vlan.id === fabric.default_vlan_id;
   return (
     <FormikForm<EmptyObject>
       buttonsBordered={false}
@@ -46,15 +52,19 @@ const VLANDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
       saved={saved}
       saving={saving}
       submitAppearance="negative"
-      submitLabel="Delete vlan"
+      submitDisabled={isDefaultVLAN}
+      submitLabel="Delete VLAN"
     >
-      <p
-        className="u-no-margin--bottom u-no-max-width"
-        data-testid="delete-message"
-      >
-        <Icon name="warning" className="is-inline" />
-        Are you sure you want to delete this VLAN?
-      </p>
+      {isDefaultVLAN ? (
+        <Notification borderless inline severity="negative">
+          This VLAN cannot be deleted because it is the default VLAN for{" "}
+          <FabricLink id={fabric.id} />.
+        </Notification>
+      ) : (
+        <Notification borderless inline severity="caution">
+          Are you sure you want to delete this VLAN?
+        </Notification>
+      )}
     </FormikForm>
   );
 };

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -124,7 +124,7 @@ describe("VLANDetailsHeader", () => {
     expect(screen.queryByTestId("section-header-subtitle-spinner")).toBeNull();
   });
 
-  it("shows the delete button when the user is an admin and the vlan is not the default", () => {
+  it("shows the delete button when the user is an admin", () => {
     state.user = userStateFactory({
       auth: authStateFactory({
         user: userFactory({ is_superuser: true }),
@@ -145,26 +145,6 @@ describe("VLANDetailsHeader", () => {
     state.user = userStateFactory({
       auth: authStateFactory({
         user: userFactory({ is_superuser: false }),
-      }),
-    });
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/vlan/1234" }]}>
-          <VLANDetailsHeader id={vlan.id} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(screen.queryByTestId("delete-vlan")).toBeNull();
-  });
-
-  it("does not show the delete button if the vlan is the default", () => {
-    state.fabric.items = [
-      fabricFactory({ id: 2, name: "fabric1", default_vlan_id: vlan.id }),
-    ];
-    state.user = userStateFactory({
-      auth: authStateFactory({
-        user: userFactory({ is_superuser: true }),
       }),
     });
     const store = mockStore(state);

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -51,9 +51,8 @@ const VLANDetailsHeader = ({ id }: Props): JSX.Element => {
   );
   const isAdmin = useSelector(authSelectors.isAdmin);
   const [formOpen, setFormOpen] = useState<HeaderForms | null>(null);
-  const isFabricDefault = fabric && vlan && fabric.default_vlan_id === vlan.id;
   const buttons = [];
-  if (isAdmin && !isFabricDefault) {
+  if (isAdmin) {
     buttons.push(
       <Button
         data-testid="delete-vlan"


### PR DESCRIPTION
## Done

- Update the delete fabric form to use `FormikForm`. Also handles the case where a fabric can't be deleted because subnets are attached.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/MAAS/r/networks` and go to the details page of a fabric without any subnets
- Click "Delete fabric", submit the form and check that a spinner shows in the submit button.
- Check that you get redirected to the network list on success.
- Go to the details page of a fabric with subnets.
- Click "Delete fabric" and check that an error shows stating that you can't delete the fabric.

## Screenshot

![Peek 2022-01-21 09-43](https://user-images.githubusercontent.com/25733845/152114763-daf88162-d310-4742-ba02-0d332eb03ca3.gif)
