### PR TITLE
feat(ui): build VLAN DHCP status section

### DIFF
--- a/ui/src/app/base/components/ControllerLink/ControllerLink.test.tsx
+++ b/ui/src/app/base/components/ControllerLink/ControllerLink.test.tsx
@@ -1,18 +1,70 @@
 import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import ControllerLink from "./ControllerLink";
 
 import baseURLs from "app/base/urls";
-import { controller as controllerFactory, modelRef } from "testing/factories";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  modelRef as modelRefFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
-const controller = controllerFactory({
-  hostname: "bolla",
-  system_id: "1234",
-  domain: modelRef({ name: "maas" }),
+const mockStore = configureStore();
+
+it("handles when controllers are loading", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [], loading: true }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ControllerLink systemId="abc123" />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByLabelText("Loading controllers")).toBeInTheDocument();
 });
-it("displays a correct link", () => {
-  render(<ControllerLink {...controller} />);
+
+it("handles when a controller does not exist", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [], loading: false }),
+  });
+  const store = mockStore(state);
+  const { container } = render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ControllerLink systemId="abc123" />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+it("renders a link if controllers have loaded and it exists", () => {
+  const controller = controllerFactory({
+    domain: modelRefFactory({ name: "maas" }),
+    hostname: "bolla",
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller], loading: false }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ControllerLink systemId={controller.system_id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
   const link = screen.getByRole("link");
   expect(link).toHaveTextContent("bolla.maas");
   expect(link).toHaveAttribute(

--- a/ui/src/app/base/components/ControllerLink/ControllerLink.tsx
+++ b/ui/src/app/base/components/ControllerLink/ControllerLink.tsx
@@ -1,16 +1,46 @@
+import { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
 import LegacyLink from "app/base/components/LegacyLink";
 import baseURLs from "app/base/urls";
-import type { BaseController } from "app/store/controller/types/base";
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
 
-const ControllerLink = ({
-  hostname,
-  system_id,
-  domain: { name: domainName },
-}: Pick<BaseController, "hostname" | "system_id" | "domain">): JSX.Element => {
+type Props = {
+  systemId?: Controller[ControllerMeta.PK] | null;
+};
+
+const ControllerLink = ({ systemId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  const controllersLoading = useSelector(controllerSelectors.loading);
+
+  useEffect(() => {
+    dispatch(controllerActions.fetch());
+  }, [dispatch]);
+
+  if (controllersLoading) {
+    // TODO: Put aria-label directly on Spinner component when issue is fixed.
+    // https://github.com/canonical-web-and-design/react-components/issues/651
+    return (
+      <span aria-label="Loading controllers">
+        <Spinner />
+      </span>
+    );
+  }
+  if (!controller) {
+    return null;
+  }
   return (
-    <LegacyLink route={baseURLs.controller({ id: system_id })}>
-      <strong>{hostname}</strong>
-      <span>.{domainName}</span>
+    <LegacyLink route={baseURLs.controller({ id: controller.system_id })}>
+      <strong>{controller.hostname}</strong>
+      <span>.{controller.domain.name}</span>
     </LegacyLink>
   );
 };

--- a/ui/src/app/base/components/FabricLink/FabricLink.test.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.test.tsx
@@ -14,7 +14,7 @@ import {
 
 const mockStore = configureStore();
 
-it("renders a spinner if fabrics are loading", () => {
+it("handles when fabrics are loading", () => {
   const state = rootStateFactory({
     fabric: fabricStateFactory({ items: [], loading: true }),
   });

--- a/ui/src/app/base/components/FabricLink/FabricLink.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import { getFabricDisplay } from "app/store/fabric/utils";
@@ -13,11 +16,16 @@ type Props = {
 };
 
 const FabricLink = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const fabric = useSelector((state: RootState) =>
     fabricSelectors.getById(state, id)
   );
   const fabricsLoading = useSelector(fabricSelectors.loading);
   const fabricDisplay = getFabricDisplay(fabric);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+  }, [dispatch]);
 
   if (fabricsLoading) {
     // TODO: Put aria-label directly on Spinner component when issue is fixed.

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.test.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.test.tsx
@@ -14,7 +14,7 @@ import {
 
 const mockStore = configureStore();
 
-it("renders a spinner if spaces are loading", () => {
+it("handles when spaces are loading", () => {
   const state = rootStateFactory({
     space: spaceStateFactory({ items: [], loading: true }),
   });

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
@@ -1,8 +1,11 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import type { RootState } from "app/store/root/types";
+import { actions as spaceActions } from "app/store/space";
 import spaceSelectors from "app/store/space/selectors";
 import type { Space, SpaceMeta } from "app/store/space/types";
 import { getSpaceDisplay } from "app/store/space/utils";
@@ -13,11 +16,16 @@ type Props = {
 };
 
 const SpaceLink = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const space = useSelector((state: RootState) =>
     spaceSelectors.getById(state, id)
   );
   const spacesLoading = useSelector(spaceSelectors.loading);
   const spaceDisplay = getSpaceDisplay(space);
+
+  useEffect(() => {
+    dispatch(spaceActions.fetch());
+  }, [dispatch]);
 
   if (spacesLoading) {
     // TODO: Put aria-label directly on Spinner component when issue is fixed.

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.test.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.test.tsx
@@ -14,7 +14,7 @@ import {
 
 const mockStore = configureStore();
 
-it("renders a spinner if subnets are loading", () => {
+it("handles when subnets are loading", () => {
   const state = rootStateFactory({
     subnet: subnetStateFactory({ items: [], loading: true }),
   });

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
@@ -1,8 +1,11 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import { getSubnetDisplay } from "app/store/subnet/utils";
@@ -13,11 +16,16 @@ type Props = {
 };
 
 const SubnetLink = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const subnet = useSelector((state: RootState) =>
     subnetSelectors.getById(state, id)
   );
   const subnetsLoading = useSelector(subnetSelectors.loading);
   const subnetDisplay = getSubnetDisplay(subnet);
+
+  useEffect(() => {
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
 
   if (subnetsLoading) {
     // TODO: Put aria-label directly on Spinner component when issue is fixed.

--- a/ui/src/app/base/components/VLANLink/VLANLink.test.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.test.tsx
@@ -14,7 +14,7 @@ import {
 
 const mockStore = configureStore();
 
-it("renders a spinner if vlans are loading", () => {
+it("handles when VLANs are loading", () => {
   const state = rootStateFactory({
     vlan: vlanStateFactory({ items: [], loading: true }),
   });
@@ -46,7 +46,7 @@ it("handles when a VLAN does not exist", () => {
   expect(container).toBeEmptyDOMElement();
 });
 
-it("renders a link if vlans have loaded and it exists", () => {
+it("renders a link if VLANs have loaded and it exists", () => {
   const vlan = vlanFactory();
   const state = rootStateFactory({
     vlan: vlanStateFactory({ items: [vlan], loading: false }),

--- a/ui/src/app/base/components/VLANLink/VLANLink.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.tsx
@@ -1,8 +1,11 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
 import { getVLANDisplay } from "app/store/vlan/utils";
@@ -13,11 +16,16 @@ type Props = {
 };
 
 const VLANLink = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
   const vlansLoading = useSelector(vlanSelectors.loading);
   const vlanDisplay = getVLANDisplay(vlan);
+
+  useEffect(() => {
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
 
   if (vlansLoading) {
     // TODO: Put aria-label directly on Spinner component when issue is fixed.

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -56,7 +56,9 @@ const generateRows = (
                 <RowCheckbox
                   data-testid="controller-checkbox"
                   handleRowCheckbox={handleRowCheckbox}
-                  inputLabel={<ControllerLink {...controller} />}
+                  inputLabel={
+                    <ControllerLink systemId={controller.system_id} />
+                  }
                   item={controller.system_id}
                   items={selectedIDs}
                 />

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
@@ -35,7 +35,10 @@ const FabricSummary = ({ fabric }: { fabric: Fabric }): JSX.Element => {
         ) : (
           controllers.map((controller) =>
             controller ? (
-              <ControllerLink key={controller.id} {...controller} />
+              <ControllerLink
+                key={controller.id}
+                systemId={controller.system_id}
+              />
             ) : null
           )
         )}

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -1,0 +1,255 @@
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
+import { render, screen, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DHCPStatus from "./DHCPStatus";
+
+import baseURLs from "app/base/urls";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("shows a spinner if data is loading", () => {
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [], loading: true }),
+    vlan: vlanStateFactory({ items: [] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByTestId("loading-data")).toBeInTheDocument();
+});
+
+it("shows a warning if there are no subnets attached to the VLAN", () => {
+  const vlan = vlanFactory();
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(
+    within(dhcpStatus).getByText(
+      "No subnets are available on this VLAN. DHCP cannot be enabled."
+    )
+  ).toBeInTheDocument();
+});
+
+it("does not show a warning if there are subnets attached to the VLAN", () => {
+  const vlan = vlanFactory();
+  const subnet = subnetFactory({ vlan: vlan.id });
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({ items: [subnet] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(
+    within(dhcpStatus).queryByText(
+      "No subnets are available on this VLAN. DHCP cannot be enabled."
+    )
+  ).not.toBeInTheDocument();
+});
+
+it("renders correctly when a VLAN does not have DHCP enabled", () => {
+  const vlan = vlanFactory({
+    dhcp_on: false,
+    external_dhcp: null,
+    relay_vlan: null,
+  });
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(within(dhcpStatus).getByTestId("dhcp-status").textContent).toBe(
+    "Disabled"
+  );
+});
+
+it("renders correctly when a VLAN has external DHCP", () => {
+  const vlan = vlanFactory({
+    dhcp_on: false,
+    external_dhcp: "192.168.1.1",
+    relay_vlan: null,
+  });
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(within(dhcpStatus).getByTestId("dhcp-status").textContent).toBe(
+    "External (192.168.1.1)"
+  );
+});
+
+it("renders correctly when a VLAN has relayed DHCP", () => {
+  const fabric = fabricFactory({ name: "fabrice" });
+  const relayVLAN = vlanFactory({
+    dhcp_on: true,
+    fabric: fabric.id,
+    name: "relay-vlan",
+    vid: 101,
+  });
+  const vlan = vlanFactory({
+    dhcp_on: false,
+    external_dhcp: null,
+    relay_vlan: relayVLAN.id,
+  });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [fabric] }),
+    vlan: vlanStateFactory({ items: [vlan, relayVLAN] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(within(dhcpStatus).getByTestId("dhcp-status").textContent).toBe(
+    "Relayed via fabrice.101 (relay-vlan)"
+  );
+});
+
+it("renders correctly when a VLAN has MAAS-configured DHCP without high availability", () => {
+  const controller = controllerFactory({
+    hostname: "primary-rack",
+    system_id: "abc123",
+  });
+  const vlan = vlanFactory({
+    dhcp_on: true,
+    external_dhcp: null,
+    primary_rack: "abc123",
+    relay_vlan: null,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(within(dhcpStatus).getByTestId("dhcp-status").textContent).toBe(
+    "Enabled"
+  );
+  expect(within(dhcpStatus).getByTestId("high-availability").textContent).toBe(
+    "No"
+  );
+  expect(
+    within(dhcpStatus).getByRole("link", { name: /primary-rack/i })
+  ).toHaveAttribute(
+    "href",
+    generateLegacyURL(baseURLs.controller({ id: controller.system_id }))
+  );
+});
+
+it("renders correctly when a VLAN has MAAS-configured DHCP with high availability", () => {
+  const primaryRack = controllerFactory({
+    hostname: "primary-rack",
+    system_id: "abc123",
+  });
+  const secondaryRack = controllerFactory({
+    hostname: "secondary-rack",
+    system_id: "def456",
+  });
+  const vlan = vlanFactory({
+    dhcp_on: true,
+    external_dhcp: null,
+    primary_rack: "abc123",
+    relay_vlan: null,
+    secondary_rack: "def456",
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [primaryRack, secondaryRack] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DHCPStatus id={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
+
+  expect(within(dhcpStatus).getByTestId("dhcp-status").textContent).toBe(
+    "Enabled"
+  );
+  expect(within(dhcpStatus).getByTestId("high-availability").textContent).toBe(
+    "Yes"
+  );
+  expect(
+    within(dhcpStatus).getByRole("link", { name: /primary-rack/i })
+  ).toHaveAttribute(
+    "href",
+    generateLegacyURL(baseURLs.controller({ id: primaryRack.system_id }))
+  );
+  expect(
+    within(dhcpStatus).getByRole("link", { name: /secondary-rack/i })
+  ).toHaveAttribute(
+    "href",
+    generateLegacyURL(baseURLs.controller({ id: secondaryRack.system_id }))
+  );
+});

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -1,5 +1,144 @@
-import TitledSection from "app/base/components/TitledSection";
+import { useEffect } from "react";
 
-const DHCPStatus = (): JSX.Element => <TitledSection title="DHCP" />;
+import {
+  Button,
+  Col,
+  Notification,
+  Row,
+  Spinner,
+} from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import ControllerLink from "app/base/components/ControllerLink";
+import Definition from "app/base/components/Definition";
+import TitledSection from "app/base/components/TitledSection";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import { getFullVLANName } from "app/store/vlan/utils";
+import subnetsURLs from "app/subnets/urls";
+import { isId } from "app/utils";
+
+type Props = {
+  id: VLAN[VLANMeta.PK] | null;
+};
+
+// Note this is not the same as the getDHCPStatus VLAN util as it uses slightly
+// different language and renders a link for the relayed VLAN.
+const getDHCPStatus = (vlan: VLAN, vlans: VLAN[], fabrics: Fabric[]) => {
+  if (vlan.dhcp_on) {
+    return "Enabled";
+  }
+  if (vlan.external_dhcp) {
+    return `External (${vlan.external_dhcp})`;
+  }
+  if (isId(vlan.relay_vlan)) {
+    return (
+      <span>
+        Relayed via{" "}
+        <Link to={subnetsURLs.vlan.index({ id: vlan.relay_vlan })}>
+          {getFullVLANName(vlan.relay_vlan, vlans, fabrics)}
+        </Link>
+      </span>
+    );
+  }
+  return "Disabled";
+};
+
+const DHCPStatus = ({ id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const fabrics = useSelector(fabricSelectors.all);
+  const fabricsLoading = useSelector(fabricSelectors.loading);
+  const vlans = useSelector(vlanSelectors.all);
+  const vlansLoading = useSelector(vlanSelectors.loading);
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, id)
+  );
+  const vlanSubnets = useSelector((state: RootState) =>
+    subnetSelectors.getByVLAN(state, id)
+  );
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+    dispatch(subnetActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  if (!vlan || fabricsLoading || subnetsLoading || vlansLoading) {
+    return (
+      <TitledSection data-testid="loading-data" title="DHCP">
+        <p>
+          <Spinner text="Loading" />
+        </p>
+      </TitledSection>
+    );
+  }
+
+  const hasVLANSubnets = vlanSubnets.length > 0;
+  const hasOwnDHCP =
+    (vlan.dhcp_on || vlan.external_dhcp) &&
+    (!!vlan.primary_rack || !!vlan.secondary_rack);
+  const hasHighAvailability = !!vlan.primary_rack && !!vlan.secondary_rack;
+  return (
+    <TitledSection buttons={<Button>Enable DHCP</Button>} title="DHCP">
+      {!hasVLANSubnets && (
+        <Notification severity="caution">
+          No subnets are available on this VLAN. DHCP cannot be enabled.
+        </Notification>
+      )}
+      <Row>
+        <Col size={6}>
+          <Definition label="Status">
+            <span data-testid="dhcp-status">
+              {getDHCPStatus(vlan, vlans, fabrics)}
+            </span>
+          </Definition>
+          {hasOwnDHCP && (
+            <Definition label="High availability">
+              <span data-testid="high-availability">
+                {hasHighAvailability ? "Yes" : "No"}
+              </span>
+            </Definition>
+          )}
+        </Col>
+        <Col size={6}>
+          {hasOwnDHCP && (
+            <>
+              {hasHighAvailability ? (
+                <>
+                  <Definition label="Primary rack">
+                    <ControllerLink systemId={vlan.primary_rack} />
+                  </Definition>
+                  <Definition label="Secondary rack">
+                    <ControllerLink systemId={vlan.secondary_rack} />
+                  </Definition>
+                </>
+              ) : (
+                <Definition label="Rack controller">
+                  <ControllerLink
+                    systemId={vlan.primary_rack || vlan.secondary_rack}
+                  />
+                </Definition>
+              )}
+            </>
+          )}
+        </Col>
+      </Row>
+      <p>
+        <a className="p-link--external" href="https://maas.io/docs/dhcp">
+          About DHCP
+        </a>
+      </p>
+    </TitledSection>
+  );
+};
 
 export default DHCPStatus;

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
@@ -5,9 +5,6 @@ import configureStore from "redux-mock-store";
 
 import VLANDetails from "./VLANDetails";
 
-import { actions as controllerActions } from "app/store/controller";
-import { actions as fabricActions } from "app/store/fabric";
-import { actions as spaceActions } from "app/store/space";
 import { actions as vlanActions } from "app/store/vlan";
 import subnetsURLs from "app/subnets/urls";
 import {
@@ -21,7 +18,7 @@ const mockStore = configureStore();
 it("dispatches actions to fetch necessary data and set vlan as active on mount", () => {
   const state = rootStateFactory({
     vlan: vlanStateFactory({
-      items: [vlanFactory({ id: 1, fabric: 2, space: 3 })],
+      items: [vlanFactory({ id: 1, space: 3 })],
     }),
   });
   const store = mockStore(state);
@@ -39,13 +36,7 @@ it("dispatches actions to fetch necessary data and set vlan as active on mount",
     </Provider>
   );
 
-  const expectedActions = [
-    vlanActions.get(1),
-    vlanActions.setActive(1),
-    controllerActions.fetch(),
-    fabricActions.get(2),
-    spaceActions.get(3),
-  ];
+  const expectedActions = [vlanActions.get(1), vlanActions.setActive(1)];
   const actualActions = store.getActions();
   expectedActions.forEach((expectedAction) => {
     expect(

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -11,11 +11,7 @@ import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
 import { useGetURLId, useWindowTitle } from "app/base/hooks";
-import { actions as controllerActions } from "app/store/controller";
-import { actions as fabricActions } from "app/store/fabric";
 import type { RootState } from "app/store/root/types";
-import { actions as spaceActions } from "app/store/space";
-import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -35,17 +31,12 @@ const VLANDetails = (): JSX.Element => {
   const subnets = useSelector((state: RootState) =>
     subnetSelectors.getByVLAN(state, id)
   );
-
   useWindowTitle(`${vlan?.name || "VLAN"} details`);
-  const fabricId = vlan?.fabric;
-  const spaceId = vlan?.space;
 
   useEffect(() => {
     if (isId(id)) {
       dispatch(vlanActions.get(id));
       dispatch(vlanActions.setActive(id));
-      dispatch(controllerActions.fetch());
-      dispatch(subnetActions.fetch());
     }
 
     const unsetActiveVLANAndCleanup = () => {
@@ -54,18 +45,6 @@ const VLANDetails = (): JSX.Element => {
     };
     return unsetActiveVLANAndCleanup;
   }, [dispatch, id]);
-
-  useEffect(() => {
-    if (isId(fabricId)) {
-      dispatch(fabricActions.get(fabricId));
-    }
-  }, [dispatch, fabricId]);
-
-  useEffect(() => {
-    if (isId(spaceId)) {
-      dispatch(spaceActions.get(spaceId));
-    }
-  }, [dispatch, spaceId]);
 
   if (!vlan) {
     const vlanNotFound = !isId(id) || !vlansLoading;
@@ -85,7 +64,7 @@ const VLANDetails = (): JSX.Element => {
   return (
     <Section header={<VLANDetailsHeader id={id} />}>
       <VLANSummary id={id} />
-      <DHCPStatus />
+      <DHCPStatus id={id} />
       <ReservedRanges />
       <VLANSubnets id={id} />
       <DHCPSnippets

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import VLANDeleteForm from "./VLANDeleteForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import authSelectors from "app/store/auth/selectors";
+import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import type { Fabric } from "app/store/fabric/types";
 import type { RootState } from "app/store/root/types";
@@ -42,6 +43,7 @@ const generateTitle = (
 };
 
 const VLANDetailsHeader = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
@@ -51,6 +53,11 @@ const VLANDetailsHeader = ({ id }: Props): JSX.Element => {
   );
   const isAdmin = useSelector(authSelectors.isAdmin);
   const [formOpen, setFormOpen] = useState<HeaderForms | null>(null);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+  }, [dispatch]);
+
   const buttons = [];
   if (isAdmin) {
     buttons.push(

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.tsx
@@ -30,14 +30,13 @@ const VLANControllers = ({ id }: Props): JSX.Element | null => {
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
-  const controllers = useSelector((state: RootState) =>
-    controllerSelectors.getByIDs(state, getRackIDs(vlan))
-  );
   const controllersLoading = useSelector(controllerSelectors.loading);
 
   if (!vlan) {
     return null;
   }
+
+  const rackIDs = getRackIDs(vlan);
   return (
     <Definition
       label={
@@ -59,15 +58,9 @@ const VLANControllers = ({ id }: Props): JSX.Element | null => {
           <Spinner />
         </span>
       ) : (
-        controllers.map((controller) =>
-          controller ? (
-            <ControllerLink
-              data-testid="ControllerLink"
-              key={controller.system_id}
-              {...controller}
-            />
-          ) : null
-        )
+        rackIDs.map((rackID) => (
+          <ControllerLink key={rackID} systemId={rackID} />
+        ))
       )}
     </Definition>
   );

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -31,6 +31,7 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
   if (!id || !vlan) {
     return null;
   }
+
   return (
     <TitledSection
       title="VLAN summary"


### PR DESCRIPTION
## Done

- Built DHCP status section in VLAN details. I've updated the design a little bit so that "High availability" is shown as a boolean instead of only showing when it's true, and also some of the model names are now links.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the VLAN details page of a VLAN with/without DHCP (MAAS, external, relayed) and check that the text matches the legacy version. Note that a lot of edge cases will be hard to test on bolla.

## Fixes

Fixes canonical-web-and-design/app-tribe#668

## Screenshot
![Screenshot 2022-02-02 at 18-54-06 Default VLAN details bolla MAAS](https://user-images.githubusercontent.com/25733845/152122679-b4a3f409-f1a7-46bb-b24a-321bfdd7c688.png)

