### PR TITLE
feat(ui): improve UX of fabric VLANs table

### DIFF
--- a/ui/src/app/store/vlan/selectors.test.ts
+++ b/ui/src/app/store/vlan/selectors.test.ts
@@ -82,6 +82,20 @@ describe("vlan selectors", () => {
     expect(vlan.getById(state, 42)).toStrictEqual(items[1]);
   });
 
+  it("can get VLANs in a fabric", () => {
+    const vlans = [
+      vlanFactory({ fabric: 1 }),
+      vlanFactory({ fabric: 2 }),
+      vlanFactory({ fabric: 1 }),
+    ];
+    const state = rootStateFactory({
+      vlan: vlanStateFactory({
+        items: vlans,
+      }),
+    });
+    expect(vlan.getByFabric(state, 1)).toStrictEqual([vlans[0], vlans[2]]);
+  });
+
   it("can filter vlans by name", () => {
     const items = [vlanFactory({ name: "abc" }), vlanFactory({ name: "def" })];
     const state = rootStateFactory({

--- a/ui/src/app/store/vlan/selectors.ts
+++ b/ui/src/app/store/vlan/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
+import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
@@ -86,6 +87,20 @@ const getUnusedForInterface = createSelector(
     });
     return vlansInFabric.filter(({ id }) => !usedVLANs.includes(id));
   }
+);
+
+/**
+ * Returns a list of VLANs in a given fabric.
+ * @param state - The redux state.
+ * @param fabricId - The id of the fabric.
+ * @returns a list of VLANs in a given fabric.
+ */
+const getByFabric = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, fabricId: Fabric[FabricMeta.PK]) => fabricId,
+  ],
+  (vlans, fabricId) => vlans.filter((vlan) => vlan.fabric === fabricId)
 );
 
 /**
@@ -189,6 +204,7 @@ const selectors = {
   configuringDHCP,
   eventErrors,
   eventErrorsForVLANs,
+  getByFabric,
   getStatusForVLAN,
   getUnusedForInterface,
   vlanState,

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
@@ -7,36 +7,37 @@ import FabricVLANs from "./FabricVLANs";
 
 import subnetsURLs from "app/subnets/urls";
 import {
+  fabric as fabricFactory,
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
-  fabric as fabricFactory,
-  vlan as vlanFactory,
-  vlanState as vlanStateFactory,
   space as spaceFactory,
   spaceState as spaceStateFactory,
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
+  subnetStatistics as subnetStatisticsFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
-it("renders correct details", async () => {
-  const fabric = fabricFactory({ id: 1, vlan_ids: [2] });
+it("renders correct details", () => {
+  const fabric = fabricFactory({ id: 1, name: "test-fabric", vlan_ids: [2] });
   const state = rootStateFactory({
     vlan: vlanStateFactory({
       loaded: true,
       loading: false,
-      items: [vlanFactory({ id: 2, fabric: 1 })],
+      items: [vlanFactory({ id: 2, fabric: 1, name: "test-vlan" })],
     }),
     space: spaceStateFactory({
       loaded: true,
       loading: false,
-      items: [spaceFactory({ id: 3 })],
+      items: [spaceFactory({ id: 3, name: "test-space" })],
     }),
     subnet: subnetStateFactory({
       loaded: true,
       loading: false,
-      items: [subnetFactory({ vlan: 2 })],
+      items: [subnetFactory({ id: 4, vlan: 2, name: "test-subnet" })],
     }),
     fabric: fabricStateFactory({
       items: [fabric],
@@ -69,7 +70,7 @@ it("renders correct details", async () => {
   ).toBeInTheDocument();
 
   expect(
-    screen.getByRole("columnheader", { name: "Subnet" })
+    screen.getByRole("columnheader", { name: "Subnets" })
   ).toBeInTheDocument();
 
   expect(
@@ -85,7 +86,7 @@ it("renders correct details", async () => {
   ).toBeInTheDocument();
 
   expect(
-    screen.getByRole("gridcell", { name: /test-name/ })
+    screen.getByRole("gridcell", { name: /test-subnet/ })
   ).toBeInTheDocument();
 
   expect(screen.getByRole("gridcell", { name: "99%" })).toBeInTheDocument();
@@ -99,6 +100,93 @@ it("renders correct details", async () => {
   ).toEqual("/vlan/2");
 
   expect(
-    screen.getByRole("link", { name: /test-name/ }).getAttribute("href")
+    screen.getByRole("link", { name: /test-subnet/ }).getAttribute("href")
   ).toEqual("/subnet/4");
+});
+
+it("handles a VLAN without any subnets", () => {
+  const fabric = fabricFactory({ name: "test-fabric", vlan_ids: [1] });
+  const space = spaceFactory({ name: "test-space" });
+  const vlan = vlanFactory({
+    fabric: fabric.id,
+    id: 1,
+    name: "test-vlan",
+    space: space.id,
+  });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [fabric] }),
+    space: spaceStateFactory({ items: [space] }),
+    subnet: subnetStateFactory({ items: [] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          { pathname: subnetsURLs.fabric.index({ id: fabric.id }) },
+        ]}
+      >
+        <FabricVLANs fabric={fabric} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("gridcell", { name: /No subnets/ })
+  ).toBeInTheDocument();
+});
+
+it("handles a VLAN with multiple subnets", () => {
+  const fabric = fabricFactory({ name: "test-fabric", vlan_ids: [1] });
+  const space = spaceFactory({ name: "test-space" });
+  const vlan = vlanFactory({
+    fabric: fabric.id,
+    id: 1,
+    name: "test-vlan",
+    space: space.id,
+  });
+  const subnets = [
+    subnetFactory({
+      name: "test-subnet-1",
+      statistics: subnetStatisticsFactory({ available_string: "66%" }),
+      vlan: vlan.id,
+    }),
+    subnetFactory({
+      name: "test-subnet-2",
+      statistics: subnetStatisticsFactory({ available_string: "77%" }),
+      vlan: vlan.id,
+    }),
+  ];
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [fabric] }),
+    space: spaceStateFactory({ items: [space] }),
+    subnet: subnetStateFactory({ items: subnets }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          { pathname: subnetsURLs.fabric.index({ id: fabric.id }) },
+        ]}
+      >
+        <FabricVLANs fabric={fabric} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  // We only render the VLAN and space cells for each VLAN once - subsequent
+  // rows should not include this duplicate data.
+  expect(screen.getAllByRole("link", { name: /test-vlan/ }).length).toBe(1);
+  expect(screen.getAllByRole("link", { name: /test-space/ }).length).toBe(1);
+  expect(
+    screen.getByRole("link", { name: /test-subnet-1/ })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: /test-subnet-2/ })
+  ).toBeInTheDocument();
+  expect(screen.getByRole("gridcell", { name: /66%/ })).toBeInTheDocument();
+  expect(screen.getByRole("gridcell", { name: /77%/ })).toBeInTheDocument();
 });

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/_index.scss
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/_index.scss
@@ -1,0 +1,39 @@
+@mixin FabricVLANs {
+  .fabric-vlans {
+    $vlan-width: 25%;
+    $space-width: 25%;
+    $subnets-width: 40%;
+    $available-width: 10%;
+
+    .truncated-border {
+      overflow: visible;
+      position: relative;
+
+      &::after {
+        background-color: $color-light;
+        content: "";
+        height: 1px;
+        left: 0;
+        position: absolute;
+        top: -1px;
+        width: $vlan-width + $space-width;
+      }
+    }
+
+    .vlan-col {
+      width: $vlan-width;
+    }
+
+    .space-col {
+      width: $space-width;
+    }
+
+    .subnets-col {
+      width: $subnets-width;
+    }
+
+    .available-col {
+      width: $available-width;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -257,8 +257,10 @@
 @include UsersList;
 
 // subnets
+@import "~app/subnets/views/FabricDetails/FabricVLANs";
 @import "~app/subnets/views/SubnetsList";
 @import "~app/subnets/views/VLANDetails/VLANSubnets";
+@include FabricVLANs;
 @include VLANSubnets;
 
 #maas-ui {


### PR DESCRIPTION
## Done

- Updated the fabric VLANs table in a few ways
  - Show a spinner while data is loading
  - Group rows by VLAN.
  - Change text for a VLAN with no subnets from "Unconfigured" to "No subnets" to be a bit more accurate

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a React fabric details page and check that the VLAN and Space cells aren't duplicated for each subnet
- Check that a VLAN without any subnets shows "No subnets"

## Screenshot

![Screenshot 2022-02-03 at 18-03-37 bolla-lxdbr0 details bolla MAAS](https://user-images.githubusercontent.com/25733845/152304210-46a20d81-0c36-4444-8f12-2532813d54a5.png)

