### PR TITLE
refactor: edit fabric form

### DIFF
--- a/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import EditFabric from "./EditFabric";
+
+import { actions as fabricActions } from "app/store/fabric";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const getRootState = () =>
+  rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [
+        fabricFactory({
+          name: "fabric-1",
+          description: "fabric-1 description",
+        }),
+      ],
+      loading: false,
+    }),
+  });
+
+it("dispatches an update action on submit", async () => {
+  const fabric = fabricFactory({
+    name: "fabric-1",
+    description: "fabric-1 description",
+  });
+  const state = getRootState();
+  state.fabric.items = [fabric];
+  const store = configureStore()(state);
+  render(
+    <Provider store={store}>
+      <EditFabric id={fabric.id} close={jest.fn()} />
+    </Provider>
+  );
+  const EditSummaryForm = screen.getByRole("form", {
+    name: "Edit fabric summary",
+  });
+  userEvent.clear(screen.getByLabelText("Name"));
+  userEvent.clear(screen.getByLabelText("Description"));
+  userEvent.type(screen.getByLabelText("Name"), "new name");
+  userEvent.type(screen.getByLabelText("Description"), "new description");
+  userEvent.click(
+    within(EditSummaryForm).getByRole("button", { name: "Save summary" })
+  );
+
+  const expectedAction = fabricActions.update({
+    id: fabric.id,
+    name: "new name",
+    description: "new description",
+  });
+  await waitFor(() => {
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.tsx
@@ -1,0 +1,96 @@
+import { useCallback } from "react";
+
+import { Col, Row, Spinner, Textarea } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import FabricController from "../FabricSummary/FabricController";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric, FabricMeta } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  close: () => void;
+  id: Fabric[FabricMeta.PK];
+};
+
+export type FormValues = {
+  name: Fabric["name"];
+  description: Fabric["description"];
+};
+
+const Schema = Yup.object().shape({
+  name: Yup.string(),
+  description: Yup.string(),
+});
+
+const EditFabric = ({ close, id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, id)
+  );
+  const saved = useSelector(fabricSelectors.saved);
+  const saving = useSelector(fabricSelectors.saving);
+  const errors = useSelector(fabricSelectors.errors);
+  const cleanup = useCallback(() => fabricActions.cleanup(), []);
+
+  if (!fabric) {
+    return (
+      <span data-testid="Spinner">
+        <Spinner text="Loading..." />
+      </span>
+    );
+  }
+  return (
+    <FormikForm<FormValues>
+      aria-label="Edit fabric summary"
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{
+        name: fabric.name,
+        description: fabric.description,
+      }}
+      onSaveAnalytics={{
+        action: "Save fabric",
+        category: "Fabric details",
+        label: "Edit fabric form",
+      }}
+      onCancel={close}
+      onSubmit={({ name, description }) => {
+        // Clear the errors from the previous submission.
+        dispatch(cleanup());
+        dispatch(
+          fabricActions.update({
+            id: fabric.id,
+            name,
+            description,
+          })
+        );
+      }}
+      onSuccess={() => close()}
+      resetOnSave
+      saved={saved}
+      saving={saving}
+      submitLabel="Save summary"
+      validationSchema={Schema}
+    >
+      <Row>
+        <Col size={6}>
+          <FormikField label="Name" name="name" type="text" />
+          <FabricController id={fabric.id} />
+          <FormikField
+            component={Textarea}
+            label="Description"
+            name="description"
+          />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default EditFabric;

--- a/ui/src/app/subnets/views/FabricDetails/EditFabric/index.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/EditFabric/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./EditFabric";

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricController.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricController.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import FabricControllers from "./FabricControllers";
+
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+  fabric as fabricFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("displays a spinner when loading controllers", () => {
+  const controller = controllerFactory({
+    hostname: "controller-1",
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      loaded: true,
+      items: [controller],
+    }),
+  });
+  const store = mockStore(state);
+  const fabric = fabricFactory({ id: 1 });
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FabricControllers id={fabric.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByTestId("Spinner")).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricControllers.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricControllers.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import ControllerLink from "app/base/components/ControllerLink";
+import Definition from "app/base/components/Definition";
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Fabric, FabricMeta } from "app/store/fabric/types";
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = {
+  id: Fabric[FabricMeta.PK];
+};
+
+const FabricControllers = ({ id }: Props): JSX.Element => {
+  const controllers = useSelector((state: RootState) =>
+    controllerSelectors.getByFabricId(state, id)
+  );
+  const controllersLoaded = useSelector(controllerSelectors.loaded);
+  const dispatch = useDispatch();
+
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+
+  useEffect(() => {
+    if (!vlansLoaded) dispatch(vlanActions.fetch());
+    if (!controllersLoaded) dispatch(controllerActions.fetch());
+  }, [dispatch, vlansLoaded, controllersLoaded]);
+
+  return (
+    <Definition label="Rack controllers">
+      {!controllersLoaded || !vlansLoaded ? (
+        <span data-testid="Spinner">
+          <Spinner />
+        </span>
+      ) : (
+        controllers.map((controller) =>
+          controller ? (
+            <ControllerLink key={controller.id} {...controller} />
+          ) : null
+        )
+      )}
+    </Definition>
+  );
+};
+
+export default FabricControllers;

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/index.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./FabricControllers";

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -8,6 +9,7 @@ import FabricSummary from "./FabricSummary";
 import {
   rootState as rootStateFactory,
   fabric as fabricFactory,
+  fabricState as fabricStateFactory,
   vlanState as vlanStateFactory,
   vlan as vlanFactory,
   controller as controllerFactory,
@@ -49,5 +51,40 @@ it("renders correct details", () => {
   ).toBeInTheDocument();
   waitFor(() =>
     expect(screen.getByRole("href", { name: "bolla.maas" })).toBeInTheDocument()
+  );
+});
+
+it("can open and close the Edit fabric summary form", async () => {
+  const fabric = fabricFactory({
+    name: "fabric-1",
+    description: "fabric-1 description",
+  });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({
+      items: [fabric],
+      loading: false,
+    }),
+  });
+  const store = configureStore()(state);
+  render(
+    <Provider store={store}>
+      <FabricSummary fabric={fabric} />
+    </Provider>
+  );
+  const fabricSummary = screen.getByRole("region", { name: "Fabric summary" });
+  userEvent.click(within(fabricSummary).getByRole("button", { name: "Edit" }));
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: "Edit fabric summary" })
+    ).toBeInTheDocument()
+  );
+
+  userEvent.click(
+    within(fabricSummary).getByRole("button", { name: "Cancel" })
+  );
+  await waitFor(() =>
+    expect(
+      screen.queryByRole("form", { name: "Edit fabric summary" })
+    ).not.toBeInTheDocument()
   );
 });

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
@@ -1,49 +1,42 @@
-import { useEffect } from "react";
+import { useState } from "react";
 
-import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { Button, Row } from "@canonical/react-components";
 
-import ControllerLink from "app/base/components/ControllerLink";
+import EditFabric from "../EditFabric";
+
+import FabricController from "./FabricController";
+
 import Definition from "app/base/components/Definition";
 import TitledSection from "app/base/components/TitledSection";
-import { actions as controllerActions } from "app/store/controller";
-import controllerSelectors from "app/store/controller/selectors";
 import type { Fabric } from "app/store/fabric/types";
-import type { RootState } from "app/store/root/types";
-import { actions as vlanActions } from "app/store/vlan";
-import vlanSelectors from "app/store/vlan/selectors";
 
 const FabricSummary = ({ fabric }: { fabric: Fabric }): JSX.Element => {
-  const dispatch = useDispatch();
-  const controllers = useSelector((state: RootState) =>
-    controllerSelectors.getByFabricId(state, fabric.id)
-  );
-  const vlansLoaded = useSelector(vlanSelectors.loaded);
-  const controllersLoaded = useSelector(controllerSelectors.loaded);
-
-  useEffect(() => {
-    if (!vlansLoaded) dispatch(vlanActions.fetch());
-    if (!controllersLoaded) dispatch(controllerActions.fetch());
-  }, [dispatch, vlansLoaded, controllersLoaded]);
+  const [editing, setEditing] = useState(false);
 
   return (
-    <TitledSection title="Fabric summary">
-      <Definition label="Name" description={fabric.name} />
-      <Definition label="Rack controllers">
-        {!controllersLoaded || !vlansLoaded ? (
-          <Spinner aria-label="loading" />
-        ) : (
-          controllers.map((controller) =>
-            controller ? (
-              <ControllerLink
-                key={controller.id}
-                systemId={controller.system_id}
-              />
-            ) : null
-          )
-        )}
-      </Definition>
-      <Definition label="Description" description={fabric.description} />
+    <TitledSection
+      title="Fabric summary"
+      buttons={
+        !editing && (
+          <Button
+            appearance="neutral"
+            className="u-no-margin--bottom"
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </Button>
+        )
+      }
+    >
+      {editing ? (
+        <EditFabric close={() => setEditing(false)} id={fabric.id} />
+      ) : (
+        <Row>
+          <Definition label="Name" description={fabric.name} />
+          <FabricController id={fabric.id} />
+          <Definition label="Description" description={fabric.description} />
+        </Row>
+      )}
     </TitledSection>
   );
 };


### PR DESCRIPTION
## Done

- Add a form to edit a fabric on the fabric details summary section.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React Fabric details page.
- In the summary section there should be an Edit button. Click it.
- The edit form should appear.
- Change some details and click save. The form should close.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/644

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
