### PR TITLE
refactor: subnets on this space

### DIFF
--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -1,5 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
+import type { Space } from "../space/types";
+
 import fabricSelectors from "app/store/fabric/selectors";
 import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
@@ -95,6 +97,25 @@ const getByPod = createSelector(
     return subnets.filter((subnet) =>
       pod.attached_vlans?.includes(subnet.vlan)
     );
+  }
+);
+
+/**
+ * Get subnets in a given space
+ * @param {RootState} state - The redux state.
+ * @param {Pod} VLANId - The id of the VLAN.
+ * @returns {Subnet[]} Subnets for a Space.
+ */
+const getBySpace = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, spaceId: Space["id"] | null) => spaceId,
+  ],
+  (subnets, spaceId) => {
+    if (!isId(spaceId)) {
+      return [];
+    }
+    return subnets.filter((subnet) => subnet.space === spaceId);
   }
 );
 
@@ -256,6 +277,7 @@ const selectors = {
   getByFabric,
   getByIds,
   getByPod,
+  getBySpace,
   getByVLAN,
   getPxeEnabledByPod,
   getStatusForSubnet,

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
@@ -58,7 +58,7 @@ const SpaceDetails = (): JSX.Element => {
   return (
     <Section header={<SpaceDetailsHeader space={space} />}>
       <SpaceSummary space={space} />
-      <SpaceSubnets />
+      <SpaceSubnets space={space} />
     </Section>
   );
 };

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SpaceSubnets from "./SpaceSubnets";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  fabric as fabricFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+  space as spaceFactory,
+  spaceState as spaceStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  subnetStatistics,
+} from "testing/factories";
+
+const mockStore = configureStore();
+const getRootState = () =>
+  rootStateFactory({
+    vlan: vlanStateFactory({
+      loaded: true,
+      loading: false,
+      items: [vlanFactory({ id: 2, fabric: 1 })],
+    }),
+    space: spaceStateFactory({
+      loaded: true,
+      loading: false,
+      items: [spaceFactory({ id: 3 })],
+    }),
+    subnet: subnetStateFactory({
+      loaded: true,
+      loading: false,
+      items: [subnetFactory({ id: 4, vlan: 2 })],
+    }),
+    fabric: fabricStateFactory({
+      items: [fabricFactory({ vlan_ids: [2] })],
+      loaded: true,
+      loading: false,
+    }),
+  });
+
+it("displays a message when there are no subnets", async () => {
+  const state = getRootState();
+  const space = spaceFactory({ id: 1, subnet_ids: [4], vlan_ids: [2] });
+  state.space.items = [space];
+
+  render(
+    <Provider store={mockStore(state)}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index({ id: space.id })}
+          component={() => <SpaceSubnets space={space} />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByText("There are no subnets on this space.")
+  ).toBeInTheDocument();
+});
+
+it("displays subnet details correctly", async () => {
+  const space = spaceFactory({ id: 1, subnet_ids: [4], vlan_ids: [2] });
+  const state = getRootState();
+  state.subnet.items = [
+    subnetFactory({
+      id: 4,
+      vlan: 2,
+      space: 1,
+      name: "test-subnet",
+      statistics: subnetStatistics({ available_string: "50%" }),
+    }),
+  ];
+  state.fabric.items = [
+    fabricFactory({ id: 1, name: "test-fabric", vlan_ids: [2] }),
+  ];
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={subnetsURLs.space.index({ id: space.id })}
+          component={() => <SpaceSubnets space={space} />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() =>
+    expect(screen.queryAllByRole("gridcell").length).toBeGreaterThan(0)
+  );
+
+  const headers = ["Subnet", "Available IPs", "VLAN", "Fabric"];
+  const cells = ["test-subnet", "50%", "test-vlan", "test-fabric"];
+
+  screen.queryAllByRole("columnheader").forEach((header, index) => {
+    expect(header).toHaveTextContent(headers[index]);
+  });
+  screen.queryAllByRole("gridcell").forEach((cell, index) => {
+    expect(cell).toHaveTextContent(cells[index]);
+  });
+});

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
@@ -1,7 +1,99 @@
-import TitledSection from "app/base/components/TitledSection";
+import { useEffect } from "react";
 
-const SpaceSubnets = (): JSX.Element => (
-  <TitledSection title="Subnets on this space" />
-);
+import type { MainTableProps } from "@canonical/react-components";
+import { Spinner, MainTable } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FabricLink from "app/base/components/FabricLink";
+import SubnetLink from "app/base/components/SubnetLink";
+import TitledSection from "app/base/components/TitledSection";
+import VLANLink from "app/base/components/VLANLink";
+import type { RootState } from "app/store/root/types";
+import type { Space } from "app/store/space/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN } from "app/store/vlan/types";
+import { getVlanById } from "app/store/vlan/utils";
+import { simpleSortByKey } from "app/utils";
+
+const generateRows = ({
+  subnets,
+  vlans,
+}: {
+  vlans: VLAN[];
+  subnets: Subnet[];
+}) => {
+  const rows: MainTableProps["rows"] = [];
+
+  if (subnets.length < 1) {
+    return [];
+  }
+  [...subnets].sort(simpleSortByKey("cidr")).forEach((subnet: Subnet) => {
+    const vlan = getVlanById(vlans, subnet.vlan) as VLAN;
+    rows.push({
+      columns: [
+        { "aria-label": "Subnet", content: <SubnetLink id={subnet?.id} /> },
+        {
+          "aria-label": "Available IPs",
+          content: subnet.statistics.available_string,
+        },
+        {
+          "aria-label": "VLAN",
+          content: <VLANLink id={subnet.vlan} />,
+        },
+        {
+          "aria-label": "Fabric",
+          content: <FabricLink id={vlan?.fabric} />,
+        },
+      ],
+    });
+  });
+
+  return rows;
+};
+
+const SpaceSubnets = ({ space }: { space: Space }): JSX.Element => {
+  const vlans = useSelector(vlanSelectors.all);
+  const subnets = useSelector((state: RootState) =>
+    subnetSelectors.getBySpace(state, space.id)
+  );
+  const dispatch = useDispatch();
+  const vlansLoading = useSelector(vlanSelectors.loading);
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+
+  useEffect(() => {
+    if (!subnetsLoaded) dispatch(subnetActions.fetch());
+    if (!vlansLoaded) dispatch(vlanActions.fetch());
+  }, [dispatch, subnetsLoaded, vlansLoaded]);
+
+  const loading = vlansLoading || subnetsLoading;
+
+  return (
+    <TitledSection title="Subnets on this space">
+      <MainTable
+        emptyStateMsg={
+          loading ? (
+            <Spinner text="Loading..." />
+          ) : (
+            "There are no subnets on this space."
+          )
+        }
+        headers={[
+          { content: "Subnet" },
+          { content: "Available IPs" },
+          { content: "VLAN" },
+          { content: "Fabric" },
+        ]}
+        rows={generateRows({ subnets, vlans })}
+        responsive
+      />
+    </TitledSection>
+  );
+};
 
 export default SpaceSubnets;


### PR DESCRIPTION
## Done

- build subnets on this space table

## Screenshots

![image](https://user-images.githubusercontent.com/7452681/152374979-c517bc93-cc99-4290-8223-6a1b8848fd96.png)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a space that has subnets, e.g. `MAAS/r/space/1` and verify everything works correctly

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
