### PR TITLE
fix(ui): small fixes in networking details pages

### DIFF
--- a/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.tsx
@@ -82,6 +82,8 @@ const EditFabric = ({ close, id }: Props): JSX.Element | null => {
         <Col size={6}>
           <FormikField label="Name" name="name" type="text" />
           <FabricController id={fabric.id} />
+        </Col>
+        <Col size={6}>
           <FormikField
             component={Textarea}
             label="Description"

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricControllers.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricControllers.tsx
@@ -39,7 +39,10 @@ const FabricControllers = ({ id }: Props): JSX.Element => {
       ) : (
         controllers.map((controller) =>
           controller ? (
-            <ControllerLink key={controller.id} {...controller} />
+            <ControllerLink
+              key={controller.id}
+              systemId={controller.system_id}
+            />
           ) : null
         )
       )}

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, Row } from "@canonical/react-components";
+import { Button, Col, Row } from "@canonical/react-components";
 
 import EditFabric from "../EditFabric";
 
@@ -32,9 +32,13 @@ const FabricSummary = ({ fabric }: { fabric: Fabric }): JSX.Element => {
         <EditFabric close={() => setEditing(false)} id={fabric.id} />
       ) : (
         <Row>
-          <Definition label="Name" description={fabric.name} />
-          <FabricController id={fabric.id} />
-          <Definition label="Description" description={fabric.description} />
+          <Col size={6}>
+            <Definition label="Name" description={fabric.name} />
+            <FabricController id={fabric.id} />
+          </Col>
+          <Col size={6}>
+            <Definition label="Description" description={fabric.description} />
+          </Col>
         </Row>
       )}
     </TitledSection>

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
@@ -22,6 +22,7 @@ import type { VLAN } from "app/store/vlan/types";
 import { simpleSortByKey } from "app/utils";
 
 const generateRows = (vlans: VLAN[], subnets: Subnet[]) => {
+  const headers = ["VLAN", "Space", "Subnet", "Available"] as const;
   const rows: MainTableProps["rows"] = [];
   const sortedVLANs = [...vlans].sort(simpleSortByKey("vid"));
 
@@ -32,21 +33,41 @@ const generateRows = (vlans: VLAN[], subnets: Subnet[]) => {
     if (!vlanHasSubnets) {
       rows.push({
         columns: [
-          { content: <VLANLink id={vlan.id} /> },
-          { content: <SpaceLink id={vlan.space} /> },
-          { content: "No subnets" },
-          { content: "—" },
+          { "aria-label": headers[0], content: <VLANLink id={vlan.id} /> },
+          { "aria-label": headers[1], content: <SpaceLink id={vlan.space} /> },
+          { "aria-label": headers[2], content: "No subnets" },
+          { "aria-label": headers[3], content: "—" },
         ],
       });
     } else {
       subnetsInVlan.forEach((subnet, i) => {
         rows.push({
-          className: i > 0 ? "truncated-border" : null,
+          className: i > 0 ? "truncated-border" : "",
           columns: [
-            { content: i === 0 ? <VLANLink id={vlan.id} /> : "" },
-            { content: i === 0 ? <SpaceLink id={vlan.space} /> : "" },
-            { content: <SubnetLink id={subnet.id} /> },
-            { content: subnet.statistics.available_string },
+            {
+              "aria-label": headers[0],
+              content: (
+                <span className={i > 0 ? "u-hide--medium u-hide--large" : ""}>
+                  <VLANLink id={vlan.id} />
+                </span>
+              ),
+            },
+            {
+              "aria-label": headers[1],
+              content: (
+                <span className={i > 0 ? "u-hide--medium u-hide--large" : ""}>
+                  <SpaceLink id={vlan.space} />
+                </span>
+              ),
+            },
+            {
+              "aria-label": headers[2],
+              content: <SubnetLink id={subnet.id} />,
+            },
+            {
+              "aria-label": headers[3],
+              content: subnet.statistics.available_string,
+            },
           ],
         });
       });

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/_index.scss
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/_index.scss
@@ -5,18 +5,20 @@
     $subnets-width: 40%;
     $available-width: 10%;
 
-    .truncated-border {
-      overflow: visible;
-      position: relative;
+    @media only screen and (min-width: $breakpoint-medium) {
+      .truncated-border {
+        overflow: visible;
+        position: relative;
 
-      &::after {
-        background-color: $color-light;
-        content: "";
-        height: 1px;
-        left: 0;
-        position: absolute;
-        top: -1px;
-        width: $vlan-width + $space-width;
+        &::after {
+          background-color: $color-light;
+          content: "";
+          height: 1px;
+          left: 0;
+          position: absolute;
+          top: -1px;
+          width: $vlan-width + $space-width;
+        }
       }
     }
 

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.tsx
@@ -32,10 +32,10 @@ const generateRows = ({
     return [];
   }
   [...subnets].sort(simpleSortByKey("cidr")).forEach((subnet: Subnet) => {
-    const vlan = getVlanById(vlans, subnet.vlan) as VLAN;
+    const vlan = getVlanById(vlans, subnet.vlan);
     rows.push({
       columns: [
-        { "aria-label": "Subnet", content: <SubnetLink id={subnet?.id} /> },
+        { "aria-label": "Subnet", content: <SubnetLink id={subnet.id} /> },
         {
           "aria-label": "Available IPs",
           content: subnet.statistics.available_string,


### PR DESCRIPTION
## Done

- Added aria-labels to VLANs on this fabric table.
- Updated fabric controllers to use system_id instead of the whole controller object.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the fabric details page of a fabric that has rack controllers and check that it renders properly
- Go to the fabric details page of a fabric that has multiple VLANs with subnets
- Resize the screen to mobile-size and check that it looks good

## Screenshot

![Screenshot 2022-02-04 at 12-49-50 fabric-0 details bolla MAAS](https://user-images.githubusercontent.com/25733845/152464347-2f1eb7d4-8402-4070-b453-2c907d282f0d.png)

