### PR TITLE
Update subnet details to display definition labels above the content.

### DIFF
--- a/ui/src/app/base/components/Definition/Definition.tsx
+++ b/ui/src/app/base/components/Definition/Definition.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { useId } from "app/base/hooks/base";
+
 type CommonProps = {
   label: React.ReactNode;
 };
@@ -16,19 +18,29 @@ type DescriptionProps =
 
 type Props = CommonProps & DescriptionProps;
 
-const Definition = ({ label, children, description }: Props): JSX.Element => (
-  <div>
-    <p className="u-text--muted">{label}</p>
-    {description ? (
-      <p>{description}</p>
-    ) : React.Children.toArray(children).length > 0 ? (
-      React.Children.toArray(children).map(
-        (child, i) => child && <p key={i}>{child}</p>
-      )
-    ) : (
-      <p>—</p>
-    )}
-  </div>
-);
+const Definition = ({ label, children, description }: Props): JSX.Element => {
+  const id = useId();
+  return (
+    <div>
+      <p className="u-text--muted" id={id}>
+        {label}
+      </p>
+      {description ? (
+        <p aria-labelledby={id}>{description}</p>
+      ) : React.Children.toArray(children).length > 0 ? (
+        React.Children.toArray(children).map(
+          (child, i) =>
+            child && (
+              <p key={i} aria-labelledby={id}>
+                {child}
+              </p>
+            )
+        )
+      ) : (
+        <p>—</p>
+      )}
+    </div>
+  );
+};
 
 export default Definition;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -63,7 +63,7 @@ const SubnetDetails = (): JSX.Element => {
 
   return (
     <Section header={<SubnetDetailsHeader subnet={subnet} />}>
-      <SubnetSummary subnet={subnet} />
+      <SubnetSummary id={id} />
       <Utilisation />
       <StaticRoutes />
       <ReservedRanges />

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
@@ -1,10 +1,15 @@
-import { render, screen } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+
+import type { TooltipProps } from "@canonical/react-components";
+import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetSummary from "./SubnetSummary";
 
+import type { RootState } from "app/store/root/types";
+import type { Subnet } from "app/store/subnet/types";
 import subnetsURLs from "app/subnets/urls";
 import {
   rootState as rootStateFactory,
@@ -20,41 +25,51 @@ import {
 
 const mockStore = configureStore();
 
-const defaultSubnetData = {
-  id: 1,
-  name: "Test subnet",
-  cidr: "192.168.1.1/32",
-  gateway_ip: "192.168.1.1/32",
-  dns_servers: "Test DNS",
-  description: "Test description",
-  managed: true,
-  active_discovery: true,
-  allow_proxy: true,
-  allow_dns: true,
-  space: 1,
-  vlan: 1,
-};
+const mockTooltip = jest.fn();
+jest.mock(
+  "@canonical/react-components/dist/components/Tooltip",
+  () => (props: PropsWithChildren<TooltipProps>) => {
+    mockTooltip(props);
+    return <span data-testid="Tooltip">{props.children}</span>;
+  }
+);
 
-const renderTestCase = (subnet = subnetFactory(defaultSubnetData)) => {
-  const state = rootStateFactory({
+let state: RootState;
+let subnet: Subnet;
+
+beforeEach(() => {
+  const spaceId = 1;
+  subnet = subnetFactory({
+    id: 1,
+    name: "Test subnet",
+    cidr: "192.168.1.1/32",
+    gateway_ip: "192.168.1.1/32",
+    dns_servers: "Test DNS",
+    description: "Test description",
+    managed: true,
+    active_discovery: true,
+    allow_proxy: true,
+    allow_dns: true,
+    space: spaceId,
+    vlan: 1,
+  });
+  state = rootStateFactory({
     subnet: subnetStateFactory({
       loaded: true,
       loading: false,
-      items: [subnetFactory(defaultSubnetData)],
+      items: [subnetFactory(subnet)],
     }),
     space: spaceStateFactory({
       loaded: true,
       loading: false,
-      items: [
-        spaceFactory({ id: defaultSubnetData.space, name: "Test space" }),
-      ],
+      items: [spaceFactory({ id: spaceId, name: "Test space" })],
     }),
     vlan: vlanStateFactory({
       loaded: true,
       loading: false,
       items: [
         vlanFactory({
-          id: defaultSubnetData.vlan,
+          id: subnet.vlan,
           name: "Test VLAN",
           fabric: 1,
         }),
@@ -67,149 +82,305 @@ const renderTestCase = (subnet = subnetFactory(defaultSubnetData)) => {
         fabricFactory({
           id: 1,
           name: "Test fabric",
-          vlan_ids: [defaultSubnetData.vlan],
+          vlan_ids: [subnet.vlan],
         }),
       ],
     }),
   });
-  const store = mockStore(state);
+});
 
-  return {
-    store,
-    subnet,
-    ...render(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
-        >
-          <Route
-            exact
-            path={subnetsURLs.subnet.index({ id: subnet.id })}
-            component={() => <SubnetSummary subnet={subnet} />}
-          />
-        </MemoryRouter>
-      </Provider>
-    ),
-  };
-};
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 it("renders correct section heading", async () => {
-  renderTestCase();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
   expect(
     screen.getByRole("heading", { name: "Subnet summary" })
   ).toBeInTheDocument();
 });
 
 it("renders corrent values for static fields", async () => {
-  renderTestCase();
-
-  expect(screen.getByLabelText("Name")).toHaveTextContent(
-    defaultSubnetData.name
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
   );
+  expect(screen.getByLabelText("Name")).toHaveTextContent(subnet.name);
 
-  expect(screen.getByLabelText("CIDR")).toHaveTextContent(
-    defaultSubnetData.cidr
-  );
+  expect(screen.getByLabelText("CIDR")).toHaveTextContent(subnet.cidr);
 
   expect(screen.getByLabelText("Gateway IP")).toHaveTextContent(
-    defaultSubnetData.gateway_ip
+    subnet.gateway_ip || ""
   );
 
-  expect(screen.getByLabelText("DNS")).toHaveTextContent(
-    defaultSubnetData.dns_servers
-  );
+  expect(screen.getByLabelText("DNS")).toHaveTextContent(subnet.dns_servers);
 
   expect(screen.getByLabelText("Description")).toHaveTextContent(
-    defaultSubnetData.description
+    subnet.description
   );
 });
 
 it("renders correct value for 'Managed allocation' if enabled", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.managed = true;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Managed allocation")).toHaveTextContent(
-    "Enabled"
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
   );
+  const label = "Managed allocation";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Enabled");
+  expect(
+    within(screen.getByText(label)).queryAllByTestId("Tooltip")
+  ).toHaveLength(0);
 });
 
 it("renders correct value for 'Managed allocation' if disabled", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.managed = false;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Managed allocation")).toHaveTextContent(
-    "Disabled"
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
   );
+  const label = "Managed allocation";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Disabled");
+  expect(
+    within(screen.getByText(label)).getByTestId("Tooltip")
+  ).toBeInTheDocument();
 });
 
 it("renders correct value for 'Active discovery' if enabled", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.active_discovery = true;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Active discovery")).toHaveTextContent(
-    "Enabled"
+  subnet.managed = true;
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
   );
+  const label = "Active discovery";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Enabled");
+  expect(
+    within(screen.getByText(label)).getByTestId("Tooltip")
+  ).toBeInTheDocument();
 });
 
 it("renders correct value for 'Active discovery' if disabled", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.active_discovery = false;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Active discovery")).toHaveTextContent(
-    "Disabled"
+  subnet.managed = false;
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
   );
+  const label = "Active discovery";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Disabled");
+  expect(
+    within(screen.getByText(label)).queryAllByTestId("Tooltip")
+  ).toHaveLength(0);
 });
 
 it("renders correct value for 'Proxy access' if allowed", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.allow_proxy = true;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Proxy access")).toHaveTextContent("Allowed");
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const label = "Proxy access";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Allowed");
+  expect(
+    within(screen.getByText(label)).getByTestId("Tooltip")
+  ).toBeInTheDocument();
+  expect(mockTooltip).toHaveBeenCalledWith(
+    expect.objectContaining({
+      "data-testid": "proxy-access-tooltip",
+      message: expect.stringContaining("MAAS will allow"),
+    })
+  );
 });
 
 it("renders correct value for 'Proxy access' if disallowed", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.allow_proxy = false;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Proxy access")).toHaveTextContent("Disallowed");
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const label = "Proxy access";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Disallowed");
+  expect(
+    within(screen.getByText(label)).getByTestId("Tooltip")
+  ).toBeInTheDocument();
+  expect(mockTooltip).toHaveBeenCalledWith(
+    expect.objectContaining({
+      "data-testid": "proxy-access-tooltip",
+      message: expect.stringContaining("MAAS will not allow"),
+    })
+  );
 });
 
 it("renders correct value for 'Allow DNS resolution' if allowed", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.allow_dns = true;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Allow DNS resolution")).toHaveTextContent(
-    "Allowed"
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const label = "Allow DNS resolution";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Allowed");
+  expect(
+    within(screen.getByText(label)).getByTestId("Tooltip")
+  ).toBeInTheDocument();
+  expect(mockTooltip).toHaveBeenCalledWith(
+    expect.objectContaining({
+      "data-testid": "allow-dns-tooltip",
+      message: expect.stringContaining("MAAS will allow"),
+    })
   );
 });
 
 it("renders correct value for 'Allow DNS resolution' if disallowed", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.allow_dns = false;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Allow DNS resolution")).toHaveTextContent(
-    "Disallowed"
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const label = "Allow DNS resolution";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Disallowed");
+  expect(
+    within(screen.getByText(label)).getByTestId("Tooltip")
+  ).toBeInTheDocument();
+  expect(mockTooltip).toHaveBeenCalledWith(
+    expect.objectContaining({
+      "data-testid": "allow-dns-tooltip",
+      message: expect.stringContaining("MAAS will not allow"),
+    })
   );
 });
 
 it("renders the correct value for 'VLAN'", async () => {
-  renderTestCase();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
   expect(screen.getByLabelText("VLAN")).toHaveTextContent("Test VLAN");
 });
 
 it("renders the correct value for 'Fabric'", async () => {
-  renderTestCase();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
   expect(screen.getByLabelText("Fabric")).toHaveTextContent("Test fabric");
 });
 
 it("renders the correct value for 'Space' if it has an ID", async () => {
-  renderTestCase();
-  expect(screen.getByLabelText("Space")).toHaveTextContent("Test space");
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const label = "Space";
+  expect(screen.getByLabelText(label)).toHaveTextContent("Test space");
+  expect(
+    within(screen.getByText(label)).queryAllByTestId("Tooltip")
+  ).toHaveLength(0);
 });
 
 it("renders the correct value for 'Space' if no ID", async () => {
-  const subnet = subnetFactory(defaultSubnetData);
   subnet.space = null;
-  renderTestCase(subnet);
-  expect(screen.getByLabelText("Space")).toHaveTextContent("No space");
+  state.subnet.items = [subnet];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
+      >
+        <SubnetSummary id={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const label = screen.getByLabelText("Space");
+  expect(label).toHaveTextContent("No space");
+  expect(within(label).getByTestId("Tooltip")).toBeInTheDocument();
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -3,30 +3,32 @@ import { useEffect } from "react";
 import { Row, Col, Tooltip, Icon } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
 
+import Definition from "app/base/components/Definition";
+import FabricLink from "app/base/components/FabricLink";
+import SpaceLink from "app/base/components/SpaceLink";
 import TitledSection from "app/base/components/TitledSection";
+import VLANLink from "app/base/components/VLANLink";
 import { actions as fabricActions } from "app/store/fabric";
-import fabricSelectors from "app/store/fabric/selectors";
-import { getFabricById } from "app/store/fabric/utils";
+import type { RootState } from "app/store/root/types";
 import { actions as spaceActions } from "app/store/space";
-import spaceSelectors from "app/store/space/selectors";
-import { getSpaceById } from "app/store/space/utils";
-import type { Subnet } from "app/store/subnet/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
-import { getVlanById } from "app/store/vlan/utils";
+import { isId } from "app/utils";
 
 type Props = {
-  subnet: Subnet;
+  id: Subnet[SubnetMeta.PK] | null;
 };
 
-const SubnetSummary = ({ subnet }: Props): JSX.Element => {
+const SubnetSummary = ({ id }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const spaces = useSelector(spaceSelectors.all);
-  const vlans = useSelector(vlanSelectors.all);
-  const fabrics = useSelector(fabricSelectors.all);
-  const space = getSpaceById(spaces, subnet.space) || null;
-  const vlan = getVlanById(vlans, subnet.vlan) || null;
-  const fabric = vlan ? getFabricById(fabrics, vlan.fabric) : null;
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, id)
+  );
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, subnet?.vlan)
+  );
 
   useEffect(() => {
     dispatch(spaceActions.fetch());
@@ -34,196 +36,125 @@ const SubnetSummary = ({ subnet }: Props): JSX.Element => {
     dispatch(fabricActions.fetch());
   }, [dispatch]);
 
+  if (!subnet) {
+    return null;
+  }
+
   return (
     <TitledSection title="Subnet summary">
       <Row>
         <Col size={6}>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-name">
-                Name
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-name">{subnet.name}</p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-cidr">
-                CIDR
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-cidr">{subnet.cidr}</p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-gateway-ip">
-                Gateway IP
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-gateway-ip">{subnet.gateway_ip}</p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-dns">
-                DNS
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-dns">{subnet.dns_servers}</p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-description">
-                Description
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-description">{subnet.description}</p>
-            </Col>
-          </Row>
+          <Definition label="Name" description={subnet.name} />
+          <Definition label="CIDR" description={subnet.cidr} />
+          <Definition label="Gateway IP">{subnet.gateway_ip}</Definition>
+          <Definition label="DNS" description={subnet.dns_servers} />
+          <Definition label="Description" description={subnet.description} />
+          <Definition
+            label={
+              <>
+                Managed allocation{" "}
+                {subnet.managed ? null : (
+                  <Tooltip
+                    message="MAAS allocates IP addresses 
+                  from this subnet, exluding the 
+                  reserved and dynamic ranges."
+                    position="btm-right"
+                  >
+                    <Icon name="information" />
+                  </Tooltip>
+                )}
+              </>
+            }
+          >
+            {subnet.managed ? "Enabled" : "Disabled"}
+          </Definition>
         </Col>
         <Col size={6}>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted">
-                <span id="subnet-managed-allocation">Managed allocation</span>{" "}
-                <Tooltip
-                  message="MAAS allocates IP addresses 
-from this subnet, exluding the 
-reserved and dynamic ranges."
-                  position="btm-right"
-                >
-                  <Icon name="information" />
-                </Tooltip>
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-managed-allocation">
-                {subnet.managed ? "Enabled" : "Disabled"}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-active-discovery">
-                <span id="subnet-active-discovery">Active discovery</span>{" "}
-                <Tooltip
-                  message="When enabled, MAAS will scan 
+          <Definition
+            label={
+              <>
+                Active discovery{" "}
+                {subnet.managed ? (
+                  <Tooltip
+                    message="When enabled, MAAS will scan 
 this subnet to discover hosts 
 that have not been discovered 
 passively."
-                  position="btm-right"
-                >
-                  <Icon name="information" />
-                </Tooltip>
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-active-discovery">
-                {subnet.active_discovery ? "Enabled" : "Disabled"}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-proxy-access">
-                <span id="subnet-proxy-access">Proxy access</span>{" "}
+                    position="btm-right"
+                  >
+                    <Icon name="information" />
+                  </Tooltip>
+                ) : null}
+              </>
+            }
+          >
+            {subnet.active_discovery ? "Enabled" : "Disabled"}
+          </Definition>
+          <Definition
+            label={
+              <>
+                Proxy access{" "}
                 <Tooltip
-                  message="MAAS will allow clients from 
+                  data-testid="proxy-access-tooltip"
+                  message={`MAAS will${
+                    subnet.allow_proxy ? "" : " not"
+                  } allow clients from 
 this subnet to access the 
-MAAS proxy."
+MAAS proxy.`}
                   position="btm-right"
                 >
                   <Icon name="information" />
                 </Tooltip>
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-proxy-access">
-                {subnet.allow_proxy ? "Allowed" : "Disallowed"}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-allow-dns-resolution">
-                <span id="subnet-allow-dns-resolution">
-                  Allow DNS resolution
-                </span>{" "}
+              </>
+            }
+          >
+            {subnet.allow_proxy ? "Allowed" : "Disallowed"}
+          </Definition>
+          <Definition
+            label={
+              <>
+                Allow DNS resolution{" "}
                 <Tooltip
-                  message="MAAS will allow clients from 
+                  data-testid="allow-dns-tooltip"
+                  message={`MAAS will${
+                    subnet.allow_dns ? "" : " not"
+                  } allow clients from 
 this subnet to use MAAS 
-for DNS resolution."
+for DNS resolution.`}
                   position="btm-right"
                 >
                   <Icon name="information" />
                 </Tooltip>
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-allow-dns-resolution">
-                {subnet.allow_dns ? "Allowed" : "Disallowed"}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-fabric">
-                Fabric
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-fabric">
-                {fabric ? fabric.name : "No fabric"}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-vlan">
-                VLAN
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-vlan">
-                {vlan && vlan.name ? vlan.name : "untagged"}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-space">
-                Space
-              </p>
-            </Col>
-            <Col size={4}>
-              <p>
-                {space && space.name ? (
-                  <span aria-labelledby="subnet-space">{space.name}</span>
-                ) : (
-                  <>
-                    <span aria-labelledby="subnet-space">No space</span>{" "}
-                    <Tooltip
-                      message="This subnet does not belong to 
+              </>
+            }
+          >
+            {subnet.allow_dns ? "Allowed" : "Disallowed"}
+          </Definition>
+          <Definition label="Fabric">
+            <FabricLink id={vlan?.fabric} />
+          </Definition>
+          <Definition label="VLAN">
+            <VLANLink id={subnet.vlan} />
+          </Definition>
+          <Definition label="Space">
+            <>
+              <SpaceLink id={subnet.space} />
+              {isId(subnet.space) ? null : (
+                <>
+                  {" "}
+                  <Tooltip
+                    message="This subnet does not belong to 
 a space. MAAS integrations require 
 a space in order to determine the 
 purpose of a network."
-                      position="btm-right"
-                    >
-                      <Icon name="warning" />
-                    </Tooltip>
-                  </>
-                )}
-              </p>
-            </Col>
-          </Row>
+                    position="btm-right"
+                  >
+                    <Icon name="warning" />
+                  </Tooltip>
+                </>
+              )}
+            </>
+          </Definition>
         </Col>
       </Row>
     </TitledSection>


### PR DESCRIPTION
## Done

- Update subnet details to display definition labels above the content.
- Conditionally display tooltips.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a React subnets details page.
- You should see the labels above the content (as opposed to the angular version where the labels are to the left).

## Screenshots

<img width="1035" alt="Screen Shot 2022-02-04 at 12 40 30 pm" src="https://user-images.githubusercontent.com/361637/152466799-6f36196b-8882-4c82-acf2-199e0a2cce09.png">
