### PR TITLE
feat(ui): add reserved ranges table

### DIFF
--- a/ui/src/app/store/iprange/selectors.test.ts
+++ b/ui/src/app/store/iprange/selectors.test.ts
@@ -4,6 +4,10 @@ import {
   rootState as rootStateFactory,
   ipRange as ipRangeFactory,
   ipRangeState as ipRangeStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
 } from "testing/factories";
 
 describe("all", () => {
@@ -70,5 +74,63 @@ describe("saved", () => {
       }),
     });
     expect(ipRange.saved(state)).toStrictEqual(true);
+  });
+});
+
+describe("getBySubnet", () => {
+  it("returns IP ranges that are in a subnet", () => {
+    const subnet = subnetFactory();
+    const subnet2 = subnetFactory();
+    const items = [
+      ipRangeFactory({ subnet: subnet.id }),
+      ipRangeFactory({ subnet: subnet.id }),
+      ipRangeFactory({ subnet: subnet2.id }),
+    ];
+    const state = rootStateFactory({
+      iprange: ipRangeStateFactory({
+        items,
+      }),
+      subnet: subnetStateFactory({
+        items: [subnet, subnet2],
+      }),
+    });
+    expect(ipRange.getBySubnet(state, subnet.id)).toStrictEqual([
+      items[0],
+      items[1],
+    ]);
+  });
+
+  it("handles a null subnet", () => {
+    const state = rootStateFactory();
+    expect(ipRange.getBySubnet(state, null)).toStrictEqual([]);
+  });
+});
+
+describe("getByVLAN", () => {
+  it("returns IP ranges that are in a VLAN", () => {
+    const vlan = vlanFactory();
+    const vlan2 = vlanFactory();
+    const items = [
+      ipRangeFactory({ vlan: vlan.id }),
+      ipRangeFactory({ vlan: vlan.id }),
+      ipRangeFactory({ vlan: vlan2.id }),
+    ];
+    const state = rootStateFactory({
+      iprange: ipRangeStateFactory({
+        items,
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan, vlan2],
+      }),
+    });
+    expect(ipRange.getByVLAN(state, vlan.id)).toStrictEqual([
+      items[0],
+      items[1],
+    ]);
+  });
+
+  it("handles a null VLAN", () => {
+    const state = rootStateFactory();
+    expect(ipRange.getByVLAN(state, null)).toStrictEqual([]);
   });
 });

--- a/ui/src/app/store/iprange/selectors.ts
+++ b/ui/src/app/store/iprange/selectors.ts
@@ -1,10 +1,60 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import type { RootState } from "../root/types";
+
 import { IPRangeMeta } from "app/store/iprange/types";
 import type { IPRange, IPRangeState } from "app/store/iprange/types";
 import { generateBaseSelectors } from "app/store/utils";
+import { isId } from "app/utils";
 
-const selectors = generateBaseSelectors<IPRangeState, IPRange, IPRangeMeta.PK>(
-  IPRangeMeta.MODEL,
+const defaultSelectors = generateBaseSelectors<
+  IPRangeState,
+  IPRange,
   IPRangeMeta.PK
+>(IPRangeMeta.MODEL, IPRangeMeta.PK);
+
+/**
+ * Finds IP ranges for a subnet.
+ * @param state - The redux state.
+ * @param id - A subnet's id.
+ * @returns IP ranges for a subnet.
+ */
+const getBySubnet = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, id: IPRange["subnet"] | undefined) => id,
+  ],
+  (ipRanges, id) => {
+    if (!isId(id)) {
+      return [];
+    }
+    return ipRanges.filter(({ subnet }) => subnet === id);
+  }
 );
+
+/**
+ * Get IP ranges for a VLAN.
+ * @param state - The redux state.
+ * @param id - The id of the VLAN.
+ * @returns IP ranges for a VLAN.
+ */
+const getByVLAN = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, id: IPRange["vlan"] | undefined) => id,
+  ],
+  (ipRanges, id) => {
+    if (!isId(id)) {
+      return [];
+    }
+    return ipRanges.filter(({ vlan }) => vlan === id);
+  }
+);
+
+const selectors = {
+  ...defaultSelectors,
+  getBySubnet,
+  getByVLAN,
+};
 
 export default selectors;

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ReservedRanges, { Labels } from "./ReservedRanges";
+
+import { IPRangeType } from "app/store/iprange/types";
+import {
+  rootState as rootStateFactory,
+  ipRange as ipRangeFactory,
+  ipRangeState as ipRangeStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders for a subnet", () => {
+  const subnet = subnetFactory();
+  const subnet2 = subnetFactory();
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({
+      items: [
+        ipRangeFactory({ start_ip: "11.1.1.1", subnet: subnet.id }),
+        ipRangeFactory({ start_ip: "11.1.1.2", subnet: subnet.id }),
+        ipRangeFactory({ start_ip: "11.1.1.3", subnet: subnet2.id }),
+      ],
+    }),
+    subnet: subnetStateFactory({
+      items: [subnet, subnet2],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.queryAllByRole("gridcell", {
+      name: Labels.StartIP,
+    })
+  ).toHaveLength(2);
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.StartIP,
+      })
+      .find((td) => td.textContent === "11.1.1.1")
+  ).toBeInTheDocument();
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.StartIP,
+      })
+      .find((td) => td.textContent === "11.1.1.2")
+  ).toBeInTheDocument();
+});
+
+it("renders for a vlan", () => {
+  const vlan = vlanFactory();
+  const vlan2 = vlanFactory();
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({
+      items: [
+        ipRangeFactory({ start_ip: "11.1.1.1", vlan: vlan.id }),
+        ipRangeFactory({ start_ip: "11.1.1.2", vlan: vlan.id }),
+        ipRangeFactory({ start_ip: "11.1.1.3", vlan: vlan2.id }),
+      ],
+    }),
+    vlan: vlanStateFactory({
+      items: [vlan, vlan2],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges vlanId={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.queryAllByRole("gridcell", {
+      name: Labels.StartIP,
+    })
+  ).toHaveLength(2);
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.StartIP,
+      })
+      .find((td) => td.textContent === "11.1.1.1")
+  ).toBeInTheDocument();
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.StartIP,
+      })
+      .find((td) => td.textContent === "11.1.1.2")
+  ).toBeInTheDocument();
+});
+
+it("displays an empty message for a subnet", () => {
+  const subnet = subnetFactory();
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByText("No IP ranges have been reserved for this subnet.")
+  ).toBeInTheDocument();
+});
+
+it("displays an empty message for a vlan", () => {
+  const vlan = vlanFactory();
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({
+      items: [vlan],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges vlanId={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByText("No IP ranges have been reserved for this VLAN.")
+  ).toBeInTheDocument();
+});
+
+it("displays content when it is dynamic", () => {
+  const subnet = subnetFactory();
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({
+      items: [
+        ipRangeFactory({
+          start_ip: "11.1.1.1",
+          subnet: subnet.id,
+          type: IPRangeType.Dynamic,
+        }),
+      ],
+    }),
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Type,
+    })
+  ).toHaveTextContent("Dynamic");
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Owner,
+    })
+  ).toHaveTextContent("MAAS");
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Comment,
+    })
+  ).toHaveTextContent("Dynamic");
+});
+
+it("displays content when it is reserved", () => {
+  const subnet = subnetFactory();
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({
+      items: [
+        ipRangeFactory({
+          comment: "what a beaut",
+          start_ip: "11.1.1.1",
+          subnet: subnet.id,
+          type: IPRangeType.Reserved,
+          user: "wombat",
+        }),
+      ],
+    }),
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Type,
+    })
+  ).toHaveTextContent("Reserved");
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Owner,
+    })
+  ).toHaveTextContent("wombat");
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Comment,
+    })
+  ).toHaveTextContent("what a beaut");
+});

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -1,7 +1,172 @@
-import TitledSection from "app/base/components/TitledSection";
+import { useEffect, useState } from "react";
 
-const ReservedRanges = (): JSX.Element => (
-  <TitledSection title="Reserved ranges" />
-);
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import TableActions from "app/base/components/TableActions";
+import TitledSection from "app/base/components/TitledSection";
+import { actions as ipRangeActions } from "app/store/iprange";
+import ipRangeSelectors from "app/store/iprange/selectors";
+import type { IPRange, IPRangeMeta } from "app/store/iprange/types";
+import { IPRangeType } from "app/store/iprange/types";
+import type { RootState } from "app/store/root/types";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import { isId } from "app/utils";
+
+export type SubnetProps = {
+  subnetId: Subnet[SubnetMeta.PK] | null;
+  vlanId?: never;
+};
+
+export type VLANProps = {
+  subnetId?: never;
+  vlanId: VLAN[VLANMeta.PK] | null;
+};
+
+export type Props = SubnetProps | VLANProps;
+
+export enum Labels {
+  StartIP = "Start IP Address",
+  EndIp = "End IP Address",
+  Owner = "Owner",
+  Type = "Type",
+  Comment = "Comment",
+  Actions = "Actions",
+}
+
+const generateRows = (
+  ipRanges: IPRange[],
+  expanded: IPRange["id"] | null,
+  setExpanded: (id: IPRange["id"] | null) => void
+) =>
+  ipRanges.map((ipRange: IPRange) => {
+    const isExpanded = expanded === ipRange.id;
+    const isDynamic = ipRange.type === IPRangeType.Dynamic;
+    const owner = isDynamic ? "MAAS" : ipRange.user;
+    const comment = isDynamic ? "Dynamic" : ipRange.comment;
+    return {
+      className: isExpanded ? "p-table__row is-active" : null,
+      columns: [
+        {
+          "aria-label": Labels.StartIP,
+          content: ipRange.start_ip,
+        },
+        {
+          "aria-label": Labels.EndIp,
+          content: ipRange.end_ip,
+        },
+        {
+          "aria-label": Labels.Owner,
+          content: owner,
+        },
+        {
+          "aria-label": Labels.Type,
+          content: isDynamic ? "Dynamic" : "Reserved",
+        },
+        { "aria-label": Labels.Comment, content: comment },
+        {
+          "aria-label": Labels.Actions,
+          content: (
+            <TableActions
+              onEdit={() => {
+                setExpanded(expanded === ipRange.id ? null : ipRange.id);
+              }}
+              onDelete={() => {
+                setExpanded(expanded === ipRange.id ? null : ipRange.id);
+              }}
+            />
+          ),
+          className: "u-align--right",
+        },
+      ],
+      expanded: isExpanded,
+      // TODO: Implement the edit form:
+      // https://github.com/canonical-web-and-design/app-tribe/issues/663
+      expandedContent: isExpanded && "Edit",
+      key: ipRange.id,
+      sortData: {
+        comment,
+        end_ip: ipRange.end_ip,
+        owner,
+        start_ip: ipRange.start_ip,
+        type: ipRange.type,
+      },
+    };
+  });
+
+const ReservedRanges = ({ subnetId, vlanId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const [expanded, setExpanded] = useState<IPRange[IPRangeMeta.PK] | null>(
+    null
+  );
+  const isSubnet = isId(subnetId);
+  const ipRangeLoading = useSelector(ipRangeSelectors.loading);
+  const ipRanges = useSelector((state: RootState) =>
+    isSubnet
+      ? ipRangeSelectors.getBySubnet(state, subnetId)
+      : ipRangeSelectors.getByVLAN(state, vlanId)
+  );
+
+  useEffect(() => {
+    dispatch(ipRangeActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <TitledSection title="Reserved ranges">
+      <MainTable
+        className="reserved-ranges-table p-table-expanding--light"
+        defaultSort="name"
+        defaultSortDirection="descending"
+        emptyStateMsg={
+          ipRangeLoading ? (
+            <Spinner text="Loading..." />
+          ) : (
+            `No IP ranges have been reserved for this ${
+              isSubnet ? "subnet" : "VLAN"
+            }.`
+          )
+        }
+        expanding
+        headers={[
+          {
+            content: Labels.StartIP,
+            sortKey: "start_ip",
+          },
+          {
+            content: Labels.EndIp,
+            sortKey: "end_ip",
+          },
+          {
+            content: Labels.Owner,
+            sortKey: "owner",
+          },
+          {
+            content: Labels.Type,
+            sortKey: "type",
+          },
+          {
+            content: Labels.Comment,
+            sortKey: "comment",
+          },
+          {
+            content: Labels.Actions,
+            className: "u-align--right",
+          },
+        ]}
+        rows={generateRows(ipRanges, expanded, setExpanded)}
+        sortable
+      />
+      <a
+        className="p-link--external"
+        href="https://maas.io/docs/ip-ranges"
+        rel="noreferrer"
+        target="_blank"
+      >
+        About IP ranges
+      </a>
+    </TitledSection>
+  );
+};
 
 export default ReservedRanges;

--- a/ui/src/app/subnets/components/ReservedRanges/_index.scss
+++ b/ui/src/app/subnets/components/ReservedRanges/_index.scss
@@ -1,0 +1,33 @@
+@mixin ReservedRanges {
+  .reserved-ranges-table {
+    th:nth-child(1),
+    td:nth-child(1) {
+      width: 25%;
+    }
+
+    th:nth-child(2),
+    td:nth-child(2) {
+      width: 25%;
+    }
+
+    th:nth-child(3),
+    td:nth-child(3) {
+      width: 13%;
+    }
+
+    th:nth-child(4),
+    td:nth-child(4) {
+      width: 13%;
+    }
+
+    th:nth-child(5),
+    td:nth-child(5) {
+      width: 12%;
+    }
+
+    th:nth-child(6),
+    td:nth-child(6) {
+      width: 12%;
+    }
+  }
+}

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -66,7 +66,7 @@ const SubnetDetails = (): JSX.Element => {
       <SubnetSummary id={id} />
       <Utilisation statistics={subnet.statistics} />
       <StaticRoutes />
-      <ReservedRanges />
+      <ReservedRanges subnetId={id} />
       <DHCPSnippets
         subnetIds={isId(id) ? [id] : []}
         modelName={SubnetMeta.MODEL}

--- a/ui/src/app/subnets/views/SubnetsList/_index.scss
+++ b/ui/src/app/subnets/views/SubnetsList/_index.scss
@@ -1,56 +1,58 @@
-.subnets-table {
-  tr:not(:first-child) {
-    border-top: 0 !important;
-  }
-  tbody tr:not(:first-child) td {
-    border-top: 1px solid $color-mid-light;
-  }
+@mixin SubnetsList {
+  .subnets-table {
+    tr:not(:first-child) {
+      border-top: 0 !important;
+    }
+    tbody tr:not(:first-child) td {
+      border-top: 1px solid $color-mid-light;
+    }
 
-  tbody {
-    tr:hover,
-    tr:focus {
-      background-color: $color-x-light;
+    tbody {
+      tr:hover,
+      tr:focus {
+        background-color: $color-x-light;
+      }
+    }
+
+    td {
+      padding-top: $spv-inner--x-small;
+      padding-bottom: $spv-inner--x-small;
+    }
+
+    .subnets-table__cell--fabric {
+      width: 13%;
+    }
+
+    .subnets-table__cell--space {
+      width: 14%;
+    }
+
+    .subnets-table__cell--vlan {
+      width: 13%;
+    }
+
+    .subnets-table__cell--subnet {
+      width: 28%;
+    }
+
+    .subnets-table__cell--ips {
+      width: 12%;
+    }
+
+    .subnets-table__cell--dhcp {
+      width: 20%;
     }
   }
 
-  td {
-    padding-top: $spv-inner--x-small;
-    padding-bottom: $spv-inner--x-small;
-  }
-
-  .subnets-table__cell--fabric {
-    width: 13%;
-  }
-
-  .subnets-table__cell--space {
-    width: 14%;
-  }
-
-  .subnets-table__cell--vlan {
-    width: 13%;
-  }
-
-  .subnets-table__cell--subnet {
-    width: 28%;
-  }
-
-  .subnets-table__cell--ips {
-    width: 12%;
-  }
-
-  .subnets-table__cell--dhcp {
-    width: 20%;
-  }
-}
-
-@media (min-width: 773px) {
-  .subnets-table__visually-hidden {
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
+  @media (min-width: 773px) {
+    .subnets-table__visually-hidden {
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
   }
 }

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -71,7 +71,7 @@ const VLANDetails = (): JSX.Element => {
         <>
           <VLANSummary id={id} />
           <DHCPStatus id={id} openForm={() => setShowDHCPForm(true)} />
-          <ReservedRanges />
+          <ReservedRanges vlanId={id} />
           <VLANSubnets id={id} />
         </>
       )}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -257,10 +257,13 @@
 @include UsersList;
 
 // subnets
+@import "~app/subnets/components/ReservedRanges";
 @import "~app/subnets/views/FabricDetails/FabricVLANs";
 @import "~app/subnets/views/SubnetsList";
 @import "~app/subnets/views/VLANDetails/VLANSubnets";
 @include FabricVLANs;
+@include ReservedRanges;
+@include SubnetsList;
 @include VLANSubnets;
 
 #maas-ui {


### PR DESCRIPTION
## Done

- Add the reserved ranges table to the subnets and vlans details pages.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using the angular client go to a subnet and add some reserved ranges, do the same for a VLAN.
- Visit the subnet and vlan details for the subnet and VLAN you added the reserved ranges to.
- You should see the reserved ranges table with the same data as the angular client.

## Fixes

Fixes: canonical-web-and-design/app-tribe#662.