### PR TITLE
feat(ui): first pass at building DHCP configuration form

### DIFF
--- a/ui/src/app/store/vlan/selectors.test.ts
+++ b/ui/src/app/store/vlan/selectors.test.ts
@@ -96,6 +96,20 @@ describe("vlan selectors", () => {
     expect(vlan.getByFabric(state, 1)).toStrictEqual([vlans[0], vlans[2]]);
   });
 
+  it("can get VLAN with DHCP", () => {
+    const vlans = [
+      vlanFactory({ dhcp_on: true }),
+      vlanFactory({ dhcp_on: false }),
+      vlanFactory({ dhcp_on: true }),
+    ];
+    const state = rootStateFactory({
+      vlan: vlanStateFactory({
+        items: vlans,
+      }),
+    });
+    expect(vlan.getWithDHCP(state)).toStrictEqual([vlans[0], vlans[2]]);
+  });
+
   it("can filter vlans by name", () => {
     const items = [vlanFactory({ name: "abc" }), vlanFactory({ name: "def" })];
     const state = rootStateFactory({

--- a/ui/src/app/store/vlan/selectors.ts
+++ b/ui/src/app/store/vlan/selectors.ts
@@ -104,6 +104,15 @@ const getByFabric = createSelector(
 );
 
 /**
+ * Returns a list of VLANs with DHCP.
+ * @param state - The redux state.
+ * @returns a list of VLANs with DHCP.
+ */
+const getWithDHCP = createSelector(defaultSelectors.all, (vlans) =>
+  vlans.filter((vlan) => vlan.dhcp_on)
+);
+
+/**
  * Get the vlans statuses.
  * @param state - The redux state.
  * @returns The vlan statuses.
@@ -121,7 +130,7 @@ const getStatusForVLAN = createSelector(
     statuses,
     (
       _state: RootState,
-      id: VLAN[VLANMeta.PK] | null,
+      id: VLAN[VLANMeta.PK] | null | undefined,
       status: keyof VLANStatus
     ) => ({
       id,
@@ -166,7 +175,7 @@ const eventErrorsForVLANs = createSelector(
     eventErrors,
     (
       _state: RootState,
-      ids: VLAN[VLANMeta.PK] | VLAN[VLANMeta.PK][] | null,
+      ids: VLAN[VLANMeta.PK] | VLAN[VLANMeta.PK][] | null | undefined,
       event?: string | null
     ) => ({
       ids,
@@ -207,6 +216,7 @@ const selectors = {
   getByFabric,
   getStatusForVLAN,
   getUnusedForInterface,
+  getWithDHCP,
   vlanState,
 };
 

--- a/ui/src/app/store/vlan/types/actions.ts
+++ b/ui/src/app/store/vlan/types/actions.ts
@@ -13,7 +13,7 @@ export type ConfigureDHCPParams = {
     start?: string;
     subnet?: Subnet[SubnetMeta.PK];
   };
-  relay_vlan?: VLAN[VLANMeta.PK];
+  relay_vlan?: VLAN[VLANMeta.PK] | null;
 };
 
 export type CreateParams = {

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
@@ -1,0 +1,263 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ConfigureDHCP from "./ConfigureDHCP";
+
+import { actions as vlanActions } from "app/store/vlan";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("shows a spinner while data is loading", () => {
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: [], loading: true }),
+    vlan: vlanStateFactory({ items: [] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByTestId("loading-data")).toBeInTheDocument();
+});
+
+it("correctly initialises data if the VLAN has DHCP from rack controllers", () => {
+  const primary = controllerFactory({ system_id: "abc123" });
+  const secondary = controllerFactory({ system_id: "def456" });
+  const vlan = vlanFactory({
+    id: 1,
+    primary_rack: primary.system_id,
+    rack_sids: [primary.system_id, secondary.system_id],
+    relay_vlan: null,
+    secondary_rack: secondary.system_id,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [primary, secondary, controllerFactory(), controllerFactory()],
+    }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("radio", { name: "Provide DHCP from rack controller(s)" })
+  ).toBeChecked();
+  expect(
+    screen.getByRole("radio", { name: "Relay to another VLAN" })
+  ).not.toBeChecked();
+  expect(screen.getByRole("combobox", { name: "Primary rack" })).toHaveValue(
+    primary.system_id
+  );
+  expect(screen.getByRole("combobox", { name: "Secondary rack" })).toHaveValue(
+    secondary.system_id
+  );
+  expect(
+    screen.queryByRole("combobox", { name: "VLAN" })
+  ).not.toBeInTheDocument();
+});
+
+it("correctly initialises data if the VLAN has relayed DHCP", () => {
+  const relay = vlanFactory({ dhcp_on: true, id: 2 });
+  const vlan = vlanFactory({
+    id: 1,
+    primary_rack: null,
+    rack_sids: [],
+    relay_vlan: relay.id,
+    secondary_rack: null,
+  });
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [relay, vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("radio", { name: "Relay to another VLAN" })
+  ).toBeChecked();
+  expect(
+    screen.getByRole("radio", { name: "Provide DHCP from rack controller(s)" })
+  ).not.toBeChecked();
+  expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue(
+    relay.id.toString()
+  );
+  expect(
+    screen.queryByRole("combobox", { name: "Primary rack" })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("combobox", { name: "Secondary rack" })
+  ).not.toBeInTheDocument();
+});
+
+it("shows an error if no rack controllers are connected to the VLAN", () => {
+  const vlan = vlanFactory({
+    id: 1,
+    primary_rack: null,
+    rack_sids: [],
+    relay_vlan: null,
+    secondary_rack: null,
+  });
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(
+      "This VLAN is not currently being utilised on any rack controller."
+    )
+  ).toBeInTheDocument();
+});
+
+it("shows a warning when attempting to disable DHCP on a VLAN", async () => {
+  const vlan = vlanFactory({
+    id: 1,
+    primary_rack: null,
+    rack_sids: [],
+    relay_vlan: null,
+    secondary_rack: null,
+  });
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() => {
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "MAAS provides DHCP" })
+    );
+  });
+
+  expect(
+    screen.getByText(
+      "Are you sure you want to disable DHCP relay on this VLAN? All subnets on this VLAN will be affected."
+    )
+  ).toBeInTheDocument();
+});
+
+it("can configure DHCP with rack controllers", async () => {
+  const primary = controllerFactory({ system_id: "abc123" });
+  const secondary = controllerFactory({ system_id: "def456" });
+  const vlan = vlanFactory({
+    id: 1,
+    primary_rack: null,
+    rack_sids: [primary.system_id, secondary.system_id],
+    relay_vlan: null,
+    secondary_rack: null,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [primary, secondary],
+    }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("combobox", { name: "Primary rack" }), {
+      target: { value: primary.system_id },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "Secondary rack" }), {
+      target: { value: secondary.system_id },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Configure DHCP" }));
+  });
+
+  const expectedAction = vlanActions.configureDHCP({
+    controllers: [primary.system_id, secondary.system_id],
+    id: vlan.id,
+    relay_vlan: null,
+  });
+  const actualAction = store
+    .getActions()
+    .find((action) => action.type === expectedAction.type);
+  expect(actualAction).toStrictEqual(expectedAction);
+});
+
+it("can configure relayed DHCP", async () => {
+  const relay = vlanFactory({ dhcp_on: true, id: 2 });
+  const vlan = vlanFactory({
+    id: 1,
+    primary_rack: null,
+    rack_sids: [],
+    relay_vlan: null,
+    secondary_rack: null,
+  });
+  const state = rootStateFactory({
+    vlan: vlanStateFactory({ items: [relay, vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() => {
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Relay to another VLAN" })
+    );
+    fireEvent.change(screen.getByRole("combobox", { name: "VLAN" }), {
+      target: { value: relay.id.toString() },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Configure DHCP" }));
+  });
+
+  const expectedAction = vlanActions.configureDHCP({
+    controllers: [],
+    id: vlan.id,
+    relay_vlan: relay.id,
+  });
+  const actualAction = store
+    .getActions()
+    .find((action) => action.type === expectedAction.type);
+  expect(actualAction).toStrictEqual(expectedAction);
+});

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect } from "react";
+
+import { Card, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import ConfigureDHCPFields from "./ConfigureDHCPFields";
+
+import FormikForm from "app/base/components/FormikForm";
+import TitledSection from "app/base/components/TitledSection";
+import { useCycled } from "app/base/hooks";
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors from "app/store/controller/selectors";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { ConfigureDHCPParams, VLAN, VLANMeta } from "app/store/vlan/types";
+import { isId } from "app/utils";
+
+type Props = {
+  closeForm: () => void;
+  id?: VLAN[VLANMeta.PK] | null;
+};
+
+export type ConfigureDHCPValues = {
+  primaryRack: string;
+  relayVLAN: number | "";
+  secondaryRack: string;
+};
+
+const Schema = Yup.object().shape({
+  primaryRack: Yup.string(),
+  relayVLAN: Yup.string(),
+  secondaryRack: Yup.string(),
+});
+
+const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const controllersLoading = useSelector(controllerSelectors.loading);
+  const fabricsLoading = useSelector(fabricSelectors.loading);
+  const vlansLoading = useSelector(vlanSelectors.loading);
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, id)
+  );
+  const configuringDHCP = useSelector((state: RootState) =>
+    vlanSelectors.getStatusForVLAN(state, id, "configuringDHCP")
+  );
+  const configureDHCPError = useSelector((state: RootState) =>
+    vlanSelectors.eventErrorsForVLANs(state, id, "configureDHCP")
+  )[0]?.error;
+  const [configuredDHCP] = useCycled(!configuringDHCP && !configureDHCPError);
+  const cleanup = useCallback(() => vlanActions.cleanup(), []);
+  const loading = !vlan || controllersLoading || fabricsLoading || vlansLoading;
+
+  useEffect(() => {
+    dispatch(controllerActions.fetch());
+    dispatch(fabricActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Card>
+      <TitledSection className="u-no-padding" title="Configure DHCP">
+        {loading ? (
+          <span data-testid="loading-data">
+            <Spinner text="Loading..." />
+          </span>
+        ) : (
+          <FormikForm<ConfigureDHCPValues>
+            allowUnchanged
+            cleanup={cleanup}
+            errors={configureDHCPError}
+            buttonsHelp={
+              <a className="p-link--external" href="https://maas.io/docs/dhcp">
+                About DHCP
+              </a>
+            }
+            initialValues={{
+              primaryRack: vlan.primary_rack || "",
+              relayVLAN: vlan.relay_vlan || "",
+              secondaryRack: vlan.secondary_rack || "",
+            }}
+            onSaveAnalytics={{
+              action: "Configure DHCP",
+              category: "VLAN details",
+              label: "Configure DHCP form",
+            }}
+            onCancel={closeForm}
+            onSubmit={(values) => {
+              dispatch(cleanup());
+              const { primaryRack, relayVLAN, secondaryRack } = values;
+              const params: ConfigureDHCPParams = {
+                controllers: [],
+                id: vlan.id,
+                relay_vlan: null,
+              };
+              if (primaryRack) {
+                params.controllers.push(primaryRack);
+              }
+              if (secondaryRack) {
+                params.controllers.push(secondaryRack);
+              }
+              if (isId(relayVLAN)) {
+                params.relay_vlan = Number(relayVLAN);
+              }
+              dispatch(vlanActions.configureDHCP(params));
+            }}
+            onSuccess={() => closeForm()}
+            saved={configuredDHCP}
+            saving={configuringDHCP}
+            submitLabel="Configure DHCP"
+            validationSchema={Schema}
+          >
+            <ConfigureDHCPFields vlan={vlan} />
+          </FormikForm>
+        )}
+      </TitledSection>
+    </Card>
+  );
+};
+
+export default ConfigureDHCP;

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+
+import {
+  Col,
+  Input,
+  Notification,
+  Row,
+  Select,
+} from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+
+import type { ConfigureDHCPValues } from "../ConfigureDHCP";
+
+import FormikField from "app/base/components/FormikField";
+import controllerSelectors from "app/store/controller/selectors";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { RootState } from "app/store/root/types";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN } from "app/store/vlan/types";
+import { getFullVLANName } from "app/store/vlan/utils";
+import { isId } from "app/utils";
+
+enum DHCPType {
+  CONTROLLERS = "controllers",
+  RELAY = "relay",
+}
+
+type Props = {
+  vlan: VLAN;
+};
+
+const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
+  const {
+    setFieldValue,
+    values: { primaryRack, secondaryRack },
+  } = useFormikContext<ConfigureDHCPValues>();
+  const fabrics = useSelector(fabricSelectors.all);
+  const allVLANs = useSelector(vlanSelectors.all);
+  const vlansWithDHCP = useSelector(vlanSelectors.getWithDHCP).filter(
+    (dhcpVLAN) => dhcpVLAN.id !== vlan.id
+  );
+  const connectedControllers = useSelector((state: RootState) =>
+    controllerSelectors.getByIDs(state, vlan.rack_sids)
+  );
+  const [enableDHCP, setEnableDHCP] = useState(true);
+  const [dhcpType, setDHCPType] = useState<DHCPType>(
+    isId(vlan.relay_vlan) ? DHCPType.RELAY : DHCPType.CONTROLLERS
+  );
+  const primaryRackOptions = connectedControllers.filter(
+    (controller) => controller.system_id !== secondaryRack
+  );
+  const secondaryRackOptions = connectedControllers.filter(
+    (controller) => controller.system_id !== primaryRack
+  );
+
+  return (
+    <Row>
+      <Col size={6}>
+        <Input
+          checked={enableDHCP}
+          id="enable-dhcp"
+          label="MAAS provides DHCP"
+          name="enableDHCP"
+          onChange={() => {
+            setEnableDHCP(!enableDHCP);
+            setFieldValue("primaryRack", "");
+            setFieldValue("relayVLAN", "");
+            setFieldValue("secondaryRack", "");
+          }}
+          type="checkbox"
+        />
+        {enableDHCP && (
+          <>
+            <Input
+              checked={dhcpType === DHCPType.CONTROLLERS}
+              id="controller-dhcp"
+              label="Provide DHCP from rack controller(s)"
+              name="dhcpType"
+              onChange={() => {
+                setDHCPType(DHCPType.CONTROLLERS);
+                setFieldValue(
+                  "primaryRack",
+                  connectedControllers[0]?.system_id || ""
+                );
+                setFieldValue("relayVLAN", "");
+              }}
+              type="radio"
+              value={DHCPType.CONTROLLERS}
+            />
+            {dhcpType === DHCPType.CONTROLLERS && (
+              <>
+                {connectedControllers.length === 0 ? (
+                  <Notification severity="negative">
+                    This VLAN is not currently being utilised on any rack
+                    controller.
+                  </Notification>
+                ) : (
+                  <>
+                    <FormikField
+                      component={Select}
+                      label={
+                        connectedControllers.length === 1
+                          ? "Rack controller"
+                          : "Primary rack"
+                      }
+                      name="primaryRack"
+                      options={primaryRackOptions.map((controller) => ({
+                        label: controller.hostname,
+                        value: controller.system_id,
+                      }))}
+                      wrapperClassName="u-nudge-right--x-large"
+                    />
+                    {connectedControllers.length > 1 && (
+                      <FormikField
+                        component={Select}
+                        label="Secondary rack"
+                        name="secondaryRack"
+                        options={[
+                          { label: "Unset", value: "" },
+                          ...secondaryRackOptions.map((controller) => ({
+                            label: controller.hostname,
+                            value: controller.system_id,
+                          })),
+                        ]}
+                        wrapperClassName="u-nudge-right--x-large"
+                      />
+                    )}
+                  </>
+                )}
+              </>
+            )}
+            <Input
+              checked={dhcpType === DHCPType.RELAY}
+              id="relay-dhcp"
+              label="Relay to another VLAN"
+              name="dhcpType"
+              onChange={() => {
+                setDHCPType(DHCPType.RELAY);
+                setFieldValue("relayVLAN", vlansWithDHCP[0]?.id || "");
+                setFieldValue("primaryRack", "");
+                setFieldValue("secondaryRack", "");
+              }}
+              type="radio"
+              value={DHCPType.RELAY}
+            />
+            {dhcpType === DHCPType.RELAY && (
+              <FormikField
+                component={Select}
+                label="VLAN"
+                name="relayVLAN"
+                options={vlansWithDHCP.map((dhcpVLAN) => ({
+                  label:
+                    getFullVLANName(dhcpVLAN.id, allVLANs, fabrics) ||
+                    dhcpVLAN.name,
+                  value: dhcpVLAN.id,
+                }))}
+                wrapperClassName="u-nudge-right--x-large"
+              />
+            )}
+          </>
+        )}
+      </Col>
+      {enableDHCP ? (
+        <>
+          {/* TODO */}
+          <h4>Reserved dynamic range</h4>
+        </>
+      ) : (
+        <Notification severity="caution">
+          Are you sure you want to disable DHCP relay on this VLAN? All subnets
+          on this VLAN will be affected.
+        </Notification>
+      )}
+    </Row>
+  );
+};
+
+export default ConfigureDHCPFields;

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ConfigureDHCPFields";

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ConfigureDHCP";

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -30,7 +30,7 @@ it("shows a spinner if data is loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={1} />
+        <DHCPStatus id={1} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +38,8 @@ it("shows a spinner if data is loading", () => {
   expect(screen.getByTestId("loading-data")).toBeInTheDocument();
 });
 
-it("shows a warning if there are no subnets attached to the VLAN", () => {
+it(`shows a warning and disables Configure DHCP button if there are no subnets
+    attached to the VLAN`, () => {
   const vlan = vlanFactory();
   const state = rootStateFactory({
     subnet: subnetStateFactory({ items: [] }),
@@ -48,12 +49,15 @@ it("shows a warning if there are no subnets attached to the VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
   const dhcpStatus = screen.getByRole("region", { name: "DHCP" });
 
+  expect(
+    within(dhcpStatus).getByRole("button", { name: "Configure DHCP" })
+  ).toBeDisabled();
   expect(
     within(dhcpStatus).getByText(
       "No subnets are available on this VLAN. DHCP cannot be enabled."
@@ -72,7 +76,7 @@ it("does not show a warning if there are subnets attached to the VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -98,7 +102,7 @@ it("renders correctly when a VLAN does not have DHCP enabled", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -122,7 +126,7 @@ it("renders correctly when a VLAN has external DHCP", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -154,7 +158,7 @@ it("renders correctly when a VLAN has relayed DHCP", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -184,7 +188,7 @@ it("renders correctly when a VLAN has MAAS-configured DHCP without high availabi
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -228,7 +232,7 @@ it("renders correctly when a VLAN has MAAS-configured DHCP with high availabilit
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} />
+        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -28,6 +28,7 @@ import { isId } from "app/utils";
 
 type Props = {
   id: VLAN[VLANMeta.PK] | null;
+  openForm: () => void;
 };
 
 // Note this is not the same as the getDHCPStatus VLAN util as it uses slightly
@@ -52,7 +53,7 @@ const getDHCPStatus = (vlan: VLAN, vlans: VLAN[], fabrics: Fabric[]) => {
   return "Disabled";
 };
 
-const DHCPStatus = ({ id }: Props): JSX.Element | null => {
+const DHCPStatus = ({ id, openForm }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const fabrics = useSelector(fabricSelectors.all);
   const fabricsLoading = useSelector(fabricSelectors.loading);
@@ -88,7 +89,14 @@ const DHCPStatus = ({ id }: Props): JSX.Element | null => {
     (!!vlan.primary_rack || !!vlan.secondary_rack);
   const hasHighAvailability = !!vlan.primary_rack && !!vlan.secondary_rack;
   return (
-    <TitledSection buttons={<Button>Enable DHCP</Button>} title="DHCP">
+    <TitledSection
+      buttons={
+        <Button disabled={!hasVLANSubnets} onClick={openForm}>
+          Configure DHCP
+        </Button>
+      }
+      title="DHCP"
+    >
       {!hasVLANSubnets && (
         <Notification severity="caution">
           No subnets are available on this VLAN. DHCP cannot be enabled.

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 
+import ConfigureDHCP from "./ConfigureDHCP";
 import DHCPStatus from "./DHCPStatus";
 import VLANDetailsHeader from "./VLANDetailsHeader";
 import VLANSubnets from "./VLANSubnets";
@@ -31,6 +32,7 @@ const VLANDetails = (): JSX.Element => {
   const subnets = useSelector((state: RootState) =>
     subnetSelectors.getByVLAN(state, id)
   );
+  const [showDHCPForm, setShowDHCPForm] = useState(false);
   useWindowTitle(`${vlan?.name || "VLAN"} details`);
 
   useEffect(() => {
@@ -63,10 +65,16 @@ const VLANDetails = (): JSX.Element => {
 
   return (
     <Section header={<VLANDetailsHeader id={id} />}>
-      <VLANSummary id={id} />
-      <DHCPStatus id={id} />
-      <ReservedRanges />
-      <VLANSubnets id={id} />
+      {showDHCPForm ? (
+        <ConfigureDHCP closeForm={() => setShowDHCPForm(false)} id={id} />
+      ) : (
+        <>
+          <VLANSummary id={id} />
+          <DHCPStatus id={id} openForm={() => setShowDHCPForm(true)} />
+          <ReservedRanges />
+          <VLANSubnets id={id} />
+        </>
+      )}
       <DHCPSnippets
         subnetIds={subnets.map(({ id }) => id)}
         modelName={VLANMeta.MODEL}


### PR DESCRIPTION
## Done

- This branch builds out the basic functionality of configuring DHCP with rack controllers or via a relay. Extra parameters for reserved ranges will come after.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the VLAN details page of a VLAN with subnets
- Click "Configure DHCP"
- Check that changing some values and submitting the form successfully updates DHCP for that VLAN.

## Fixes

Fixes canonical-web-and-design/app-tribe#669

## Screenshot
![Peek 2022-01-21 09-43](https://user-images.githubusercontent.com/25733845/152498153-33211da7-0d97-4cd0-8472-03bd303e86b4.gif)
