### PR TITLE
refactor: subnet utilisation section

### DIFF
--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -64,7 +64,7 @@ const SubnetDetails = (): JSX.Element => {
   return (
     <Section header={<SubnetDetailsHeader subnet={subnet} />}>
       <SubnetSummary id={id} />
-      <Utilisation />
+      <Utilisation statistics={subnet.statistics} />
       <StaticRoutes />
       <ReservedRanges />
       <DHCPSnippets

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
@@ -9,7 +9,6 @@ import DeleteSubnet from "./DeleteSubnet";
 
 import { actions as subnetActions } from "app/store/subnet";
 import { actions as vlanActions } from "app/store/vlan";
-import subnetURLs from "app/subnets/urls";
 import subnetsURLs from "app/subnets/urls";
 import {
   subnetDetails as subnetFactory,
@@ -158,6 +157,6 @@ it("redirects on save", async () => {
     </Provider>
   );
   await waitFor(() =>
-    expect(history.location.pathname).toEqual(subnetURLs.index)
+    expect(history.location.pathname).toEqual(subnetsURLs.index)
   );
 });

--- a/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+
+import SubnetUtilisation from "./SubnetUtilisation";
+
+import { subnetStatistics as subnetStatisticsFactory } from "testing/factories";
+
+it("renders subnet utilisation statistics", () => {
+  const subnetStatistics = subnetStatisticsFactory({
+    available_string: "100%",
+    num_available: 111,
+    total_addresses: 111,
+    usage_string: "50%",
+  });
+
+  render(<SubnetUtilisation statistics={subnetStatistics} />);
+
+  expect(screen.getByLabelText("Subnet addresses")).toHaveTextContent(
+    subnetStatistics.total_addresses.toString()
+  );
+  expect(screen.getByLabelText("Availability")).toHaveTextContent(
+    `${subnetStatistics.num_available} (${subnetStatistics.available_string})`
+  );
+  expect(screen.getByLabelText("Used")).toHaveTextContent(
+    subnetStatistics.usage_string.toString()
+  );
+});

--- a/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
@@ -1,7 +1,57 @@
-import TitledSection from "app/base/components/TitledSection";
+import { Row, Col } from "@canonical/react-components";
 
-const SubnetUtilisation = (): JSX.Element => (
-  <TitledSection title="Utilisation" />
-);
+import TitledSection from "app/base/components/TitledSection";
+import type { SubnetStatistics } from "app/store/subnet/types";
+
+type Props = {
+  statistics: SubnetStatistics;
+};
+
+const SubnetUtilisation = ({ statistics }: Props): JSX.Element => {
+  return (
+    <TitledSection title="Utilisation">
+      <Row>
+        <Col size={6}>
+          <Row>
+            <Col size={2}>
+              <p className="u-text--muted" id="subnet-addresses">
+                Subnet addresses
+              </p>
+            </Col>
+            <Col size={4}>
+              <p aria-labelledby="subnet-addresses">
+                {statistics.total_addresses}
+              </p>
+            </Col>
+          </Row>
+          <Row>
+            <Col size={2}>
+              <p className="u-text--muted" id="subnet-availability">
+                Availability
+              </p>
+            </Col>
+            <Col size={4}>
+              <p aria-labelledby="subnet-availability">
+                {statistics.num_available} ({statistics.available_string})
+              </p>
+            </Col>
+          </Row>
+        </Col>
+        <Col size={6}>
+          <Row>
+            <Col size={2}>
+              <p className="u-text--muted" id="subnet-used">
+                Used
+              </p>
+            </Col>
+            <Col size={4}>
+              <p aria-labelledby="subnet-used">{statistics.usage_string}</p>
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    </TitledSection>
+  );
+};
 
 export default SubnetUtilisation;

--- a/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.tsx
@@ -1,5 +1,6 @@
 import { Row, Col } from "@canonical/react-components";
 
+import Definition from "app/base/components/Definition";
 import TitledSection from "app/base/components/TitledSection";
 import type { SubnetStatistics } from "app/store/subnet/types";
 
@@ -12,42 +13,17 @@ const SubnetUtilisation = ({ statistics }: Props): JSX.Element => {
     <TitledSection title="Utilisation">
       <Row>
         <Col size={6}>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-addresses">
-                Subnet addresses
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-addresses">
-                {statistics.total_addresses}
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-availability">
-                Availability
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-availability">
-                {statistics.num_available} ({statistics.available_string})
-              </p>
-            </Col>
-          </Row>
+          <Definition
+            label="Subnet addresses"
+            description={`${statistics.total_addresses}`}
+          />
+          <Definition
+            label="Availability"
+            description={`${statistics.num_available} (${statistics.available_string})`}
+          />
         </Col>
         <Col size={6}>
-          <Row>
-            <Col size={2}>
-              <p className="u-text--muted" id="subnet-used">
-                Used
-              </p>
-            </Col>
-            <Col size={4}>
-              <p aria-labelledby="subnet-used">{statistics.usage_string}</p>
-            </Col>
-          </Row>
+          <Definition label="Used" description={statistics.usage_string} />
         </Col>
       </Row>
     </TitledSection>


### PR DESCRIPTION
## Done

- Utilisation section on subnet pages

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet page
- Check the utilisation section is populated

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/656

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
