### PR TITLE
feat(ui): edit reserved ranges

### DIFF
--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ReservedRangeForm from "./ReservedRangeForm";
+
+import { actions as ipRangeActions } from "app/store/iprange";
+import type { IPRange } from "app/store/iprange/types";
+import { IPRangeType } from "app/store/iprange/types";
+import type { RootState } from "app/store/root/types";
+import {
+  rootState as rootStateFactory,
+  ipRange as ipRangeFactory,
+  ipRangeState as ipRangeStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ReservedRangeForm", () => {
+  let state: RootState;
+  let ipRange: IPRange;
+
+  beforeEach(() => {
+    ipRange = ipRangeFactory({
+      comment: "what a beaut",
+      start_ip: "11.1.1.1",
+      type: IPRangeType.Reserved,
+      user: "wombat",
+    });
+    state = rootStateFactory({
+      iprange: ipRangeStateFactory({
+        items: [ipRange],
+      }),
+    });
+  });
+
+  it("displays a spinner when it is editing and data is loading", () => {
+    state.iprange.items = [];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.getByTestId("Spinner")).toBeInTheDocument();
+  });
+
+  it("does not display a spinner when it is not in edit mode", () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ReservedRangeForm onClose={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.queryAllByTestId("Spinner")).toHaveLength(0);
+  });
+
+  it("initialises the reserved range details when editing", () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Start IP address" })
+    ).toHaveAttribute("value", ipRange.start_ip);
+    expect(
+      screen.getByRole("textbox", { name: "End IP address" })
+    ).toHaveAttribute("value", ipRange.end_ip);
+    expect(screen.getByRole("textbox", { name: "Purpose" })).toHaveAttribute(
+      "value",
+      ipRange.comment
+    );
+  });
+
+  it("initialises the details when editing a dynamic range", () => {
+    ipRange.type = IPRangeType.Dynamic;
+    state.iprange.items = [ipRange];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.getByRole("textbox", { name: "Purpose" })).toHaveAttribute(
+      "value",
+      "Dynamic"
+    );
+    expect(screen.getByRole("textbox", { name: "Purpose" })).toHaveAttribute(
+      "disabled"
+    );
+  });
+
+  it("dispatches an action to update a reserved range", async () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    await waitFor(() => fireEvent.submit(screen.getByRole("form")));
+    const expected = ipRangeActions.update({
+      comment: ipRange.comment,
+      end_ip: ipRange.end_ip,
+      id: ipRange.id,
+      start_ip: ipRange.start_ip,
+    });
+    expect(
+      store.getActions().find((action) => action.type === expected.type)
+    ).toStrictEqual(expected);
+  });
+
+  it("resets the comment when updating a dynamic range", async () => {
+    ipRange.type = IPRangeType.Dynamic;
+    state.iprange.items = [ipRange];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    await waitFor(() => fireEvent.submit(screen.getByRole("form")));
+    const expected = ipRangeActions.update({
+      comment: ipRange.comment,
+      end_ip: ipRange.end_ip,
+      id: ipRange.id,
+      start_ip: ipRange.start_ip,
+    });
+    const actual = store
+      .getActions()
+      .find((action) => action.type === expected.type);
+    expect(actual.payload.params.comment).toBe(expected.payload.params.comment);
+  });
+});

--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
@@ -1,0 +1,130 @@
+import { useCallback } from "react";
+
+import { Col, Row, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as ipRangeActions } from "app/store/iprange";
+import ipRangeSelectors from "app/store/iprange/selectors";
+import type { IPRange } from "app/store/iprange/types";
+import { IPRangeType, IPRangeMeta } from "app/store/iprange/types";
+import type { RootState } from "app/store/root/types";
+import { isId } from "app/utils";
+
+type Props = {
+  id?: IPRange[IPRangeMeta.PK] | null;
+  onClose: () => void;
+};
+
+export type FormValues = {
+  comment: IPRange["comment"];
+  end_ip: IPRange["end_ip"];
+  start_ip: IPRange["start_ip"];
+};
+
+const Schema = Yup.object().shape({
+  comment: Yup.string(),
+  end_ip: Yup.string().required("Start IP is required"),
+  start_ip: Yup.string().required("End IP is required"),
+});
+
+const ReservedRangeForm = ({
+  id,
+  onClose,
+  ...props
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const ipRange = useSelector((state: RootState) =>
+    ipRangeSelectors.getById(state, id)
+  );
+  const saved = useSelector(ipRangeSelectors.saved);
+  const saving = useSelector(ipRangeSelectors.saving);
+  const errors = useSelector(ipRangeSelectors.errors);
+  const cleanup = useCallback(() => ipRangeActions.cleanup(), []);
+  const isEditing = isId(id);
+
+  if (isEditing && !ipRange) {
+    return (
+      <span data-testid="Spinner">
+        <Spinner text="Loading..." />
+      </span>
+    );
+  }
+  let initialComment = "";
+  const showDynamicComment = isEditing && ipRange?.type === IPRangeType.Dynamic;
+  if (showDynamicComment) {
+    initialComment = "Dynamic";
+  } else if (isEditing) {
+    initialComment = ipRange?.comment ?? "";
+  }
+
+  return (
+    <FormikForm<FormValues>
+      aria-label={`${isEditing ? "Edit" : "Create"} reserved range`}
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{
+        comment: initialComment,
+        end_ip: ipRange?.end_ip ?? "",
+        start_ip: ipRange?.start_ip ?? "",
+      }}
+      onSaveAnalytics={{
+        action: "Save reserved range",
+        category: "Reserved ranges table",
+        label: `${isEditing ? "Edit" : "Create"} reserved range form`,
+      }}
+      onCancel={onClose}
+      onSubmit={(values) => {
+        // Clear the errors from the previous submission.
+        dispatch(cleanup());
+        if (isEditing && ipRange) {
+          dispatch(
+            ipRangeActions.update({
+              [IPRangeMeta.PK]: ipRange[IPRangeMeta.PK],
+              ...values,
+              // Reset the value of the comment field so that "Dynamic" isn't stored.
+              comment: showDynamicComment ? ipRange?.comment : values.comment,
+            })
+          );
+        }
+      }}
+      onSuccess={() => onClose()}
+      resetOnSave
+      saved={saved}
+      saving={saving}
+      submitLabel={isEditing ? "Save" : "Reserve"}
+      validationSchema={Schema}
+      {...props}
+    >
+      <Row>
+        <Col size={6}>
+          <FormikField
+            label="Start IP address"
+            name="start_ip"
+            required
+            type="text"
+          />
+          <FormikField
+            disabled={showDynamicComment}
+            label="Purpose"
+            name="comment"
+            placeholder="IP range purpose (optional)"
+            type="text"
+          />
+        </Col>
+        <Col size={6}>
+          <FormikField
+            label="End IP address"
+            name="end_ip"
+            required
+            type="text"
+          />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default ReservedRangeForm;

--- a/ui/src/app/subnets/components/ReservedRangeForm/index.ts
+++ b/ui/src/app/subnets/components/ReservedRangeForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReservedRangeForm";

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -231,6 +231,32 @@ it("displays content when it is reserved", () => {
   ).toHaveTextContent("what a beaut");
 });
 
+it("displays an edit form", async () => {
+  const vlan = vlanFactory();
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({
+      items: [ipRangeFactory({ start_ip: "11.1.1.1", vlan: vlan.id })],
+    }),
+    vlan: vlanStateFactory({
+      items: [vlan],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges vlanId={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  await waitFor(() => {
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+  });
+  expect(
+    screen.getByRole("form", { name: "Edit reserved range" })
+  ).toBeInTheDocument();
+});
+
 it("displays confirm delete message", async () => {
   const vlan = vlanFactory();
   const state = rootStateFactory({

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -5,6 +5,8 @@ import { MainTable, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 
+import ReservedRangeForm from "../ReservedRangeForm";
+
 import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import TitledSection from "app/base/components/TitledSection";
@@ -78,13 +80,14 @@ const generateRows = (
     const owner = isDynamic ? "MAAS" : ipRange.user;
     const comment = isDynamic ? "Dynamic" : ipRange.comment;
     let expandedContent: ReactNode | null = null;
+    const onClose = () => setExpanded(null);
     if (expanded?.type === ExpandedType.Delete) {
       expandedContent = (
         <TableDeleteConfirm
           deleted={saved}
           deleting={saving}
           message="Ensure all in-use IP addresses are registered in MAAS before releasing this range to avoid potential collisions. Are you sure you want to remove this IP range?"
-          onClose={() => setExpanded(null)}
+          onClose={onClose}
           onConfirm={() => {
             dispatch(ipRangeActions.delete(ipRange.id));
           }}
@@ -92,9 +95,7 @@ const generateRows = (
         />
       );
     } else if (expanded?.type === ExpandedType.Update) {
-      // TODO: Implement the edit form:
-      // https://github.com/canonical-web-and-design/app-tribe/issues/663
-      expandedContent = "edit";
+      expandedContent = <ReservedRangeForm onClose={onClose} id={ipRange.id} />;
     }
     return {
       className: isExpanded ? "p-table__row is-active" : null,


### PR DESCRIPTION
## Done

- Add a form to edit reserved ranges.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the react details page for a subnet or VLAN with reserved and dynamic ranges (or add some).
- Click the edit icon for a reserved range and the form should appear and you should be able to change the Purpose field.
- Change some values and confirm and the range should get updated.
- Click the edit icon for a dynamic range and the form should appear and the Purpose field should be disabled and display "Dynamic".
- Change some values and confirm and the range should get updated.

## Fixes

Fixes: canonical-web-and-design/app-tribe#722.