### PR TITLE
feat(ui): add reserved ranges table/form to Configure DHCP section

### DIFF
--- a/ui/src/app/store/iprange/utils.test.ts
+++ b/ui/src/app/store/iprange/utils.test.ts
@@ -1,0 +1,65 @@
+import { IPRangeType } from "./types";
+import {
+  getCommentDisplay,
+  getOwnerDisplay,
+  getTypeDisplay,
+  isDynamic,
+} from "./utils";
+
+import { ipRange as ipRangeFactory } from "testing/factories";
+
+describe("isDynamic", () => {
+  it("returns whether an IP range is dynamic", () => {
+    const dynamicIP = ipRangeFactory({ type: IPRangeType.Dynamic });
+    const reservedIP = ipRangeFactory({ type: IPRangeType.Reserved });
+
+    expect(isDynamic(dynamicIP)).toBe(true);
+    expect(isDynamic(reservedIP)).toBe(false);
+  });
+});
+
+describe("getCommentDisplay", () => {
+  it("correctly formats an IP range's comment", () => {
+    const dynamicIP = ipRangeFactory({
+      comment: "something",
+      type: IPRangeType.Dynamic,
+    });
+    const reservedIP = ipRangeFactory({
+      comment: "something",
+      type: IPRangeType.Reserved,
+    });
+
+    expect(getCommentDisplay(dynamicIP)).toBe("Dynamic");
+    expect(getCommentDisplay(reservedIP)).toBe("something");
+  });
+});
+
+describe("getOwnerDisplay", () => {
+  it("correctly formats an IP range's owner", () => {
+    const dynamicIP = ipRangeFactory({
+      type: IPRangeType.Dynamic,
+      user: "user",
+    });
+    const reservedIP = ipRangeFactory({
+      type: IPRangeType.Reserved,
+      user: "user",
+    });
+
+    expect(getOwnerDisplay(dynamicIP)).toBe("MAAS");
+    expect(getOwnerDisplay(reservedIP)).toBe("user");
+  });
+});
+
+describe("getTypeDisplay", () => {
+  it("correctly formats an IP range's type", () => {
+    const dynamicIP = ipRangeFactory({
+      type: IPRangeType.Dynamic,
+    });
+    const reservedIP = ipRangeFactory({
+      type: IPRangeType.Reserved,
+    });
+
+    expect(getTypeDisplay(dynamicIP)).toBe("Dynamic");
+    expect(getTypeDisplay(reservedIP)).toBe("Reserved");
+  });
+});

--- a/ui/src/app/store/iprange/utils.ts
+++ b/ui/src/app/store/iprange/utils.ts
@@ -1,0 +1,34 @@
+import type { IPRange } from "./types";
+import { IPRangeType } from "./types";
+
+/**
+ * Get whether an IP range is dynamic.
+ * @param ipRange - The IP range to check.
+ * @returns Whether the IP range is dynamic.
+ */
+export const isDynamic = (ipRange: IPRange): boolean =>
+  ipRange.type === IPRangeType.Dynamic;
+
+/**
+ * Get comment text for an IP range.
+ * @param ipRange - The IP range to check.
+ * @returns Comment text for an IP range.
+ */
+export const getCommentDisplay = (ipRange: IPRange): string =>
+  isDynamic(ipRange) ? "Dynamic" : ipRange.comment || "—";
+
+/**
+ * Get owner text for an IP range.
+ * @param ipRange - The IP range to check.
+ * @returns Owner text for an IP range.
+ */
+export const getOwnerDisplay = (ipRange: IPRange): string =>
+  isDynamic(ipRange) ? "MAAS" : ipRange.user;
+
+/**
+ * Get type text for an IP range.
+ * @param ipRange - The IP range to check.
+ * @returns Type text for an IP range.
+ */
+export const getTypeDisplay = (ipRange: IPRange): string =>
+  isDynamic(ipRange) ? "Dynamic" : "Reserved";

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -13,7 +13,11 @@ import TitledSection from "app/base/components/TitledSection";
 import { actions as ipRangeActions } from "app/store/iprange";
 import ipRangeSelectors from "app/store/iprange/selectors";
 import type { IPRange, IPRangeMeta } from "app/store/iprange/types";
-import { IPRangeType } from "app/store/iprange/types";
+import {
+  getCommentDisplay,
+  getOwnerDisplay,
+  getTypeDisplay,
+} from "app/store/iprange/utils";
 import type { RootState } from "app/store/root/types";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
@@ -76,9 +80,9 @@ const generateRows = (
 ) =>
   ipRanges.map((ipRange: IPRange) => {
     const isExpanded = expanded?.id === ipRange.id;
-    const isDynamic = ipRange.type === IPRangeType.Dynamic;
-    const owner = isDynamic ? "MAAS" : ipRange.user;
-    const comment = isDynamic ? "Dynamic" : ipRange.comment;
+    const comment = getCommentDisplay(ipRange);
+    const owner = getOwnerDisplay(ipRange);
+    const type = getTypeDisplay(ipRange);
     let expandedContent: ReactNode | null = null;
     const onClose = () => setExpanded(null);
     if (expanded?.type === ExpandedType.Delete) {
@@ -114,7 +118,7 @@ const generateRows = (
         },
         {
           "aria-label": Labels.Type,
-          content: isDynamic ? "Dynamic" : "Reserved",
+          content: type,
         },
         { "aria-label": Labels.Comment, content: comment },
         {

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -5,15 +5,22 @@ import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import ConfigureDHCPFields from "./ConfigureDHCPFields";
+import DHCPReservedRanges from "./DHCPReservedRanges";
 
 import FormikForm from "app/base/components/FormikForm";
 import TitledSection from "app/base/components/TitledSection";
 import { useCycled } from "app/base/hooks";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
+import { actions as ipRangeActions } from "app/store/iprange";
+import ipRangeSelectors from "app/store/iprange/selectors";
 import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import type { ConfigureDHCPParams, VLAN, VLANMeta } from "app/store/vlan/types";
@@ -25,21 +32,37 @@ type Props = {
 };
 
 export type ConfigureDHCPValues = {
-  primaryRack: string;
-  relayVLAN: number | "";
-  secondaryRack: string;
+  endIP: string;
+  gatewayIP: string;
+  primaryRack: Controller[ControllerMeta.PK];
+  relayVLAN: VLAN[VLANMeta.PK] | "";
+  secondaryRack: Controller[ControllerMeta.PK];
+  startIP: string;
+  subnet: Subnet[SubnetMeta.PK] | "";
 };
 
 const Schema = Yup.object().shape({
+  endIP: Yup.string().when("subnet", {
+    is: (val: string) => isId(val),
+    then: Yup.string().required("End IP address is required"),
+  }),
+  gatewayIP: Yup.string(),
   primaryRack: Yup.string(),
   relayVLAN: Yup.string(),
   secondaryRack: Yup.string(),
+  startIP: Yup.string().when("subnet", {
+    is: (val: string) => isId(val),
+    then: Yup.string().required("Start IP address is required"),
+  }),
+  subnet: Yup.string(),
 });
 
 const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const controllersLoading = useSelector(controllerSelectors.loading);
   const fabricsLoading = useSelector(fabricSelectors.loading);
+  const ipRangesLoading = useSelector(ipRangeSelectors.loading);
+  const subnetsLoading = useSelector(subnetSelectors.loading);
   const vlansLoading = useSelector(vlanSelectors.loading);
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
@@ -50,13 +73,22 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
   const configureDHCPError = useSelector((state: RootState) =>
     vlanSelectors.eventErrorsForVLANs(state, id, "configureDHCP")
   )[0]?.error;
-  const [configuredDHCP] = useCycled(!configuringDHCP && !configureDHCPError);
+  const [configuredDHCP, resetConfiguredDHCP] = useCycled(!configuringDHCP);
+  const saved = configuredDHCP && !configureDHCPError;
   const cleanup = useCallback(() => vlanActions.cleanup(), []);
-  const loading = !vlan || controllersLoading || fabricsLoading || vlansLoading;
+  const loading =
+    !vlan ||
+    controllersLoading ||
+    fabricsLoading ||
+    ipRangesLoading ||
+    subnetsLoading ||
+    vlansLoading;
 
   useEffect(() => {
     dispatch(controllerActions.fetch());
     dispatch(fabricActions.fetch());
+    dispatch(ipRangeActions.fetch());
+    dispatch(subnetActions.fetch());
     dispatch(vlanActions.fetch());
   }, [dispatch]);
 
@@ -78,9 +110,13 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
               </a>
             }
             initialValues={{
+              endIP: "",
+              gatewayIP: "",
               primaryRack: vlan.primary_rack || "",
               relayVLAN: vlan.relay_vlan || "",
               secondaryRack: vlan.secondary_rack || "",
+              startIP: "",
+              subnet: "",
             }}
             onSaveAnalytics={{
               action: "Configure DHCP",
@@ -89,6 +125,7 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
             }}
             onCancel={closeForm}
             onSubmit={(values) => {
+              resetConfiguredDHCP();
               dispatch(cleanup());
               const { primaryRack, relayVLAN, secondaryRack } = values;
               const params: ConfigureDHCPParams = {
@@ -105,15 +142,24 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
               if (isId(relayVLAN)) {
                 params.relay_vlan = Number(relayVLAN);
               }
+              if (isId(values.subnet)) {
+                params.extra = {
+                  end: values.endIP,
+                  gateway: values.gatewayIP,
+                  start: values.startIP,
+                  subnet: Number(values.subnet),
+                };
+              }
               dispatch(vlanActions.configureDHCP(params));
             }}
             onSuccess={() => closeForm()}
-            saved={configuredDHCP}
+            saved={saved}
             saving={configuringDHCP}
             submitLabel="Configure DHCP"
             validationSchema={Schema}
           >
             <ConfigureDHCPFields vlan={vlan} />
+            <DHCPReservedRanges id={vlan.id} />
           </FormikForm>
         )}
       </TitledSection>

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
@@ -161,15 +161,10 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
           </>
         )}
       </Col>
-      {enableDHCP ? (
-        <>
-          {/* TODO */}
-          <h4>Reserved dynamic range</h4>
-        </>
-      ) : (
+      {!enableDHCP && (
         <Notification severity="caution">
-          Are you sure you want to disable DHCP relay on this VLAN? All subnets
-          on this VLAN will be affected.
+          Are you sure you want to disable DHCP on this VLAN? All subnets on
+          this VLAN will be affected.
         </Notification>
       )}
     </Row>

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -1,0 +1,176 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DHCPReservedRanges, { Headers } from "./DHCPReservedRanges";
+
+import subnetsURLs from "app/subnets/urls";
+import {
+  ipRange as ipRangeFactory,
+  ipRangeState as ipRangeStateFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  subnetStatistics as subnetStatisticsFactory,
+  subnetStatisticsRange as subnetStatisticsRangeFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+const initialValues = {
+  endIP: "",
+  gatewayIP: "",
+  primaryRack: "",
+  relayVLAN: "",
+  secondaryRack: "",
+  startIP: "",
+  subnet: "",
+};
+
+it("renders a table of IP ranges if the VLAN has any defined", () => {
+  const vlan = vlanFactory();
+  const subnet = subnetFactory({ gateway_ip: "192.168.1.11", vlan: vlan.id });
+  const ipRange = ipRangeFactory({
+    start_ip: "192.168.1.1",
+    end_ip: "192.168.1.10",
+    subnet: subnet.id,
+    vlan: vlan.id,
+  });
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({ items: [ipRange] }),
+    subnet: subnetStateFactory({ items: [subnet] }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
+      "link"
+    )
+  ).toHaveAttribute("href", subnetsURLs.subnet.index({ id: subnet.id }));
+  expect(
+    screen.getByRole("gridcell", { name: Headers.StartIP }).textContent
+  ).toBe(ipRange.start_ip);
+  expect(
+    screen.getByRole("gridcell", { name: Headers.EndIP }).textContent
+  ).toBe(ipRange.end_ip);
+  expect(
+    screen.getByRole("gridcell", { name: Headers.GatewayIP }).textContent
+  ).toBe(subnet.gateway_ip);
+});
+
+it(`renders only a subnet select field if no IP ranges exist and no subnet is
+    selected`, () => {
+  const vlan = vlanFactory();
+  const subnet = subnetFactory({ gateway_ip: "192.168.1.11", vlan: vlan.id });
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({ items: [] }),
+    subnet: subnetStateFactory({ items: [subnet], loaded: true }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
+      "combobox",
+      { name: "Subnet" }
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("gridcell", { name: Headers.StartIP })
+  ).toBeEmptyDOMElement();
+  expect(
+    screen.getByRole("gridcell", { name: Headers.EndIP })
+  ).toBeEmptyDOMElement();
+  expect(
+    screen.getByRole("gridcell", { name: Headers.GatewayIP })
+  ).toBeEmptyDOMElement();
+});
+
+it(`renders a subnet select field and prepopulated fields for a reserved range
+    if no IP ranges exist and a subnet is selected`, async () => {
+  const vlan = vlanFactory();
+  const subnet = subnetFactory({
+    gateway_ip: "192.168.1.11",
+    statistics: subnetStatisticsFactory({
+      suggested_dynamic_range: subnetStatisticsRangeFactory({
+        start: "192.168.1.1",
+        end: "192.168.1.5",
+      }),
+    }),
+    vlan: vlan.id,
+  });
+  const state = rootStateFactory({
+    iprange: ipRangeStateFactory({ items: [] }),
+    subnet: subnetStateFactory({ items: [subnet], loaded: true }),
+    vlan: vlanStateFactory({ items: [vlan] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("combobox", { name: "Subnet" }), {
+      target: { value: subnet.id },
+    });
+  });
+
+  expect(
+    within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
+      "combobox",
+      { name: "Subnet" }
+    )
+  ).toBeInTheDocument();
+  expect(
+    within(screen.getByRole("gridcell", { name: Headers.StartIP })).getByRole(
+      "textbox",
+      { name: Headers.StartIP }
+    )
+  ).toHaveAttribute("value", subnet.statistics.suggested_dynamic_range.start);
+  expect(
+    within(screen.getByRole("gridcell", { name: Headers.EndIP })).getByRole(
+      "textbox",
+      { name: Headers.EndIP }
+    )
+  ).toHaveAttribute("value", subnet.statistics.suggested_dynamic_range.end);
+  expect(
+    within(screen.getByRole("gridcell", { name: Headers.GatewayIP })).getByRole(
+      "textbox",
+      { name: Headers.GatewayIP }
+    )
+  ).toHaveAttribute("value", subnet.gateway_ip);
+});

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
@@ -1,0 +1,208 @@
+import type { ChangeEventHandler } from "react";
+import { useEffect } from "react";
+
+import { MainTable } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useDispatch, useSelector } from "react-redux";
+
+import type { ConfigureDHCPValues } from "../ConfigureDHCP";
+
+import FormikField from "app/base/components/FormikField";
+import SubnetLink from "app/base/components/SubnetLink";
+import SubnetSelect from "app/base/components/SubnetSelect";
+import TitledSection from "app/base/components/TitledSection";
+import { actions as ipRangeActions } from "app/store/iprange";
+import ipRangeSelectors from "app/store/iprange/selectors";
+import type { IPRange } from "app/store/iprange/types";
+import { getCommentDisplay } from "app/store/iprange/utils";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import { isId } from "app/utils";
+
+type Props = {
+  id: VLAN[VLANMeta.PK];
+};
+
+export enum Headers {
+  Comment = "Comment",
+  EndIP = "End IP address",
+  GatewayIP = "Gateway IP",
+  StartIP = "Start IP address",
+  Subnet = "Subnet",
+}
+
+const generateIPRangeRows = (ipRanges: IPRange[], subnets: Subnet[]) =>
+  ipRanges.map((ipRange) => {
+    const subnet = subnets.find((subnet) => subnet.id === ipRange.subnet);
+    const comment = getCommentDisplay(ipRange);
+    const gatewayIP = subnet?.gateway_ip || "—";
+
+    return {
+      columns: [
+        {
+          "aria-label": Headers.Subnet,
+          content: <SubnetLink id={ipRange.subnet} />,
+        },
+        {
+          "aria-label": Headers.StartIP,
+          content: ipRange.start_ip,
+        },
+        {
+          "aria-label": Headers.EndIP,
+          content: ipRange.end_ip,
+        },
+        {
+          "aria-label": Headers.GatewayIP,
+          content: gatewayIP,
+        },
+        {
+          "aria-label": Headers.Comment,
+          content: comment,
+        },
+      ],
+      key: ipRange.id,
+      sortData: {
+        comment,
+        endIP: ipRange.end_ip,
+        gatewayIP,
+        subnet: subnet?.cidr || "",
+        startIP: ipRange.start_ip,
+      },
+    };
+  });
+
+const generateFormRow = (
+  vlanId: VLAN[VLANMeta.PK],
+  subnetSelected: boolean,
+  handleSubnetChange: ChangeEventHandler
+) => {
+  return [
+    {
+      columns: [
+        {
+          "aria-label": Headers.Subnet,
+          content: (
+            <SubnetSelect
+              labelClassName="u-visually-hidden"
+              name="subnet"
+              onChange={handleSubnetChange}
+              vlan={vlanId}
+            />
+          ),
+        },
+        {
+          "aria-label": Headers.StartIP,
+          content: subnetSelected ? (
+            <FormikField
+              label={Headers.StartIP}
+              labelClassName="u-visually-hidden"
+              name="startIP"
+              type="text"
+            />
+          ) : null,
+        },
+        {
+          "aria-label": Headers.EndIP,
+          content: subnetSelected ? (
+            <FormikField
+              label={Headers.EndIP}
+              labelClassName="u-visually-hidden"
+              name="endIP"
+              type="text"
+            />
+          ) : null,
+        },
+        {
+          "aria-label": Headers.GatewayIP,
+          content: subnetSelected ? (
+            <FormikField
+              label={Headers.GatewayIP}
+              labelClassName="u-visually-hidden"
+              name="gatewayIP"
+              type="text"
+            />
+          ) : null,
+        },
+      ],
+    },
+  ];
+};
+
+const DHCPReservedRanges = ({ id }: Props): JSX.Element => {
+  const { handleChange, setFieldValue, values } =
+    useFormikContext<ConfigureDHCPValues>();
+  const dispatch = useDispatch();
+  const ipRanges = useSelector((state: RootState) =>
+    ipRangeSelectors.getByVLAN(state, id)
+  );
+  const subnets = useSelector(subnetSelectors.all);
+
+  useEffect(() => {
+    dispatch(ipRangeActions.fetch());
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
+
+  // If the VLAN already has IP ranges defined in its subnets we only display
+  // a table of that IP range data. Otherwise, we allow the user to define a
+  // range of IP addresses to be used for DHCP.
+  const hasIPRanges = ipRanges.length > 0;
+  const subnetSelected = isId(values.subnet);
+  const handleSubnetChange: ChangeEventHandler<HTMLSelectElement> = async (
+    e
+  ) => {
+    await handleChange(e);
+    // We set reserved range defaults based on the selected subnet if they exist
+    // otherwise leave the field empty.
+    const subnet = subnets.find(
+      (subnet) => Number(e.target.value) === subnet.id
+    );
+    setFieldValue(
+      "endIP",
+      subnet?.statistics.suggested_dynamic_range?.end || ""
+    );
+    setFieldValue(
+      "gatewayIP",
+      subnet?.gateway_ip || subnet?.statistics.suggested_gateway || ""
+    );
+    setFieldValue(
+      "startIP",
+      subnet?.statistics.suggested_dynamic_range?.start || ""
+    );
+  };
+  return (
+    <TitledSection title="Reserved dynamic range">
+      {hasIPRanges ? (
+        <MainTable
+          defaultSort="startIP"
+          defaultSortDirection="ascending"
+          headers={[
+            { content: Headers.Subnet, sortKey: "subnet" },
+            { content: Headers.StartIP, sortKey: "startIP" },
+            { content: Headers.EndIP, sortKey: "endIP" },
+            { content: Headers.GatewayIP, sortKey: "gatewayIP" },
+            { content: Headers.Comment, sortKey: "comment" },
+          ]}
+          responsive
+          rows={generateIPRangeRows(ipRanges, subnets)}
+          sortable
+        />
+      ) : (
+        <MainTable
+          headers={[
+            { content: Headers.Subnet },
+            { content: Headers.StartIP },
+            { content: Headers.EndIP },
+            { content: Headers.GatewayIP },
+          ]}
+          responsive
+          rows={generateFormRow(id, subnetSelected, handleSubnetChange)}
+        />
+      )}
+    </TitledSection>
+  );
+};
+
+export default DHCPReservedRanges;

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/index.ts
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DHCPReservedRanges";


### PR DESCRIPTION
## Done

- Added Reserved dynamic range table to Configure DHCP form
  - Shows a list of ranges if they exists, otherwise
  - Renders `extra` form fields in table cells

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the VLAN details page of a VLAN that does not have any DHCP enabled and has no reserved IP ranges
- Click "Configure DHCP" and check that a table shows, allowing you to select a subnet and define a range
- Select a subnet and check that the fields are prepopulated where appropriate
- Check that submitting the form simultaneously enables DHCP and creates a reserved IP range
- Click "Configure DHCP" again and check that the range you just defined shows up, and you can't create a new one

## Fixes

Fixes canonical-web-and-design/app-tribe#670

## Screenshot

![Peek 2022-01-21 09-43](https://user-images.githubusercontent.com/25733845/152775496-e8776ba8-d37d-427d-93c2-83f3ec35d5f6.gif)
