### PR TITLE
fix(ui): improve validation of Configure DHCP form.

### DIFF
--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -10,6 +10,9 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
+import type { ConfigureDHCPValues } from "../ConfigureDHCP";
+import { DHCPType } from "../ConfigureDHCP";
+
 import DHCPReservedRanges, { Headers } from "./DHCPReservedRanges";
 
 import subnetsURLs from "app/subnets/urls";
@@ -26,15 +29,38 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
-const initialValues = {
-  endIP: "",
-  gatewayIP: "",
-  primaryRack: "",
-  relayVLAN: "",
-  secondaryRack: "",
-  startIP: "",
-  subnet: "",
-};
+let initialValues: ConfigureDHCPValues;
+
+beforeEach(() => {
+  initialValues = {
+    dhcpType: DHCPType.CONTROLLERS,
+    enableDHCP: true,
+    endIP: "",
+    gatewayIP: "",
+    primaryRack: "",
+    relayVLAN: "",
+    secondaryRack: "",
+    startIP: "",
+    subnet: "",
+  };
+});
+
+it("does not render if DHCP is selected to be disabled", () => {
+  initialValues.enableDHCP = false;
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  const { container } = render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <DHCPReservedRanges id={1} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(container).toBeEmptyDOMElement();
+});
 
 it("renders a table of IP ranges if the VLAN has any defined", () => {
   const vlan = vlanFactory();

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
@@ -131,7 +131,7 @@ const generateFormRow = (
   ];
 };
 
-const DHCPReservedRanges = ({ id }: Props): JSX.Element => {
+const DHCPReservedRanges = ({ id }: Props): JSX.Element | null => {
   const { handleChange, setFieldValue, values } =
     useFormikContext<ConfigureDHCPValues>();
   const dispatch = useDispatch();
@@ -144,6 +144,10 @@ const DHCPReservedRanges = ({ id }: Props): JSX.Element => {
     dispatch(ipRangeActions.fetch());
     dispatch(subnetActions.fetch());
   }, [dispatch]);
+
+  if (!values.enableDHCP) {
+    return null;
+  }
 
   // If the VLAN already has IP ranges defined in its subnets we only display
   // a table of that IP range data. Otherwise, we allow the user to define a
@@ -172,6 +176,7 @@ const DHCPReservedRanges = ({ id }: Props): JSX.Element => {
       subnet?.statistics.suggested_dynamic_range?.start || ""
     );
   };
+
   return (
     <TitledSection title="Reserved dynamic range">
       {hasIPRanges ? (


### PR DESCRIPTION
## Done

- Improved validation of Configure DHCP form
  - Validates that either a rack controller or relay VLAN must be defined
  - Validates that if a subnet is selected for the dynamic range, it must have at least one free IP address

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a VLAN that has no rack controllers and click "Configure DHCP"
- Check that the form is disabled if "Provide DHCP form rack controller(s)" is checked
- Go to the details page of a VLAN that has a subnet with no free IP addresses
- Click "Configure DHCP" and select the subnet from the dropdown
- Blur the field and check that an error message shows up and the form is disabled

## Fixes

Fixes canonical-web-and-design/app-tribe#724

