### PR TITLE
refactor: static routes section

### DIFF
--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import StaticRoutes, { Labels } from "./StaticRoutes";
+
+import {
+  rootState as rootStateFactory,
+  staticRoute as staticRouteFactory,
+  staticRouteState as staticRouteStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders for a subnet", () => {
+  const subnet = subnetFactory({ id: 1 });
+  const state = rootStateFactory({
+    staticroute: staticRouteStateFactory({
+      items: [
+        staticRouteFactory({
+          gateway_ip: "11.1.1.1",
+          source: 1,
+        }),
+        staticRouteFactory({
+          gateway_ip: "11.1.1.2",
+          source: 1,
+        }),
+      ],
+    }),
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <StaticRoutes subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.queryAllByRole("gridcell", {
+      name: Labels.GatewayIp,
+    })
+  ).toHaveLength(2);
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.GatewayIp,
+      })
+      .find((td) => td.textContent === "11.1.1.1")
+  ).toBeInTheDocument();
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.GatewayIp,
+      })
+      .find((td) => td.textContent === "11.1.1.2")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -1,5 +1,190 @@
-import TitledSection from "app/base/components/TitledSection";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 
-const StaticRoutes = (): JSX.Element => <TitledSection title="Static routes" />;
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import type { Dispatch } from "redux";
+
+import TableActions from "app/base/components/TableActions";
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import TitledSection from "app/base/components/TitledSection";
+import { actions as staticRouteActions } from "app/store/staticroute";
+import staticRouteSelectors from "app/store/staticroute/selectors";
+import type { StaticRoute, StaticRouteMeta } from "app/store/staticroute/types";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+
+export type Props = {
+  subnetId: Subnet[SubnetMeta.PK] | null;
+};
+
+export enum Labels {
+  GatewayIp = "Gateway IP",
+  Destination = "Destination",
+  Metric = "Metric",
+  Actions = "Actions",
+}
+
+export enum ExpandedType {
+  Create,
+  Delete,
+  Update,
+}
+
+type Expanded = {
+  id: StaticRoute[StaticRouteMeta.PK];
+  type: ExpandedType;
+};
+
+const toggleExpanded = (
+  id: StaticRoute[StaticRouteMeta.PK],
+  expanded: Expanded | null,
+  expandedType: ExpandedType,
+  setExpanded: (expanded: Expanded | null) => void
+) =>
+  setExpanded(
+    expanded?.id === id && expanded.type === expandedType
+      ? null
+      : {
+          id,
+          type: expandedType,
+        }
+  );
+
+const generateRows = (
+  dispatch: Dispatch,
+  staticRoutes: StaticRoute[],
+  expanded: Expanded | null,
+  setExpanded: (expanded: Expanded | null) => void,
+  saved: boolean,
+  saving: boolean
+) =>
+  staticRoutes.map((staticRoute: StaticRoute) => {
+    const isExpanded = expanded?.id === staticRoute.id;
+    let expandedContent: ReactNode | null = null;
+    const onClose = () => setExpanded(null);
+    if (expanded?.type === ExpandedType.Delete) {
+      expandedContent = (
+        <TableDeleteConfirm
+          deleted={saved}
+          deleting={saving}
+          message="Are you sure you want to remove this static route?"
+          onClose={onClose}
+          onConfirm={() => {
+            dispatch(staticRouteActions.delete(staticRoute.id));
+          }}
+          sidebar={false}
+        />
+      );
+    } else if (expanded?.type === ExpandedType.Update) {
+      expandedContent = <>Todo: static route edit form</>;
+    }
+    return {
+      className: isExpanded ? "p-table__row is-active" : null,
+      columns: [
+        {
+          "aria-label": Labels.GatewayIp,
+          content: staticRoute.gateway_ip,
+        },
+        {
+          "aria-label": Labels.Destination,
+          content: staticRoute.destination,
+        },
+        {
+          "aria-label": Labels.Metric,
+          content: staticRoute.metric,
+        },
+        {
+          "aria-label": Labels.Actions,
+          content: (
+            <TableActions
+              onDelete={() => {
+                toggleExpanded(
+                  staticRoute.id,
+                  expanded,
+                  ExpandedType.Delete,
+                  setExpanded
+                );
+              }}
+              onEdit={() => {
+                toggleExpanded(
+                  staticRoute.id,
+                  expanded,
+                  ExpandedType.Update,
+                  setExpanded
+                );
+              }}
+            />
+          ),
+          className: "u-align--right",
+        },
+      ],
+      expanded: isExpanded,
+      expandedContent: expandedContent,
+      key: staticRoute.id,
+      sortData: {
+        gateway_ip: staticRoute.gateway_ip,
+      },
+    };
+  });
+
+const StaticRoutes = ({ subnetId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const [expanded, setExpanded] = useState<Expanded | null>(null);
+  const loading = useSelector(staticRouteSelectors.loading);
+  const saved = useSelector(staticRouteSelectors.saved);
+  const saving = useSelector(staticRouteSelectors.saving);
+  const staticRoutes = useSelector(staticRouteSelectors.all).filter(
+    (staticRoute) => staticRoute.source === subnetId
+  );
+
+  useEffect(() => {
+    dispatch(staticRouteActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <TitledSection title="Static routes">
+      <MainTable
+        className="reserved-ranges-table p-table-expanding--light"
+        defaultSort="name"
+        defaultSortDirection="descending"
+        emptyStateMsg={
+          loading ? (
+            <Spinner text="Loading..." />
+          ) : (
+            "No static routes for this subnet."
+          )
+        }
+        expanding
+        headers={[
+          {
+            content: Labels.GatewayIp,
+            sortKey: "gateway_ip",
+          },
+          {
+            content: Labels.Destination,
+            sortKey: "destination",
+          },
+          {
+            content: Labels.Metric,
+            sortKey: "metric",
+          },
+          {
+            content: Labels.Actions,
+            className: "u-align--right",
+          },
+        ]}
+        rows={generateRows(
+          dispatch,
+          staticRoutes,
+          expanded,
+          setExpanded,
+          saved,
+          saving
+        )}
+        sortable
+      />
+    </TitledSection>
+  );
+};
 
 export default StaticRoutes;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -65,7 +65,7 @@ const SubnetDetails = (): JSX.Element => {
     <Section header={<SubnetDetailsHeader subnet={subnet} />}>
       <SubnetSummary id={id} />
       <Utilisation statistics={subnet.statistics} />
-      <StaticRoutes />
+      <StaticRoutes subnetId={id} />
       <ReservedRanges subnetId={id} />
       <DHCPSnippets
         subnetIds={isId(id) ? [id] : []}


### PR DESCRIPTION
## Done

- Show static routes table for a subnet.

I added the delete and confirmation panel based on the pattern that was build in the section below (Reserved ranges). But since there will be some changes to do, we can deal with those in the corresponding issue https://github.com/canonical-web-and-design/app-tribe/issues/660

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet page (id=14 has a static route associated)
- Check that the data has the right format

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/657

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
