### PR TITLE
refactor(ui): turn subnet utils into hooks

### DIFF
--- a/ui/src/app/store/subnet/hooks.test.tsx
+++ b/ui/src/app/store/subnet/hooks.test.tsx
@@ -1,0 +1,130 @@
+import type { ReactNode } from "react";
+
+import { renderHook } from "@testing-library/react-hooks";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
+
+import { useIsDHCPEnabled, useCanBeDeleted } from "./hooks";
+
+import {
+  subnetDetails as subnetFactory,
+  subnetIP as subnetIPFactory,
+  subnetState as subnetStateFactory,
+  vlanState as vlanStateFactory,
+  vlan as vlanFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+const generateWrapper =
+  (store: MockStoreEnhanced<unknown>) =>
+  ({ children }: { children: ReactNode }) =>
+    <Provider store={store}>{children}</Provider>;
+
+describe("useCanBeDeleted", () => {
+  it("can be deleted if DHCP is disabled and the subnet has no ips", () => {
+    const vlan = vlanFactory({ dhcp_on: false });
+    const subnet = subnetFactory({
+      ip_addresses: [],
+      vlan: vlan.id,
+    });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnet],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useCanBeDeleted(subnet.id), {
+      wrapper: generateWrapper(store),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("cannot be deleted if DHCP is enabled", () => {
+    const vlan = vlanFactory({ dhcp_on: true });
+    const subnet = subnetFactory({
+      vlan: vlan.id,
+    });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnet],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useCanBeDeleted(subnet.id), {
+      wrapper: generateWrapper(store),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("cannot be deleted if DHCP is disabled but the subnet has ips", () => {
+    const vlan = vlanFactory({ dhcp_on: false });
+    const subnet = subnetFactory({
+      ip_addresses: [subnetIPFactory()],
+      vlan: vlan.id,
+    });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnet],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useCanBeDeleted(subnet.id), {
+      wrapper: generateWrapper(store),
+    });
+    expect(result.current).toBe(true);
+  });
+});
+
+describe("useIsDHCPEnabled", () => {
+  it("is enabled if the subnet's VLAN has DHCP turned on", () => {
+    const vlan = vlanFactory({ dhcp_on: true });
+    const subnet = subnetFactory({
+      vlan: vlan.id,
+    });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnet],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useIsDHCPEnabled(subnet.id), {
+      wrapper: generateWrapper(store),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("is disabled if the subnet's VLAN has DHCP turned off", () => {
+    const vlan = vlanFactory({ dhcp_on: false });
+    const subnet = subnetFactory({
+      vlan: vlan.id,
+    });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnet],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useIsDHCPEnabled(subnet.id), {
+      wrapper: generateWrapper(store),
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/ui/src/app/store/subnet/hooks.ts
+++ b/ui/src/app/store/subnet/hooks.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import { getHasIPAddresses } from "./utils";
+
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+/**
+ * Get if DHCP is enabled on a given subnet
+ * @param id - The id of the subnet to check.
+ */
+export const useIsDHCPEnabled = (
+  id?: Subnet[SubnetMeta.PK] | null
+): boolean => {
+  const dispatch = useDispatch();
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, id)
+  );
+  const vlanOnSubnet = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, subnet?.vlan)
+  );
+
+  useEffect(() => {
+    dispatch(vlanActions.fetch());
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
+
+  return vlanOnSubnet?.dhcp_on || false;
+};
+
+/**
+ * Get if a subnet can be deleted.
+ * @param id - The id of the subnet to check.
+ */
+export const useCanBeDeleted = (id?: Subnet[SubnetMeta.PK] | null): boolean => {
+  const dispatch = useDispatch();
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, id)
+  );
+  const isDHCPEnabled = useIsDHCPEnabled(id);
+
+  useEffect(() => {
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
+
+  return !isDHCPEnabled || (isDHCPEnabled && !getHasIPAddresses(subnet));
+};

--- a/ui/src/app/store/subnet/utils.test.ts
+++ b/ui/src/app/store/subnet/utils.test.ts
@@ -1,7 +1,8 @@
-import { getSubnetDisplay, isSubnetDetails } from "./utils";
+import { getHasIPAddresses, getSubnetDisplay, isSubnetDetails } from "./utils";
 
 import {
   subnet as subnetFactory,
+  subnetIP as subnetIPFactory,
   subnetDetails as subnetDetailsFactory,
 } from "testing/factories";
 
@@ -39,5 +40,26 @@ describe("subnet utils", () => {
       expect(isSubnetDetails(subnet)).toBe(false);
       expect(isSubnetDetails(subnetDetails)).toBe(true);
     });
+  });
+});
+
+describe("getHasIPAddresses", function () {
+  it("handles no arguments provided", function () {
+    expect(getHasIPAddresses()).toBe(false);
+  });
+
+  it("handles non-details subnets", function () {
+    const subnet = subnetFactory();
+    expect(getHasIPAddresses(subnet)).toBe(false);
+  });
+
+  it("returns true if argument has IP addresses", function () {
+    const subnet = subnetDetailsFactory({ ip_addresses: [subnetIPFactory()] });
+    expect(getHasIPAddresses(subnet)).toBe(true);
+  });
+
+  it("returns false if argument has no IP addresses", function () {
+    const subnet = subnetDetailsFactory({ ip_addresses: [] });
+    expect(getHasIPAddresses(subnet)).toBe(false);
   });
 });

--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -64,41 +64,5 @@ export const getSubnetsInSpace = (
   spaceId: Space["id"]
 ): Subnet[] => subnets.filter((subnet) => subnet.space === spaceId);
 
-/**
- * Get VLAN on a given subnet
- * @param subnets - Subnets.
- * @param vlanId - VLAN id.
- * @return Subnets for a given VLAN id.
- */
-export const getVLANOnSubnet = (
-  vlans: VLAN[],
-  subnet: Subnet
-): VLAN | undefined => vlans.find((vlan) => vlan.id === subnet.vlan);
-
-/**
- * Get if DHCP is enabled on a given subnet
- * @param subnet - All VLANS.
- * @param subnet - The subnet to check.
- */
-export const getIsDHCPEnabled = (
-  vlans?: VLAN[],
-  subnet?: Subnet | null
-): boolean => {
-  if (!vlans || !subnet) {
-    return false;
-  }
-  const vlanOnSubnet = getVLANOnSubnet(vlans, subnet);
-  return vlanOnSubnet?.dhcp_on || false;
-};
-
-/**
- * Get if a subnet can be deleted.
- * @param subnet - The subnet to check.
- */
-export const getCanBeDeleted = (vlans: VLAN[], subnet: Subnet): boolean => {
-  const isDHCPEnabled = getIsDHCPEnabled(vlans, subnet);
-  return !isDHCPEnabled || (isDHCPEnabled && !getHasIPAddresses(subnet));
-};
-
-export const getHasIPAddresses = (subnet?: Subnet): boolean =>
-  isSubnetDetails(subnet) ? subnet?.ip_addresses.length === 0 : false;
+export const getHasIPAddresses = (subnet?: Subnet | null): boolean =>
+  isSubnetDetails(subnet) ? subnet?.ip_addresses.length > 0 : false;

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDelete/SpaceDelete.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDelete/SpaceDelete.tsx
@@ -11,7 +11,7 @@ import { useHistory } from "react-router";
 
 import { useCycled } from "app/base/hooks";
 import { actions as spaceActions } from "app/store/space";
-import { default as spaceSelectors } from "app/store/space/selectors";
+import spaceSelectors from "app/store/space/selectors";
 import type { Space } from "app/store/space/types";
 import { getCanBeDeleted } from "app/store/space/utils";
 import urls from "app/subnets/urls";

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.tsx
@@ -1,17 +1,15 @@
+import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Notification, Row, Col } from "@canonical/react-components";
+import { Col, Notification, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikForm from "app/base/components/FormikForm";
 import TitledSection from "app/base/components/TitledSection";
 import type { EmptyObject } from "app/base/types";
-import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
-import { default as subnetSelectors } from "app/store/subnet/selectors";
-import { getCanBeDeleted, getIsDHCPEnabled } from "app/store/subnet/utils";
-import { actions as vlanActions } from "app/store/vlan";
-import { default as vlanSelectors } from "app/store/vlan/selectors";
+import { useCanBeDeleted, useIsDHCPEnabled } from "app/store/subnet/hooks";
+import subnetSelectors from "app/store/subnet/selectors";
 import subnetURLs from "app/subnets/urls";
 import type { SubnetActionProps } from "app/subnets/views/SubnetDetails/types";
 
@@ -19,73 +17,63 @@ export const DeleteSubnet = ({
   id,
   setActiveForm,
 }: Omit<SubnetActionProps, "activeForm">): JSX.Element | null => {
-  const subnet = useSelector((state: RootState) =>
-    subnetSelectors.getById(state, id)
-  );
-  const vlans = useSelector(vlanSelectors.all);
-  const vlanLoaded = useSelector(vlanSelectors.loaded);
-  const subnetLoaded = useSelector(subnetSelectors.loaded);
-  const canBeDeleted = subnet ? getCanBeDeleted(vlans, subnet) : false;
   const dispatch = useDispatch();
   const errors = useSelector(subnetSelectors.errors);
   const saving = useSelector(subnetSelectors.saving);
   const saved = useSelector(subnetSelectors.saved);
-  const dhcpEnabled = getIsDHCPEnabled(vlans, subnet);
   const handleClose = () => setActiveForm(null);
+  const canBeDeleted = useCanBeDeleted(id);
+  const dhcpEnabled = useIsDHCPEnabled(id);
 
   useEffect(() => {
-    if (!vlanLoaded) dispatch(vlanActions.fetch());
-    if (!subnetLoaded) dispatch(subnetActions.fetch());
-  }, [dispatch, vlanLoaded, subnetLoaded]);
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
+
+  let message: ReactNode;
+
+  if (canBeDeleted) {
+    message = (
+      <>
+        <p>Are you sure you want to delete this subnet?</p>
+        {dhcpEnabled ? null : (
+          <p>
+            Beware IP addresses on devices on this subnet might not be retained.
+          </p>
+        )}
+      </>
+    );
+  } else {
+    message = (
+      <Notification inline severity="negative" title="Error:">
+        This subnet cannot be deleted as there are nodes that have an IP address
+        obtained through DHCP services on this subnet. Release these nodes in
+        order to proceed.
+      </Notification>
+    );
+  }
 
   return (
     <TitledSection title="Delete subnet?" headingVisuallyHidden>
-      {!canBeDeleted ? (
-        <Row>
-          <Col size={8}>
-            <Notification
-              inline
-              severity="negative"
-              title="Error:"
-              onDismiss={handleClose}
-            >
-              This subnet cannot be deleted as there are nodes that have an IP
-              address obtained through DHCP services on this subnet. Release
-              these nodes in order to proceed.
-            </Notification>
-          </Col>
-        </Row>
-      ) : (
-        <Row>
-          <Col size={8}>
-            <p>Are you sure you want to delete this subnet?</p>
-            {dhcpEnabled ? null : (
-              <p>
-                Beware IP addresses on devices on this subnet might not be
-                retained.
-              </p>
-            )}
-          </Col>
-          <Col size={4} className="u-align--right">
-            <FormikForm<EmptyObject>
-              aria-label="Delete subnet"
-              buttonsBordered={false}
-              cleanup={subnetActions.cleanup}
-              errors={errors}
-              initialValues={{}}
-              onCancel={handleClose}
-              onSubmit={() => {
-                dispatch(subnetActions.delete(id));
-              }}
-              savedRedirect={subnetURLs.index}
-              saved={saved}
-              saving={saving}
-              submitLabel="Delete"
-              submitAppearance="negative"
-            />
-          </Col>
-        </Row>
-      )}
+      <Row>
+        <Col size={8}>{message}</Col>
+      </Row>
+      <FormikForm<EmptyObject>
+        aria-label="Delete subnet"
+        buttonsBordered={false}
+        cleanup={subnetActions.cleanup}
+        errors={errors}
+        initialValues={{}}
+        onCancel={handleClose}
+        onSubmit={() => {
+          dispatch(subnetActions.delete(id));
+        }}
+        savedRedirect={subnetURLs.index}
+        saved={saved}
+        saving={saving}
+        submitAppearance="negative"
+        submitDisabled={!canBeDeleted}
+        submitLabel="Delete"
+      />
     </TitledSection>
   );
 };


### PR DESCRIPTION
## Done

- Update the delete subnet utils to be hooks.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet whose VLAN has DHCP enabled.
- Use the take action menu to open the delete form.
- There should be an error that it can't be deleted and the delete button should be disabled.
- Go to a subnet whose VLAN has DHCP disabled.
- Use the take action menu to open the delete form.
- You should be able to submit the form.

## Fixes

Fixes: canonical-web-and-design/app-tribe#720.