### PR TITLE
refactor: update links to the react subnets pages

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -70,17 +70,6 @@ function MasterController(
             {link.label}
           </a>
         )}
-        generateLegacyLink={(link, props, _appendNewBase) => (
-          <a
-            className={props.className}
-            aria-current={props["aria-current"]}
-            aria-label={props["aria-label"]}
-            role={props.role}
-            href={generateLegacyURL(link.url)}
-          >
-            {link.label}
-          </a>
-        )}
         location={window.location}
         logout={() => {
           localStorage.clear();

--- a/legacy/src/app/partials/cards/images.html
+++ b/legacy/src/app/partials/cards/images.html
@@ -15,5 +15,5 @@
   </ul>
 </div>
 <footer>
-  <p><a href="{$ legacyURLBase $}/images">Go to images &rsaquo;</a></p>
+  <p><a href="{$ newURLBase $}/images">Go to images &rsaquo;</a></p>
 </footer>

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -421,7 +421,7 @@
           You can now enable <strong>high availability DHCP</strong> on {$
           node.vlan.fabric_name $} {$ getNotificationVLANText() $}.
           <a
-            href="{$ legacyURLBase $}/vlan/{$ node.vlan.id $}?provide_dhcp=true"
+            href="{$ newURLBase $}/vlan/{$ node.vlan.id $}?provide_dhcp=true"
             >Reconfigure</a
           >
           the DHCP configuration.
@@ -865,12 +865,12 @@
               <tr class="p-table__row" data-ng-repeat="vlanRow in vlanTable">
                 <td title="{$ vlanRow['fabric'].name $}">
                   <a
-                    href="{$ legacyURLBase $}/fabric/{$ vlanRow['fabric'].id $}"
+                    href="{$ newURLBase $}/fabric/{$ vlanRow['fabric'].id $}"
                     >{$ vlanRow['fabric'].name $}</a
                   >
                 </td>
                 <td title="{$ getVLANText(vlanRow['vlan']) $}">
-                  <a href="{$ legacyURLBase $}/vlan/{$ vlanRow['vlan'].id $}"
+                  <a href="{$ newURLBase $}/vlan/{$ vlanRow['vlan'].id $}"
                     >{$ getVLANText(vlanRow['vlan']) $}</a
                   >
                 </td>
@@ -892,7 +892,7 @@
                     data-ng-repeat="subnet in vlanRow['subnets']"
                   >
                     <a
-                      href="{$ legacyURLBase $}/subnet/{$ subnet.id $}"
+                      href="{$ newURLBase $}/subnet/{$ subnet.id $}"
                       title="{$ getSubnetText(subnet) $}"
                       >{$ getSubnetText(subnet) $}</a
                     >
@@ -1165,7 +1165,7 @@
                           <a
                             class="p-link--soft"
                             data-ng-if="interface.fabric"
-                            href="{$ legacyURLBase $}/fabric/{$ interface.fabric.id $}"
+                            href="{$ newURLBase $}/fabric/{$ interface.fabric.id $}"
                             >{$ interface.fabric.name $}</a
                           >
                           <span data-ng-if="!interface.fabric.name"
@@ -1178,7 +1178,7 @@
                           <a
                             class="p-muted-text p-link--muted"
                             data-ng-if="interface.vlan"
-                            href="{$ legacyURLBase $}/vlan/{$ interface.vlan.id $}"
+                            href="{$ newURLBase $}/vlan/{$ interface.vlan.id $}"
                           >
                             {$ getVLANText(interface.vlan) $}
                           </a>
@@ -1200,7 +1200,7 @@
                         <span data-ng-if="interface.subnet.cidr">
                           <a
                             class="p-link--soft"
-                            href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                            href="{$ newURLBase $}/subnet/{$ interface.subnet.id $}"
                             >{$ interface.subnet.cidr $}</a
                           >
                         </span>
@@ -1216,7 +1216,7 @@
                       >
                         <a
                           class="p-muted-text p-link--muted"
-                          href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                          href="{$ newURLBase $}/subnet/{$ interface.subnet.id $}"
                           >{$ interface.subnet.name $}</a
                         >
                       </div>
@@ -1463,7 +1463,7 @@
                           <a
                             class="p-link--soft"
                             data-ng-if="editInterface.fabric"
-                            href="{$ legacyURLBase $}/fabric/{$ editInterface.fabric.id $}"
+                            href="{$ newURLBase $}/fabric/{$ editInterface.fabric.id $}"
                             >{$ editInterface.fabric.name $}</a
                           >
                           <span data-ng-if="!editInterface.fabric.name"
@@ -1476,7 +1476,7 @@
                           <a
                             class="p-muted-text p-link--muted"
                             data-ng-if="editInterface.vlan"
-                            href="{$ legacyURLBase $}/vlan/{$ editInterface.vlan.id $}"
+                            href="{$ newURLBase $}/vlan/{$ editInterface.vlan.id $}"
                           >
                             {$ getVLANText(editInterface.vlan) $}
                           </a>
@@ -1498,7 +1498,7 @@
                         <span data-ng-if="editInterface.subnet.cidr">
                           <a
                             class="p-link--soft"
-                            href="{$ legacyURLBase $}/subnet/{$ editInterface.subnet.id $}"
+                            href="{$ newURLBase $}/subnet/{$ editInterface.subnet.id $}"
                             >{$ editInterface.subnet.cidr $}</a
                           >
                         </span>
@@ -1514,7 +1514,7 @@
                       >
                         <a
                           class="p-muted-text p-link--muted"
-                          href="{$ legacyURLBase $}/subnet/{$ editInterface.subnet.id $}"
+                          href="{$ newURLBase $}/subnet/{$ editInterface.subnet.id $}"
                           >{$ editInterface.subnet.name $}</a
                         >
                       </div>
@@ -2330,7 +2330,7 @@
                         <a
                           class="p-link--soft"
                           data-ng-if="interface.fabric"
-                          href="{$ legacyURLBase $}/fabric/{$ interface.fabric.id $}"
+                          href="{$ newURLBase $}/fabric/{$ interface.fabric.id $}"
                           >{$ interface.fabric.name $}</a
                         >
                         <span data-ng-if="!interface.fabric.name"
@@ -2346,7 +2346,7 @@
                         <a
                           class="p-muted-text p-link--muted"
                           data-ng-if="interface.vlan"
-                          href="{$ legacyURLBase $}/vlan/{$ interface.vlan.id $}"
+                          href="{$ newURLBase $}/vlan/{$ interface.vlan.id $}"
                         >
                           {$ getVLANText(interface.vlan) $}
                         </a>
@@ -2369,7 +2369,7 @@
                         <span data-ng-if="interface.subnet.cidr">
                           <a
                             class="p-link--soft"
-                            href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                            href="{$ newURLBase $}/subnet/{$ interface.subnet.id $}"
                             >{$ interface.subnet.cidr $}</a
                           >
                         </span>
@@ -2387,7 +2387,7 @@
                       <div class="u-text-overflow">
                         <a
                           class="p-muted-text p-link--muted"
-                          href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                          href="{$ newURLBase $}/subnet/{$ interface.subnet.id $}"
                           >{$ interface.subnet.name $}</a
                         >
                       </div>

--- a/shared/src/components/Header/Header.test.tsx
+++ b/shared/src/components/Header/Header.test.tsx
@@ -36,7 +36,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -70,7 +69,6 @@ describe("Header", () => {
     render(
       <Header
         authUser={null}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -95,7 +93,6 @@ describe("Header", () => {
           is_superuser: true,
           username: "koala",
         }}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -118,7 +115,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={false}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -143,7 +139,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -167,7 +162,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -191,7 +185,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -216,7 +209,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -240,7 +232,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {
@@ -265,7 +256,6 @@ describe("Header", () => {
           username: "koala",
         }}
         completedIntro={true}
-        generateLegacyLink={generateURL}
         generateNewLink={generateURL}
         location={
           {

--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -24,7 +24,6 @@ type Props = {
   completedIntro?: boolean;
   debug?: boolean;
   enableAnalytics?: boolean;
-  generateLegacyLink: GenerateLinkType;
   generateNewLink: GenerateLinkType;
   location: Location | HistoryLocation;
   logout: () => void;
@@ -46,7 +45,7 @@ const useVisible = (initialValue: boolean): [boolean, ToggleVisible] => {
 
 const generateURL = (
   url: NavItem["url"],
-  isLegacy: NavItem["isLegacy"],
+  isLegacy: boolean,
   appendNewBase: boolean
 ) => {
   if (isLegacy) {
@@ -81,7 +80,6 @@ export const Header = ({
   completedIntro,
   debug,
   enableAnalytics,
-  generateLegacyLink,
   generateNewLink,
   location,
   logout,
@@ -188,7 +186,6 @@ export const Header = ({
     },
     {
       highlight: ["/networks", "/subnet", "/space", "/fabric", "/vlan"],
-      isLegacy: true,
       label: "Subnets",
       url: "/networks?by=fabric",
     },
@@ -204,9 +201,7 @@ export const Header = ({
     );
 
   const generateLink: GenerateNavLink = (link: NavItem, props = undefined) => {
-    return link.isLegacy
-      ? generateLegacyLink(link, props, appendNewBase)
-      : generateNewLink(link, props, appendNewBase);
+    return generateNewLink(link, props, appendNewBase);
   };
 
   const generateNavItems = (links: NavItem[]) => {
@@ -395,7 +390,6 @@ Header.propTypes = {
   completedIntro: PropTypes.bool,
   debug: PropTypes.bool,
   enableAnalytics: PropTypes.bool,
-  generateLegacyLink: PropTypes.func.isRequired,
   generateNewLink: PropTypes.func.isRequired,
   location: PropTypes.shape({
     search: PropTypes.string,

--- a/shared/src/components/Header/types.ts
+++ b/shared/src/components/Header/types.ts
@@ -4,7 +4,6 @@ export type NavItem = {
   adminOnly?: boolean;
   highlight?: string | string[];
   inHardwareMenu?: boolean;
-  isLegacy?: boolean;
   label: string;
   url: string;
 };

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -3,12 +3,7 @@ import { useEffect } from "react";
 
 import { Notification } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import {
-  Footer,
-  generateLegacyURL,
-  Header,
-  navigateToLegacy,
-} from "@maas-ui/maas-ui-shared";
+import { Footer, Header } from "@maas-ui/maas-ui-shared";
 import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useHistory, useLocation } from "react-router-dom";
@@ -151,24 +146,6 @@ export const App = (): JSX.Element => {
         completedIntro={completedIntro && completedUserIntro}
         debug={debug}
         enableAnalytics={analyticsEnabled as boolean}
-        generateLegacyLink={(
-          link: LinkType,
-          props: LinkProps,
-          _appendNewBase: boolean
-        ) => (
-          <a
-            className={props.className}
-            aria-current={props["aria-current"]}
-            aria-label={props["aria-label"]}
-            role={props.role}
-            href={generateLegacyURL(link.url)}
-            onClick={(evt) => {
-              navigateToLegacy(link.url, evt);
-            }}
-          >
-            {link.label}
-          </a>
-        )}
         generateNewLink={(
           link: LinkType,
           props: LinkProps,

--- a/ui/src/app/base/components/ControllerLink/ControllerLink.test.tsx
+++ b/ui/src/app/base/components/ControllerLink/ControllerLink.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ControllerLink from "./ControllerLink";
 
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import {
   controller as controllerFactory,
   controllerState as controllerStateFactory,
@@ -69,6 +69,8 @@ it("renders a link if controllers have loaded and it exists", () => {
   expect(link).toHaveTextContent("bolla.maas");
   expect(link).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: controller.system_id }))
+    generateLegacyURL(
+      controllersURLs.controller.index({ id: controller.system_id })
+    )
   );
 });

--- a/ui/src/app/base/components/ControllerLink/ControllerLink.tsx
+++ b/ui/src/app/base/components/ControllerLink/ControllerLink.tsx
@@ -4,7 +4,7 @@ import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
+import controllerURLs from "app/controllers/urls";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
@@ -38,7 +38,9 @@ const ControllerLink = ({ systemId }: Props): JSX.Element | null => {
     return null;
   }
   return (
-    <LegacyLink route={baseURLs.controller({ id: controller.system_id })}>
+    <LegacyLink
+      route={controllerURLs.controller.index({ id: controller.system_id })}
+    >
       <strong>{controller.hostname}</strong>
       <span>.{controller.domain.name}</span>
     </LegacyLink>

--- a/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.test.tsx
+++ b/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricColumn from "./FabricColumn";
@@ -47,7 +48,9 @@ describe("FabricColumn", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FabricColumn nic={nic} node={state.machine.items[0]} />
+        <MemoryRouter>
+          <FabricColumn nic={nic} node={state.machine.items[0]} />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("DoubleRow").exists()).toBe(false);
@@ -70,10 +73,12 @@ describe("FabricColumn", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FabricColumn nic={nic} node={state.machine.items[0]} />
+        <MemoryRouter>
+          <FabricColumn nic={nic} node={state.machine.items[0]} />
+        </MemoryRouter>
       </Provider>
     );
-    const links = wrapper.find("DoubleRow LegacyLink");
+    const links = wrapper.find("DoubleRow Link");
     expect(links.at(0).text()).toBe("fabric-name");
     expect(links.at(1).text()).toBe("2 (vlan-name)");
   });

--- a/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.tsx
+++ b/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.tsx
@@ -1,15 +1,15 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
 import fabricSelectors from "app/store/fabric/selectors";
 import type { RootState } from "app/store/root/types";
 import type { NetworkInterface, NetworkLink, Node } from "app/store/types/node";
 import { getInterfaceFabric, isBondOrBridgeParent } from "app/store/utils";
 import vlanSelectors from "app/store/vlan/selectors";
 import { getVLANDisplay } from "app/store/vlan/utils";
+import subnetURLs from "app/subnets/urls";
 
 type Props = {
   link?: NetworkLink | null;
@@ -38,24 +38,24 @@ const FabricColumn = ({ link, nic, node }: Props): JSX.Element | null => {
       data-testid="fabric"
       primary={
         fabric ? (
-          <LegacyLink
+          <Link
             className="p-link--soft"
-            route={baseURLs.fabric({ id: fabric.id })}
+            to={subnetURLs.fabric.index({ id: fabric.id })}
           >
             {fabricContent}
-          </LegacyLink>
+          </Link>
         ) : (
           fabricContent
         )
       }
       secondary={
         vlan ? (
-          <LegacyLink
+          <Link
             className="p-link--muted"
-            route={baseURLs.vlan({ id: vlan.id })}
+            to={subnetURLs.vlan.index({ id: vlan.id })}
           >
             {getVLANDisplay(vlan)}
-          </LegacyLink>
+          </Link>
         ) : null
       }
     />

--- a/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.test.tsx
+++ b/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
 
 import SubnetColumn from "./SubnetColumn";
@@ -54,10 +55,12 @@ describe("SubnetColumn", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+        <MemoryRouter>
+          <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+        </MemoryRouter>
       </Provider>
     );
-    const links = wrapper.find("LegacyLink");
+    const links = wrapper.find("Link");
     expect(links.at(0).text()).toBe("subnet-cidr");
     expect(links.at(1).text()).toBe("subnet-name");
   });
@@ -84,10 +87,12 @@ describe("SubnetColumn", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SubnetColumn link={link} nic={nic} node={state.device.items[0]} />
+        <MemoryRouter>
+          <SubnetColumn link={link} nic={nic} node={state.device.items[0]} />
+        </MemoryRouter>
       </Provider>
     );
-    const links = wrapper.find("LegacyLink");
+    const links = wrapper.find("Link");
     expect(links.at(0).text()).toBe("subnet-cidr");
     expect(links.at(1).text()).toBe("subnet-name");
   });
@@ -112,7 +117,9 @@ describe("SubnetColumn", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+        <MemoryRouter>
+          <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("DoubleRow").prop("primary")).toBe("Unconfigured");
@@ -141,10 +148,12 @@ describe("SubnetColumn", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SubnetColumn nic={nic} node={state.machine.items[0]} />
+        <MemoryRouter>
+          <SubnetColumn nic={nic} node={state.machine.items[0]} />
+        </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("LegacyLink").exists()).toBe(false);
+    expect(wrapper.find("Link").exists()).toBe(false);
     expect(wrapper.find("DoubleRow").prop("primary")).toBe(
       "subnet-cidr (subnet-name)"
     );

--- a/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
+++ b/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
@@ -1,11 +1,10 @@
 import type { ReactNode } from "react";
 
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
 import { useIsAllNetworkingDisabled } from "app/base/hooks";
-import baseURLs from "app/base/urls";
 import fabricSelectors from "app/store/fabric/selectors";
 import subnetSelectors from "app/store/subnet/selectors";
 import { getSubnetDisplay } from "app/store/subnet/utils";
@@ -17,6 +16,7 @@ import {
   getLinkInterface,
 } from "app/store/utils";
 import vlanSelectors from "app/store/vlan/selectors";
+import subnetsURLs from "app/subnets/urls";
 
 type Props = {
   link?: NetworkLink | null;
@@ -57,12 +57,12 @@ const SubnetColumn = ({ link, nic, node }: Props): JSX.Element | null => {
   let primary: ReactNode = null;
   if (showLinkSubnet) {
     primary = subnet ? (
-      <LegacyLink
+      <Link
         className="p-link--soft"
-        route={baseURLs.subnet({ id: subnet.id })}
+        to={subnetsURLs.subnet.index({ id: subnet.id })}
       >
         {subnetDisplay}
-      </LegacyLink>
+      </Link>
     ) : (
       subnetDisplay
     );
@@ -77,12 +77,12 @@ const SubnetColumn = ({ link, nic, node }: Props): JSX.Element | null => {
       primary={primary}
       secondary={
         showLinkSubnet && subnet ? (
-          <LegacyLink
+          <Link
             className="p-link--muted"
-            route={baseURLs.subnet({ id: subnet.id })}
+            to={subnetsURLs.subnet.index({ id: subnet.id })}
           >
             {subnet.name}
-          </LegacyLink>
+          </Link>
         ) : null
       }
     />

--- a/ui/src/app/base/urls.ts
+++ b/ui/src/app/base/urls.ts
@@ -1,23 +1,5 @@
-import type { Controller } from "app/store/controller/types";
-import type { Fabric } from "app/store/fabric/types";
-import type { Subnet } from "app/store/subnet/types";
-import type { VLAN } from "app/store/vlan/types";
-import type { Zone } from "app/store/zone/types";
-import { argPath } from "app/utils";
-
 const urls = {
-  controller: argPath<{ id: Controller["system_id"] }>("/controller/:id"),
-  controllers: "/controllers",
-  fabric: argPath<{ id: Fabric["id"] }>("/fabric/:id"),
-  images: "/images",
   index: "/",
-  intro: {
-    index: "/intro",
-    user: "/intro/user",
-  },
-  subnet: argPath<{ id: Subnet["id"] }>("/subnet/:id"),
-  vlan: argPath<{ id: VLAN["id"] }>("/vlan/:id"),
-  zone: argPath<{ id: Zone["id"] }>("/zone/:id"),
 };
 
 export default urls;

--- a/ui/src/app/controllers/urls.ts
+++ b/ui/src/app/controllers/urls.ts
@@ -1,6 +1,12 @@
+import type { Controller } from "app/store/controller/types";
+import { argPath } from "app/utils";
+
 const urls = {
   controllers: {
     index: "/controllers",
+  },
+  controller: {
+    index: argPath<{ id: Controller["system_id"] }>("/controller/:id"),
   },
 };
 

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ControllerListTable from "./ControllerListTable";
 
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import type { Controller } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -47,7 +47,7 @@ describe("ControllerListTable", () => {
     );
 
     expect(wrapper.find("LegacyLink").at(0).prop("route")).toBe(
-      baseURLs.controller({ id: controller.system_id })
+      controllersURLs.controller.index({ id: controller.system_id })
     );
   });
 

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/VLANsColumn/VLANsColumn.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/VLANsColumn/VLANsColumn.tsx
@@ -2,7 +2,7 @@ import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
@@ -44,7 +44,9 @@ export const VLANsColumn = ({ systemId }: Props): JSX.Element | null => {
     <DoubleRow
       primary={
         <LegacyLink
-          route={`${baseURLs.controller({ id: systemId })}?area=vlans`}
+          route={`${controllersURLs.controller.index({
+            id: systemId,
+          })}?area=vlans`}
         >
           <span data-testid="vlan-count">{getVlanCount(controller)}</span>
         </LegacyLink>

--- a/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
 
 import DashboardConfigurationSubnetForm from "./DashboardConfigurationSubnetForm";
@@ -26,7 +27,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DashboardConfigurationSubnetForm />
+        <MemoryRouter>
+          <DashboardConfigurationSubnetForm />
+        </MemoryRouter>
       </Provider>
     );
 
@@ -40,7 +43,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DashboardConfigurationSubnetForm />
+        <MemoryRouter>
+          <DashboardConfigurationSubnetForm />
+        </MemoryRouter>
       </Provider>
     );
 
@@ -55,7 +60,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DashboardConfigurationSubnetForm />
+        <MemoryRouter>
+          <DashboardConfigurationSubnetForm />
+        </MemoryRouter>
       </Provider>
     );
 
@@ -75,7 +82,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DashboardConfigurationSubnetForm />
+        <MemoryRouter>
+          <DashboardConfigurationSubnetForm />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("submitDisabled")).toBe(true);
@@ -92,15 +101,17 @@ describe("DashboardConfigurationSubnetForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DashboardConfigurationSubnetForm />
+        <MemoryRouter>
+          <DashboardConfigurationSubnetForm />
+        </MemoryRouter>
       </Provider>
     );
 
     expect(wrapper.find("a[data-testid='subnet-link']").prop("href")).toBe(
-      "/MAAS/l/subnet/1"
+      "/subnet/1"
     );
     expect(wrapper.find("a[data-testid='fabric-link']").prop("href")).toBe(
-      "/MAAS/l/fabric/3"
+      "/fabric/3"
     );
   });
 
@@ -118,7 +129,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DashboardConfigurationSubnetForm />
+        <MemoryRouter>
+          <DashboardConfigurationSubnetForm />
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {

--- a/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.tsx
+++ b/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.tsx
@@ -2,11 +2,10 @@ import { useEffect } from "react";
 
 import { Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
-import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
 import configSelectors from "app/store/config/selectors";
 import { NetworkDiscovery } from "app/store/config/types";
 import { actions as fabricActions } from "app/store/fabric";
@@ -14,6 +13,7 @@ import fabricSelectors from "app/store/fabric/selectors";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet } from "app/store/subnet/types";
+import subnetsURLS from "app/subnets/urls";
 import { simpleSortByKey } from "app/utils";
 
 type SubnetDiscoveryValues = {
@@ -79,21 +79,23 @@ const DashboardConfigurationSubnetForm = (): JSX.Element => {
                   disabled={discoveryDisabled}
                   label={
                     <>
-                      <LegacyLink
+                      <Link
                         data-testid="subnet-link"
-                        route={baseURLs.subnet({ id: subnet.id })}
+                        to={subnetsURLS.subnet.index({ id: subnet.id })}
                       >
                         {subnet.cidr}
-                      </LegacyLink>
+                      </Link>
                       {targetFabric && (
                         <>
                           <span> on </span>
-                          <LegacyLink
+                          <Link
                             data-testid="fabric-link"
-                            route={baseURLs.fabric({ id: targetFabric.id })}
+                            to={subnetsURLS.fabric.index({
+                              id: targetFabric.id,
+                            })}
                           >
                             {targetFabric.name}
-                          </LegacyLink>
+                          </Link>
                         </>
                       )}
                     </>

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -1,14 +1,13 @@
 import { Col, Icon, Row, Select, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import type { DiscoveryAddValues } from "../types";
 import { DeviceType } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
-import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import { DeviceMeta } from "app/store/device/types";
@@ -21,6 +20,7 @@ import { getSubnetDisplay } from "app/store/subnet/utils";
 import { NodeStatusCode } from "app/store/types/node";
 import vlanSelectors from "app/store/vlan/selectors";
 import { getVLANDisplay } from "app/store/vlan/utils";
+import subnetsURLs from "app/subnets/urls";
 
 type Props = {
   discovery: Discovery;
@@ -149,18 +149,18 @@ const DiscoveryAddFormFields = ({
           <div className="">
             <p>Fabric</p>
             <p>
-              <LegacyLink route={baseURLs.fabric({ id: discovery.fabric })}>
+              <Link to={subnetsURLs.fabric.index({ id: discovery.fabric })}>
                 {discovery.fabric_name}
-              </LegacyLink>
+              </Link>
             </p>
           </div>
           <div className="u-nudge-down--small">
             <p>VLAN</p>
             <p>
               {vlanDisplay ? (
-                <LegacyLink route={baseURLs.vlan({ id: discovery.vlan })}>
+                <Link to={subnetsURLs.vlan.index({ id: discovery.vlan })}>
                   {vlanDisplay}
-                </LegacyLink>
+                </Link>
               ) : null}
             </p>
           </div>
@@ -168,9 +168,9 @@ const DiscoveryAddFormFields = ({
             <p>Subnet</p>
             {discovery.subnet && subnetDisplay ? (
               <p>
-                <LegacyLink route={baseURLs.subnet({ id: discovery.subnet })}>
+                <Link to={subnetsURLs.subnet.index({ id: discovery.subnet })}>
                   {subnetDisplay}
-                </LegacyLink>
+                </Link>
               </p>
             ) : null}
           </div>

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
 
 import DeviceNetworkTable from "./DeviceNetworkTable";
@@ -52,11 +53,13 @@ describe("DeviceNetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeviceNetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <DeviceNetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -66,11 +69,13 @@ describe("DeviceNetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeviceNetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <DeviceNetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
@@ -102,11 +107,13 @@ describe("DeviceNetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeviceNetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <DeviceNetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
@@ -143,11 +150,13 @@ describe("DeviceNetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeviceNetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <DeviceNetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("SubnetColumn LegacyLink").at(0).text()).toBe(
@@ -173,11 +182,13 @@ describe("DeviceNetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeviceNetworkTable
-          expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <DeviceNetworkTable
+            expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     const row = wrapper.findWhere(
@@ -204,11 +215,13 @@ describe("DeviceNetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeviceNetworkTable
-          expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <DeviceNetworkTable
+            expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     const row = wrapper.findWhere(

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -159,9 +159,7 @@ describe("DeviceNetworkTable", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("SubnetColumn LegacyLink").at(0).text()).toBe(
-      "subnet-cidr"
-    );
+    expect(wrapper.find("SubnetColumn Link").at(0).text()).toBe("subnet-cidr");
     expect(wrapper.find("[data-testid='ip-address']").text()).toBe("1.2.3.99");
   });
 

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
 
 import EditInterfaceTable from "./EditInterfaceTable";
@@ -55,7 +56,9 @@ describe("EditInterfaceTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+        <MemoryRouter>
+          <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -65,7 +68,9 @@ describe("EditInterfaceTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+        <MemoryRouter>
+          <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
@@ -96,7 +101,9 @@ describe("EditInterfaceTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+        <MemoryRouter>
+          <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
@@ -16,7 +16,7 @@ import DeleteRecordForm from "./DeleteRecordForm";
 import EditRecordForm from "./EditRecordForm";
 
 import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import deviceURLs from "app/devices/urls";
 import machineURLs from "app/machines/urls";
 import authSelectors from "app/store/auth/selectors";
@@ -116,7 +116,11 @@ const ResourceRecords = ({ id }: Props): JSX.Element | null => {
         case NodeType.REGION_CONTROLLER:
         case NodeType.REGION_AND_RACK_CONTROLLER:
           nameCell = (
-            <LegacyLink route={baseURLs.controller({ id: resource.system_id })}>
+            <LegacyLink
+              route={controllersURLs.controller.index({
+                id: resource.system_id,
+              })}
+            >
               {resource.name}
             </LegacyLink>
           );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -16,9 +16,8 @@ import { Link } from "react-router-dom";
 import type { DeployFormValues } from "../DeployForm";
 
 import FormikField from "app/base/components/FormikField";
-import LegacyLink from "app/base/components/LegacyLink";
 import UploadTextArea from "app/base/components/UploadTextArea";
-import baseURLs from "app/base/urls";
+import imagesURLs from "app/images/urls";
 import prefsURLs from "app/preferences/urls";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
@@ -55,7 +54,7 @@ export const DeployFormFields = (): JSX.Element => {
         <Notification data-testid="images-error" severity="negative">
           You will not be able to deploy a machine until at least one valid
           image has been downloaded. To download an image, visit the{" "}
-          <LegacyLink route={baseURLs.images}>images page</LegacyLink>.
+          <Link to={imagesURLs.index}>images page</Link>.
         </Notification>
       )}
       <div className="u-sv2">

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
 
 import NetworkTable from "./NetworkTable";
@@ -52,13 +53,15 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -68,13 +71,15 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
@@ -106,13 +111,15 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
@@ -151,18 +158,18 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("SubnetColumn LegacyLink").at(0).text()).toBe(
-      "subnet-cidr"
-    );
+    expect(wrapper.find("SubnetColumn Link").at(0).text()).toBe("subnet-cidr");
     expect(wrapper.find("IPColumn DoubleRow").prop("primary")).toBe("1.2.3.99");
   });
 
@@ -202,22 +209,22 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     const alias = wrapper.findWhere(
       (n) => n.name() === "TableRow" && n.key() === "alias:1"
     );
     expect(alias.exists()).toBe(true);
-    expect(alias.find("SubnetColumn LegacyLink").at(0).text()).toBe(
-      "subnet2-cidr"
-    );
+    expect(alias.find("SubnetColumn Link").at(0).text()).toBe("subnet2-cidr");
     expect(alias.find("IPColumn DoubleRow").prop("primary")).toBe("1.2.3.101");
   });
 
@@ -238,13 +245,15 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     const row = wrapper.findWhere(
@@ -271,13 +280,15 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable
-          expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <NetworkTable
+            expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
+            setExpanded={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
       </Provider>
     );
     const row = wrapper.findWhere(
@@ -313,13 +324,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       // There should be one checkbox for the child interface.
@@ -330,13 +343,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("GroupCheckbox").prop("items")).toStrictEqual([
@@ -348,13 +363,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("Icon[name='tick']").length).toBe(1);
@@ -364,13 +381,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("DoubleRow[data-testid='fabric']").length).toBe(1);
@@ -380,13 +399,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("DoubleRow[data-testid='dhcp']").length).toBe(1);
@@ -396,13 +417,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("SubnetColumn").length).toBe(1);
@@ -412,13 +435,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("IPColumn").length).toBe(1);
@@ -428,13 +453,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       expect(wrapper.find("NetworkTableActions").length).toBe(1);
@@ -493,13 +520,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       const names = wrapper
@@ -524,13 +553,15 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </MemoryRouter>
         </Provider>
       );
       wrapper.find("TableHeader").first().find("button").simulate("click");

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -3,9 +3,8 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import LegacyLink from "app/base/components/LegacyLink";
 import { useCanEdit, useIsRackControllerConnected } from "app/base/hooks";
-import baseURLs from "app/base/urls";
+import imagesURLs from "app/images/urls";
 import machineURLs from "app/machines/urls";
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
 import { actions as generalActions } from "app/store/general";
@@ -109,9 +108,8 @@ const SummaryNotifications = ({ id }: Props): JSX.Element | null => {
           content: (
             <>
               No boot images have been imported for a valid architecture to be
-              selected. Visit the{" "}
-              <LegacyLink route={baseURLs.images}>images page</LegacyLink> to
-              start the import process.
+              selected. Visit the <Link to={imagesURLs.index}>images page</Link>{" "}
+              to start the import process.
             </>
           ),
           severity: "negative",

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.tsx
@@ -1,15 +1,15 @@
 import { memo } from "react";
 
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import MachineTestStatus from "../MachineTestStatus";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import subnetsURLs from "app/subnets/urls";
 
 type Props = { systemId: Machine["system_id"] };
 
@@ -32,12 +32,12 @@ export const FabricColumn = ({ systemId }: Props): JSX.Element | null => {
             tooltipPosition="top-left"
           >
             {fabricName && (fabricID || fabricID === 0) ? (
-              <LegacyLink
+              <Link
                 className="p-link--soft"
-                route={baseURLs.fabric({ id: fabricID })}
+                to={subnetsURLs.fabric.index({ id: fabricID })}
               >
                 {fabricName}
-              </LegacyLink>
+              </Link>
             ) : (
               "-"
             )}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.tsx.snap
@@ -11,12 +11,12 @@ exports[`FabricColumn renders 1`] = `
         status={1}
         tooltipPosition="top-left"
       >
-        <LegacyLink
+        <Link
           className="p-link--soft"
-          route="/fabric/0"
+          to="/fabric/0"
         >
           fabric-0
-        </LegacyLink>
+        </Link>
       </MachineTestStatus>
     }
     primaryAriaLabel="Fabric"
@@ -62,24 +62,24 @@ exports[`FabricColumn renders 1`] = `
                       className="is-inline p-icon--running"
                     />
                   </Icon>
-                  <LegacyLink
+                  <Link
                     className="p-link--soft"
-                    route="/fabric/0"
+                    to="/fabric/0"
                   >
-                    <Link
+                    <LinkAnchor
                       className="p-link--soft"
-                      href="/MAAS/l/fabric/0"
-                      onClick={[Function]}
+                      href="/fabric/0"
+                      navigate={[Function]}
                     >
                       <a
                         className="p-link--soft"
-                        href="/MAAS/l/fabric/0"
+                        href="/fabric/0"
                         onClick={[Function]}
                       >
                         fabric-0
                       </a>
-                    </Link>
-                  </LegacyLink>
+                    </LinkAnchor>
+                  </Link>
                 </span>
               </ScriptStatus>
             </MachineTestStatus>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
@@ -2,10 +2,9 @@ import { memo, useEffect, useState } from "react";
 
 import { Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
 import { useToggleMenu } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -14,6 +13,7 @@ import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import zoneSelectors from "app/store/zone/selectors";
 import type { Zone, ZoneMeta } from "app/store/zone/types";
+import zonesURLs from "app/zones/urls";
 
 type Props = {
   onToggleMenu?: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
@@ -88,12 +88,12 @@ export const ZoneColumn = ({
           {updating !== null ? (
             <Spinner className="u-nudge-left--small" />
           ) : null}
-          <LegacyLink
+          <Link
             className="p-link--soft"
-            route={baseURLs.zone({ id: machine.zone.id })}
+            to={zonesURLs.details({ id: machine.zone.id })}
           >
             {machine.zone.name}
-          </LegacyLink>
+          </Link>
         </span>
       }
       primaryTitle={machine.zone.name}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.tsx.snap
@@ -21,12 +21,12 @@ exports[`ZoneColumn renders 1`] = `
       <span
         data-testid="zone"
       >
-        <LegacyLink
+        <Link
           className="p-link--soft"
-          route="/zone/0"
+          to="/zone/0"
         >
           zone-north
-        </LegacyLink>
+        </Link>
       </span>
     }
     primaryTitle="zone-north"
@@ -55,24 +55,24 @@ exports[`ZoneColumn renders 1`] = `
             <span
               data-testid="zone"
             >
-              <LegacyLink
+              <Link
                 className="p-link--soft"
-                route="/zone/0"
+                to="/zone/0"
               >
-                <Link
+                <LinkAnchor
                   className="p-link--soft"
-                  href="/MAAS/l/zone/0"
-                  onClick={[Function]}
+                  href="/zone/0"
+                  navigate={[Function]}
                 >
                   <a
                     className="p-link--soft"
-                    href="/MAAS/l/zone/0"
+                    href="/zone/0"
                     onClick={[Function]}
                   >
                     zone-north
                   </a>
-                </Link>
-              </LegacyLink>
+                </LinkAnchor>
+              </Link>
             </span>
           </div>
           <TableMenu

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
@@ -97,7 +97,7 @@ describe("DhcpTarget", () => {
       </Provider>
     );
     const link = wrapper.find("Link");
-    expect(link?.prop("href")?.includes("/subnet/1")).toBe(true);
+    expect(link?.prop("href")?.toString().includes("/subnet/1")).toBe(true);
     expect(link.text()).toEqual("10.0.0.99");
   });
 

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
@@ -97,7 +97,7 @@ describe("DhcpTarget", () => {
       </Provider>
     );
     const link = wrapper.find("Link");
-    expect(link?.prop("href")?.toString().includes("/subnet/1")).toBe(true);
+    expect(link?.prop("to")?.toString().includes("/subnet/1")).toBe(true);
     expect(link.text()).toEqual("10.0.0.99");
   });
 

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.tsx
@@ -4,11 +4,12 @@ import { Spinner } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
 import LegacyLink from "app/base/components/LegacyLink";
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import deviceURLs from "app/devices/urls";
 import machineURLs from "app/machines/urls";
 import { useDhcpTarget } from "app/settings/hooks";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
+import subnetsURLs from "app/subnets/urls";
 
 type Props = {
   nodeId?: DHCPSnippet["node"];
@@ -40,16 +41,19 @@ const DhcpTarget = ({ nodeId, subnetId }: Props): JSX.Element | null => {
   }
   let route;
   if (type === "machine" && nodeId) {
-    return <Link to={machineURLs.machine.index({ id: nodeId })}>{name}</Link>;
+    route = machineURLs.machine.index({ id: nodeId });
   } else if (type === "controller" && nodeId) {
-    route = baseURLs.controller({ id: nodeId });
+    return (
+      <LegacyLink route={controllersURLs.controller.index({ id: nodeId })}>
+        {name}
+      </LegacyLink>
+    );
   } else if (type === "device" && nodeId) {
-    return <Link to={deviceURLs.device.index({ id: nodeId })}>{name}</Link>;
+    route = deviceURLs.device.index({ id: nodeId });
   } else if (type === "subnet" && subnetId) {
-    route = baseURLs.subnet({ id: subnetId });
+    route = subnetsURLs.subnet.index({ id: subnetId });
   }
-
-  return route ? <LegacyLink route={route}>{name}</LegacyLink> : null;
+  return route ? <Link to={route}>{name}</Link> : null;
 };
 
 export default DhcpTarget;

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 
 import DHCPStatus from "./DHCPStatus";
 
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import {
   controller as controllerFactory,
   controllerState as controllerStateFactory,
@@ -204,7 +204,9 @@ it("renders correctly when a VLAN has MAAS-configured DHCP without high availabi
     within(dhcpStatus).getByRole("link", { name: /primary-rack/i })
   ).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: controller.system_id }))
+    generateLegacyURL(
+      controllersURLs.controller.index({ id: controller.system_id })
+    )
   );
 });
 
@@ -248,12 +250,16 @@ it("renders correctly when a VLAN has MAAS-configured DHCP with high availabilit
     within(dhcpStatus).getByRole("link", { name: /primary-rack/i })
   ).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: primaryRack.system_id }))
+    generateLegacyURL(
+      controllersURLs.controller.index({ id: primaryRack.system_id })
+    )
   );
   expect(
     within(dhcpStatus).getByRole("link", { name: /secondary-rack/i })
   ).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: secondaryRack.system_id }))
+    generateLegacyURL(
+      controllersURLs.controller.index({ id: secondaryRack.system_id })
+    )
   );
 });

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 
 import VLANControllers from "./VLANControllers";
 
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import type { RootState } from "app/store/root/types";
 import type { VLAN } from "app/store/vlan/types";
 import {
@@ -72,10 +72,10 @@ it("renders correct details", () => {
   );
   expect(screen.getByRole("link", { name: /controller-abc/i })).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: "abc123" }))
+    generateLegacyURL(controllersURLs.controller.index({ id: "abc123" }))
   );
   expect(screen.getByRole("link", { name: /controller-def/i })).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: "def456" }))
+    generateLegacyURL(controllersURLs.controller.index({ id: "def456" }))
   );
 });

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 
 import VLANSummary from "./VLANSummary";
 
-import baseURLs from "app/base/urls";
+import controllersURLs from "app/controllers/urls";
 import type { Controller } from "app/store/controller/types";
 import type { Fabric } from "app/store/fabric/types";
 import type { RootState } from "app/store/root/types";
@@ -86,7 +86,9 @@ it("renders correct details", () => {
     within(vlanSummary).getByRole("link", { name: /controller-abc/i })
   ).toHaveAttribute(
     "href",
-    generateLegacyURL(baseURLs.controller({ id: controller.system_id }))
+    generateLegacyURL(
+      controllersURLs.controller.index({ id: controller.system_id })
+    )
   );
 });
 


### PR DESCRIPTION
## Done

- Update the links to subnets and subpages to use the React versions.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load the UI and click on "Subnets" in the header. It should take you to the React networks page.
- Click on a subnet, vlan, space and fabric and you should get taken to the React pages.
- Click on a VLAN that has a rack controller.
- Click on the controller and you should get taken to the legacy controller page.
- Click on the VLANs tab.
- Click on a fabric, vlan and subnet and you should get returned to the React pages.

## Fixes

Fixes: canonical-web-and-design/app-tribe#677.