### PR TITLE
refactor: subnets add static route form

### DIFF
--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -4,11 +4,11 @@ import type {
   ElementType,
   HTMLProps,
 } from "react";
-import { useRef } from "react";
 
 import { Input } from "@canonical/react-components";
-import { nanoid } from "@reduxjs/toolkit";
 import { useField } from "formik";
+
+import { useId } from "app/base/hooks/base";
 
 export type Props<C extends ElementType | ComponentType = typeof Input> = {
   component?: C;
@@ -23,12 +23,12 @@ const FormikField = <C extends ElementType | ComponentType = typeof Input>({
   label,
   ...props
 }: Props<C>): JSX.Element => {
-  const id = useRef(nanoid());
+  const id = useId();
   const [field, meta] = useField({ name, type: props.type, value });
   return (
     <Component
       error={meta.touched ? meta.error : null}
-      id={id.current}
+      id={id}
       aria-label={label}
       label={label}
       {...field}

--- a/ui/src/app/store/user/selectors.ts
+++ b/ui/src/app/store/user/selectors.ts
@@ -60,11 +60,23 @@ const markingIntroCompleteErrors = createSelector(
     eventErrors.find((eventError) => eventError.event === "markIntroComplete")
       ?.error || null
 );
+
+/**
+ * Get the auth user superuser status.
+ * @param state - The redux state.
+ * @returns {Bool} Is auth user superuser.
+ */
+const isSuperUser = createSelector(
+  [userState],
+  (userState) => userState.auth.user?.is_superuser ?? false
+);
+
 const selectors = {
   ...defaultSelectors,
   eventErrors,
   markingIntroComplete,
   markingIntroCompleteErrors,
+  isSuperUser,
   statuses,
 };
 

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { Labels } from "../StaticRoutes";
+
+import AddStaticRouteForm from "./AddStaticRouteForm";
+
+import { actions as staticRouteActions } from "app/store/staticroute";
+import {
+  rootState as rootStateFactory,
+  staticRouteState as staticRouteStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  authState as authStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches a correct action on add static route form submit", async () => {
+  const subnet = subnetFactory({ id: 1, cidr: "172.16.1.0/24" });
+  const destinationSubnet = subnetFactory({ id: 2, cidr: "223.16.1.0/24" });
+  const state = rootStateFactory({
+    user: userStateFactory({
+      auth: authStateFactory({
+        user: userFactory(),
+      }),
+      items: [userFactory(), userFactory(), userFactory()],
+    }),
+    staticroute: staticRouteStateFactory({
+      loaded: true,
+      items: [],
+    }),
+    subnet: subnetStateFactory({
+      loaded: true,
+      items: [subnet, destinationSubnet],
+    }),
+  });
+
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <AddStaticRouteForm subnetId={subnet.id} handleDismiss={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: "Add static route" })
+    ).toBeInTheDocument()
+  );
+
+  const addStaticRouteForm = screen.getByRole("form", {
+    name: "Add static route",
+  });
+
+  const gatewayIp = "11.1.1.2";
+  userEvent.type(
+    within(addStaticRouteForm).getByLabelText(Labels.GatewayIp),
+    gatewayIp
+  );
+  userEvent.clear(within(addStaticRouteForm).getByLabelText(Labels.Metric));
+  userEvent.type(within(addStaticRouteForm).getByLabelText(Labels.Metric), "1");
+  userEvent.selectOptions(
+    within(addStaticRouteForm).getByLabelText(Labels.Destination),
+    `${destinationSubnet.id}`
+  );
+  userEvent.click(
+    within(addStaticRouteForm).getByRole("button", {
+      name: "Save",
+    })
+  );
+
+  const expectedActions = [
+    staticRouteActions.create({
+      source: subnet.id,
+      gateway_ip: gatewayIp,
+      destination: destinationSubnet.id,
+      metric: 1,
+    }),
+  ];
+  const actualActions = store.getActions();
+  await waitFor(() =>
+    expect(
+      actualActions.filter(
+        (action) => action.type === staticRouteActions.create.type
+      )
+    ).toStrictEqual(expectedActions)
+  );
+});

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.tsx
@@ -1,0 +1,146 @@
+import { useEffect } from "react";
+
+import { Col, Row, Select, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import { Labels } from "../StaticRoutes";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import type { RootState } from "app/store/root/types";
+import { actions as staticRouteActions } from "app/store/staticroute";
+import staticRouteSelectors from "app/store/staticroute/selectors";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import { toFormikNumber } from "app/utils";
+
+export type AddStaticRouteValues = {
+  source: Subnet[SubnetMeta.PK];
+  destination: string;
+  metric: string;
+  gateway_ip: string;
+};
+
+export enum AddStaticRouteFormLabels {
+  AddStaticRoute = "Add static route",
+  Save = "Save",
+  Cancel = "Cancel",
+}
+
+const addStaticRouteSchema = Yup.object().shape({
+  gateway_ip: Yup.string().required("Gateway IP is required"),
+  destination: Yup.string().required("Destination is required"),
+  metric: Yup.number().required("Metric is required"),
+});
+
+const getDestinationsForSource = (subnets: Subnet[], source: Subnet | null) => {
+  const filtered: Subnet[] = [];
+  if (source) {
+    subnets.forEach((subnet) => {
+      if (subnet.id !== source.id && subnet.version === source.version) {
+        filtered.push(subnet);
+      }
+    });
+  }
+
+  return filtered;
+};
+
+export type Props = {
+  subnetId: Subnet[SubnetMeta.PK];
+  handleDismiss: () => void;
+};
+const AddStaticRouteForm = ({
+  subnetId,
+  handleDismiss,
+}: Props): JSX.Element | null => {
+  const staticRouteErrors = useSelector(staticRouteSelectors.errors);
+  const saving = useSelector(staticRouteSelectors.saving);
+  const saved = useSelector(staticRouteSelectors.saved);
+  const dispatch = useDispatch();
+  const staticRoutesLoading = useSelector(staticRouteSelectors.loading);
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+  const staticRoutesLoaded = useSelector(staticRouteSelectors.loaded);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+  const loading = staticRoutesLoading || subnetsLoading;
+  const subnets = useSelector(subnetSelectors.all);
+  const source = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, subnetId)
+  );
+  const destinationSubnets = getDestinationsForSource(subnets, source);
+
+  useEffect(() => {
+    if (!staticRoutesLoaded) dispatch(staticRouteActions.fetch());
+    if (!subnetsLoaded) dispatch(subnetActions.fetch());
+  }, [dispatch, staticRoutesLoaded, subnetsLoaded]);
+
+  if (loading) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return (
+    <FormikForm<AddStaticRouteValues>
+      aria-label={AddStaticRouteFormLabels.AddStaticRoute}
+      cleanup={staticRouteActions.cleanup}
+      errors={staticRouteErrors}
+      initialValues={{
+        source: subnetId,
+        gateway_ip: "",
+        destination: "",
+        metric: "0",
+      }}
+      onSaveAnalytics={{
+        action: AddStaticRouteFormLabels.Save,
+        category: "Subnet",
+        label: AddStaticRouteFormLabels.AddStaticRoute,
+      }}
+      onSubmit={({ gateway_ip, destination, metric }) => {
+        dispatch(staticRouteActions.cleanup());
+        dispatch(
+          staticRouteActions.create({
+            source: subnetId,
+            gateway_ip,
+            destination: toFormikNumber(destination) as number,
+            metric: toFormikNumber(metric),
+          })
+        );
+      }}
+      onSuccess={() => {
+        handleDismiss();
+      }}
+      resetOnSave
+      saving={saving}
+      saved={saved}
+      submitLabel={AddStaticRouteFormLabels.Save}
+      onCancel={handleDismiss}
+      validationSchema={addStaticRouteSchema}
+    >
+      <Row>
+        <Col size={4}>
+          <FormikField label={Labels.GatewayIp} name="gateway_ip" type="text" />
+        </Col>
+        <Col size={4}>
+          <FormikField
+            component={Select}
+            label={Labels.Destination}
+            name="destination"
+            options={[
+              { label: "Select destination", value: "", disabled: true },
+              ...destinationSubnets.map((subnet) => ({
+                label: subnet.cidr,
+                value: subnet.id,
+              })),
+            ]}
+          />
+        </Col>
+        <Col size={4}>
+          <FormikField label={Labels.Metric} name="metric" type="text" />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default AddStaticRouteForm;

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddStaticRouteForm";

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
-import { MainTable, Spinner } from "@canonical/react-components";
+import { Button, MainTable, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
+
+import AddStaticRouteForm from "./AddStaticRouteForm";
 
 import SubnetLink from "app/base/components/SubnetLink";
 import TableActions from "app/base/components/TableActions";
@@ -16,9 +18,10 @@ import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import { getSubnetDisplay } from "app/store/subnet/utils";
+import userSelectors from "app/store/user/selectors";
 
 export type Props = {
-  subnetId: Subnet[SubnetMeta.PK] | null;
+  subnetId: Subnet[SubnetMeta.PK];
 };
 
 export enum Labels {
@@ -148,7 +151,9 @@ const StaticRoutes = ({ subnetId }: Props): JSX.Element | null => {
   );
   const subnets = useSelector(subnetSelectors.all);
   const subnetsLoading = useSelector(subnetSelectors.loading);
+  const isSuperUser = useSelector(userSelectors.isSuperUser);
   const loading = staticRoutesLoading || subnetsLoading;
+  const [isAddStaticRouteOpen, setIsAddStaticRouteOpen] = useState(false);
 
   useEffect(() => {
     dispatch(staticRouteActions.fetch());
@@ -156,7 +161,21 @@ const StaticRoutes = ({ subnetId }: Props): JSX.Element | null => {
   }, [dispatch]);
 
   return (
-    <TitledSection title="Static routes">
+    <TitledSection
+      title="Static routes"
+      buttons={
+        isSuperUser ? (
+          <Button
+            disabled={isAddStaticRouteOpen}
+            onClick={() => {
+              setIsAddStaticRouteOpen(true);
+            }}
+          >
+            Add static route
+          </Button>
+        ) : null
+      }
+    >
       <MainTable
         className="reserved-ranges-table p-table-expanding--light"
         defaultSort="gateway_ip"
@@ -198,6 +217,12 @@ const StaticRoutes = ({ subnetId }: Props): JSX.Element | null => {
         )}
         sortable
       />
+      {isAddStaticRouteOpen ? (
+        <AddStaticRouteForm
+          subnetId={subnetId}
+          handleDismiss={() => setIsAddStaticRouteOpen(false)}
+        />
+      ) : null}
     </TitledSection>
   );
 };

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -46,19 +46,18 @@ const SubnetDetails = (): JSX.Element => {
     return unsetActiveSubnetAndCleanup;
   }, [dispatch, id, isValidID]);
 
-  if (!subnet) {
-    const subnetNotFound = !isValidID || !subnetsLoading;
-
-    if (subnetNotFound) {
-      return (
-        <ModelNotFound
-          id={id}
-          linkURL={subnetURLs.indexBy({ by: "fabric" })}
-          modelName="subnet"
-        />
-      );
-    }
+  if (subnetsLoading) {
     return <Section header={<SectionHeader loading />} />;
+  }
+
+  if (!subnet || !isValidID) {
+    return (
+      <ModelNotFound
+        id={id}
+        linkURL={subnetURLs.indexBy({ by: "fabric" })}
+        modelName="subnet"
+      />
+    );
   }
 
   return (
@@ -67,10 +66,7 @@ const SubnetDetails = (): JSX.Element => {
       <Utilisation statistics={subnet.statistics} />
       <StaticRoutes subnetId={id} />
       <ReservedRanges subnetId={id} />
-      <DHCPSnippets
-        subnetIds={isId(id) ? [id] : []}
-        modelName={SubnetMeta.MODEL}
-      />
+      <DHCPSnippets subnetIds={[id]} modelName={SubnetMeta.MODEL} />
       <UsedIPs />
     </Section>
   );


### PR DESCRIPTION
## Done

- subnets add static route form
- refactor SubnetDetails logic so that child elements always receive a valid subnet id, otherwise display ModelNotFound component
- add `useId` to `FormikField`

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/153249325-e2d71ade-e198-48ab-b714-73fb66244fc1.png)
![image](https://user-images.githubusercontent.com/7452681/153249361-0221bbe3-1830-4f67-9701-9bb138e038ac.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to any subnet and add a static route. Verify all works correctly.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
