### PR TITLE
feat(ui): add useScrollToTop hook

### DIFF
--- a/ui/src/app/base/hooks/base.test.tsx
+++ b/ui/src/app/base/hooks/base.test.tsx
@@ -1,7 +1,24 @@
 import { renderHook } from "@testing-library/react-hooks";
 import TestRenderer from "react-test-renderer";
 
-import { useCycled, useId, useProcessing, useScrollOnRender } from "./base";
+import {
+  useCycled,
+  useId,
+  useProcessing,
+  useScrollOnRender,
+  useScrollToTop,
+} from "./base";
+
+const mockUseLocationValue = {
+  pathname: "/original-pathname",
+  search: "",
+  hash: "",
+  state: null,
+};
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useLocation: () => mockUseLocationValue,
+}));
 
 const { act } = TestRenderer;
 
@@ -226,6 +243,35 @@ describe("hooks", () => {
       const previousResult = result;
       rerender();
       expect(result.current).toEqual(previousResult.current);
+    });
+  });
+
+  describe("useScrollToTop", () => {
+    it("scrolls to the top of the page on pathname change", () => {
+      const scrollToSpy = jest.fn();
+      global.scrollTo = scrollToSpy;
+      const { rerender } = renderHook(() => useScrollToTop());
+
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+
+      mockUseLocationValue.pathname = "/new-pathname";
+      rerender();
+
+      expect(scrollToSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not scroll to the top of the page if pathname stays the same", () => {
+      const scrollToSpy = jest.fn();
+      global.scrollTo = scrollToSpy;
+      const { rerender } = renderHook(() => useScrollToTop());
+
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+
+      rerender();
+
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/src/app/base/hooks/base.ts
+++ b/ui/src/app/base/hooks/base.ts
@@ -4,6 +4,7 @@ import { NotificationSeverity } from "@canonical/react-components";
 import type { NotificationProps } from "@canonical/react-components";
 import { nanoid } from "nanoid/non-secure";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 
 import configSelectors from "app/store/config/selectors";
 import { actions as messageActions } from "app/store/message";
@@ -163,3 +164,14 @@ export const useScrollOnRender = <T extends HTMLElement>(): ((
  * @returns non-secure random ID string
  */
 export const useId = (): string => useRef(nanoid()).current;
+
+/**
+ * Scroll to the top of the window on URL pathname change.
+ */
+export const useScrollToTop = (): void => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+};

--- a/ui/src/app/base/hooks/index.ts
+++ b/ui/src/app/base/hooks/index.ts
@@ -4,6 +4,7 @@ export {
   useCycled,
   useProcessing,
   useScrollOnRender,
+  useScrollToTop,
   useWindowTitle,
 } from "./base";
 export { useFormikFormDisabled, useFormikErrors } from "./forms";

--- a/ui/src/app/subnets/views/Subnets.tsx
+++ b/ui/src/app/subnets/views/Subnets.tsx
@@ -1,5 +1,6 @@
 import { Route, Switch } from "react-router-dom";
 
+import { useScrollToTop } from "app/base/hooks";
 import NotFound from "app/base/views/NotFound";
 import subnetsURLs from "app/subnets/urls";
 import FabricDetails from "app/subnets/views/FabricDetails";
@@ -9,6 +10,8 @@ import SubnetsList from "app/subnets/views/SubnetsList/SubnetsList";
 import VLANDetails from "app/subnets/views/VLANDetails";
 
 const Subnets = (): JSX.Element => {
+  useScrollToTop();
+
   return (
     <Switch>
       <Route exact path={subnetsURLs.index} render={() => <SubnetsList />} />


### PR DESCRIPTION
## Done

- Added a hook to scroll to the top of the window when `pathname` changes and used in Subnets pages

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React Subnets pages
- Click around between the list and fabric/space/subnet/VLAN details pages and check that the window is scrolled to the top on every URL change

## Fixes

Fixes canonical-web-and-design/app-tribe#726

