### PR TITLE
fix(ui): minor improvements to subnet summary edit form

### DIFF
--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace/SubnetSpace.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace/SubnetSpace.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import SubnetSpace from "./SubnetSpace";
+
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+it("shows a warning tooltip if the subnet is not in a space", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <SubnetSpace spaceId={null} />
+    </Provider>
+  );
+
+  expect(screen.getByTestId("no-space")).toBeInTheDocument();
+});
+
+it("does not show a warning tooltip if the subnet is in a space", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <SubnetSpace spaceId={1} />
+    </Provider>
+  );
+
+  expect(screen.queryByTestId("no-space")).not.toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace/SubnetSpace.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace/SubnetSpace.tsx
@@ -1,0 +1,36 @@
+import { Icon, Tooltip } from "@canonical/react-components";
+
+import Definition from "app/base/components/Definition";
+import SpaceLink from "app/base/components/SpaceLink";
+import type { Space, SpaceMeta } from "app/store/space/types";
+import { breakLines, isId, unindentString } from "app/utils";
+
+type Props = {
+  spaceId?: Space[SpaceMeta.PK] | null;
+};
+
+const formatTooltip = (message: string) => breakLines(unindentString(message));
+
+const SubnetSummary = ({ spaceId }: Props): JSX.Element | null => {
+  return (
+    <Definition label="Space">
+      <>
+        <SpaceLink id={spaceId} />
+        {isId(spaceId) ? null : (
+          <Tooltip
+            className="u-nudge-right--small"
+            message={formatTooltip(
+              `This subnet does not belong to a space. MAAS integrations require
+              a space in order to determine the purpose of a network.`
+            )}
+            position="btm-right"
+          >
+            <Icon data-testid="no-space" name="warning" />
+          </Tooltip>
+        )}
+      </>
+    </Definition>
+  );
+};
+
+export default SubnetSummary;

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetSpace";

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -3,11 +3,11 @@ import { useEffect, useState } from "react";
 import { Row, Col, Tooltip, Icon, Button } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
 
+import SubnetSpace from "./SubnetSpace";
 import SubnetSummaryForm from "./SubnetSummaryForm";
 
 import Definition from "app/base/components/Definition";
 import FabricLink from "app/base/components/FabricLink";
-import SpaceLink from "app/base/components/SpaceLink";
 import TitledSection from "app/base/components/TitledSection";
 import VLANLink from "app/base/components/VLANLink";
 import { actions as fabricActions } from "app/store/fabric";
@@ -17,11 +17,13 @@ import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
-import { isId } from "app/utils";
+import { breakLines, unindentString } from "app/utils";
 
 type Props = {
   id: Subnet[SubnetMeta.PK] | null;
 };
+
+const formatTooltip = (message: string) => breakLines(unindentString(message));
 
 const SubnetSummary = ({ id }: Props): JSX.Element | null => {
   const [isEdit, setIsEdit] = useState(false);
@@ -73,9 +75,9 @@ const SubnetSummary = ({ id }: Props): JSX.Element | null => {
                   Managed allocation{" "}
                   {subnet.managed ? null : (
                     <Tooltip
-                      message="MAAS allocates IP addresses 
-                  from this subnet, exluding the 
-                  reserved and dynamic ranges."
+                      message={formatTooltip(`MAAS allocates IP addresses from
+                        this subnet, excluding the reserved and dynamic
+                        ranges.`)}
                       position="btm-right"
                     >
                       <Icon name="information" />
@@ -94,10 +96,11 @@ const SubnetSummary = ({ id }: Props): JSX.Element | null => {
                   Active discovery{" "}
                   {subnet.managed ? (
                     <Tooltip
-                      message="When enabled, MAAS will scan 
-this subnet to discover hosts 
-that have not been discovered 
-passively."
+                      message={formatTooltip(
+                        `When enabled, MAAS will scan this
+                        subnet to discover hosts that have not been discovered
+                        passively.`
+                      )}
                       position="btm-right"
                     >
                       <Icon name="information" />
@@ -114,11 +117,12 @@ passively."
                   Proxy access{" "}
                   <Tooltip
                     data-testid="proxy-access-tooltip"
-                    message={`MAAS will${
-                      subnet.allow_proxy ? "" : " not"
-                    } allow clients from 
-this subnet to access the 
-MAAS proxy.`}
+                    message={formatTooltip(
+                      `MAAS will ${
+                        subnet.allow_proxy ? "" : "not"
+                      } allow clients from this subnet to access the MAAS
+                      proxy.`
+                    )}
                     position="btm-right"
                   >
                     <Icon name="information" />
@@ -134,11 +138,12 @@ MAAS proxy.`}
                   Allow DNS resolution{" "}
                   <Tooltip
                     data-testid="allow-dns-tooltip"
-                    message={`MAAS will${
-                      subnet.allow_dns ? "" : " not"
-                    } allow clients from 
-this subnet to use MAAS 
-for DNS resolution.`}
+                    message={formatTooltip(
+                      `MAAS will ${
+                        subnet.allow_dns ? "" : "not"
+                      } allow clients from this subnet to use MAAS for DNS
+                      resolution.`
+                    )}
                     position="btm-right"
                   >
                     <Icon name="information" />
@@ -154,25 +159,7 @@ for DNS resolution.`}
             <Definition label="VLAN">
               <VLANLink id={subnet.vlan} />
             </Definition>
-            <Definition label="Space">
-              <>
-                <SpaceLink id={subnet.space} />
-                {isId(subnet.space) ? null : (
-                  <>
-                    {" "}
-                    <Tooltip
-                      message="This subnet does not belong to 
-a space. MAAS integrations require 
-a space in order to determine the 
-purpose of a network."
-                      position="btm-right"
-                    >
-                      <Icon name="warning" />
-                    </Tooltip>
-                  </>
-                )}
-              </>
-            </Definition>
+            <SubnetSpace spaceId={subnet.space} />
           </Col>
         </Row>
       )}

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -76,6 +76,8 @@ it("can dispatch an action to update the subnet", async () => {
     fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
       target: { value: fabrics[1].id.toString() },
     });
+  });
+  await waitFor(() => {
     fireEvent.change(screen.getByRole("combobox", { name: "VLAN" }), {
       target: { value: vlans[1].id.toString() },
     });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import SubnetSummaryFormFields from "./SubnetSummaryFormFields";
+
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  rootState as rootStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+it("updates to use the fabric's default VLAN on fabric change", async () => {
+  const fabrics = [
+    fabricFactory({ default_vlan_id: 3, id: 1, vlan_ids: [3] }),
+    fabricFactory({ default_vlan_id: 5, id: 2, vlan_ids: [4, 5] }),
+  ];
+  const vlans = [
+    vlanFactory({ fabric: 1, id: 3 }),
+    vlanFactory({ fabric: 2, id: 4 }),
+    vlanFactory({ fabric: 2, id: 5 }),
+  ];
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ items: fabrics, loaded: true }),
+    vlan: vlanStateFactory({ items: vlans, loaded: true }),
+  });
+  const store = configureStore()(state);
+  render(
+    <Provider store={store}>
+      <Formik initialValues={{ fabric: 1, vlan: 3 }} onSubmit={jest.fn()}>
+        <SubnetSummaryFormFields />
+      </Formik>
+    </Provider>
+  );
+
+  expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("3");
+
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
+      target: { value: fabrics[1].id.toString() },
+    });
+  });
+
+  expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("5");
+});

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.tsx
@@ -1,26 +1,64 @@
+import type { ChangeEventHandler } from "react";
+
 import { Textarea, Row, Col } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
 
 import type { SubnetSummaryFormValues } from "../types";
 
 import FabricSelect from "app/base/components/FabricSelect";
 import FormikField from "app/base/components/FormikField";
 import VLANSelect from "app/base/components/VLANSelect";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { RootState } from "app/store/root/types";
+import vlanSelectors from "app/store/vlan/selectors";
+import SubnetSpace from "app/subnets/views/SubnetDetails/SubnetSummary/SubnetSpace";
 
 const SubnetSummaryFormFields = (): JSX.Element => {
-  const { values } = useFormikContext<SubnetSummaryFormValues>();
+  const { handleChange, setFieldValue, values } =
+    useFormikContext<SubnetSummaryFormValues>();
+  const fabrics = useSelector(fabricSelectors.all);
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, Number(values.vlan))
+  );
+
+  const handleFabricChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    handleChange(e);
+    const fabric = fabrics.find(
+      (fabric) => fabric.id === Number(e.target.value)
+    );
+    if (fabric) {
+      setFieldValue("vlan", fabric.default_vlan_id.toString());
+    }
+  };
 
   return (
     <Row>
       <Col size={6}>
-        <FormikField label="Name" name="name" type="text" />
-        <FormikField label="CIDR" name="cidr" type="text" />
-        <FormikField label="Gateway IP" name="gateway_ip" type="text" />
         <FormikField
+          label="Name"
+          name="name"
+          placeholder="Subnet name"
+          type="text"
+        />
+        <FormikField
+          label="CIDR"
+          name="cidr"
+          placeholder="1.1.1.1/24"
+          type="text"
+        />
+        <FormikField
+          label="Gateway IP"
+          name="gateway_ip"
+          placeholder="1.1.1.1"
+          type="text"
+        />
+        <FormikField
+          help="Space-separated list of DNS nameserver IP addresses."
           label="DNS"
           name="dns_servers"
+          placeholder="1.1.1.1 2.2.2.2"
           type="text"
-          placeholder="DNS nameservers for subnet"
         />
         <FormikField
           label="Description"
@@ -46,13 +84,13 @@ const SubnetSummaryFormFields = (): JSX.Element => {
           name="allow_dns"
           type="checkbox"
         />
-        <FabricSelect name="fabric" />
+        <FabricSelect name="fabric" onChange={handleFabricChange} />
         <VLANSelect
           fabric={Number(values.fabric)}
           name="vlan"
-          setDefaultValueFromFabric
           showSpinnerOnLoad
         />
+        <SubnetSpace spaceId={vlan?.space} />
       </Col>
     </Row>
   );


### PR DESCRIPTION
## Done

- Minor improvements to subnet summary and edit form
  - Render the space in the edit form
  - Handle setting the VLAN based on the selected fabric's default VLAN ID
  - Added help text and placeholders

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a subnet and click "Edit"
- Check that there are placeholders for the fields, and the DNS field has help text explaining the format the API expects
- Check that the Space info is still shown
- Go to the details page of a subnet that is not in the default VLAN for that fabric
- Click "Edit" and check that the "VLAN" select doesn't change value

## Fixes

Fixes #1536
