### PR TITLE
fix(ui): reserved ranges layout

### DIFF
--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -84,7 +84,7 @@ describe("ReservedRangeForm", () => {
       ipRange.end_ip
     );
     expect(
-      screen.getByRole("textbox", { name: Labels.Purpose })
+      screen.getByRole("textbox", { name: Labels.Comment })
     ).toHaveAttribute("value", ipRange.comment);
   });
 
@@ -102,10 +102,10 @@ describe("ReservedRangeForm", () => {
       </Provider>
     );
     expect(
-      screen.getByRole("textbox", { name: Labels.Purpose })
+      screen.getByRole("textbox", { name: Labels.Comment })
     ).toHaveAttribute("value", "Dynamic");
     expect(
-      screen.getByRole("textbox", { name: Labels.Purpose })
+      screen.getByRole("textbox", { name: Labels.Comment })
     ).toHaveAttribute("disabled");
   });
 
@@ -133,7 +133,7 @@ describe("ReservedRangeForm", () => {
       "1.1.1.2"
     );
     userEvent.type(
-      screen.getByRole("textbox", { name: Labels.Purpose }),
+      screen.getByRole("textbox", { name: Labels.Comment }),
       "reserved"
     );
     await waitFor(() => fireEvent.submit(screen.getByRole("form")));
@@ -198,7 +198,7 @@ describe("ReservedRangeForm", () => {
     expect(actual.payload.params.comment).toBe(expected.payload.params.comment);
   });
 
-  it("does not display the purpose field when creating a dynamic range", async () => {
+  it("does not display the Comment field when creating a dynamic range", async () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
@@ -213,7 +213,7 @@ describe("ReservedRangeForm", () => {
       </Provider>
     );
     expect(
-      screen.queryAllByRole("textbox", { name: Labels.Purpose })
+      screen.queryAllByRole("textbox", { name: Labels.Comment })
     ).toHaveLength(0);
   });
 });

--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
@@ -31,7 +31,7 @@ export enum Labels {
   CreateRange = "Create reserved range",
   EditRange = "Edit reserved range",
   EndIp = "End IP address",
-  Purpose = "Purpose",
+  Comment = "Comment",
   StartIp = "Start IP address",
 }
 
@@ -120,24 +120,15 @@ const ReservedRangeForm = ({
       {...props}
     >
       <Row>
-        <Col size={6}>
+        <Col size={4}>
           <FormikField
             label={Labels.StartIp}
             name="start_ip"
             required
             type="text"
           />
-          {isEditing || createType === IPRangeType.Reserved ? (
-            <FormikField
-              disabled={showDynamicComment}
-              label={Labels.Purpose}
-              name="comment"
-              placeholder="IP range purpose (optional)"
-              type="text"
-            />
-          ) : null}
         </Col>
-        <Col size={6}>
+        <Col size={4}>
           <FormikField
             label={Labels.EndIp}
             name="end_ip"
@@ -145,6 +136,17 @@ const ReservedRangeForm = ({
             type="text"
           />
         </Col>
+        {isEditing || createType === IPRangeType.Reserved ? (
+          <Col size={4}>
+            <FormikField
+              disabled={showDynamicComment}
+              label={Labels.Comment}
+              name="comment"
+              placeholder="IP range comment (optional)"
+              type="text"
+            />
+          </Col>
+        ) : null}
       </Row>
     </FormikForm>
   );

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -229,6 +229,7 @@ const ReservedRanges = ({
       ) : null}
       <MainTable
         className="reserved-ranges-table p-table-expanding--light"
+        responsive
         defaultSort="name"
         defaultSortDirection="descending"
         emptyStateMsg={

--- a/ui/src/app/subnets/components/ReservedRanges/_index.scss
+++ b/ui/src/app/subnets/components/ReservedRanges/_index.scss
@@ -1,33 +1,36 @@
 @mixin ReservedRanges {
   .reserved-ranges-table {
+    td {
+      white-space: normal;
+    }
     th:nth-child(1),
     td:nth-child(1) {
-      width: 25%;
+      flex: 0.25;
     }
 
     th:nth-child(2),
     td:nth-child(2) {
-      width: 25%;
+      flex: 0.25;
     }
 
     th:nth-child(3),
     td:nth-child(3) {
-      width: 13%;
+      flex: 0.13;
     }
 
     th:nth-child(4),
     td:nth-child(4) {
-      width: 13%;
+      flex: 0.13;
     }
 
     th:nth-child(5),
     td:nth-child(5) {
-      width: 12%;
+      flex: 0.12;
     }
 
     th:nth-child(6),
     td:nth-child(6) {
-      width: 12%;
+      flex: 0.12;
     }
   }
 }


### PR DESCRIPTION
## Done

- update reserved ranges layout
    -  update edit form layout to fin in a row
    - update label to “comment” to be consistent with the API
    - fix table widths using flex (width was ignored)
    - edit form displays in a single column (current limitation of the MainTable component)

## Screenshots
### before
![Pasted Graphic 6](https://user-images.githubusercontent.com/7452681/153380017-aee44b61-faa5-47db-a135-f0750a312e52.png)
### after
![Pasted Graphic 5](https://user-images.githubusercontent.com/7452681/153380038-6a58e5dc-e0a0-498a-8d26-0df56d74f228.png)
### before
![Reserved ranges](https://user-images.githubusercontent.com/7452681/153380063-7e827f6d-a94d-4235-8333-e63003571c60.png)
### after
![Reserved ranges](https://user-images.githubusercontent.com/7452681/153380078-8436056c-ed71-4a3d-a385-1737ecbecb2f.png)
![START IP ADDRESS](https://user-images.githubusercontent.com/7452681/153380089-bb1ed475-8614-40dc-ad31-029c8da9dff7.png)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet view with reserved ranges
- verify reserved ranges table is displayed correctly

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
