### PR TITLE
refactor: subnet used IPs

### DIFF
--- a/ui/src/app/store/subnet/types/enum.ts
+++ b/ui/src/app/store/subnet/types/enum.ts
@@ -6,6 +6,14 @@ export enum IPAddressType {
   DISCOVERED = 6,
 }
 
+export enum IPAddressTypeLabel {
+  AUTO = "Automatic",
+  STICKY = "Sticky",
+  USER_RESERVED = "User reserved",
+  DHCP = "DHCP",
+  OBSERVED = "Discovered",
+}
+
 export enum SubnetMeta {
   MODEL = "subnet",
   PK = "id",

--- a/ui/src/app/store/subnet/types/enum.ts
+++ b/ui/src/app/store/subnet/types/enum.ts
@@ -11,7 +11,7 @@ export enum IPAddressTypeLabel {
   STICKY = "Sticky",
   USER_RESERVED = "User reserved",
   DHCP = "DHCP",
-  OBSERVED = "Discovered",
+  DISCOVERED = "Discovered",
 }
 
 export enum SubnetMeta {

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -67,7 +67,7 @@ const SubnetDetails = (): JSX.Element => {
       <StaticRoutes subnetId={id} />
       <ReservedRanges subnetId={id} />
       <DHCPSnippets subnetIds={[id]} modelName={SubnetMeta.MODEL} />
-      <UsedIPs />
+      <UsedIPs subnetId={id} />
     </Section>
   );
 };

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.test.tsx
@@ -13,7 +13,7 @@ import {
 
 const mockStore = configureStore();
 
-it("renders for a subnet", () => {
+it("displays correct IP addresses", () => {
   const subnet = subnetFactory({
     ip_addresses: [
       {

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SubnetUsedIPs, { Labels } from "./SubnetUsedIPs";
+
+import {
+  rootState as rootStateFactory,
+  subnetDetails as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("renders for a subnet", () => {
+  const subnet = subnetFactory({
+    ip_addresses: [
+      {
+        ip: "11.1.1.1",
+        alloc_type: 3,
+        created: "yesterday",
+        updated: "today",
+      },
+      {
+        ip: "11.1.1.2",
+        alloc_type: 2,
+        created: "yesterday",
+        updated: "today",
+      },
+    ],
+  });
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <SubnetUsedIPs subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.queryAllByRole("gridcell", {
+      name: Labels.IpAddresses,
+    })
+  ).toHaveLength(2);
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.IpAddresses,
+      })
+      .find((td) => td.textContent === "11.1.1.1")
+  ).toBeInTheDocument();
+  expect(
+    screen
+      .queryAllByRole("gridcell", {
+        name: Labels.IpAddresses,
+      })
+      .find((td) => td.textContent === "11.1.1.2")
+  ).toBeInTheDocument();
+});
+
+it("displays an empty message for a subnet", () => {
+  const subnet = subnetFactory({
+    ip_addresses: [],
+  });
+  const state = rootStateFactory({
+    subnet: subnetStateFactory({
+      items: [subnet],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <SubnetUsedIPs subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByText("No IP addresses for this subnet.")
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
@@ -56,10 +56,11 @@ const SubnetUsedIPs = ({ subnetId }: Props): JSX.Element => {
   return (
     <TitledSection title="Used IP addresses">
       <MainTable
-        className="p-table-expanding--light"
+        className="used-ip-table p-table-expanding--light"
         defaultSort="name"
         defaultSortDirection="descending"
         sortable
+        responsive
         emptyStateMsg={
           loading ? (
             <Spinner text="Loading..." />
@@ -70,23 +71,23 @@ const SubnetUsedIPs = ({ subnetId }: Props): JSX.Element => {
         headers={[
           {
             content: Labels.IpAddresses,
-            sortKey: "ip_addresses",
+            sortKey: "ip",
           },
           {
             content: Labels.Type,
-            sortKey: "end_ip",
-          },
-          {
-            content: Labels.Node,
-            sortKey: "owner",
-          },
-          {
-            content: Labels.Interface,
             sortKey: "type",
           },
           {
+            content: Labels.Node,
+            sortKey: "node",
+          },
+          {
+            content: Labels.Interface,
+            sortKey: "interface",
+          },
+          {
             content: Labels.Usage,
-            sortKey: "comment",
+            sortKey: "usage",
           },
           {
             content: Labels.Owner,
@@ -131,6 +132,15 @@ const SubnetUsedIPs = ({ subnetId }: Props): JSX.Element => {
                 content: ip_address.updated,
               },
             ],
+            sortData: {
+              ip: ip_address.ip,
+              type: type,
+              node: ip_address.node_summary?.hostname,
+              interface: ip_address.node_summary?.via,
+              usage: usage,
+              owner: ip_address.user,
+              updated: ip_address.updated,
+            },
           };
         })}
       />

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/SubnetUsedIPs.tsx
@@ -1,7 +1,141 @@
-import TitledSection from "app/base/components/TitledSection";
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 
-const SubnetUsedIPs = (): JSX.Element => (
-  <TitledSection title="Used IP addresses" />
-);
+import TitledSection from "app/base/components/TitledSection";
+import type { RootState } from "app/store/root/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import type {
+  Subnet,
+  SubnetDetails,
+  SubnetIP,
+  SubnetMeta,
+} from "app/store/subnet/types";
+import { IPAddressType, IPAddressTypeLabel } from "app/store/subnet/types/enum";
+import { NodeType, NodeTypeDisplay } from "app/store/types/node";
+
+export type Props = {
+  subnetId: Subnet[SubnetMeta.PK] | null;
+};
+
+export enum Labels {
+  IpAddresses = "IP addresses",
+  Type = "Type",
+  Node = "Node",
+  Interface = "interface",
+  Usage = "Usage",
+  Owner = "Owner",
+  LastSeen = "Last Seen",
+}
+
+const getType = (ip: SubnetIP) => {
+  return IPAddressTypeLabel[
+    IPAddressType[ip.alloc_type] as keyof typeof IPAddressTypeLabel
+  ];
+};
+
+const getUsage = (ip: SubnetIP) => {
+  const isContainer = ip.node_summary?.is_container;
+  const nodeType = ip.node_summary?.node_type;
+  if (nodeType === 1 && isContainer) {
+    return "Container";
+  }
+  if (nodeType) {
+    return NodeTypeDisplay[NodeType[nodeType] as keyof typeof NodeTypeDisplay];
+  } else {
+    return "Unknown";
+  }
+};
+
+const SubnetUsedIPs = ({ subnetId }: Props): JSX.Element => {
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, subnetId)
+  ) as SubnetDetails;
+  const loading = useSelector(subnetSelectors.loading);
+  const ip_addresses = subnet.ip_addresses;
+
+  return (
+    <TitledSection title="Used IP addresses">
+      <MainTable
+        className="p-table-expanding--light"
+        defaultSort="name"
+        defaultSortDirection="descending"
+        sortable
+        emptyStateMsg={
+          loading ? (
+            <Spinner text="Loading..." />
+          ) : (
+            "No IP addresses for this subnet."
+          )
+        }
+        headers={[
+          {
+            content: Labels.IpAddresses,
+            sortKey: "ip_addresses",
+          },
+          {
+            content: Labels.Type,
+            sortKey: "end_ip",
+          },
+          {
+            content: Labels.Node,
+            sortKey: "owner",
+          },
+          {
+            content: Labels.Interface,
+            sortKey: "type",
+          },
+          {
+            content: Labels.Usage,
+            sortKey: "comment",
+          },
+          {
+            content: Labels.Owner,
+            sortKey: "owner",
+          },
+          {
+            content: Labels.LastSeen,
+            sortKey: "updated",
+          },
+        ]}
+        rows={ip_addresses?.map((ip_address) => {
+          const type = getType(ip_address);
+          const usage = getUsage(ip_address);
+          return {
+            columns: [
+              {
+                "aria-label": Labels.IpAddresses,
+                content: ip_address.ip,
+              },
+              {
+                "aria-label": Labels.Type,
+                content: type,
+              },
+              {
+                "aria-label": Labels.Node,
+                content: ip_address.node_summary?.hostname,
+              },
+              {
+                "aria-label": Labels.Interface,
+                content: ip_address.node_summary?.via,
+              },
+              {
+                "aria-label": Labels.Usage,
+                content: usage,
+              },
+              {
+                "aria-label": Labels.Owner,
+                content: ip_address.user,
+              },
+              {
+                "aria-label": Labels.LastSeen,
+                content: ip_address.updated,
+              },
+            ],
+          };
+        })}
+      />
+    </TitledSection>
+  );
+};
 
 export default SubnetUsedIPs;

--- a/ui/src/app/subnets/views/SubnetDetails/UsedIPs/_index.scss
+++ b/ui/src/app/subnets/views/SubnetDetails/UsedIPs/_index.scss
@@ -1,0 +1,8 @@
+@mixin UsedIpTable {
+  .used-ip-table {
+    th:nth-child(1),
+    td:nth-child(1) {
+      width: 24%;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -262,11 +262,13 @@
 @import "~app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/BootArchitecturesTable";
 @import "~app/subnets/views/SubnetsList";
 @import "~app/subnets/views/VLANDetails/VLANSubnets";
+@import "~app/subnets/views/SubnetDetails/UsedIPs/_index.scss";
 @include BootArchitecturesTable;
 @include FabricVLANs;
 @include ReservedRanges;
 @include SubnetsList;
 @include VLANSubnets;
+@include UsedIpTable;
 
 #maas-ui {
   background-color: $color-light;


### PR DESCRIPTION
## Done

- Used IPs table for subnets

## QA

- Check that the used IPs section is populated (subnet with id=11 has some content) or alternatively an empty message is displayed.

## Issue
Fixes https://github.com/canonical-web-and-design/app-tribe/issues/661