### PR TITLE
feat(ui): build subnets edit static route form

### DIFF
--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -66,3 +66,9 @@ export const getSubnetsInSpace = (
 
 export const getHasIPAddresses = (subnet?: Subnet | null): boolean =>
   isSubnetDetails(subnet) ? subnet?.ip_addresses.length > 0 : false;
+
+export const getIsDestinationForSource = (
+  destination: Subnet,
+  source: Subnet | null
+): boolean =>
+  destination.id !== source?.id && destination.version === source?.version;

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.tsx
@@ -15,6 +15,7 @@ import staticRouteSelectors from "app/store/staticroute/selectors";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
+import { getIsDestinationForSource } from "app/store/subnet/utils";
 import { toFormikNumber } from "app/utils";
 
 export type AddStaticRouteValues = {
@@ -35,9 +36,6 @@ const addStaticRouteSchema = Yup.object().shape({
   destination: Yup.string().required("Destination is required"),
   metric: Yup.number().required("Metric is required"),
 });
-
-const isDestinationForSource = (destination: Subnet, source: Subnet | null) =>
-  destination.id !== source?.id && destination.version === source?.version;
 
 export type Props = {
   subnetId: Subnet[SubnetMeta.PK];
@@ -115,7 +113,7 @@ const AddStaticRouteForm = ({
               disabled: true,
             }}
             filterFunction={(destination) =>
-              isDestinationForSource(destination, source)
+              getIsDestinationForSource(destination, source)
             }
             label={Labels.Destination}
             name="destination"

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import EditStaticRouteForm from "./EditStaticRouteForm";
+
+import { actions as staticRouteActions } from "app/store/staticroute";
+import {
+  rootState as rootStateFactory,
+  staticRouteState as staticRouteStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  authState as authStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches a correct action on add static route form submit", async () => {
+  const subnet = subnetFactory({ id: 1, cidr: "172.16.1.0/24" });
+  const destinationSubnet = subnetFactory({ id: 2, cidr: "223.16.1.0/24" });
+  const state = rootStateFactory({
+    user: userStateFactory({
+      auth: authStateFactory({
+        user: userFactory(),
+      }),
+      items: [userFactory(), userFactory(), userFactory()],
+    }),
+    staticroute: staticRouteStateFactory({
+      loaded: true,
+      items: [],
+    }),
+    subnet: subnetStateFactory({
+      loaded: true,
+      items: [subnet, destinationSubnet],
+    }),
+  });
+
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <EditStaticRouteForm subnetId={subnet.id} handleDismiss={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: "Add static route" })
+    ).toBeInTheDocument()
+  );
+
+  const addStaticRouteForm = screen.getByRole("form", {
+    name: "Add static route",
+  });
+
+  const gatewayIp = "11.1.1.2";
+  userEvent.type(
+    within(addStaticRouteForm).getByLabelText(Labels.GatewayIp),
+    gatewayIp
+  );
+  userEvent.clear(within(addStaticRouteForm).getByLabelText(Labels.Metric));
+  userEvent.type(within(addStaticRouteForm).getByLabelText(Labels.Metric), "1");
+  userEvent.selectOptions(
+    within(addStaticRouteForm).getByLabelText(Labels.Destination),
+    `${destinationSubnet.id}`
+  );
+  userEvent.click(
+    within(addStaticRouteForm).getByRole("button", {
+      name: "Save",
+    })
+  );
+
+  const expectedActions = [
+    staticRouteActions.create({
+      source: subnet.id,
+      gateway_ip: gatewayIp,
+      destination: destinationSubnet.id,
+      metric: 1,
+    }),
+  ];
+  const actualActions = store.getActions();
+  await waitFor(() =>
+    expect(
+      actualActions.filter(
+        (action) => action.type === staticRouteActions.create.type
+      )
+    ).toStrictEqual(expectedActions)
+  );
+});

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.tsx
@@ -61,8 +61,6 @@ const EditStaticRouteForm = ({
   const dispatch = useDispatch();
   const staticRoutesLoading = useSelector(staticRouteSelectors.loading);
   const subnetsLoading = useSelector(subnetSelectors.loading);
-  const staticRoutesLoaded = useSelector(staticRouteSelectors.loaded);
-  const subnetsLoaded = useSelector(subnetSelectors.loaded);
   const loading = staticRoutesLoading || subnetsLoading;
   const subnets = useSelector(subnetSelectors.all);
   const staticRoute = useSelector((state: RootState) =>
@@ -74,9 +72,9 @@ const EditStaticRouteForm = ({
   const destinationSubnets = getDestinationsForSource(subnets, source);
 
   useEffect(() => {
-    if (!staticRoutesLoaded) dispatch(staticRouteActions.fetch());
-    if (!subnetsLoaded) dispatch(subnetActions.fetch());
-  }, [dispatch, staticRoutesLoaded, subnetsLoaded]);
+    dispatch(staticRouteActions.fetch());
+    dispatch(subnetActions.fetch());
+  }, [dispatch]);
 
   if (!staticRoute || loading) {
     return <Spinner text="Loading..." />;

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.tsx
@@ -1,0 +1,149 @@
+import { useEffect } from "react";
+
+import { Col, Row, Select, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import { Labels } from "../StaticRoutes";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import type { RootState } from "app/store/root/types";
+import { actions as staticRouteActions } from "app/store/staticroute";
+import staticRouteSelectors from "app/store/staticroute/selectors";
+import type { StaticRoute, StaticRouteMeta } from "app/store/staticroute/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
+import { toFormikNumber } from "app/utils";
+
+export type AddStaticRouteValues = Pick<
+  StaticRoute,
+  "source" | "destination" | "metric" | "gateway_ip"
+>;
+
+export enum EditStaticRouteFormLabels {
+  EditStaticRoute = "Edit static route",
+  Save = "Save",
+  Cancel = "Cancel",
+}
+
+const addStaticRouteSchema = Yup.object().shape({
+  gateway_ip: Yup.string().required("Gateway IP is required"),
+  destination: Yup.string().required("Destination is required"),
+  metric: Yup.number().required("Metric is required"),
+});
+
+const getDestinationsForSource = (subnets: Subnet[], source: Subnet | null) => {
+  const filtered: Subnet[] = [];
+  if (source) {
+    subnets.forEach((subnet) => {
+      if (subnet.id !== source.id && subnet.version === source.version) {
+        filtered.push(subnet);
+      }
+    });
+  }
+
+  return filtered;
+};
+
+export type Props = {
+  staticRouteId: StaticRoute[StaticRouteMeta.PK];
+  handleDismiss: () => void;
+};
+const EditStaticRouteForm = ({
+  staticRouteId,
+  handleDismiss,
+}: Props): JSX.Element | null => {
+  const staticRouteErrors = useSelector(staticRouteSelectors.errors);
+  const saving = useSelector(staticRouteSelectors.saving);
+  const saved = useSelector(staticRouteSelectors.saved);
+  const dispatch = useDispatch();
+  const staticRoutesLoading = useSelector(staticRouteSelectors.loading);
+  const subnetsLoading = useSelector(subnetSelectors.loading);
+  const staticRoutesLoaded = useSelector(staticRouteSelectors.loaded);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+  const loading = staticRoutesLoading || subnetsLoading;
+  const subnets = useSelector(subnetSelectors.all);
+  const staticRoute = useSelector((state: RootState) =>
+    staticRouteSelectors.getById(state, staticRouteId)
+  );
+  const source = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, staticRoute?.source)
+  );
+  const destinationSubnets = getDestinationsForSource(subnets, source);
+
+  useEffect(() => {
+    if (!staticRoutesLoaded) dispatch(staticRouteActions.fetch());
+    if (!subnetsLoaded) dispatch(subnetActions.fetch());
+  }, [dispatch, staticRoutesLoaded, subnetsLoaded]);
+
+  if (!staticRoute || loading) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return (
+    <FormikForm<AddStaticRouteValues>
+      aria-label={EditStaticRouteFormLabels.EditStaticRoute}
+      cleanup={staticRouteActions.cleanup}
+      errors={staticRouteErrors}
+      initialValues={{
+        source: staticRoute.source,
+        gateway_ip: staticRoute.gateway_ip,
+        destination: staticRoute.destination,
+        metric: staticRoute.metric,
+      }}
+      onSaveAnalytics={{
+        action: EditStaticRouteFormLabels.Save,
+        category: "Subnet",
+        label: EditStaticRouteFormLabels.EditStaticRoute,
+      }}
+      onSubmit={({ gateway_ip, destination, metric }) => {
+        dispatch(staticRouteActions.cleanup());
+        dispatch(
+          staticRouteActions.update({
+            id: staticRouteId,
+            source: staticRoute.source,
+            gateway_ip,
+            destination: toFormikNumber(destination) as number,
+            metric: toFormikNumber(metric),
+          })
+        );
+      }}
+      onSuccess={() => {
+        handleDismiss();
+      }}
+      resetOnSave
+      saving={saving}
+      saved={saved}
+      submitLabel={EditStaticRouteFormLabels.Save}
+      onCancel={handleDismiss}
+      validationSchema={addStaticRouteSchema}
+    >
+      <Row>
+        <Col size={4}>
+          <FormikField label={Labels.GatewayIp} name="gateway_ip" type="text" />
+        </Col>
+        <Col size={4}>
+          <FormikField
+            component={Select}
+            label={Labels.Destination}
+            name="destination"
+            options={[
+              { label: "Select destination", value: "", disabled: true },
+              ...destinationSubnets.map((subnet) => ({
+                label: subnet.cidr,
+                value: subnet.id,
+              })),
+            ]}
+          />
+        </Col>
+        <Col size={4}>
+          <FormikField label={Labels.Metric} name="metric" type="text" />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default EditStaticRouteForm;

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/index.ts
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditStaticRouteForm";

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -136,17 +136,16 @@ it("can open and close the add static route form", async () => {
 it("can open and close the edit static route form", async () => {
   const subnet = subnetFactory({ id: 1 });
   const state = rootStateFactory({
-    user: userStateFactory({
-      auth: authStateFactory({
-        user: userFactory(),
-      }),
-      items: [userFactory(), userFactory(), userFactory()],
-    }),
     staticroute: staticRouteStateFactory({
-      items: [],
+      items: [
+        staticRouteFactory({
+          gateway_ip: "11.1.1.1",
+          source: 1,
+        }),
+      ],
     }),
     subnet: subnetStateFactory({
-      items: [subnet, subnetFactory({ id: 2 })],
+      items: [subnet],
     }),
   });
 
@@ -158,13 +157,7 @@ it("can open and close the edit static route form", async () => {
       </MemoryRouter>
     </Provider>
   );
-  await waitFor(() =>
-    expect(
-      screen.getByRole("button", {
-        name: "Edit",
-      })
-    ).toBeInTheDocument()
-  );
+
   userEvent.click(
     screen.getByRole("button", {
       name: "Edit",

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { AddStaticRouteFormLabels } from "./AddStaticRouteForm/AddStaticRouteForm";
+import { EditStaticRouteFormLabels } from "./EditStaticRouteForm/EditStaticRouteForm";
 import StaticRoutes, { Labels } from "./StaticRoutes";
 
 import {
@@ -127,6 +128,69 @@ it("can open and close the add static route form", async () => {
     expect(
       screen.queryByRole("form", {
         name: AddStaticRouteFormLabels.AddStaticRoute,
+      })
+    ).not.toBeInTheDocument()
+  );
+});
+
+it("can open and close the edit static route form", async () => {
+  const subnet = subnetFactory({ id: 1 });
+  const state = rootStateFactory({
+    user: userStateFactory({
+      auth: authStateFactory({
+        user: userFactory(),
+      }),
+      items: [userFactory(), userFactory(), userFactory()],
+    }),
+    staticroute: staticRouteStateFactory({
+      items: [],
+    }),
+    subnet: subnetStateFactory({
+      items: [subnet, subnetFactory({ id: 2 })],
+    }),
+  });
+
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <StaticRoutes subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", {
+        name: "Edit",
+      })
+    ).toBeInTheDocument()
+  );
+  userEvent.click(
+    screen.getByRole("button", {
+      name: "Edit",
+    })
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", {
+        name: EditStaticRouteFormLabels.EditStaticRoute,
+      })
+    ).toBeInTheDocument()
+  );
+
+  userEvent.click(
+    within(
+      screen.getByRole("form", {
+        name: EditStaticRouteFormLabels.EditStaticRoute,
+      })
+    ).getByRole("button", { name: "Cancel" })
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.queryByRole("form", {
+        name: EditStaticRouteFormLabels.EditStaticRoute,
       })
     ).not.toBeInTheDocument()
   );

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 
 import AddStaticRouteForm from "./AddStaticRouteForm";
+import EditStaticRouteForm from "./EditStaticRouteForm";
 
 import FormCard from "app/base/components/FormCard";
 import SubnetLink from "app/base/components/SubnetLink";
@@ -88,7 +89,19 @@ const generateRows = (
         />
       );
     } else if (expanded?.type === ExpandedType.Update) {
-      expandedContent = <>Todo: static route edit form</>;
+      expandedContent = (
+        <EditStaticRouteForm
+          staticRouteId={staticRoute.id}
+          handleDismiss={() =>
+            toggleExpanded(
+              staticRoute.id,
+              expanded,
+              ExpandedType.Update,
+              setExpanded
+            )
+          }
+        />
+      );
     }
     return {
       className: isExpanded ? "p-table__row is-active" : null,

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -191,7 +191,8 @@ const StaticRoutes = ({ subnetId }: Props): JSX.Element | null => {
       }
     >
       <MainTable
-        className="reserved-ranges-table p-table-expanding--light"
+        className="static-routes-table p-table-expanding--light"
+        responsive
         defaultSort="gateway_ip"
         defaultSortDirection="ascending"
         emptyStateMsg={

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/_index.scss
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/_index.scss
@@ -1,0 +1,27 @@
+@mixin StaticRoutes {
+  .static-routes-table {
+    td {
+      white-space: normal;
+    }
+
+    th:nth-child(1),
+    td:nth-child(1) {
+      flex-grow: 0.37;
+    }
+
+    th:nth-child(2),
+    td:nth-child(2) {
+      flex-grow: 0.37;
+    }
+
+    th:nth-child(3),
+    td:nth-child(3) {
+      flex-grow: 0.13;
+    }
+
+    th:nth-child(4),
+    td:nth-child(4) {
+      flex-grow: 0.13;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -259,12 +259,14 @@
 // subnets
 @import "~app/subnets/components/ReservedRanges";
 @import "~app/subnets/views/FabricDetails/FabricVLANs";
+@import "~app/subnets/views/SubnetDetails/StaticRoutes";
 @import "~app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/BootArchitecturesTable";
 @import "~app/subnets/views/SubnetsList";
 @import "~app/subnets/views/VLANDetails/VLANSubnets";
 @include BootArchitecturesTable;
 @include FabricVLANs;
 @include ReservedRanges;
+@include StaticRoutes;
 @include SubnetsList;
 @include VLANSubnets;
 


### PR DESCRIPTION
## Done

-  build subnets edit static route form
    - add responsive static routes table
    - update static routes table layout widths
    - move `getIsDestinationForSource` to utils

## Screenshots
## After
![Static routes](https://user-images.githubusercontent.com/7452681/153439984-99ef3feb-cb92-476a-9236-3657ba32fc34.png)
![Static routes](https://user-images.githubusercontent.com/7452681/153439995-6d5cb644-1357-4ec9-baf9-def7d3b36b9a.png)
(displayed in a single column - MainTable's current limitation)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
