### PR TITLE
feat(ui): display a subnet column for VLAN reserved ranges

### DIFF
--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
@@ -31,7 +31,7 @@ export enum Labels {
   CreateRange = "Create reserved range",
   EditRange = "Edit reserved range",
   EndIp = "End IP address",
-  Comment = "Comment",
+  Comment = "Purpose",
   StartIp = "Start IP address",
 }
 
@@ -142,7 +142,7 @@ const ReservedRangeForm = ({
               disabled={showDynamicComment}
               label={Labels.Comment}
               name="comment"
-              placeholder="IP range comment (optional)"
+              placeholder="IP range purpose (optional)"
               type="text"
             />
           </Col>

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -364,3 +364,38 @@ it("can display an add form", async () => {
     screen.getByRole("form", { name: ReservedRangeFormLabels.CreateRange })
   ).toBeInTheDocument();
 });
+
+it("displays the subnet column when the table is for a VLAN", () => {
+  state.iprange.items = [
+    ipRangeFactory({ start_ip: "11.1.1.1", vlan: vlan.id }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges hasVLANSubnets vlanId={vlan.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("gridcell", {
+      name: Labels.Subnet,
+    })
+  ).toBeInTheDocument();
+});
+
+it("does not display the subnet column when the table is for a subnet", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <ReservedRanges subnetId={subnet.id} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.queryByRole("gridcell", {
+      name: Labels.Subnet,
+    })
+  ).not.toBeInTheDocument();
+});

--- a/ui/src/app/subnets/components/ReservedRanges/_index.scss
+++ b/ui/src/app/subnets/components/ReservedRanges/_index.scss
@@ -1,36 +1,57 @@
 @mixin ReservedRanges {
   .reserved-ranges-table {
-    td {
-      white-space: normal;
-    }
-    th:nth-child(1),
-    td:nth-child(1) {
+    .start-ip-col {
       flex: 0.25;
     }
 
-    th:nth-child(2),
-    td:nth-child(2) {
+    .end-ip-col {
       flex: 0.25;
     }
 
-    th:nth-child(3),
-    td:nth-child(3) {
+    .owner-col {
       flex: 0.13;
     }
 
-    th:nth-child(4),
-    td:nth-child(4) {
+    .type-col {
       flex: 0.13;
     }
 
-    th:nth-child(5),
-    td:nth-child(5) {
-      flex: 0.12;
+    .comment-col {
+      flex: 0.2;
     }
 
-    th:nth-child(6),
-    td:nth-child(6) {
+    .actions-col {
       flex: 0.12;
+    }
+  }
+
+  .reserved-ranges-table--has-subnet {
+    .subnet-col {
+      flex: 0.17;
+    }
+
+    .start-ip-col {
+      flex: 0.18;
+    }
+
+    .end-ip-col {
+      flex: 0.18;
+    }
+
+    .owner-col {
+      flex: 0.1;
+    }
+
+    .type-col {
+      flex: 0.1;
+    }
+
+    .comment-col {
+      flex: 0.17;
+    }
+
+    .actions-col {
+      flex: 0.1;
     }
   }
 }


### PR DESCRIPTION
## Done

- Display a subnet column when the reserved ranges table is displayed for a VLAN.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet details page and scroll down to the reserved ranges table.
- There should be no subnet column on the left hand side.
- Go to a VLAN details page and scroll down to the reserved ranges table.
- There should be a subnet column on the left hand side.

## Fixes

Fixes: canonical-web-and-design/app-tribe#723

## Screenshots

VLAN details:
<img width="1348" alt="Screen Shot 2022-02-11 at 1 39 18 pm" src="https://user-images.githubusercontent.com/361637/153530902-158249ca-ff59-4ed0-ab57-420dc3b1eda1.png">
Subnet details:
<img width="1346" alt="Screen Shot 2022-02-11 at 1 39 29 pm" src="https://user-images.githubusercontent.com/361637/153530907-ebe42281-aa74-4e69-b508-0eec670ee6c8.png">
