### PR TITLE
feat(ui): sort subnet selects

### DIFF
--- a/ui/src/app/base/components/FabricSelect/FabricSelect.test.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.test.tsx
@@ -97,4 +97,30 @@ describe("FabricSelect", () => {
     );
     expect(wrapper.find(DynamicSelect).prop("options").length).toBe(0);
   });
+
+  it("orders the fabrics by name", () => {
+    state.fabric.items = [
+      fabricFactory({ id: 1, name: "FABric2" }),
+      fabricFactory({ id: 2, name: "FABric1" }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ fabric: "" }} onSubmit={jest.fn()}>
+          <FabricSelect name="fabric" />
+        </Formik>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
+      { disabled: true, label: "Select fabric", value: "" },
+      {
+        label: "FABric1",
+        value: "2",
+      },
+      {
+        label: "FABric2",
+        value: "1",
+      },
+    ]);
+  });
 });

--- a/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
@@ -6,6 +6,7 @@ import DynamicSelect from "app/base/components/DynamicSelect";
 import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
+import { simpleSortByKey } from "app/utils";
 
 type Props = {
   defaultOption?: { label: string; value: string; disabled?: boolean } | null;
@@ -33,10 +34,12 @@ export const FabricSelect = ({
       name={name}
       options={[
         ...(defaultOption ? [defaultOption] : []),
-        ...fabrics.map((fabric) => ({
-          label: fabric.name,
-          value: fabric.id.toString(),
-        })),
+        ...fabrics
+          .map((fabric) => ({
+            label: fabric.name,
+            value: fabric.id.toString(),
+          }))
+          .sort(simpleSortByKey("label", { alphanumeric: true })),
       ]}
       {...props}
     />

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
@@ -130,3 +130,22 @@ it("can hide the default option", () => {
   );
   expect(screen.queryAllByRole("option")).toHaveLength(0);
 });
+
+it("orders the spaces by name", () => {
+  state.space.items = [
+    spaceFactory({ id: 1, name: "space3" }),
+    spaceFactory({ id: 2, name: "space1" }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <Formik initialValues={{ space: "" }} onSubmit={jest.fn()}>
+        <SpaceSelect name="space" />
+      </Formik>
+    </Provider>
+  );
+  const options = screen.queryAllByRole("option");
+  expect(options[0].textContent).toBe("Select space");
+  expect(options[1].textContent).toBe("space1");
+  expect(options[2].textContent).toBe("space3");
+});

--- a/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
+++ b/ui/src/app/base/components/SpaceSelect/SpaceSelect.tsx
@@ -7,6 +7,7 @@ import FormikField from "app/base/components/FormikField";
 import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
 import { actions as spaceActions } from "app/store/space";
 import spaceSelectors from "app/store/space/selectors";
+import { simpleSortByKey } from "app/utils";
 
 type Props = {
   defaultOption?: { label: string; value: string; disabled?: boolean } | null;
@@ -35,10 +36,12 @@ export const SpaceSelect = ({
       name={name}
       options={[
         ...(defaultOption ? [defaultOption] : []),
-        ...spaces.map((space) => ({
-          label: space.name,
-          value: space.id.toString(),
-        })),
+        ...spaces
+          .map((space) => ({
+            label: space.name,
+            value: space.id.toString(),
+          }))
+          .sort(simpleSortByKey("label", { alphanumeric: true })),
       ]}
       {...props}
     />

--- a/ui/src/app/base/components/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/base/components/SubnetSelect/SubnetSelect.test.tsx
@@ -144,4 +144,40 @@ describe("SubnetSelect", () => {
       },
     ]);
   });
+
+  it("orders the subnets by name", () => {
+    state.subnet.items = [
+      subnetFactory({
+        id: 1,
+        name: "sub1",
+        cidr: "1.1.1.1/24",
+        vlan: 3,
+      }),
+      subnetFactory({
+        id: 2,
+        name: "sub2",
+        cidr: "0.0.0.0/24",
+        vlan: 4,
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ subnet: "" }} onSubmit={jest.fn()}>
+          <SubnetSelect name="subnet" />
+        </Formik>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
+      { label: "Select subnet", value: "" },
+      {
+        label: "0.0.0.0/24 (sub2)",
+        value: "2",
+      },
+      {
+        label: "1.1.1.1/24 (sub1)",
+        value: "1",
+      },
+    ]);
+  });
 });

--- a/ui/src/app/base/components/SubnetSelect/SubnetSelect.tsx
+++ b/ui/src/app/base/components/SubnetSelect/SubnetSelect.tsx
@@ -10,6 +10,7 @@ import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet } from "app/store/subnet/types";
 import { getSubnetDisplay } from "app/store/subnet/utils";
+import { simpleSortByKey } from "app/utils";
 
 type Option = NonNullable<SelectProps["options"]>[0];
 
@@ -46,10 +47,12 @@ export const SubnetSelect = ({
     subnets = subnets.filter(filterFunction);
   }
 
-  const subnetOptions = subnets.map<Option>((subnet) => ({
-    label: getSubnetDisplay(subnet),
-    value: subnet.id.toString(),
-  }));
+  const subnetOptions = subnets
+    .map<Option>((subnet) => ({
+      label: getSubnetDisplay(subnet),
+      value: subnet.id.toString(),
+    }))
+    .sort(simpleSortByKey("label", { alphanumeric: true }));
 
   if (defaultOption) {
     subnetOptions.unshift(defaultOption);

--- a/ui/src/app/base/components/VLANSelect/VLANSelect.test.tsx
+++ b/ui/src/app/base/components/VLANSelect/VLANSelect.test.tsx
@@ -8,6 +8,7 @@ import DynamicSelect from "../DynamicSelect";
 import VLANSelect from "./VLANSelect";
 
 import type { RootState } from "app/store/root/types";
+import { VlanVid } from "app/store/vlan/types";
 import {
   rootState as rootStateFactory,
   vlan as vlanFactory,
@@ -100,7 +101,7 @@ describe("VLANSelect", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <Formik initialValues={{ subnet: "" }} onSubmit={jest.fn()}>
+        <Formik initialValues={{ vlan: "" }} onSubmit={jest.fn()}>
           <VLANSelect name="vlan" fabric={3} />
         </Formik>
       </Provider>
@@ -132,6 +133,83 @@ describe("VLANSelect", () => {
       {
         label: "2 (vlan2)",
         value: "2",
+      },
+    ]);
+  });
+
+  it("can generate the vlan names", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ vlan: "" }} onSubmit={jest.fn()}>
+          <VLANSelect
+            generateName={(vlan) => `name: ${vlan.name}`}
+            name="vlan"
+          />
+        </Formik>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
+      { disabled: true, label: "Select VLAN", value: "" },
+      {
+        label: "name: vlan2",
+        value: "2",
+      },
+      {
+        label: "name: vlan1",
+        value: "1",
+      },
+    ]);
+  });
+
+  it("orders the vlans by name", () => {
+    state.vlan.items = [
+      vlanFactory({ id: 1, name: "vlan1", vid: 21, fabric: 3 }),
+      vlanFactory({ id: 2, name: "vlan2", vid: 2, fabric: 4 }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ vlan: "" }} onSubmit={jest.fn()}>
+          <VLANSelect name="vlan" />
+        </Formik>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
+      { disabled: true, label: "Select VLAN", value: "" },
+      {
+        label: "2 (vlan2)",
+        value: "2",
+      },
+      {
+        label: "21 (vlan1)",
+        value: "1",
+      },
+    ]);
+  });
+
+  it("orders untagged vlans to the start", () => {
+    state.vlan.items = [
+      vlanFactory({ id: 1, name: "vlan1", vid: 21, fabric: 3 }),
+      vlanFactory({ id: 2, vid: VlanVid.UNTAGGED, fabric: 4 }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ vlan: "" }} onSubmit={jest.fn()}>
+          <VLANSelect name="vlan" />
+        </Formik>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
+      { disabled: true, label: "Select VLAN", value: "" },
+      {
+        label: "untagged",
+        value: "2",
+      },
+      {
+        label: "21 (vlan1)",
+        value: "1",
       },
     ]);
   });

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
@@ -8,6 +8,7 @@ import type { ConfigureDHCPValues } from "../ConfigureDHCP";
 import { DHCPType } from "../ConfigureDHCP";
 
 import FormikField from "app/base/components/FormikField";
+import VLANSelect from "app/base/components/VLANSelect";
 import controllerSelectors from "app/store/controller/selectors";
 import fabricSelectors from "app/store/fabric/selectors";
 import type { RootState } from "app/store/root/types";
@@ -87,10 +88,12 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
                           : "Primary rack"
                       }
                       name="primaryRack"
-                      options={primaryRackOptions.map((controller) => ({
-                        label: controller.hostname,
-                        value: controller.system_id,
-                      }))}
+                      options={primaryRackOptions
+                        .map((controller) => ({
+                          label: controller.hostname,
+                          value: controller.system_id,
+                        }))
+                        .sort((a, b) => a.label.localeCompare(b.label))}
                       wrapperClassName="u-nudge-right--x-large"
                     />
                     {connectedControllers.length > 1 && (
@@ -100,10 +103,12 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
                         name="secondaryRack"
                         options={[
                           { label: "Unset", value: "" },
-                          ...secondaryRackOptions.map((controller) => ({
-                            label: controller.hostname,
-                            value: controller.system_id,
-                          })),
+                          ...secondaryRackOptions
+                            .map((controller) => ({
+                              label: controller.hostname,
+                              value: controller.system_id,
+                            }))
+                            .sort((a, b) => a.label.localeCompare(b.label)),
                         ]}
                         wrapperClassName="u-nudge-right--x-large"
                       />
@@ -125,17 +130,16 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
               value={DHCPType.RELAY}
             />
             {dhcpType === DHCPType.RELAY && (
-              <FormikField
-                component={Select}
+              <VLANSelect
+                defaultOption={null}
+                generateName={(dhcpVLAN) =>
+                  getFullVLANName(dhcpVLAN.id, allVLANs, fabrics) ||
+                  dhcpVLAN.name
+                }
                 label="VLAN"
                 name="relayVLAN"
-                options={vlansWithDHCP.map((dhcpVLAN) => ({
-                  label:
-                    getFullVLANName(dhcpVLAN.id, allVLANs, fabrics) ||
-                    dhcpVLAN.name,
-                  value: dhcpVLAN.id,
-                }))}
                 wrapperClassName="u-nudge-right--x-large"
+                vlans={vlansWithDHCP}
               />
             )}
           </>

--- a/ui/src/app/utils/simpleSortByKey.test.ts
+++ b/ui/src/app/utils/simpleSortByKey.test.ts
@@ -1,11 +1,15 @@
 import { simpleSortByKey } from "./simpleSortByKey";
 
 describe("simpleSortByKey", () => {
-  const arr = [
-    { name: "Bob", age: 30 },
-    { name: "Chris", age: 20 },
-    { name: "Alice", age: 25 },
-  ];
+  let arr: { name: string; age: number }[];
+
+  beforeEach(() => {
+    arr = [
+      { name: "Bob", age: 30 },
+      { name: "Chris", age: 20 },
+      { name: "Alice", age: 25 },
+    ];
+  });
 
   it("correctly sorts objects by key", () => {
     expect(arr.sort(simpleSortByKey("name"))).toEqual([
@@ -30,6 +34,19 @@ describe("simpleSortByKey", () => {
       { name: "Bob", age: 30 },
       { name: "Alice", age: 25 },
       { name: "Chris", age: 20 },
+    ]);
+  });
+
+  it("can sort alphanumeric strings", () => {
+    arr = [
+      { name: "Chris2", age: 20 },
+      { name: "Chris12", age: 30 },
+      { name: "Chris1", age: 25 },
+    ];
+    expect(arr.sort(simpleSortByKey("name", { alphanumeric: true }))).toEqual([
+      { name: "Chris1", age: 25 },
+      { name: "Chris2", age: 20 },
+      { name: "Chris12", age: 30 },
     ]);
   });
 });

--- a/ui/src/app/utils/simpleSortByKey.ts
+++ b/ui/src/app/utils/simpleSortByKey.ts
@@ -9,10 +9,22 @@
 export const simpleSortByKey =
   <O, K extends keyof O>(
     key: K,
-    { reverse } = { reverse: false }
+    { alphanumeric, reverse }: { alphanumeric?: boolean; reverse?: boolean } = {
+      alphanumeric: false,
+      reverse: false,
+    }
   ): ((a: O, b: O) => number) =>
   (a: O, b: O) => {
-    if (a[key] > b[key]) return reverse ? -1 : 1;
-    if (a[key] < b[key]) return reverse ? 1 : -1;
+    const paramA = a[key];
+    const paramB = b[key];
+    if (
+      alphanumeric &&
+      typeof paramA === "string" &&
+      typeof paramB === "string"
+    ) {
+      return paramA.localeCompare(paramB, "en", { numeric: true });
+    }
+    if (paramA > paramB) return reverse ? -1 : 1;
+    if (a[key] < paramB) return reverse ? 1 : -1;
     return 0;
   };


### PR DESCRIPTION
## Done

- Update the subnet entities to sort by name.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Subnets.
- Open the various "Add.." forms in the header.
- Check that subnets, fabrics and spaces are all sorted alphabetically and that VLANs have "untagged" at the top.
- Open a VLAN details page and click "Configure DHCP".
- Click "Relay to another VLAN" and check that the VLANs are sorted alphabetically.

## Fixes

Fixes: #2534.