### PR TITLE
refactor: use not.toBeInTheDocument assertions

### DIFF
--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -62,7 +62,7 @@ describe("ReservedRangeForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.queryAllByTestId("Spinner")).toHaveLength(0);
+    expect(screen.queryByTestId("Spinner")).not.toBeInTheDocument();
   });
 
   it("initialises the reserved range details when editing", () => {
@@ -213,7 +213,7 @@ describe("ReservedRangeForm", () => {
       </Provider>
     );
     expect(
-      screen.queryAllByRole("textbox", { name: Labels.Comment })
-    ).toHaveLength(0);
+      screen.queryByRole("textbox", { name: Labels.Comment })
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
@@ -121,10 +121,10 @@ it("does not display a message if DHCP is enabled on the VLAN", () => {
   });
 
   expect(
-    within(deleteSubnetSection).queryAllByText(
+    within(deleteSubnetSection).queryByText(
       /Beware IP addresses on devices on this subnet might not be retained/
     )
-  ).toHaveLength(0);
+  ).not.toBeInTheDocument();
 });
 
 it("dispatches an action to load vlans and subnets if not loaded", () => {

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
@@ -151,8 +151,8 @@ it("renders correct value for 'Managed allocation' if enabled", async () => {
   const label = "Managed allocation";
   expect(screen.getByLabelText(label)).toHaveTextContent("Enabled");
   expect(
-    within(screen.getByText(label)).queryAllByTestId("Tooltip")
-  ).toHaveLength(0);
+    within(screen.getByText(label)).queryByTestId("Tooltip")
+  ).not.toBeInTheDocument();
 });
 
 it("renders correct value for 'Managed allocation' if disabled", async () => {
@@ -213,8 +213,8 @@ it("renders correct value for 'Active discovery' if disabled", async () => {
   const label = "Active discovery";
   expect(screen.getByLabelText(label)).toHaveTextContent("Disabled");
   expect(
-    within(screen.getByText(label)).queryAllByTestId("Tooltip")
-  ).toHaveLength(0);
+    within(screen.getByText(label)).queryByTestId("Tooltip")
+  ).not.toBeInTheDocument();
 });
 
 it("renders correct value for 'Proxy access' if allowed", async () => {
@@ -363,8 +363,8 @@ it("renders the correct value for 'Space' if it has an ID", async () => {
   const label = "Space";
   expect(screen.getByLabelText(label)).toHaveTextContent("Test space");
   expect(
-    within(screen.getByText(label)).queryAllByTestId("Tooltip")
-  ).toHaveLength(0);
+    within(screen.getByText(label)).queryByTestId("Tooltip")
+  ).not.toBeInTheDocument();
 });
 
 it("renders the correct value for 'Space' if no ID", async () => {

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
@@ -104,8 +104,12 @@ it("can display the edit form", () => {
   const formName = "Edit VLAN";
   const button = screen.getByRole("button", { name: "Edit" });
   expect(button).toBeInTheDocument();
-  expect(screen.queryAllByRole("form", { name: formName })).toHaveLength(0);
+  expect(
+    screen.queryByRole("form", { name: formName })
+  ).not.toBeInTheDocument();
   userEvent.click(button);
-  expect(screen.queryAllByRole("button", { name: "Edit" })).toHaveLength(0);
+  expect(
+    screen.queryByRole("button", { name: "Edit" })
+  ).not.toBeInTheDocument();
   expect(screen.getByRole("form", { name: formName })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Done

- use `not.toBeInTheDocument()` assertions instead of `toHaveLength(0)`
    - this is done for consistency with other tests, but also `not.toBeInTheDocument()` is more meaningful
   
https://testing-library.com/docs/guide-disappearance/#nottobeinthedocument

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
