### PR TITLE
fix(ui): redirect after trying to delete a new fabric

### DIFF
--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -52,12 +52,31 @@ context("Subnets - Add", () => {
     submitForm(formName);
   };
 
-  it(`displays a newly added Fabric in the subnets table`, () => {
+  it("can add and delete a new fabric", () => {
     const name = `cypress-${generateId()}`;
     completeForm("Fabric", name);
+
     cy.findByRole("table", { name: "Subnets" }).within(() => {
       cy.findByRole("row", { name }).within(() =>
-        cy.findByRole("link", { name }).should("be.visible")
+        cy.findByRole("link", { name }).click()
+      );
+    });
+
+    cy.url().should("include", generateNewURL("/fabric"));
+
+    cy.findByRole("button", { name: "Delete fabric" }).click();
+
+    cy.findByText("Are you sure you want to delete this fabric?").should(
+      "be.visible"
+    );
+
+    cy.findByRole("button", { name: "Delete fabric" }).click();
+
+    cy.url().should("include", generateNewURL("/networks?by=fabric"));
+
+    cy.findByRole("table", { name: "Subnets" }).within(() => {
+      cy.findByRole("row", { name }).within(() =>
+        cy.findByRole("link", { name }).should("not.exist")
       );
     });
   });

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -27,6 +27,7 @@ const AddFabric = ({
       aria-label="Add fabric"
       buttonsBordered={false}
       allowAllEmpty
+      cleanup={fabricActions.cleanup}
       initialValues={{ name: "", description: "" }}
       onSaveAnalytics={{
         action: "Add fabric",


### PR DESCRIPTION
## Done

- fix invalid redirect after trying to delete a new fabric

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Add a new fabric
- Click on the link in the list to open details of the newly added fabric
- Click Delete fabric
- Verify delete fabric confirmation is shown and you're able to delete the fabric

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
