### PR TITLE
fix(ui): use consistent naming for machine allocation action

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -32,7 +32,7 @@ const getLabel = (
     case NodeActions.ABORT:
       return `${processing ? "Aborting" : "Abort"} actions for ${modelString}`;
     case NodeActions.ACQUIRE:
-      return `${processing ? "Acquiring" : "Acquire"} ${modelString}`;
+      return `${processing ? "Allocating" : "Allocate"} ${modelString}`;
     case NodeActions.CLONE:
       return processing ? "Cloning in progress" : `Clone to ${modelString}`;
     case NodeActions.COMMISSION:

--- a/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
+++ b/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
@@ -20,7 +20,7 @@ const getErrorSentence = (
     case NodeActions.ABORT:
       return `${nodeString} cannot abort action`;
     case NodeActions.ACQUIRE:
-      return `${nodeString} cannot be acquired`;
+      return `${nodeString} cannot be allocated`;
     case NodeActions.CLONE:
       return `${nodeString} cannot be cloned to`;
     case NodeActions.COMMISSION:

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.tsx
@@ -28,7 +28,7 @@ describe("OwnerColumn", () => {
           data: [
             machineActionFactory({
               name: NodeActions.ACQUIRE,
-              title: "Acquire...",
+              title: "Allocate...",
             }),
             machineActionFactory({
               name: NodeActions.RELEASE,
@@ -102,7 +102,7 @@ describe("OwnerColumn", () => {
     expect(wrapper.find('[data-testid="tags"]').text()).toEqual("aloof, minty");
   });
 
-  it("can show a menu item to acquire a machine", () => {
+  it("can show a menu item to allocate a machine", () => {
     state.machine.items[0].actions = [NodeActions.ACQUIRE];
     const store = mockStore(state);
     const wrapper = mount(
@@ -117,7 +117,7 @@ describe("OwnerColumn", () => {
     // Open the menu so the elements get rendered.
     wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
     expect(wrapper.find(".p-contextual-menu__link").at(0).text()).toEqual(
-      "Acquire..."
+      "Allocate..."
     );
   });
 

--- a/ui/src/app/store/general/selectors/machineActions.test.ts
+++ b/ui/src/app/store/general/selectors/machineActions.test.ts
@@ -75,7 +75,7 @@ describe("machineActions selectors", () => {
       }),
       machineActionFactory({
         name: NodeActions.ACQUIRE,
-        title: "Acquire...",
+        title: "Allocate...",
         sentence: "acquired",
         type: "lifecycle",
       }),
@@ -95,7 +95,7 @@ describe("machineActions selectors", () => {
     });
     expect(machineActions.getByName(state, NodeActions.ACQUIRE)).toStrictEqual({
       name: NodeActions.ACQUIRE,
-      title: "Acquire...",
+      title: "Allocate...",
       sentence: "acquired",
       type: "lifecycle",
     });

--- a/ui/src/app/store/utils/node/base.ts
+++ b/ui/src/app/store/utils/node/base.ts
@@ -47,7 +47,7 @@ export const getNodeActionTitle = (actionName: NodeActions): string => {
     case NodeActions.ABORT:
       return "Abort";
     case NodeActions.ACQUIRE:
-      return "Acquire";
+      return "Allocate";
     case NodeActions.CLONE:
       return "Clone from";
     case NodeActions.COMMISSION:


### PR DESCRIPTION
## Done

- use consistent naming for machine allocation action (under take action button you can "Acquire" a machine(s) but under status the machine is "Allocated")

## Screenshots
<img width="346" alt="Add hardware" src="https://user-images.githubusercontent.com/7452681/154716082-e0c0e162-f910-49cb-b649-d86c3b33bdf5.png">

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select any ready machine from the list and click "Take action" to reveal the dropdown menu.
- Verify consistent naming is used ("allocate" instead of "acquire")

## Fixes

Fixes: #1649 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
