### PR TITLE
test: update cypress networks path

### DIFF
--- a/integration/cypress/integration/accessibility/accessibility.spec.ts
+++ b/integration/cypress/integration/accessibility/accessibility.spec.ts
@@ -1,6 +1,4 @@
-import { generateLegacyURL, generateNewURL } from "@maas-ui/maas-ui-shared";
-
-const legacyPages = ["/networks"];
+import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 type Page = { heading: string; url: string };
 const pages: Page[] = [
@@ -26,9 +24,7 @@ pages.forEach(({ heading, url }: Page) => {
       cy.login();
     }
 
-    const pageUrl = legacyPages.includes(url)
-      ? generateLegacyURL(url)
-      : generateNewURL(url);
+    const pageUrl = generateNewURL(url);
 
     cy.visit(pageUrl);
 

--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -1,4 +1,4 @@
-import { generateLegacyURL, generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 context("Header", () => {
   beforeEach(() => {
@@ -59,7 +59,7 @@ context("Header", () => {
 
   it("navigates to subnets", () => {
     cy.get(".p-navigation__link a:contains(Subnets)").click();
-    cy.location("pathname").should("eq", generateLegacyURL("/networks"));
+    cy.location("pathname").should("eq", generateNewURL("/networks"));
     cy.location("search").should("eq", "?by=fabric");
     cy.get(".p-navigation__link.is-selected a").contains("Subnets");
   });


### PR DESCRIPTION
## Done

- update cypress tests to use the new networks path

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
