### PR TITLE
fix(ui): fix validation of VLAN DHCP configuration form

### DIFF
--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
@@ -48,12 +48,6 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
         <FormikField
           label="MAAS provides DHCP"
           name="enableDHCP"
-          onChange={async (e: ChangeEvent) => {
-            await handleChange(e);
-            setFieldValue("primaryRack", "");
-            setFieldValue("relayVLAN", "");
-            setFieldValue("secondaryRack", "");
-          }}
           type="checkbox"
         />
         {enableDHCP && (


### PR DESCRIPTION
## Done

- Fixed validation of VLAN DHCP configuration form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a VLAN configured with DHCP provided from a rack controller
- Uncheck "MAAS provides DHCP" and then recheck it
- The form should not be disabled

## Fixes

Fixes #3629 
