### PR TITLE
fix(ui): oversized canonical banner on small viewports

### DIFF
--- a/shared/src/components/Footer/Footer.tsx
+++ b/shared/src/components/Footer/Footer.tsx
@@ -74,7 +74,7 @@ export const Footer = ({
             Canonical are registered trademarks of Canonical Ltd.
           </p>
         </div>
-        <div className="col-2">
+        <div className="col-small-1 col-medium-1 col-2">
           <svg
             className="p-footer__logo u-float--right"
             xmlns="http://www.w3.org/2000/svg"

--- a/shared/src/components/Footer/Footer.tsx
+++ b/shared/src/components/Footer/Footer.tsx
@@ -79,6 +79,7 @@ export const Footer = ({
             className="p-footer__logo u-float--right"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="-0.835 -0.92 761 101"
+            aria-label="Canonical"
           >
             <path
               fill="#772953"


### PR DESCRIPTION
## Done

- fix oversized canonical banner on small viewports
- add aria-label to canonical logo

## Screenshots
### Before
![Local documentation • Legal information](https://user-images.githubusercontent.com/7452681/155093557-84097850-a6e1-43a1-969d-8b773875fdf0.png)
![Local documentation• Legal information](https://user-images.githubusercontent.com/7452681/155093572-bf59da6f-29b2-4083-96f9-4c676231a345.png)

### After
![Local documentation • Legal information](https://user-images.githubusercontent.com/7452681/155093602-1aeac34a-5f10-401a-bed5-10261c440291.png)
![0 2022 Canonical Ltd  Ubuntu and Canonical are registered trademarks of Canonical Ltd](https://user-images.githubusercontent.com/7452681/155093605-7f0ee1f0-e4ce-45ed-9577-43d7730e25b6.png)

## QA
- login
- resize the window to verify the canonical banner in the footer is using a similar size on all screen sizes

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
