### PR TITLE
feat(ui): add hidden columns dropdown to machines table

### DIFF
--- a/integration/cypress/integration/machines/list.spec.ts
+++ b/integration/cypress/integration/machines/list.spec.ts
@@ -18,7 +18,7 @@ context("Machine listing", () => {
     );
   });
 
-  it.skip("can hide machine table columns", () => {
+  it("can hide machine table columns", () => {
     cy.findAllByRole("columnheader").should("have.length", 8);
 
     cy.findAllByRole("button", { name: "Hidden columns" }).click();

--- a/ui/src/app/machines/views/MachineList/MachineList.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.tsx
@@ -44,6 +44,19 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
+  const [hiddenColumns, setHiddenColumns] = useStorageState<string[]>(
+    localStorage,
+    "hiddenColumns",
+    []
+  );
+
+  const toggleHiddenColumn = (column: string): void => {
+    if (hiddenColumns.includes(column)) {
+      setHiddenColumns(hiddenColumns.filter((c) => c !== column));
+    } else {
+      setHiddenColumns([...hiddenColumns, column]);
+    }
+  };
 
   useEffect(() => {
     dispatch(tagActions.fetch());
@@ -70,6 +83,8 @@ const MachineList = ({
         </Notification>
       ) : null}
       <MachineListControls
+        hiddenColumns={hiddenColumns}
+        toggleHiddenColumn={toggleHiddenColumn}
         filter={searchFilter}
         grouping={grouping}
         setFilter={setSearchFilter}
@@ -77,6 +92,7 @@ const MachineList = ({
         setHiddenGroups={setHiddenGroups}
       />
       <MachineListTable
+        hiddenColumns={hiddenColumns}
         filter={searchFilter}
         grouping={grouping}
         hiddenGroups={hiddenGroups}

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Col, Row } from "@canonical/react-components";
 
 import GroupSelect from "./GroupSelect";
+import HiddenColumnsSelect from "./HiddenColumnsSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
@@ -13,8 +14,8 @@ type Props = {
   setFilter: (filter: string) => void;
   setGrouping: (group: string) => void;
   setHiddenGroups: (groups: string[]) => void;
-  hiddenColumns?: string[];
-  toggleHiddenColumn?: (column: string) => void;
+  hiddenColumns: string[];
+  toggleHiddenColumn: (column: string) => void;
 };
 
 const MachineListControls = ({
@@ -23,6 +24,8 @@ const MachineListControls = ({
   setFilter,
   setGrouping,
   setHiddenGroups,
+  hiddenColumns,
+  toggleHiddenColumn,
 }: Props): JSX.Element => {
   const [searchText, setSearchText] = useState(filter);
 
@@ -33,7 +36,7 @@ const MachineListControls = ({
 
   return (
     <Row className="machine-list-controls">
-      <Col size={3}>
+      <Col size={2}>
         <MachinesFilterAccordion
           searchText={searchText}
           setSearchText={(searchText) => {
@@ -48,11 +51,17 @@ const MachineListControls = ({
           setSearchText={setSearchText}
         />
       </Col>
-      <Col size={3}>
+      <Col size={2}>
         <GroupSelect
           grouping={grouping}
           setGrouping={setGrouping}
           setHiddenGroups={setHiddenGroups}
+        />
+      </Col>
+      <Col size={2}>
+        <HiddenColumnsSelect
+          hiddenColumns={hiddenColumns}
+          toggleHiddenColumn={toggleHiddenColumn}
         />
       </Col>
     </Row>


### PR DESCRIPTION
## Done

- enable hidden columns dropdown to machines table (implemented in https://github.com/canonical-web-and-design/maas-ui/pull/3641)
- hidden columns are persisted to local storage
 
## Screenshots
![Kapture 2022-02-22 at 11 53 06](https://user-images.githubusercontent.com/7452681/155118076-bde66c90-6c74-4d09-b519-acfcc2f1789f.gif)

## Background
It has been raised by our users that customising the machines table view by hiding certain columns would be very useful.  I decided to create a proof of concept PR as it's a very easy change and will have immediate positive impact.

> most of the time I don’t want to see how many cores, RAM, disks, storage, arch a machine has, because I know the hardware by its name, zone or pool. 
[MAAS UI prototype post](https://discourse.maas.io/t/maas-ui-the-new-maas-layout-and-react-sprint-migration/4705/5?u=petermakowski)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
