### PR TITLE
fix(ui): handle "None" workaround flag for IPMI power field

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Formik } from "formik";
+
+import IPMIPowerFields, {
+  NONE_WORKAROUND_VALUE,
+  WORKAROUNDS_FIELD_NAME,
+} from "./IPMIPowerFields";
+
+import type { PowerField } from "app/store/general/types";
+import { PowerFieldType } from "app/store/general/types";
+import { powerField as powerFieldFactory } from "testing/factories";
+
+let workaroundsField: PowerField;
+beforeEach(() => {
+  workaroundsField = powerFieldFactory({
+    field_type: PowerFieldType.MULTIPLE_CHOICE,
+    label: "Workaround flags",
+    name: WORKAROUNDS_FIELD_NAME,
+    choices: [
+      ["one", "One"],
+      [NONE_WORKAROUND_VALUE, "None"],
+    ],
+  });
+});
+
+it("does not render the 'None' choice for the workaround flags field", async () => {
+  render(
+    <Formik
+      initialValues={{
+        power_parameters: { [WORKAROUNDS_FIELD_NAME]: [] },
+      }}
+      onSubmit={jest.fn()}
+    >
+      <IPMIPowerFields fields={[workaroundsField]} />
+    </Formik>
+  );
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("checkbox", { name: "None" })
+    ).not.toBeInTheDocument();
+  });
+  expect(screen.getByRole("checkbox", { name: "One" })).toBeInTheDocument();
+});

--- a/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { Input } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import BasePowerField from "../BasePowerField";
+
+import type { AnyObject } from "app/base/types";
+import type { PowerField as PowerFieldType } from "app/store/general/types";
+import type { PowerParameters } from "app/store/types/node";
+
+type Props = {
+  disabled?: boolean;
+  fields: PowerFieldType[];
+  powerParametersValueName?: string;
+};
+
+export const WORKAROUNDS_FIELD_NAME = "workaround_flags";
+
+export const NONE_WORKAROUND_VALUE = "";
+
+export const IPMIPowerFields = <V extends AnyObject>({
+  disabled = false,
+  fields,
+  powerParametersValueName = "power_parameters",
+}: Props): JSX.Element | null => {
+  const { setFieldValue, values } = useFormikContext<V>();
+  const workaroundsFieldName = `${powerParametersValueName}.${WORKAROUNDS_FIELD_NAME}`;
+  const workaroundsFieldValue = (
+    values[powerParametersValueName] as PowerParameters
+  )[WORKAROUNDS_FIELD_NAME];
+  const isMultiChoice = Array.isArray(workaroundsFieldValue);
+
+  // Automatically set workaround flags to "None" value if all choices are
+  // unselected.
+  useEffect(() => {
+    if (isMultiChoice && workaroundsFieldValue.length === 0) {
+      setFieldValue(workaroundsFieldName, [NONE_WORKAROUND_VALUE]);
+    }
+  }, [
+    isMultiChoice,
+    setFieldValue,
+    workaroundsFieldName,
+    workaroundsFieldValue,
+  ]);
+
+  return (
+    <>
+      {fields.reduce<ReactNode[]>((content, field) => {
+        const { name, label, choices } = field;
+        const isWorkaroundField = name === WORKAROUNDS_FIELD_NAME;
+
+        if (isWorkaroundField && isMultiChoice) {
+          content.push(
+            <div key={field.name}>
+              <p>{label}</p>
+              {choices
+                // We don't explicitly include the "None" choice, but instead use
+                // it as the value only when all other choices are unselected.
+                .filter(
+                  ([checkboxValue]) => checkboxValue !== NONE_WORKAROUND_VALUE
+                )
+                .map(([checkboxValue, label]) => {
+                  const checked = workaroundsFieldValue.includes(checkboxValue);
+                  const id = `${workaroundsFieldName}.${checkboxValue}`;
+                  return (
+                    <Input
+                      checked={checked}
+                      disabled={disabled}
+                      id={id}
+                      key={id}
+                      label={label}
+                      onChange={(e) => {
+                        const { value } = e.target;
+                        const newFieldValue = (
+                          workaroundsFieldValue.includes(value)
+                            ? workaroundsFieldValue.filter(
+                                (val) => val !== checkboxValue
+                              )
+                            : [...workaroundsFieldValue, checkboxValue]
+                        ).filter((val) => val !== NONE_WORKAROUND_VALUE);
+                        setFieldValue(workaroundsFieldName, newFieldValue);
+                      }}
+                      type="checkbox"
+                      value={checkboxValue}
+                    />
+                  );
+                })}
+            </div>
+          );
+        } else {
+          content.push(
+            <BasePowerField
+              disabled={disabled}
+              field={field}
+              key={field.name}
+              powerParametersValueName={powerParametersValueName}
+            />
+          );
+        }
+        return content;
+      }, [])}
+    </>
+  );
+};
+
+export default IPMIPowerFields;

--- a/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/index.ts
+++ b/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/index.ts
@@ -1,0 +1,5 @@
+export {
+  default,
+  NONE_WORKAROUND_VALUE,
+  WORKAROUNDS_FIELD_NAME,
+} from "./IPMIPowerFields";

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -6,6 +6,7 @@ import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
 import BasePowerField from "./BasePowerField";
+import IPMIPowerFields from "./IPMIPowerFields";
 import type { LXDPowerFieldsProps } from "./LXDPowerFields";
 import LXDPowerFields from "./LXDPowerFields";
 
@@ -73,6 +74,15 @@ export const PowerTypeFields = <V extends AnyObject>({
       fieldScopes.includes(field.scope)
     );
     switch (selectedPowerType.name) {
+      case PowerTypeNames.IPMI:
+        fieldContent = (
+          <IPMIPowerFields
+            disabled={disableFields}
+            fields={fieldsInScope}
+            powerParametersValueName={powerParametersValueName}
+          />
+        );
+        break;
       case PowerTypeNames.LXD:
         fieldContent = (
           <LXDPowerFields


### PR DESCRIPTION
## Done

- Created a custom component for IPMI power fields which handles the "None" workaround flag

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and click "Add hardware > Machine"
- Select "IPMI" as the power type and check there is no "None" workaround flag
- Unselect all workaround flags and submit the form
- Check that the action that gets dispatched includes the power parameter `workaround_flags: [""]` (where an empty string is the value for "None")
- Add another IPMI machine, this time with workaround flags
- Check that the action that gets dispatched does not include the "None" value

## Fixes

Fixes #3523 
