### PR TITLE
fix(ui): fix KVM config form disabled submit button after initial submit

### DIFF
--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -1,126 +1,202 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import KVMConfigurationCard from "./KVMConfigurationCard";
 
+import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
 import {
   podDetails as podFactory,
   podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
 
 const mockStore = configureStore();
+let state: RootState;
 
-describe("KVMConfigurationCard", () => {
-  let state: RootState;
+beforeEach(() => {
+  state = rootStateFactory({
+    pod: podStateFactory({
+      items: [podFactory({ id: 1, name: "pod1" })],
+      loaded: true,
+    }),
+    resourcepool: resourcePoolStateFactory({
+      items: [resourcePoolFactory({ id: 2 })],
+      loaded: true,
+    }),
+    zone: zoneStateFactory({
+      items: [zoneFactory({ id: 3 })],
+      loaded: true,
+    }),
+  });
+});
 
-  beforeEach(() => {
-    state = rootStateFactory({
-      pod: podStateFactory({
-        items: [podFactory({ id: 1, name: "pod1" })],
-        loaded: true,
-      }),
+it("can handle updating a lxd KVM", async () => {
+  const pod = podFactory({
+    id: 1,
+    tags: ["tag1", "tag2"],
+    type: PodType.LXD,
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+      >
+        <KVMConfigurationCard pod={pod} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("combobox", { name: "Zone" }), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "Resource pool" }), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByRole("slider", { name: "CPU overcommit" }), {
+      target: { value: "5" },
+    });
+    fireEvent.change(
+      screen.getByRole("slider", { name: "Memory overcommit" }),
+      { target: { value: "7" } }
+    );
+  });
+  await waitFor(() => {
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  });
+
+  const expectedAction = podActions.update({
+    cpu_over_commit_ratio: 5,
+    id: pod.id,
+    memory_over_commit_ratio: 7,
+    pool: 2,
+    power_address: pod.power_parameters.power_address,
+    tags: "tag1,tag2",
+    type: PodType.LXD,
+    zone: 3,
+  });
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});
+
+it("can handle updating a virsh KVM", async () => {
+  const pod = podFactory({
+    id: 1,
+    tags: ["tag1", "tag2"],
+    type: PodType.VIRSH,
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+      >
+        <KVMConfigurationCard pod={pod} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("combobox", { name: "Zone" }), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "Resource pool" }), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("Password (optional)"), {
+      target: { value: "password" },
+    });
+    fireEvent.change(screen.getByRole("slider", { name: "CPU overcommit" }), {
+      target: { value: "5" },
+    });
+    fireEvent.change(
+      screen.getByRole("slider", { name: "Memory overcommit" }),
+      { target: { value: "7" } }
+    );
+  });
+  await waitFor(() => {
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  });
+
+  const expectedAction = podActions.update({
+    cpu_over_commit_ratio: 5,
+    id: pod.id,
+    memory_over_commit_ratio: 7,
+    pool: 2,
+    power_address: pod.power_parameters.power_address,
+    power_pass: "password",
+    tags: "tag1,tag2",
+    type: PodType.VIRSH,
+    zone: 3,
+  });
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});
+
+it("enables the submit button if form is unchanged after pod successfully updated", async () => {
+  const pod = podFactory({
+    cpu_over_commit_ratio: 1,
+    id: 1,
+    type: PodType.LXD,
+  });
+  const store = mockStore(state);
+  const { rerender } = render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+      >
+        <KVMConfigurationCard pod={pod} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  // Submit should be disabled by default.
+  expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+
+  // Change value to something other than the initial.
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("slider", { name: "CPU overcommit" }), {
+      target: { value: (pod.cpu_over_commit_ratio + 1).toString() },
     });
   });
 
-  it("can handle updating a lxd KVM", () => {
-    const pod = podFactory({ id: 1, type: PodType.LXD });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
-        >
-          <KVMConfigurationCard pod={pod} />
-        </MemoryRouter>
-      </Provider>
-    );
+  // Submit should be enabled.
+  expect(
+    screen.getByRole("button", { name: "Save changes" })
+  ).not.toBeDisabled();
 
-    act(() =>
-      submitFormikForm(wrapper, {
-        cpu_over_commit_ratio: 2,
-        memory_over_commit_ratio: 2,
-        pool: "1",
-        power_address: "192.168.1.1",
-        tags: ["tag1", "tag2"],
-        type: PodType.LXD,
-        zone: "2",
-      })
-    );
-    expect(
-      store.getActions().find((action) => action.type === "pod/update")
-    ).toStrictEqual({
-      type: "pod/update",
-      meta: {
-        method: "update",
-        model: "pod",
-      },
-      payload: {
-        params: {
-          cpu_over_commit_ratio: 2,
-          id: 1,
-          memory_over_commit_ratio: 2,
-          pool: 1,
-          power_address: "192.168.1.1",
-          power_pass: undefined,
-          tags: "tag1,tag2",
-          zone: 2,
-        },
-      },
+  // Trigger success handler by changing pod saved value to true.
+  const newStore = mockStore({ ...state, pod: { ...state.pod, saved: true } });
+  rerender(
+    <Provider store={newStore}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+      >
+        <KVMConfigurationCard pod={pod} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  // Change back to initial value.
+  await waitFor(() => {
+    fireEvent.change(screen.getByRole("slider", { name: "CPU overcommit" }), {
+      target: { value: pod.cpu_over_commit_ratio.toString() },
     });
   });
 
-  it("can handle updating a virsh KVM", () => {
-    const pod = podFactory({ id: 1, type: PodType.VIRSH });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
-        >
-          <KVMConfigurationCard pod={pod} />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    act(() =>
-      submitFormikForm(wrapper, {
-        cpu_over_commit_ratio: 2,
-        memory_over_commit_ratio: 2,
-        pool: "1",
-        power_address: "192.168.1.1",
-        power_pass: "password",
-        tags: ["tag1", "tag2"],
-        type: PodType.VIRSH,
-        zone: "2",
-      })
-    );
-    expect(
-      store.getActions().find((action) => action.type === "pod/update")
-    ).toStrictEqual({
-      type: "pod/update",
-      meta: {
-        method: "update",
-        model: "pod",
-      },
-      payload: {
-        params: {
-          cpu_over_commit_ratio: 2,
-          id: 1,
-          memory_over_commit_ratio: 2,
-          pool: 1,
-          power_address: "192.168.1.1",
-          power_pass: "password", // virsh uses power_pass key
-          tags: "tag1,tag2",
-          zone: 2,
-        },
-      },
-    });
-  });
+  // Submit should still be enabled.
+  expect(
+    screen.getByRole("button", { name: "Save changes" })
+  ).not.toBeDisabled();
 });

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -10,7 +10,12 @@ import FormikForm from "app/base/components/FormikForm";
 import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/constants";
 import podSelectors from "app/store/pod/selectors";
-import type { Pod, PodDetails, PodPowerParameters } from "app/store/pod/types";
+import type {
+  Pod,
+  PodDetails,
+  PodPowerParameters,
+  UpdateParams,
+} from "app/store/pod/types";
 
 const KVMConfigurationSchema = Yup.object().shape({
   cpu_over_commit_ratio: Yup.number().required("CPU overcommit ratio required"),
@@ -42,6 +47,7 @@ type Props = {
 };
 
 const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
+  const [hasUpdated, setHasUpdated] = useState(false);
   const dispatch = useDispatch();
   const podErrors = useSelector(podSelectors.errors);
   const podSaved = useSelector(podSelectors.saved);
@@ -51,6 +57,7 @@ const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
   return (
     <FormCard highlighted={false} sidebar={false} title="KVM configuration">
       <FormikForm<KVMConfigurationValues>
+        allowUnchanged={hasUpdated}
         cleanup={cleanup}
         errors={podErrors}
         initialValues={{
@@ -69,19 +76,22 @@ const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
           label: "KVM configuration form",
         }}
         onSubmit={(values) => {
-          const params = {
+          const params: UpdateParams = {
             cpu_over_commit_ratio: values.cpu_over_commit_ratio,
             id: pod.id,
             memory_over_commit_ratio: values.memory_over_commit_ratio,
             pool: Number(values.pool),
             power_address: values.power_address,
-            power_pass:
-              (values.type === PodType.VIRSH && values.power_pass) || undefined,
             tags: values.tags.join(","), // API expects comma-separated string
+            type: values.type,
             zone: Number(values.zone),
           };
+          if (values.type === PodType.VIRSH) {
+            params.power_pass = values.power_pass;
+          }
           dispatch(podActions.update(params));
         }}
+        onSuccess={() => setHasUpdated(true)}
         saving={podSaving}
         saved={podSaved}
         submitLabel="Save changes"

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -47,7 +47,6 @@ type Props = {
 };
 
 const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
-  const [hasUpdated, setHasUpdated] = useState(false);
   const dispatch = useDispatch();
   const podErrors = useSelector(podSelectors.errors);
   const podSaved = useSelector(podSelectors.saved);
@@ -57,8 +56,8 @@ const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
   return (
     <FormCard highlighted={false} sidebar={false} title="KVM configuration">
       <FormikForm<KVMConfigurationValues>
-        allowUnchanged={hasUpdated}
         cleanup={cleanup}
+        enableReinitialize
         errors={podErrors}
         initialValues={{
           cpu_over_commit_ratio: pod.cpu_over_commit_ratio,
@@ -91,7 +90,6 @@ const KVMConfigurationCard = ({ pod, zoneDisabled }: Props): JSX.Element => {
           }
           dispatch(podActions.update(params));
         }}
-        onSuccess={() => setHasUpdated(true)}
         saving={podSaving}
         saved={podSaved}
         submitLabel="Save changes"

--- a/ui/src/app/store/pod/types/actions.ts
+++ b/ui/src/app/store/pod/types/actions.ts
@@ -31,6 +31,7 @@ export type CreateParams = {
   password?: string;
   pool?: Pod["pool"];
   power_address?: PodPowerParameters["power_address"];
+  power_pass?: PodPowerParameters["power_pass"];
   project?: PodPowerParameters["project"];
   tags?: string;
   type?: Pod["type"];


### PR DESCRIPTION
## Done

- Allow changing KVM values to initial after first submit
- Rewrite KVM config tests to use RTL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the config page of a KVM and check that the submit button is disabled
- Change a value (like CPU overcommit) and check that the submit button becomes enabled
- Submit the form
- After success, change the value back to the initial value and check that the submit button is still enabled

## Fixes

Fixes #2673 

