### PR TITLE
test: fix nanoid mock to return unique ids

### DIFF
--- a/ui/src/__mocks__/nanoid.ts
+++ b/ui/src/__mocks__/nanoid.ts
@@ -1,1 +1,10 @@
-export const nanoid = (): string => "Uakgb_J5m9g-0JDMbcJqLJ";
+let id = 0;
+
+beforeEach(() => {
+  id = 0;
+});
+
+export const nanoid = (): string => {
+  id++;
+  return `mock-nanoid-${id}`;
+};

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`OwnerColumn renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-controls="mock-nanoid-1"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-pressed="false"
@@ -107,7 +107,7 @@ exports[`OwnerColumn renders 1`] = `
                   type="button"
                 >
                   <button
-                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-controls="mock-nanoid-1"
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-pressed="false"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`PoolColumn renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-controls="mock-nanoid-1"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-pressed="false"
@@ -133,7 +133,7 @@ exports[`PoolColumn renders 1`] = `
                   type="button"
                 >
                   <button
-                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-controls="mock-nanoid-1"
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-pressed="false"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`PowerColumn renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-controls="mock-nanoid-1"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-pressed="false"
@@ -161,7 +161,7 @@ exports[`PowerColumn renders 1`] = `
                   type="button"
                 >
                   <button
-                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-controls="mock-nanoid-1"
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-pressed="false"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
   aria-hidden="false"
   aria-label="submenu"
   className="p-contextual-menu__dropdown"
-  id="Uakgb_J5m9g-0JDMbcJqLJ"
+  id="mock-nanoid-1"
   style={null}
 >
   <div
@@ -374,7 +374,7 @@ exports[`StatusColumn renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-controls="mock-nanoid-1"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-pressed="false"
@@ -385,7 +385,7 @@ exports[`StatusColumn renders 1`] = `
                   type="button"
                 >
                   <button
-                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-controls="mock-nanoid-1"
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-pressed="false"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`ZoneColumn renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-controls="mock-nanoid-1"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-pressed="false"
@@ -129,7 +129,7 @@ exports[`ZoneColumn renders 1`] = `
                   type="button"
                 >
                   <button
-                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-controls="mock-nanoid-1"
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-pressed="false"


### PR DESCRIPTION
## Done

- fix nanoid mock to return unique ids (`nanoid` is used by react-components)
  - use `mock-nanoid-N` convention to make it easier to identify in snapshots / debug

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
