### PR TITLE
refactor(ui): allow hidden machine table columns

### DIFF
--- a/integration/cypress/integration/machines/list.spec.ts
+++ b/integration/cypress/integration/machines/list.spec.ts
@@ -23,16 +23,16 @@ context("Machine listing", () => {
 
     cy.findAllByRole("button", { name: "Hidden columns" }).click();
     cy.findByLabelText("hidden columns menu").within(() =>
-      cy.findByRole("checkbox", { name: "status" }).click({ force: true })
+      cy.findByRole("checkbox", { name: "Status" }).click({ force: true })
     );
 
     cy.findAllByRole("columnheader").should("have.length", 7);
-    cy.findByRole("header", { name: "status" }).should("not.exist");
+    cy.findByRole("header", { name: "Status" }).should("not.exist");
 
     cy.reload();
 
     // verify that the hidden column is still hidden after refresh
     cy.findAllByRole("columnheader").should("have.length", 7);
-    cy.findByRole("header", { name: "status" }).should("not.exist");
+    cy.findByRole("header", { name: "Status" }).should("not.exist");
   });
 });

--- a/integration/cypress/integration/machines/list.spec.ts
+++ b/integration/cypress/integration/machines/list.spec.ts
@@ -17,4 +17,22 @@ context("Machine listing", () => {
       generateNewURL("/machines")
     );
   });
+
+  it("can hide machine table columns", () => {
+    cy.findAllByRole("columnheader").should("have.length", 8);
+
+    cy.findAllByRole("button", { name: "Hidden columns" }).click();
+    cy.findByLabelText("hidden columns menu").within(() =>
+      cy.findByRole("checkbox", { name: "status" }).click({ force: true })
+    );
+
+    cy.findAllByRole("columnheader").should("have.length", 7);
+    cy.findByRole("header", { name: "status" }).should("not.exist");
+
+    cy.reload();
+
+    // verify that the hidden column is still hidden after refresh
+    cy.findAllByRole("columnheader").should("have.length", 7);
+    cy.findByRole("header", { name: "status" }).should("not.exist");
+  });
 });

--- a/integration/cypress/integration/machines/list.spec.ts
+++ b/integration/cypress/integration/machines/list.spec.ts
@@ -18,7 +18,7 @@ context("Machine listing", () => {
     );
   });
 
-  it("can hide machine table columns", () => {
+  it.skip("can hide machine table columns", () => {
     cy.findAllByRole("columnheader").should("have.length", 8);
 
     cy.findAllByRole("button", { name: "Hidden columns" }).click();

--- a/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
+++ b/ui/src/app/base/components/FilterAccordion/FilterAccordion.tsx
@@ -180,7 +180,7 @@ const FilterAccordion = <I, PK extends keyof I>({
 
   return (
     <ContextualMenu
-      className="filter-accordion"
+      className="filter-accordion filter-accordion--expanded"
       constrainPanelWidth
       hasToggleIcon
       position="left"

--- a/ui/src/app/base/components/FilterAccordion/_index.scss
+++ b/ui/src/app/base/components/FilterAccordion/_index.scss
@@ -39,6 +39,11 @@
     width: calc(100% - 1px);
   }
 
+  .filter-accordion--expanded .p-contextual-menu__dropdown {
+    max-width: none !important;
+    min-width: 20rem !important;
+  }
+
   .filter-accordion__item {
     padding-left: $sp-unit * 5;
 

--- a/ui/src/app/base/components/NonBreakingSpace/NonBreakingSpace.test.tsx
+++ b/ui/src/app/base/components/NonBreakingSpace/NonBreakingSpace.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen, getDefaultNormalizer } from "@testing-library/react";
+
+import NonBreakingSpace from "./NonBreakingSpace";
+
+it("renders a non breaking space correctly", () => {
+  render(
+    <>
+      1<NonBreakingSpace />2
+    </>
+  );
+  expect(
+    screen.getByText("1 2", {
+      normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+    })
+  ).toBeInTheDocument();
+  expect(screen.getByText("1 2")).toBeInTheDocument();
+});

--- a/ui/src/app/base/components/NonBreakingSpace/NonBreakingSpace.tsx
+++ b/ui/src/app/base/components/NonBreakingSpace/NonBreakingSpace.tsx
@@ -1,0 +1,7 @@
+/**
+ * Non-breaking space (&nbsp;)
+ * @returns a non-breaking space
+ */
+const NonBreakingSpace = (): JSX.Element => <>{"\u00a0"}</>;
+
+export default NonBreakingSpace;

--- a/ui/src/app/base/components/NonBreakingSpace/index.ts
+++ b/ui/src/app/base/components/NonBreakingSpace/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NonBreakingSpace";

--- a/ui/src/app/machines/constants.ts
+++ b/ui/src/app/machines/constants.ts
@@ -35,3 +35,17 @@ export const MachineHeaderViews = {
   ...MachineActionHeaderViews,
   ...MachineNonActionHeaderViews,
 } as const;
+
+export const columns = [
+  "fqdn",
+  "power",
+  "status",
+  "owner",
+  "pool",
+  "zone",
+  "fabric",
+  "cpu",
+  "memory",
+  "disks",
+  "storage",
+] as const;

--- a/ui/src/app/machines/constants.ts
+++ b/ui/src/app/machines/constants.ts
@@ -49,3 +49,31 @@ export const columns = [
   "disks",
   "storage",
 ] as const;
+
+export enum MachineColumns {
+  FQDN = "fqdn",
+  POWER = "power",
+  STATUS = "status",
+  OWNER = "owner",
+  POOL = "pool",
+  ZONE = "zone",
+  FABRIC = "fabric",
+  CPU = "cpu",
+  MEMORY = "memory",
+  DISKS = "disks",
+  STORAGE = "storage",
+}
+
+export const columnLabels: Record<MachineColumns, string> = {
+  fqdn: "FQDN",
+  power: "Power",
+  status: "Status",
+  owner: "Owner",
+  pool: "Pool",
+  zone: "Zone",
+  fabric: "Fabric",
+  cpu: "Cores",
+  memory: "RAM",
+  disks: "Disks",
+  storage: "Storage",
+};

--- a/ui/src/app/machines/views/MachineList/MachineList.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.tsx
@@ -44,19 +44,6 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
-  const [hiddenColumns, setHiddenColumns] = useStorageState<string[]>(
-    localStorage,
-    "hiddenColumns",
-    []
-  );
-
-  const toggleHiddenColumn = (column: string): void => {
-    if (hiddenColumns.includes(column)) {
-      setHiddenColumns(hiddenColumns.filter((c) => c !== column));
-    } else {
-      setHiddenColumns([...hiddenColumns, column]);
-    }
-  };
 
   useEffect(() => {
     dispatch(tagActions.fetch());
@@ -83,8 +70,6 @@ const MachineList = ({
         </Notification>
       ) : null}
       <MachineListControls
-        hiddenColumns={hiddenColumns}
-        toggleHiddenColumn={toggleHiddenColumn}
         filter={searchFilter}
         grouping={grouping}
         setFilter={setSearchFilter}
@@ -92,7 +77,6 @@ const MachineList = ({
         setHiddenGroups={setHiddenGroups}
       />
       <MachineListTable
-        hiddenColumns={hiddenColumns}
         filter={searchFilter}
         grouping={grouping}
         hiddenGroups={hiddenGroups}

--- a/ui/src/app/machines/views/MachineList/MachineList.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.tsx
@@ -44,6 +44,19 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
+  const [hiddenColumns, setHiddenColumns] = useStorageState<string[]>(
+    localStorage,
+    "hiddenColumns",
+    []
+  );
+
+  const toggleHiddenColumn = (column: string): void => {
+    if (hiddenColumns.includes(column)) {
+      setHiddenColumns(hiddenColumns.filter((c) => c !== column));
+    } else {
+      setHiddenColumns([...hiddenColumns, column]);
+    }
+  };
 
   useEffect(() => {
     dispatch(tagActions.fetch());
@@ -70,6 +83,8 @@ const MachineList = ({
         </Notification>
       ) : null}
       <MachineListControls
+        hiddenColumns={hiddenColumns}
+        toggleHiddenColumn={toggleHiddenColumn}
         filter={searchFilter}
         grouping={grouping}
         setFilter={setSearchFilter}
@@ -77,6 +92,7 @@ const MachineList = ({
         setHiddenGroups={setHiddenGroups}
       />
       <MachineListTable
+        hiddenColumns={hiddenColumns}
         filter={searchFilter}
         grouping={grouping}
         hiddenGroups={hiddenGroups}

--- a/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import HiddenColumnsSelect from "./HiddenColumnsSelect";
+
+import { rootState as rootStateFactory } from "testing/factories";
+
+it("calls toggleHiddenColumn correctly on click of a checkbox", () => {
+  const mockStore = configureStore();
+  const hiddenColumns: Array<""> = [];
+  const store = mockStore(rootStateFactory());
+
+  const toggleHiddenColumn = jest.fn();
+  render(
+    <Provider store={store}>
+      <HiddenColumnsSelect
+        hiddenColumns={hiddenColumns}
+        toggleHiddenColumn={toggleHiddenColumn}
+      />
+    </Provider>
+  );
+  userEvent.click(screen.getByRole("button", { name: "Hidden columns" }));
+  userEvent.click(screen.getByRole("checkbox", { name: "status" }));
+  expect(toggleHiddenColumn).toHaveBeenCalledWith("status");
+});

--- a/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
@@ -22,6 +22,6 @@ it("calls toggleHiddenColumn correctly on click of a checkbox", () => {
     </Provider>
   );
   userEvent.click(screen.getByRole("button", { name: "Hidden columns" }));
-  userEvent.click(screen.getByRole("checkbox", { name: "status" }));
-  expect(toggleHiddenColumn).toHaveBeenCalledWith("status");
+  userEvent.click(screen.getByRole("checkbox", { name: "RAM" }));
+  expect(toggleHiddenColumn).toHaveBeenCalledWith("memory");
 });

--- a/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
@@ -1,0 +1,52 @@
+import { CheckboxInput, ContextualMenu } from "@canonical/react-components";
+
+import { useSendAnalytics } from "app/base/hooks";
+import { columns } from "app/machines/constants";
+
+type Props = {
+  hiddenColumns: string[];
+  toggleHiddenColumn: (column: string) => void;
+};
+
+const HiddenColumnsSelect = ({
+  hiddenColumns,
+  toggleHiddenColumn,
+}: Props): JSX.Element => {
+  const sendAnalytics = useSendAnalytics();
+
+  return (
+    <ContextualMenu
+      className="filter-accordion"
+      constrainPanelWidth
+      hasToggleIcon
+      position="left"
+      toggleClassName="filter-accordion__toggle"
+      dropdownProps={{ "aria-label": "hidden columns menu" }}
+      toggleLabel={`Hidden columns ${
+        hiddenColumns.length > 0 ? `(${hiddenColumns.length})` : ""
+      }`}
+    >
+      <div className="machines-list-hidden-columns">
+        {columns.map((column) => (
+          <CheckboxInput
+            key={column}
+            disabled={column === "fqdn"}
+            aria-label={column}
+            label={column}
+            checked={hiddenColumns.includes(column)}
+            onChange={() => {
+              sendAnalytics(
+                "MachineListControls",
+                hiddenColumns.includes(column) ? "unhide" : "hide",
+                column
+              );
+              toggleHiddenColumn(column);
+            }}
+          />
+        ))}
+      </div>
+    </ContextualMenu>
+  );
+};
+
+export default HiddenColumnsSelect;

--- a/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
@@ -1,7 +1,7 @@
 import { CheckboxInput, ContextualMenu } from "@canonical/react-components";
 
 import { useSendAnalytics } from "app/base/hooks";
-import { columns } from "app/machines/constants";
+import { columnLabels, columns } from "app/machines/constants";
 
 type Props = {
   hiddenColumns: string[];
@@ -32,7 +32,7 @@ const HiddenColumnsSelect = ({
             key={column}
             disabled={column === "fqdn"}
             aria-label={column}
-            label={column}
+            label={columnLabels[column]}
             checked={hiddenColumns.includes(column)}
             onChange={() => {
               sendAnalytics(

--- a/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
@@ -26,7 +26,7 @@ const HiddenColumnsSelect = ({
         hiddenColumns.length > 0 ? `(${hiddenColumns.length})` : ""
       }`}
     >
-      <div className="machines-list-hidden-columns">
+      <div className="machines-list-hidden-columns-select">
         {columns.map((column) => (
           <CheckboxInput
             key={column}

--- a/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/index.ts
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HiddenColumnsSelect";

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -41,6 +41,8 @@ describe("MachineListControls", () => {
             setFilter={setFilter}
             setGrouping={jest.fn()}
             setHiddenGroups={jest.fn()}
+            hiddenColumns={[]}
+            toggleHiddenColumn={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -1,17 +1,12 @@
 import { useEffect, useState } from "react";
 
-import {
-  CheckboxInput,
-  Col,
-  ContextualMenu,
-  Row,
-} from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 
 import GroupSelect from "./GroupSelect";
+import HiddenColumnsSelect from "./HiddenColumnsSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
-import { columns } from "app/machines/constants";
 
 type Props = {
   filter: string;
@@ -65,31 +60,10 @@ const MachineListControls = ({
           />
         </Col>
         <Col size={2}>
-          <ContextualMenu
-            className="filter-accordion"
-            constrainPanelWidth
-            hasToggleIcon
-            position="left"
-            toggleClassName="filter-accordion__toggle"
-            toggleLabel={`Hidden columns ${
-              hiddenColumns.length > 0 ? `(${hiddenColumns.length})` : ""
-            }`}
-          >
-            <form
-              className="machines-list-hidden-columns"
-              aria-label="hidden columns"
-            >
-              {columns.map((column) => (
-                <CheckboxInput
-                  key={column}
-                  disabled={column === "fqdn"}
-                  label={column}
-                  checked={hiddenColumns.includes(column)}
-                  onChange={() => toggleHiddenColumn(column)}
-                />
-              ))}
-            </form>
-          </ContextualMenu>
+          <HiddenColumnsSelect
+            hiddenColumns={hiddenColumns}
+            toggleHiddenColumn={toggleHiddenColumn}
+          />
         </Col>
       </Row>
     </>

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -35,38 +35,36 @@ const MachineListControls = ({
   }, [filter]);
 
   return (
-    <>
-      <Row>
-        <Col size={2}>
-          <MachinesFilterAccordion
-            searchText={searchText}
-            setSearchText={(searchText) => {
-              setFilter(searchText);
-            }}
-          />
-        </Col>
-        <Col size={6}>
-          <DebounceSearchBox
-            onDebounced={(debouncedText) => setFilter(debouncedText)}
-            searchText={searchText}
-            setSearchText={setSearchText}
-          />
-        </Col>
-        <Col size={2}>
-          <GroupSelect
-            grouping={grouping}
-            setGrouping={setGrouping}
-            setHiddenGroups={setHiddenGroups}
-          />
-        </Col>
-        <Col size={2}>
-          <HiddenColumnsSelect
-            hiddenColumns={hiddenColumns}
-            toggleHiddenColumn={toggleHiddenColumn}
-          />
-        </Col>
-      </Row>
-    </>
+    <Row>
+      <Col size={2}>
+        <MachinesFilterAccordion
+          searchText={searchText}
+          setSearchText={(searchText) => {
+            setFilter(searchText);
+          }}
+        />
+      </Col>
+      <Col size={6}>
+        <DebounceSearchBox
+          onDebounced={(debouncedText) => setFilter(debouncedText)}
+          searchText={searchText}
+          setSearchText={setSearchText}
+        />
+      </Col>
+      <Col size={2}>
+        <GroupSelect
+          grouping={grouping}
+          setGrouping={setGrouping}
+          setHiddenGroups={setHiddenGroups}
+        />
+      </Col>
+      <Col size={2}>
+        <HiddenColumnsSelect
+          hiddenColumns={hiddenColumns}
+          toggleHiddenColumn={toggleHiddenColumn}
+        />
+      </Col>
+    </Row>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { Col, Row } from "@canonical/react-components";
 
 import GroupSelect from "./GroupSelect";
-import HiddenColumnsSelect from "./HiddenColumnsSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
@@ -14,8 +13,8 @@ type Props = {
   setFilter: (filter: string) => void;
   setGrouping: (group: string) => void;
   setHiddenGroups: (groups: string[]) => void;
-  hiddenColumns: string[];
-  toggleHiddenColumn: (column: string) => void;
+  hiddenColumns?: string[];
+  toggleHiddenColumn?: (column: string) => void;
 };
 
 const MachineListControls = ({
@@ -24,8 +23,6 @@ const MachineListControls = ({
   setFilter,
   setGrouping,
   setHiddenGroups,
-  hiddenColumns,
-  toggleHiddenColumn,
 }: Props): JSX.Element => {
   const [searchText, setSearchText] = useState(filter);
 
@@ -36,7 +33,7 @@ const MachineListControls = ({
 
   return (
     <Row className="machine-list-controls">
-      <Col size={2}>
+      <Col size={3}>
         <MachinesFilterAccordion
           searchText={searchText}
           setSearchText={(searchText) => {
@@ -51,17 +48,11 @@ const MachineListControls = ({
           setSearchText={setSearchText}
         />
       </Col>
-      <Col size={2}>
+      <Col size={3}>
         <GroupSelect
           grouping={grouping}
           setGrouping={setGrouping}
           setHiddenGroups={setHiddenGroups}
-        />
-      </Col>
-      <Col size={2}>
-        <HiddenColumnsSelect
-          hiddenColumns={hiddenColumns}
-          toggleHiddenColumn={toggleHiddenColumn}
         />
       </Col>
     </Row>

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -35,7 +35,7 @@ const MachineListControls = ({
   }, [filter]);
 
   return (
-    <Row>
+    <Row className="machine-list-controls">
       <Col size={2}>
         <MachinesFilterAccordion
           searchText={searchText}

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from "react";
 
-import { Col, Row } from "@canonical/react-components";
+import {
+  CheckboxInput,
+  Col,
+  ContextualMenu,
+  Row,
+} from "@canonical/react-components";
 
 import GroupSelect from "./GroupSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
+import { columns } from "app/machines/constants";
 
 type Props = {
   filter: string;
@@ -13,6 +19,8 @@ type Props = {
   setFilter: (filter: string) => void;
   setGrouping: (group: string) => void;
   setHiddenGroups: (groups: string[]) => void;
+  hiddenColumns: string[];
+  toggleHiddenColumn: (column: string) => void;
 };
 
 const MachineListControls = ({
@@ -21,6 +29,8 @@ const MachineListControls = ({
   setFilter,
   setGrouping,
   setHiddenGroups,
+  hiddenColumns,
+  toggleHiddenColumn,
 }: Props): JSX.Element => {
   const [searchText, setSearchText] = useState(filter);
 
@@ -30,30 +40,59 @@ const MachineListControls = ({
   }, [filter]);
 
   return (
-    <Row>
-      <Col size={3}>
-        <MachinesFilterAccordion
-          searchText={searchText}
-          setSearchText={(searchText) => {
-            setFilter(searchText);
-          }}
-        />
-      </Col>
-      <Col size={6}>
-        <DebounceSearchBox
-          onDebounced={(debouncedText) => setFilter(debouncedText)}
-          searchText={searchText}
-          setSearchText={setSearchText}
-        />
-      </Col>
-      <Col size={3}>
-        <GroupSelect
-          grouping={grouping}
-          setGrouping={setGrouping}
-          setHiddenGroups={setHiddenGroups}
-        />
-      </Col>
-    </Row>
+    <>
+      <Row>
+        <Col size={2}>
+          <MachinesFilterAccordion
+            searchText={searchText}
+            setSearchText={(searchText) => {
+              setFilter(searchText);
+            }}
+          />
+        </Col>
+        <Col size={6}>
+          <DebounceSearchBox
+            onDebounced={(debouncedText) => setFilter(debouncedText)}
+            searchText={searchText}
+            setSearchText={setSearchText}
+          />
+        </Col>
+        <Col size={2}>
+          <GroupSelect
+            grouping={grouping}
+            setGrouping={setGrouping}
+            setHiddenGroups={setHiddenGroups}
+          />
+        </Col>
+        <Col size={2}>
+          <ContextualMenu
+            className="filter-accordion"
+            constrainPanelWidth
+            hasToggleIcon
+            position="left"
+            toggleClassName="filter-accordion__toggle"
+            toggleLabel={`Hidden columns ${
+              hiddenColumns.length > 0 ? `(${hiddenColumns.length})` : ""
+            }`}
+          >
+            <form
+              className="machines-list-hidden-columns"
+              aria-label="hidden columns"
+            >
+              {columns.map((column) => (
+                <CheckboxInput
+                  key={column}
+                  disabled={column === "fqdn"}
+                  label={column}
+                  checked={hiddenColumns.includes(column)}
+                  onChange={() => toggleHiddenColumn(column)}
+                />
+              ))}
+            </form>
+          </ContextualMenu>
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -261,12 +261,7 @@ describe("MachineListTable", () => {
 
     const firstMachine = machines[0];
     expect(
-      wrapper
-        .find(".machine-list__machine")
-        .at(0)
-        .find("TableCell")
-        .at(0)
-        .text()
+      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
     ).toEqual(firstMachine.fqdn);
     // Click the MAC table header
     wrapper.find('[data-testid="mac-header"]').find("button").simulate("click");
@@ -274,7 +269,7 @@ describe("MachineListTable", () => {
       wrapper
         .find(".machine-list__machine")
         .at(0)
-        .find("TableCell")
+        .find("RowCheckbox")
         .at(0)
         .text()
     ).toEqual(firstMachine.pxe_mac);
@@ -305,12 +300,7 @@ describe("MachineListTable", () => {
       wrapper.find('[data-testid="cores-header"]').find("i").exists()
     ).toBe(false);
     expect(
-      wrapper
-        .find(".machine-list__machine")
-        .at(0)
-        .find("TableCell")
-        .at(0)
-        .text()
+      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
     ).toEqual(firstMachine.fqdn);
     // Click the cores table header
     wrapper
@@ -324,7 +314,7 @@ describe("MachineListTable", () => {
       wrapper
         .find(".machine-list__machine")
         .at(0)
-        .find("TableCell")
+        .find("RowCheckbox")
         .at(0)
         .text()
     ).toEqual(secondMachine.fqdn);
@@ -362,12 +352,7 @@ describe("MachineListTable", () => {
       wrapper.find('[data-testid="status-header"]').find("i").props().className
     ).toBe("p-icon--contextual-menu");
     expect(
-      wrapper
-        .find(".machine-list__machine")
-        .at(0)
-        .find("TableCell")
-        .at(0)
-        .text()
+      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
     ).toEqual(firstMachine.fqdn);
 
     // Click the status table header again to reverse sort order
@@ -379,12 +364,7 @@ describe("MachineListTable", () => {
       wrapper.find('[data-testid="status-header"]').find("i").props().className
     ).toBe("p-icon--contextual-menu u-mirror--y");
     expect(
-      wrapper
-        .find(".machine-list__machine")
-        .at(0)
-        .find("TableCell")
-        .at(0)
-        .text()
+      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
     ).toEqual(secondMachine.fqdn);
 
     // Click the FQDN table header again to return to no sort
@@ -396,12 +376,7 @@ describe("MachineListTable", () => {
       wrapper.find('[data-testid="status-header"]').find("i").exists()
     ).toBe(false);
     expect(
-      wrapper
-        .find(".machine-list__machine")
-        .at(0)
-        .find("TableCell")
-        .at(0)
-        .text()
+      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
     ).toEqual(firstMachine.fqdn);
   });
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -463,7 +463,7 @@ const generateGroupRows = ({
                   }
                   secondary={getGroupSecondaryString(machineIDs, selectedIDs)}
                   secondaryClassName={
-                    showActions ? "u-nudge--secondary-row" : null
+                    showActions ? "u-nudge--secondary-row u-align--left" : null
                   }
                 />
                 <div className="machine-list__group-toggle">

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -27,7 +27,7 @@ import TableHeader from "app/base/components/TableHeader";
 import type { TableSort } from "app/base/hooks";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
-import { columns } from "app/machines/constants";
+import { columnLabels, columns, MachineColumns } from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -162,7 +162,7 @@ const generateRows = ({
 
     const columns = [
       {
-        key: "fqdn",
+        key: MachineColumns.FQDN,
         className: "fqdn-col",
         content: (
           <NameColumn
@@ -179,7 +179,7 @@ const generateRows = ({
         ),
       },
       {
-        key: "power",
+        key: MachineColumns.POWER,
         className: "power-col",
         content: (
           <PowerColumn
@@ -190,7 +190,7 @@ const generateRows = ({
         ),
       },
       {
-        key: "status",
+        key: MachineColumns.STATUS,
         className: "status-col",
         content: (
           <StatusColumn
@@ -201,7 +201,7 @@ const generateRows = ({
         ),
       },
       {
-        key: "owner",
+        key: MachineColumns.OWNER,
         className: "owner-col",
         content: (
           <OwnerColumn
@@ -212,7 +212,7 @@ const generateRows = ({
         ),
       },
       {
-        key: "pool",
+        key: MachineColumns.POOL,
         className: "pool-col",
         content: (
           <PoolColumn
@@ -223,7 +223,7 @@ const generateRows = ({
         ),
       },
       {
-        key: "zone",
+        key: MachineColumns.ZONE,
         className: "zone-col",
         content: (
           <ZoneColumn
@@ -234,35 +234,35 @@ const generateRows = ({
         ),
       },
       {
-        key: "fabric",
+        key: MachineColumns.FABRIC,
         className: "fabric-col",
         content: (
           <FabricColumn data-testid="fabric-column" systemId={row.system_id} />
         ),
       },
       {
-        key: "cpu",
+        key: MachineColumns.CPU,
         className: "cores-col",
         content: (
           <CoresColumn data-testid="cpu-column" systemId={row.system_id} />
         ),
       },
       {
-        key: "memory",
+        key: MachineColumns.MEMORY,
         className: "ram-col",
         content: (
           <RamColumn data-testid="memory-column" systemId={row.system_id} />
         ),
       },
       {
-        key: "disks",
+        key: MachineColumns.DISKS,
         className: "disks-col",
         content: (
           <DisksColumn data-testid="disks-column" systemId={row.system_id} />
         ),
       },
       {
-        key: "storage",
+        key: MachineColumns.STORAGE,
         className: "storage-col",
         content: (
           <StorageColumn
@@ -527,7 +527,7 @@ export const MachineListTable = ({
   const { currentSort, sortRows, updateSort } = useTableSort<Machine, SortKey>(
     getSortValue,
     {
-      key: "fqdn",
+      key: MachineColumns.FQDN,
       direction: SortDirection.DESCENDING,
     }
   );
@@ -598,7 +598,7 @@ export const MachineListTable = ({
 
   const headers = [
     {
-      key: "fqdn",
+      key: MachineColumns.FQDN,
       className: "fqdn-col",
       content: (
         <div className="u-flex">
@@ -620,7 +620,7 @@ export const MachineListTable = ({
               }}
               sortKey="fqdn"
             >
-              FQDN
+              {columnLabels[MachineColumns.FQDN]}
             </TableHeader>
             &nbsp;<strong>|</strong>&nbsp;
             <TableHeader
@@ -640,7 +640,7 @@ export const MachineListTable = ({
       ),
     },
     {
-      key: "power",
+      key: MachineColumns.POWER,
       className: "power-col",
       content: (
         <TableHeader
@@ -650,12 +650,12 @@ export const MachineListTable = ({
           onClick={() => updateSort("power_state")}
           sortKey="power_state"
         >
-          Power
+          {columnLabels[MachineColumns.POWER]}
         </TableHeader>
       ),
     },
     {
-      key: "status",
+      key: MachineColumns.STATUS,
       className: "status-col",
       content: (
         <TableHeader
@@ -665,12 +665,12 @@ export const MachineListTable = ({
           onClick={() => updateSort("status")}
           sortKey="status"
         >
-          Status
+          {columnLabels[MachineColumns.STATUS]}
         </TableHeader>
       ),
     },
     {
-      key: "owner",
+      key: MachineColumns.OWNER,
       className: "owner-col",
       content: (
         <>
@@ -680,14 +680,14 @@ export const MachineListTable = ({
             onClick={() => updateSort("owner")}
             sortKey="owner"
           >
-            Owner
+            {columnLabels[MachineColumns.OWNER]}
           </TableHeader>
           <TableHeader>Tags</TableHeader>
         </>
       ),
     },
     {
-      key: "pool",
+      key: MachineColumns.POOL,
       className: "pool-col",
       content: (
         <>
@@ -697,14 +697,14 @@ export const MachineListTable = ({
             onClick={() => updateSort("pool")}
             sortKey="pool"
           >
-            Pool
+            {columnLabels[MachineColumns.POOL]}
           </TableHeader>
           <TableHeader>Note</TableHeader>
         </>
       ),
     },
     {
-      key: "zone",
+      key: MachineColumns.ZONE,
       className: "zone-col",
       content: (
         <>
@@ -714,14 +714,14 @@ export const MachineListTable = ({
             onClick={() => updateSort("zone")}
             sortKey="zone"
           >
-            Zone
+            {columnLabels[MachineColumns.ZONE]}
           </TableHeader>
           <TableHeader>Spaces</TableHeader>
         </>
       ),
     },
     {
-      key: "fabric",
+      key: MachineColumns.FABRIC,
       className: "fabric-col",
       content: (
         <>
@@ -731,14 +731,14 @@ export const MachineListTable = ({
             onClick={() => updateSort("fabric")}
             sortKey="fabric"
           >
-            Fabric
+            {columnLabels[MachineColumns.FABRIC]}
           </TableHeader>
           <TableHeader>VLAN</TableHeader>
         </>
       ),
     },
     {
-      key: "cpu",
+      key: MachineColumns.CPU,
       className: "cores-col u-align--right",
       content: (
         <>
@@ -748,14 +748,14 @@ export const MachineListTable = ({
             onClick={() => updateSort("cpu_count")}
             sortKey="cpu_count"
           >
-            Cores
+            {columnLabels[MachineColumns.CPU]}
           </TableHeader>
           <TableHeader>Arch</TableHeader>
         </>
       ),
     },
     {
-      key: "memory",
+      key: MachineColumns.MEMORY,
       className: "ram-col u-align--right",
       content: (
         <TableHeader
@@ -764,12 +764,12 @@ export const MachineListTable = ({
           onClick={() => updateSort("memory")}
           sortKey="memory"
         >
-          RAM
+          {columnLabels[MachineColumns.MEMORY]}
         </TableHeader>
       ),
     },
     {
-      key: "disks",
+      key: MachineColumns.DISKS,
       className: "disks-col u-align--right",
       content: (
         <TableHeader
@@ -778,12 +778,12 @@ export const MachineListTable = ({
           onClick={() => updateSort("physical_disk_count")}
           sortKey="physical_disk_count"
         >
-          Disks
+          {columnLabels[MachineColumns.DISKS]}
         </TableHeader>
       ),
     },
     {
-      key: "storage",
+      key: MachineColumns.STORAGE,
       className: "storage-col u-align--right",
       content: (
         <TableHeader
@@ -792,7 +792,7 @@ export const MachineListTable = ({
           onClick={() => updateSort("storage")}
           sortKey="storage"
         >
-          Storage
+          {columnLabels[MachineColumns.STORAGE]}
         </TableHeader>
       ),
     },

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -27,6 +27,7 @@ import TableHeader from "app/base/components/TableHeader";
 import type { TableSort } from "app/base/hooks";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
+import { columns } from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -159,7 +160,7 @@ const generateRows = ({
   return sortedMachines.map((row) => {
     const isActive = activeRow === row.system_id;
 
-    const columns: TableColumn[] = [
+    const columns = [
       {
         key: "fqdn",
         className: "fqdn-col",
@@ -277,11 +278,7 @@ const generateRows = ({
       className: classNames("machine-list__machine", "truncated-border", {
         "machine-list__machine--active": isActive,
       }),
-      columns: filterColumns(
-        columns as TableColumn[],
-        hiddenColumns,
-        showActions
-      ),
+      columns: filterColumns(columns, hiddenColumns, showActions),
     };
   });
 };
@@ -446,64 +443,54 @@ const generateGroupRows = ({
         className: "machine-list__group",
         columns: [
           {
+            colSpan: columns.length - hiddenColumns.length,
             content: (
-              <DoubleRow
-                data-testid="group-cell"
-                primary={
-                  showActions ? (
-                    <GroupCheckbox
-                      inRow
-                      items={machineIDs}
-                      selectedItems={selectedIDs}
-                      handleGroupCheckbox={handleGroupCheckbox}
-                      inputLabel={<strong>{label}</strong>}
-                    />
-                  ) : (
-                    <strong>{label}</strong>
-                  )
-                }
-                secondary={getGroupSecondaryString(machineIDs, selectedIDs)}
-                secondaryClassName={
-                  showActions ? "u-nudge--secondary-row" : null
-                }
-              />
-            ),
-          },
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {
-            content: (
-              <div className="machine-list__group-toggle">
-                <Button
-                  appearance="base"
-                  dense
-                  hasIcon
-                  onClick={() => {
-                    if (collapsed) {
-                      setHiddenGroups &&
-                        setHiddenGroups(
-                          hiddenGroups.filter((group) => group !== label)
-                        );
-                    } else {
-                      setHiddenGroups &&
-                        setHiddenGroups(hiddenGroups.concat([label]));
-                    }
-                  }}
-                >
-                  {collapsed ? (
-                    <i className="p-icon--plus">Show</i>
-                  ) : (
-                    <i className="p-icon--minus">Hide</i>
-                  )}
-                </Button>
-              </div>
+              <>
+                <DoubleRow
+                  data-testid="group-cell"
+                  primary={
+                    showActions ? (
+                      <GroupCheckbox
+                        inRow
+                        items={machineIDs}
+                        selectedItems={selectedIDs}
+                        handleGroupCheckbox={handleGroupCheckbox}
+                        inputLabel={<strong>{label}</strong>}
+                      />
+                    ) : (
+                      <strong>{label}</strong>
+                    )
+                  }
+                  secondary={getGroupSecondaryString(machineIDs, selectedIDs)}
+                  secondaryClassName={
+                    showActions ? "u-nudge--secondary-row" : null
+                  }
+                />
+                <div className="machine-list__group-toggle">
+                  <Button
+                    appearance="base"
+                    dense
+                    hasIcon
+                    onClick={() => {
+                      if (collapsed) {
+                        setHiddenGroups &&
+                          setHiddenGroups(
+                            hiddenGroups.filter((group) => group !== label)
+                          );
+                      } else {
+                        setHiddenGroups &&
+                          setHiddenGroups(hiddenGroups.concat([label]));
+                      }
+                    }}
+                  >
+                    {collapsed ? (
+                      <i className="p-icon--plus">Show</i>
+                    ) : (
+                      <i className="p-icon--minus">Hide</i>
+                    )}
+                  </Button>
+                </div>
+              </>
             ),
           },
         ],

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -159,7 +159,7 @@ const generateRows = ({
   return sortedMachines.map((row) => {
     const isActive = activeRow === row.system_id;
 
-    const columns = [
+    const columns: TableColumn[] = [
       {
         key: "fqdn",
         className: "fqdn-col",
@@ -277,7 +277,11 @@ const generateRows = ({
       className: classNames("machine-list__machine", "truncated-border", {
         "machine-list__machine--active": isActive,
       }),
-      columns: filterColumns(columns, hiddenColumns, showActions),
+      columns: filterColumns(
+        columns as TableColumn[],
+        hiddenColumns,
+        showActions
+      ),
     };
   });
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import NonBreakingSpace from "app/base/components/NonBreakingSpace";
 import RowCheckbox from "app/base/components/RowCheckbox";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
@@ -130,8 +131,11 @@ export const NameColumn = ({
           primaryRow
         )
       }
-      secondary={secondaryRow}
-      secondaryClassName={handleCheckbox && "u-nudge--secondary-row"}
+      // fallback to non-breaking space to keep equal height of all rows
+      secondary={secondaryRow || <NonBreakingSpace />}
+      secondaryClassName={
+        handleCheckbox && "u-nudge--secondary-row u-align--left"
+      }
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
@@ -31,8 +31,8 @@ exports[`NameColumn renders 1`] = `
         items={Array []}
       />
     }
-    secondary=""
-    secondaryClassName="u-nudge--secondary-row"
+    secondary={<NonBreakingSpace />}
+    secondaryClassName="u-nudge--secondary-row u-align--left"
   >
     <div
       className="p-double-row"
@@ -170,6 +170,13 @@ exports[`NameColumn renders 1`] = `
               </Input>
             </RowCheckbox>
           </div>
+        </div>
+        <div
+          className="p-double-row__secondary-row u-truncate u-nudge--secondary-row u-align--left"
+        >
+          <NonBreakingSpace>
+             
+          </NonBreakingSpace>
         </div>
       </div>
     </div>

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -117,4 +117,8 @@
   .machine-list--inline-input {
     display: inline;
   }
+
+  .machines-list-hidden-columns {
+    padding: $sph-inner/2 $sph-inner;
+  }
 }

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -131,6 +131,10 @@
     display: inline;
   }
 
+  .machine-list-controls {
+    grid-gap: 0.5rem;
+  }
+
   .machines-list-hidden-columns-select {
     padding: $sph-inner/2 $sph-inner;
   }

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -50,12 +50,6 @@
     .storage-col {
       @include breakpoint-widths(0, 0, 9%, 8%, 6%);
     }
-
-    th:last-child,
-    td:last-child {
-      text-align: right;
-      justify-content: flex-end;
-    }
   }
 
   .machine-list--grouped .machine-list__machine {

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -50,6 +50,12 @@
     .storage-col {
       @include breakpoint-widths(0, 0, 9%, 8%, 6%);
     }
+
+    th:last-child,
+    td:last-child {
+      text-align: right;
+      justify-content: flex-end;
+    }
   }
 
   .machine-list--grouped .machine-list__machine {
@@ -90,7 +96,14 @@
     }
   }
 
+  .machine-list__group td {
+    position: relative;
+  }
+
   .machine-list__group-toggle {
+    position: absolute;
+    top: 0;
+    right: 0;
     align-items: center;
     display: flex;
     height: 3rem;
@@ -118,7 +131,7 @@
     display: inline;
   }
 
-  .machines-list-hidden-columns {
+  .machines-list-hidden-columns-select {
     padding: $sph-inner/2 $sph-inner;
   }
 }


### PR DESCRIPTION
## Done

- refactor machine table to allow hiding columns
  - add a mock generating unique ids for nanoid (used by react-components, otherwise testing-library can't find correct labels and test fails)
  - refactor table to use colspan instead of empty columns
  - add fallback to non-breaking space to keep equal height of all rows

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the machines list view and verify everything looks correctly.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
