### PR TITLE
fix(ui): correctly handle add machine form validation asynchronously

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -111,10 +111,10 @@ export const PowerTypeFields = <V extends AnyObject>({
               value: powerType.name,
             })),
           ]}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          onChange={async (e: React.ChangeEvent<HTMLSelectElement>) => {
             // Reset errors and touched formik state when selecting a new power
             // type, in order to start validation from new.
-            handleChange(e);
+            await handleChange(e);
             setErrors(initialErrors);
             setTouched(initialTouched);
 

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -1,12 +1,12 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddMachineForm from "./AddMachineForm";
 
-import { PowerFieldScope, PowerFieldType } from "app/store/general/types";
+import { PowerFieldType } from "app/store/general/types";
+import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import {
   architecturesState as architecturesStateFactory,
@@ -24,280 +24,310 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
 
 const mockStore = configureStore();
 
-describe("AddMachine", () => {
-  let state: RootState;
+let state: RootState;
 
-  beforeEach(() => {
-    state = rootStateFactory({
-      domain: domainStateFactory({
-        items: [domainFactory({ name: "maas" })],
+beforeEach(() => {
+  state = rootStateFactory({
+    domain: domainStateFactory({
+      items: [domainFactory({ name: "maas" })],
+      loaded: true,
+    }),
+    general: generalStateFactory({
+      architectures: architecturesStateFactory({
+        data: ["amd64/generic"],
         loaded: true,
       }),
-      general: generalStateFactory({
-        architectures: architecturesStateFactory({
-          data: ["amd64/generic"],
-          loaded: true,
-        }),
-        defaultMinHweKernel: defaultMinHweKernelStateFactory({
-          data: "ga-16.04",
-          loaded: true,
-        }),
-        hweKernels: hweKernelsStateFactory({
-          data: [
-            ["ga-16.04", "xenial (ga-16.04)"],
-            ["ga-18.04", "bionic (ga-18.04)"],
-          ],
-          loaded: true,
-        }),
-        powerTypes: powerTypesStateFactory({
-          data: [
-            powerTypeFactory({
-              name: "manual",
-              description: "Manual",
-              fields: [],
-            }),
-            powerTypeFactory({
-              name: "dummy",
-              description: "Dummy power type",
-              fields: [
-                powerFieldFactory({
-                  name: "power_address",
-                  label: "IP address",
-                  required: true,
-                  field_type: PowerFieldType.STRING,
-                  choices: [],
-                  default: "",
-                  scope: PowerFieldScope.BMC,
-                }),
-              ],
-            }),
-          ],
-          loaded: true,
-        }),
-      }),
-      resourcepool: resourcePoolStateFactory({
-        items: [resourcePoolFactory({ name: "default" })],
+      defaultMinHweKernel: defaultMinHweKernelStateFactory({
+        data: "ga-16.04",
         loaded: true,
       }),
-      zone: zoneStateFactory({
-        items: [
-          zoneFactory({
-            name: "default",
+      hweKernels: hweKernelsStateFactory({
+        data: [
+          ["ga-16.04", "xenial (ga-16.04)"],
+          ["ga-18.04", "bionic (ga-18.04)"],
+        ],
+        loaded: true,
+      }),
+      powerTypes: powerTypesStateFactory({
+        data: [
+          powerTypeFactory({
+            name: "manual",
+            fields: [],
+          }),
+          powerTypeFactory({
+            name: "amt",
+            fields: [
+              powerFieldFactory({
+                name: "power_address",
+                label: "IP address",
+                field_type: PowerFieldType.STRING,
+              }),
+            ],
+          }),
+          powerTypeFactory({
+            name: "apc",
+            fields: [
+              powerFieldFactory({
+                name: "power_id",
+                label: "Power ID",
+                field_type: PowerFieldType.STRING,
+              }),
+            ],
           }),
         ],
         loaded: true,
       }),
-    });
+    }),
+    resourcepool: resourcePoolStateFactory({
+      items: [resourcePoolFactory({ name: "swimming" })],
+      loaded: true,
+    }),
+    zone: zoneStateFactory({
+      items: [
+        zoneFactory({
+          name: "twilight",
+        }),
+      ],
+      loaded: true,
+    }),
   });
+});
 
-  it("fetches the necessary data on load if not already loaded", () => {
-    state.resourcepool.loaded = false;
-    const store = mockStore(state);
-    mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
-        >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-    const expectedActions = [
-      "FETCH_DOMAIN",
-      "general/fetchArchitectures",
-      "general/fetchDefaultMinHweKernel",
-      "general/fetchHweKernels",
-      "general/fetchPowerTypes",
-      "resourcepool/fetch",
-      "zone/fetch",
-    ];
-    const actions = store.getActions();
-    expectedActions.forEach((expectedAction) => {
-      expect(actions.some((action) => action.type === expectedAction));
-    });
+it("fetches the necessary data on load if not already loaded", () => {
+  state.resourcepool.loaded = false;
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+      >
+        <AddMachineForm clearHeaderContent={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const expectedActions = [
+    "FETCH_DOMAIN",
+    "general/fetchArchitectures",
+    "general/fetchDefaultMinHweKernel",
+    "general/fetchHweKernels",
+    "general/fetchPowerTypes",
+    "resourcepool/fetch",
+    "zone/fetch",
+  ];
+  const actions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(actions.some((action) => action.type === expectedAction));
   });
+});
 
-  it("displays a spinner if data has not loaded", () => {
-    state.resourcepool.loaded = false;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
-        >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Spinner").length).toBe(1);
+it("displays a spinner if data has not loaded", () => {
+  state.resourcepool.loaded = false;
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+      >
+        <AddMachineForm clearHeaderContent={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByTestId("loading")).toBeInTheDocument();
+});
+
+it("enables submit when a power type with no fields is chosen", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+      >
+        <AddMachineForm clearHeaderContent={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  // Choose the "manual" power type which has no power fields, and fill in other
+  // required fields.
+  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
+    target: { value: "manual" },
   });
+  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
+    target: { value: "11:11:11:11:11:11" },
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
+  });
+});
 
-  it("can handle saving a machine", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
-        >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
+it("can handle saving a machine", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+      >
+        <AddMachineForm clearHeaderContent={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
 
-    submitFormikForm(wrapper, {
-      architecture: "amd64/generic",
-      domain: "maas",
-      extra_macs: [],
-      hostname: "machine",
-      min_hwe_kernel: "ga-16.04",
-      pool: "default",
-      power_parameters: {},
-      power_type: "manual",
-      pxe_mac: "11:11:11:11:11:11",
-      zone: "default",
-    });
+  fireEvent.change(screen.getByRole("textbox", { name: "Machine name" }), {
+    target: { value: "mean-bean" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Domain" }), {
+    target: { value: "maas" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Architecture" }), {
+    target: { value: "amd64/generic" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Minimum kernel" }), {
+    target: { value: "ga-16.04" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Zone" }), {
+    target: { value: "twilight" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Resource pool" }), {
+    target: { value: "swimming" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
+    target: { value: "11:11:11:11:11:11" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
+    target: { value: "manual" },
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save machine" }));
+
+  const expectedAction = machineActions.create({
+    architecture: "amd64/generic",
+    domain: { name: "maas" },
+    extra_macs: [],
+    hostname: "mean-bean",
+    min_hwe_kernel: "ga-16.04",
+    pool: { name: "swimming" },
+    power_parameters: {},
+    power_type: "manual",
+    pxe_mac: "11:11:11:11:11:11",
+    zone: { name: "twilight" },
+  });
+  await waitFor(() => {
     expect(
-      store.getActions().find((action) => action.type === "machine/create")
-    ).toStrictEqual({
-      type: "machine/create",
-      meta: {
-        method: "create",
-        model: "machine",
-      },
-      payload: {
-        params: {
-          architecture: "amd64/generic",
-          domain: state.domain.items[0],
-          extra_macs: [],
-          hostname: "machine",
-          min_hwe_kernel: "ga-16.04",
-          pool: state.resourcepool.items[0],
-          power_parameters: {},
-          power_type: "manual",
-          pxe_mac: "11:11:11:11:11:11",
-          zone: state.zone.items[0],
-        },
-      },
-    });
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
   });
+});
 
-  it("correctly trims power parameters before dispatching action", async () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
-        >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
+it("correctly trims power parameters before dispatching action", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+      >
+        <AddMachineForm clearHeaderContent={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
 
-    const powerTypes = wrapper.find("select[name='power_type']");
-
-    // Select the dummy power type from the dropdown, which only has one param.
-    await act(async () => {
-      powerTypes.simulate("change", {
-        target: { name: "power_type", value: "dummy" },
-      });
-    });
-    wrapper.update();
-
-    // Submit the form with an extra power parameter, power_id.
-    await act(async () =>
-      submitFormikForm(wrapper, {
-        architecture: "amd64/generic",
-        domain: "maas",
-        extra_macs: [],
-        hostname: "machine",
-        min_hwe_kernel: "ga-16.04",
-        pool: "default",
-        power_parameters: { power_address: "192.168.1.1", power_id: "1" },
-        power_type: "dummy",
-        pxe_mac: "11:11:11:11:11:11",
-        zone: "default",
-      })
-    );
-
-    // Expect the power_id param to be removed when action is dispatched.
-    expect(
-      store.getActions().find((action) => action.type === "machine/create")
-    ).toStrictEqual({
-      type: "machine/create",
-      meta: {
-        method: "create",
-        model: "machine",
-      },
-      payload: {
-        params: {
-          architecture: "amd64/generic",
-          domain: state.domain.items[0],
-          extra_macs: [],
-          hostname: "machine",
-          min_hwe_kernel: "ga-16.04",
-          pool: state.resourcepool.items[0],
-          power_parameters: { power_address: "192.168.1.1" },
-          power_type: "dummy",
-          pxe_mac: "11:11:11:11:11:11",
-          zone: state.zone.items[0],
-        },
-      },
-    });
+  // Choose initial power type and fill in fields.
+  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
+    target: { value: "11:11:11:11:11:11" },
   });
+  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
+    target: { value: "amt" },
+  });
+  const amtField = await screen.findByRole("textbox", { name: "IP address" });
+  fireEvent.change(amtField, { target: { value: "192.168.1.1" } });
 
-  it("correctly filters empty extra mac fields", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
-        >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
+  // Change power type and fill in new fields.
+  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
+    target: { value: "apc" },
+  });
+  const apcField = await screen.findByRole("textbox", { name: "Power ID" });
+  fireEvent.change(apcField, { target: { value: "12345" } });
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save machine" }));
 
-    // Submit the form with two extra macs, where one is an empty string
-    submitFormikForm(wrapper, {
-      architecture: "amd64/generic",
-      domain: "maas",
-      extra_macs: ["12:12:12:12:12:12", ""],
-      hostname: "machine",
-      min_hwe_kernel: "ga-16.04",
-      pool: "default",
-      power_parameters: {},
-      power_type: "dummy",
-      pxe_mac: "11:11:11:11:11:11",
-      zone: "default",
-    });
-
-    // Expect the empty extra mac to be filtered out
+  const expectedAction = machineActions.create({
+    architecture: "amd64/generic",
+    domain: { name: "maas" },
+    extra_macs: [],
+    hostname: "",
+    min_hwe_kernel: "ga-16.04",
+    pool: { name: "swimming" },
+    // Create action should not include power_address parameter since it does
+    // not exist for the currently selected power type.
+    power_parameters: {
+      power_id: "12345",
+    },
+    power_type: "apc",
+    pxe_mac: "11:11:11:11:11:11",
+    zone: { name: "twilight" },
+  });
+  await waitFor(() => {
     expect(
-      store.getActions().find((action) => action.type === "machine/create")
-    ).toStrictEqual({
-      type: "machine/create",
-      meta: {
-        method: "create",
-        model: "machine",
-      },
-      payload: {
-        params: {
-          architecture: "amd64/generic",
-          domain: state.domain.items[0],
-          extra_macs: ["12:12:12:12:12:12"],
-          hostname: "machine",
-          min_hwe_kernel: "ga-16.04",
-          pool: state.resourcepool.items[0],
-          power_parameters: {},
-          power_type: "dummy",
-          pxe_mac: "11:11:11:11:11:11",
-          zone: state.zone.items[0],
-        },
-      },
-    });
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("correctly filters empty extra mac fields", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+      >
+        <AddMachineForm clearHeaderContent={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  // Submit the form with two extra macs, where one is an empty string
+  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
+    target: { value: "manual" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
+    target: { value: "11:11:11:11:11:11" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Add MAC address" }));
+  fireEvent.click(screen.getByRole("button", { name: "Add MAC address" }));
+  fireEvent.change(screen.getByLabelText("Extra MAC address 1"), {
+    target: { value: "22:22:22:22:22:22" },
+  });
+  fireEvent.change(screen.getByLabelText("Extra MAC address 2"), {
+    target: { value: "" },
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save machine" }));
+
+  const expectedAction = machineActions.create({
+    architecture: "amd64/generic",
+    domain: { name: "maas" },
+    // There should only be one extra MAC defined.
+    extra_macs: ["22:22:22:22:22:22"],
+    hostname: "",
+    min_hwe_kernel: "ga-16.04",
+    pool: { name: "swimming" },
+    power_parameters: {},
+    power_type: "manual",
+    pxe_mac: "11:11:11:11:11:11",
+    zone: { name: "twilight" },
+  });
+  await waitFor(() => {
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
   });
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -116,7 +116,7 @@ export const AddMachineForm = ({ clearHeaderContent }: Props): JSX.Element => {
   return (
     <>
       {!allLoaded ? (
-        <Strip shallow>
+        <Strip data-testid="loading" shallow>
           <Spinner text="Loading" />
         </Strip>
       ) : (
@@ -156,18 +156,18 @@ export const AddMachineForm = ({ clearHeaderContent }: Props): JSX.Element => {
           onSubmit={(values) => {
             const params = {
               architecture: values.architecture,
-              domain: domains.find((domain) => domain.name === values.domain),
+              domain: { name: values.domain },
               extra_macs: values.extra_macs.filter(Boolean),
               hostname: values.hostname,
               min_hwe_kernel: values.min_hwe_kernel,
-              pool: resourcePools.find((pool) => pool.name === values.pool),
+              pool: { name: values.pool },
               power_parameters: formatPowerParameters(
                 powerType,
                 values.power_parameters
               ),
-              power_type: values.power_type,
+              power_type: values.power_type as PowerType["name"],
               pxe_mac: values.pxe_mac,
-              zone: zones.find((zone) => zone.name === values.zone),
+              zone: { name: values.zone },
             };
             dispatch(machineActions.create(params));
             setSavingMachine(values.hostname || "Machine");

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
@@ -61,6 +61,7 @@ export const AddMachineFormFields = ({ saved }: Props): JSX.Element => {
             key={`extra-macs-${i}`}
           >
             <Input
+              aria-label={`Extra MAC address ${i + 1}`}
               error={errors?.extra_macs && errors.extra_macs[i]}
               maxLength={17}
               onChange={(e) => {

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/types.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/types.ts
@@ -1,3 +1,4 @@
+import type { PowerType } from "app/store/general/types";
 import type { PowerParameters } from "app/store/types/node";
 
 export type AddMachineValues = {
@@ -8,7 +9,7 @@ export type AddMachineValues = {
   min_hwe_kernel: string;
   pool: string;
   power_parameters: PowerParameters;
-  power_type: string;
+  power_type: PowerType["name"] | "";
   pxe_mac: string;
   zone: string;
 };

--- a/ui/src/app/store/machine/types/actions.ts
+++ b/ui/src/app/store/machine/types/actions.ts
@@ -1,6 +1,8 @@
 import type { Machine, MachineStatus } from "./base";
 import type { MachineMeta } from "./enum";
 
+import type { Domain } from "app/store/domain/types";
+import type { PowerType } from "app/store/general/types";
 import type { LicenseKeys } from "app/store/licensekeys/types";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import type { Script } from "app/store/script/types";
@@ -15,6 +17,7 @@ import type {
   NetworkInterface,
   NetworkInterfaceParams,
   NetworkLink,
+  PowerParameters,
 } from "app/store/types/node";
 import type { Zone } from "app/store/zone/types";
 
@@ -112,7 +115,7 @@ export type CreateParams = {
   cpu_count?: Machine["cpu_count"];
   description?: Machine["description"];
   distro_series?: Machine["distro_series"];
-  domain?: Machine["domain"];
+  domain?: { name: Domain["name"] };
   ephemeral_deploy?: boolean;
   extra_macs: Machine["extra_macs"];
   hostname?: Machine["hostname"];
@@ -122,8 +125,12 @@ export type CreateParams = {
   memory?: Machine["memory"];
   min_hwe_kernel?: string;
   osystem?: Machine["osystem"];
+  pool?: { name: ResourcePool["name"] };
+  power_parameters: PowerParameters;
+  power_type: PowerType["name"];
   pxe_mac: Machine["pxe_mac"];
   swap_size?: string;
+  zone?: { name: Zone["name"] };
 };
 
 export type CreatePartitionParams = {
@@ -327,7 +334,7 @@ export type UpdateFilesystemParams = {
   tags?: string[];
 } & OptionalFilesystemParams;
 
-export type UpdateParams = CreateParams & {
+export type UpdateParams = Partial<CreateParams> & {
   [MachineMeta.PK]: Machine[MachineMeta.PK];
   tags?: Machine["tags"];
 };


### PR DESCRIPTION
## Done

- Handle `PowerTypeFields` validation on power type change asynchronously, which means selecting "Manual" no longer requires field blur to validate
- Fixed incorrect types for machine create/update actions
- Converted `AddMachineForm.test.tsx` to RTL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and click "Add hardware > Machine"
- Choose a non-default domain, pool and zone, and fill in the MAC address
- Select "Manual" as the power type and check that the submit button is enabled without needing to blur the select
- Submit the form and check that the machine is created with the correct parameters

## Fixes

Fixes #1043 
