### PR TITLE
fix(ui): include cert and key values when adding LXD host with a trust password

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.test.tsx
@@ -138,6 +138,10 @@ describe("AuthenticationForm", () => {
 
   it("dispatches an action to fetch projects if using a password", () => {
     const setNewPodValues = jest.fn();
+    const generatedCert = generatedCertificateFactory({
+      CN: "my-favourite-kvm@host",
+    });
+    state.general.generatedCertificate.data = generatedCert;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -161,6 +165,8 @@ describe("AuthenticationForm", () => {
     wrapper.update();
 
     const expectedAction = podActions.getProjects({
+      certificate: generatedCert.certificate,
+      key: generatedCert.private_key,
       password: "password",
       power_address: "192.168.1.1",
       type: PodType.LXD,

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -102,9 +102,9 @@ export const AuthenticationForm = ({
       onSubmit={(values) => {
         dispatch(podActions.cleanup());
         setAuthenticating(true);
+        const certificate = generatedCertificate?.certificate || "";
+        const key = generatedCertificate?.private_key || "";
         if (useCertificate) {
-          const certificate = generatedCertificate?.certificate || "";
-          const key = generatedCertificate?.private_key || "";
           setNewPodValues({
             ...newPodValues,
             certificate,
@@ -121,6 +121,8 @@ export const AuthenticationForm = ({
           setNewPodValues({ ...newPodValues, password: values.password });
           dispatch(
             podActions.getProjects({
+              certificate,
+              key,
               password: values.password,
               power_address: newPodValues.power_address,
               type: PodType.LXD,

--- a/ui/src/app/store/pod/reducers.test.ts
+++ b/ui/src/app/store/pod/reducers.test.ts
@@ -468,6 +468,7 @@ describe("pod reducer", () => {
     const serverAddress = "192.168.1.1";
     const newProjects = [podProjectFactory()];
     const podState = podStateFactory({
+      errors: "it's not working",
       items: [],
       projects: {},
     });
@@ -482,6 +483,7 @@ describe("pod reducer", () => {
       )
     ).toEqual(
       podStateFactory({
+        errors: null,
         projects: { [serverAddress]: newProjects },
       })
     );

--- a/ui/src/app/store/pod/slice.ts
+++ b/ui/src/app/store/pod/slice.ts
@@ -299,6 +299,7 @@ const podSlice = createSlice({
           GenericItemMeta<GetProjectsParams>
         >
       ) => {
+        state.errors = null;
         const address = action.meta.item.power_address;
         if (address) {
           state.projects[address] = action.payload;


### PR DESCRIPTION
## Done

- Fixed bug where user is unable to add a LXD host with a trust password
- Fixed bug where adding certificate trust after submitting the authentication form would send the user to the start of the Add LXD host wizard.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- QAing this for real will require setting up a local LXD server with a trust password, which you can do so by [following the docs](https://maas.io/docs/snap/3.1/ui/how-to-use-lxd).
- Go to the LXD host list and click "Add LXD host"
- Input a name and the address of the LXD server and submit the first step of the form
- Choose to authenticate with the trust password, submit the second step of the form and check that projects for the LXD server are successfully fetched
- Close the form and reopen, again entering a name and LXD address and submitting the first step of the form
- Leave the certificate radio checked and submit the form
- Add certificate trust via the LXD CLI and check that eventually the form is automatically taken to the next step

## Fixes

Fixes #3367 

## Screenshots
### Broken
![Peek 2022-02-24 15-51](https://user-images.githubusercontent.com/25733845/155468684-94063a9a-1263-4d04-8b8c-493104acf935.gif)

### Fixed
![Peek 2022-02-24 15-50](https://user-images.githubusercontent.com/25733845/155468641-b9309d8d-1d8c-4b18-995b-fd1a18032e72.gif)