### PR TITLE
test: add eslint-plugin-testing-library

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   parser: "babel-eslint",
   plugins: [
     "react",
+    "testing-library",
     "no-only-tests",
     "@typescript-eslint",
     "prettier",
@@ -105,6 +106,16 @@ module.exports = {
       files: ["**/*.js?(x)"],
       rules: {
         "no-unused-vars": 2,
+      },
+    },
+    {
+      files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
+      extends: ["plugin:testing-library/react"],
+      rules: {
+        "testing-library/prefer-find-by": "warn",
+        "testing-library/prefer-presence-queries": "warn",
+        "testing-library/no-node-access": "warn",
+        "testing-library/no-wait-for-side-effects": "warn",
       },
     },
   ],

--- a/ui/package.json
+++ b/ui/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
+    "eslint-plugin-testing-library": "5.0.5",
     "formik-devtools-extension": "0.1.7",
     "jest-fetch-mock": "3.0.3",
     "jest-websocket-mock": "2.3.0",

--- a/ui/src/app/base/hooks/base.test.tsx
+++ b/ui/src/app/base/hooks/base.test.tsx
@@ -46,9 +46,9 @@ describe("hooks", () => {
       if (html) {
         html.scrollTop = 10;
       }
-      const onRenderRef = renderHook(() => useScrollOnRender());
+      const { result } = renderHook(() => useScrollOnRender());
       targetNode.getBoundingClientRect = () => ({ y: 10 } as DOMRect);
-      onRenderRef.result.current(targetNode);
+      result.current(targetNode);
       expect(scrollToSpy).not.toHaveBeenCalled();
     });
 
@@ -56,9 +56,9 @@ describe("hooks", () => {
       if (html) {
         html.scrollTop = 100;
       }
-      const onRenderRef = renderHook(() => useScrollOnRender());
+      const { result } = renderHook(() => useScrollOnRender());
       targetNode.getBoundingClientRect = () => ({ y: 1000 } as DOMRect);
-      onRenderRef.result.current(targetNode);
+      result.current(targetNode);
       expect(scrollToSpy).toHaveBeenCalledWith({
         top: 1000,
         left: 0,
@@ -70,9 +70,9 @@ describe("hooks", () => {
       if (html) {
         html.scrollTop = 1000;
       }
-      const onRenderRef = renderHook(() => useScrollOnRender());
+      const { result } = renderHook(() => useScrollOnRender());
       targetNode.getBoundingClientRect = () => ({ y: 10 } as DOMRect);
-      onRenderRef.result.current(targetNode);
+      result.current(targetNode);
       expect(scrollToSpy).toHaveBeenCalledWith({
         top: 10,
         left: 0,
@@ -84,10 +84,10 @@ describe("hooks", () => {
       if (html) {
         html.scrollTop = 100;
       }
-      const onRenderRef = renderHook(() => useScrollOnRender());
+      const { result } = renderHook(() => useScrollOnRender());
       targetNode.getBoundingClientRect = () =>
         ({ height: 400, y: 400 } as DOMRect);
-      onRenderRef.result.current(targetNode);
+      result.current(targetNode);
       expect(scrollToSpy).toHaveBeenCalledWith({
         top: 400,
         left: 0,

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -49,9 +49,7 @@ it("renders correct details", () => {
   expect(
     screen.getByRole("heading", { name: "Fabric summary" })
   ).toBeInTheDocument();
-  waitFor(() =>
-    expect(screen.getByRole("href", { name: "bolla.maas" })).toBeInTheDocument()
-  );
+  expect(screen.getByText("test-fabric")).toBeInTheDocument();
 });
 
 it("can open and close the Edit fabric summary form", async () => {
@@ -73,11 +71,7 @@ it("can open and close the Edit fabric summary form", async () => {
   );
   const fabricSummary = screen.getByRole("region", { name: "Fabric summary" });
   userEvent.click(within(fabricSummary).getByRole("button", { name: "Edit" }));
-  await waitFor(() =>
-    expect(
-      screen.getByRole("form", { name: "Edit fabric summary" })
-    ).toBeInTheDocument()
-  );
+  await screen.findByRole("form", { name: "Edit fabric summary" });
 
   userEvent.click(
     within(fabricSummary).getByRole("button", { name: "Cancel" })

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -13,7 +13,7 @@ const renderTestCase = () => {
   const store = configureStore()(rootStateFactory());
   const setActiveForm = jest.fn();
 
-  const renderResult = render(
+  const view = render(
     <Provider store={store}>
       <MemoryRouter
         initialEntries={[{ pathname: "/networks", key: "testKey" }]}
@@ -22,7 +22,7 @@ const renderTestCase = () => {
       </MemoryRouter>
     </Provider>
   );
-  return { ...renderResult, store, props: { setActiveForm } };
+  return { ...view, store, props: { setActiveForm } };
 };
 
 test("renders the form correctly", async () => {

--- a/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -57,7 +57,7 @@ it("correctly dispatches space create action on form submit", async () => {
   userEvent.type(screen.getByRole("textbox", { name: /CIDR/ }), cidr);
   userEvent.type(screen.getByRole("textbox", { name: /Name/ }), name);
 
-  await waitFor(() => screen.getByRole("combobox", { name: "VLAN" }));
+  await screen.findByRole("combobox", { name: "VLAN" });
   userEvent.selectOptions(
     screen.getByRole("combobox", { name: "Fabric" }),
     fabric.name

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -33,9 +33,7 @@ it("displays validation messages for VID", async () => {
   userEvent.type(VidTextBox, "abc");
   userEvent.click(submitButton);
 
-  await waitFor(() =>
-    expect(screen.getByText(errorMessage)).toBeInTheDocument()
-  );
+  await screen.findByText(errorMessage);
 
   userEvent.clear(VidTextBox);
   userEvent.type(VidTextBox, "123");
@@ -47,9 +45,7 @@ it("displays validation messages for VID", async () => {
   userEvent.clear(VidTextBox);
   userEvent.type(VidTextBox, "99999");
 
-  await waitFor(() =>
-    expect(screen.getByText(errorMessage)).toBeInTheDocument()
-  );
+  await screen.findByText(errorMessage);
 });
 
 it("correctly dispatches VLAN create action on form submit", async () => {

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -158,9 +158,9 @@ it("displays space details", async () => {
     </Provider>
   );
 
-  const spaceSummary = await waitFor(() =>
-    screen.getByRole("region", { name: "Space summary" })
-  );
+  const spaceSummary = await screen.findByRole("region", {
+    name: "Space summary",
+  });
   expect(within(spaceSummary).getByText(space.name)).toBeInTheDocument();
   expect(within(spaceSummary).getByText(space.description)).toBeInTheDocument();
 });

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -53,11 +53,7 @@ it("can open and close the Edit space summary form", async () => {
   );
   const spaceSummary = screen.getByRole("region", { name: "Space summary" });
   userEvent.click(within(spaceSummary).getByRole("button", { name: "Edit" }));
-  await waitFor(() =>
-    expect(
-      screen.getByRole("form", { name: "Edit space summary" })
-    ).toBeInTheDocument()
-  );
+  await screen.findByRole("form", { name: "Edit space summary" });
 
   userEvent.click(within(spaceSummary).getByRole("button", { name: "Cancel" }));
 

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -50,11 +50,7 @@ it("dispatches a correct action on add static route form submit", async () => {
     </Provider>
   );
 
-  await waitFor(() =>
-    expect(
-      screen.getByRole("form", { name: "Add static route" })
-    ).toBeInTheDocument()
-  );
+  await screen.findByRole("form", { name: "Add static route" });
 
   const addStaticRouteForm = screen.getByRole("form", {
     name: "Add static route",

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -95,26 +95,18 @@ it("can open and close the add static route form", async () => {
       </MemoryRouter>
     </Provider>
   );
-  await waitFor(() =>
-    expect(
-      screen.getByRole("button", {
-        name: AddStaticRouteFormLabels.AddStaticRoute,
-      })
-    ).toBeInTheDocument()
-  );
+  await screen.findByRole("button", {
+    name: AddStaticRouteFormLabels.AddStaticRoute,
+  });
   userEvent.click(
     screen.getByRole("button", {
       name: AddStaticRouteFormLabels.AddStaticRoute,
     })
   );
 
-  await waitFor(() =>
-    expect(
-      screen.getByRole("form", {
-        name: AddStaticRouteFormLabels.AddStaticRoute,
-      })
-    ).toBeInTheDocument()
-  );
+  await screen.findByRole("form", {
+    name: AddStaticRouteFormLabels.AddStaticRoute,
+  });
 
   userEvent.click(
     within(
@@ -164,13 +156,9 @@ it("can open and close the edit static route form", async () => {
     })
   );
 
-  await waitFor(() =>
-    expect(
-      screen.getByRole("form", {
-        name: EditStaticRouteFormLabels.EditStaticRoute,
-      })
-    ).toBeInTheDocument()
-  );
+  await screen.findByRole("form", {
+    name: EditStaticRouteFormLabels.EditStaticRoute,
+  });
 
   userEvent.click(
     within(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,6 +3933,14 @@
     "@typescript-eslint/types" "5.12.0"
     "@typescript-eslint/visitor-keys" "5.12.0"
 
+"@typescript-eslint/scope-manager@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz#58734fd45d2d1dec49641aacc075fba5f0968817"
+  integrity sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/visitor-keys" "5.12.1"
+
 "@typescript-eslint/type-utils@5.12.0":
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.12.0.tgz#aaf45765de71c6d9707c66ccff76ec2b9aa31bb6"
@@ -3956,6 +3964,11 @@
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.12.0.tgz#5b4030a28222ee01e851836562c07769eecda0b8"
   integrity sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==
+
+"@typescript-eslint/types@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.12.1.tgz#46a36a28ff4d946821b58fe5a73c81dc2e12aa89"
+  integrity sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==
 
 "@typescript-eslint/typescript-estree@3.10.1":
   version "3.10.1"
@@ -3997,6 +4010,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz#6a9425b9c305bcbc38e2d1d9a24c08e15e02b722"
+  integrity sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/visitor-keys" "5.12.1"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/utils@5.12.0":
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.12.0.tgz#92fd3193191621ab863add2f553a7b38b65646af"
@@ -4006,6 +4032,18 @@
     "@typescript-eslint/scope-manager" "5.12.0"
     "@typescript-eslint/types" "5.12.0"
     "@typescript-eslint/typescript-estree" "5.12.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/utils@^5.10.2":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.12.1.tgz#447c24a05d9c33f9c6c64cb48f251f2371eef920"
+  integrity sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.12.1"
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/typescript-estree" "5.12.1"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -4030,6 +4068,14 @@
   integrity sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==
   dependencies:
     "@typescript-eslint/types" "5.12.0"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz#f722da106c8f9695ae5640574225e45af3e52ec3"
+  integrity sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
     eslint-visitor-keys "^3.0.0"
 
 "@uirouter/angularjs@1.0.30":
@@ -7935,6 +7981,13 @@ eslint-plugin-react@^7.21.5:
     prop-types "^15.7.2"
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
+
+eslint-plugin-testing-library@5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.5.tgz#5757961ec20a6ca8b0992d2c5487db1b51612d8d"
+  integrity sha512-0j355vJpJCE/2g+aayIgJRUB6jBVqpD5ztMLGcadR1PgrgGPnPxN1HJuOAsAAwiMo27GwRnpJB8KOQzyNuNZrw==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.2"
 
 eslint-plugin-testing-library@^3.9.2:
   version "3.10.2"


### PR DESCRIPTION
## Done

- add eslint plugin testing library helping follow testing-library best practices
- fix all violations of following eslint rules:
  - [await-async-utils](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/await-async-utils.md) - Ensure that promises returned by async utils are handled properly.
  - [render-result-naming-convention](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/render-result-naming-convention.md) - This rule aims to ensure the return value from render is named properly.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
