### PR TITLE
fix: skip link, contain all content by landmarks

### DIFF
--- a/shared/src/components/Footer/Footer.tsx
+++ b/shared/src/components/Footer/Footer.tsx
@@ -40,7 +40,7 @@ export const Footer = ({
   }, [debug, enableAnalytics, version]);
 
   return (
-    <footer className="p-strip--light is-shallow p-footer">
+    <div className="p-strip--light is-shallow p-footer">
       <div className="row">
         <div className="col-10 p-footer__nav">
           <ul className="p-inline-list--middot">
@@ -92,7 +92,7 @@ export const Footer = ({
           </svg>
         </div>
       </div>
-    </footer>
+    </div>
   );
 };
 

--- a/shared/src/components/Footer/Footer.tsx
+++ b/shared/src/components/Footer/Footer.tsx
@@ -40,7 +40,7 @@ export const Footer = ({
   }, [debug, enableAnalytics, version]);
 
   return (
-    <div className="p-strip--light is-shallow p-footer">
+    <footer className="p-strip--light is-shallow p-footer">
       <div className="row">
         <div className="col-10 p-footer__nav">
           <ul className="p-inline-list--middot">
@@ -92,7 +92,7 @@ export const Footer = ({
           </svg>
         </div>
       </div>
-    </div>
+    </footer>
   );
 };
 

--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -215,7 +215,6 @@ export const Header = ({
           "u-hide--hardware-menu-threshold": link.inHardwareMenu,
         })}
         key={link.url}
-        role="presentation"
       >
         {generateLink(link, {
           "aria-current": isSelected(path, link, appendNewBase)
@@ -240,7 +239,6 @@ export const Header = ({
                   "p-navigation__link p-subnav is-dark hardware-menu",
                   { "is-active": hardwareMenuOpen }
                 )}
-                role="presentation"
               >
                 {/* eslint-disable-next-line */}
                 <a

--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -318,9 +318,9 @@ export const Header = ({
 
   return (
     <>
-      <span className="u-off-screen">
-        <a href="#main-content">Skip to main content</a>
-      </span>
+      <a href="#main-content" className="p-link--skip">
+        Skip to main content
+      </a>
       <header id="navigation" className="p-navigation is-dark">
         <div className="p-navigation__row row">
           <div className="p-navigation__banner">

--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -291,7 +291,7 @@ export const Header = ({
                 )}
             </li>
           )}
-          <li className="p-navigation__link" role="presentation">
+          <li className="p-navigation__link">
             {/* eslint-disable-next-line */}
             <a
               href="#"

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -13,7 +13,7 @@ export const StatusBar = ({
   version,
 }: Props): JSX.Element => {
   return (
-    <section className="p-status-bar">
+    <aside className="p-status-bar" aria-label="status bar">
       <div className="row">
         <div className="col-6">
           <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
@@ -25,7 +25,7 @@ export const StatusBar = ({
           </div>
         )}
       </div>
-    </section>
+    </aside>
   );
 };
 

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -13,7 +13,7 @@ export const StatusBar = ({
   version,
 }: Props): JSX.Element => {
   return (
-    <aside className="p-status-bar">
+    <section className="p-status-bar">
       <div className="row">
         <div className="col-6">
           <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
@@ -25,7 +25,7 @@ export const StatusBar = ({
           </div>
         )}
       </div>
-    </aside>
+    </section>
   );
 };
 

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -13,7 +13,7 @@ export const StatusBar = ({
   version,
 }: Props): JSX.Element => {
   return (
-    <div className="p-status-bar">
+    <aside className="p-status-bar">
       <div className="row">
         <div className="col-6">
           <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
@@ -25,7 +25,7 @@ export const StatusBar = ({
           </div>
         )}
       </div>
-    </div>
+    </aside>
   );
 };
 

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -172,7 +172,7 @@ export const App = (): JSX.Element => {
         uuid={uuid as string}
         version={version}
       />
-      {content}
+      <div id="main-content">{content}</div>
       {version && (
         <Footer
           debug={debug}

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -172,15 +172,17 @@ export const App = (): JSX.Element => {
         uuid={uuid as string}
         version={version}
       />
-      <div id="main-content">{content}</div>
-      {version && (
-        <Footer
-          debug={debug}
-          enableAnalytics={analyticsEnabled as boolean}
-          version={version}
-        />
-      )}
-      <StatusBar />
+      <main id="main-content">{content}</main>
+      <footer>
+        {version && (
+          <Footer
+            debug={debug}
+            enableAnalytics={analyticsEnabled as boolean}
+            version={version}
+          />
+        )}
+        <StatusBar />
+      </footer>
     </div>
   );
 };

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -173,16 +173,14 @@ export const App = (): JSX.Element => {
         version={version}
       />
       <main id="main-content">{content}</main>
-      <footer>
-        {version && (
-          <Footer
-            debug={debug}
-            enableAnalytics={analyticsEnabled as boolean}
-            version={version}
-          />
-        )}
-        <StatusBar />
-      </footer>
+      {version && (
+        <Footer
+          debug={debug}
+          enableAnalytics={analyticsEnabled as boolean}
+          version={version}
+        />
+      )}
+      <StatusBar />
     </div>
   );
 };

--- a/ui/src/app/base/components/Login/Login.tsx
+++ b/ui/src/app/base/components/Login/Login.tsx
@@ -46,7 +46,7 @@ export const Login = (): JSX.Element => {
   }, [dispatch, externalAuthURL]);
 
   return (
-    <Strip element="main">
+    <Strip>
       <Row>
         <Col size={6} emptyLarge={4}>
           {externalAuthURL && error && (

--- a/ui/src/app/base/components/Section/Section.tsx
+++ b/ui/src/app/base/components/Section/Section.tsx
@@ -20,7 +20,7 @@ const Section = ({
 }: Props): JSX.Element => {
   const { SIDEBAR, TOTAL } = COL_SIZES;
   return (
-    <main className="section" {...props}>
+    <div className="section" {...props}>
       {header ? (
         <div className="section__header-wrapper">
           <Row>
@@ -47,7 +47,7 @@ const Section = ({
           {children}
         </Col>
       </Strip>
-    </main>
+    </div>
   );
 };
 

--- a/ui/src/app/base/components/Section/Section.tsx
+++ b/ui/src/app/base/components/Section/Section.tsx
@@ -20,7 +20,7 @@ const Section = ({
 }: Props): JSX.Element => {
   const { SIDEBAR, TOTAL } = COL_SIZES;
   return (
-    <div className="section" {...props}>
+    <main className="section" {...props}>
       {header ? (
         <div className="section__header-wrapper">
           <Row>
@@ -29,7 +29,7 @@ const Section = ({
         </div>
       ) : null}
       <Strip
-        element="main"
+        element="section"
         includeCol={false}
         rowClassName="section__content-wrapper"
         shallow
@@ -47,7 +47,7 @@ const Section = ({
           {children}
         </Col>
       </Strip>
-    </div>
+    </main>
   );
 };
 

--- a/ui/src/app/base/components/Section/__snapshots__/Section.test.tsx.snap
+++ b/ui/src/app/base/components/Section/__snapshots__/Section.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Section renders 1`] = `
-<div
+<main
   className="section"
 >
   <div
@@ -16,7 +16,7 @@ exports[`Section renders 1`] = `
     </Row>
   </div>
   <Strip
-    element="main"
+    element="section"
     includeCol={false}
     rowClassName="section__content-wrapper"
     shallow={true}
@@ -38,5 +38,5 @@ exports[`Section renders 1`] = `
       content
     </Col>
   </Strip>
-</div>
+</main>
 `;

--- a/ui/src/app/base/components/Section/__snapshots__/Section.test.tsx.snap
+++ b/ui/src/app/base/components/Section/__snapshots__/Section.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Section renders 1`] = `
-<main
+<div
   className="section"
 >
   <div
@@ -38,5 +38,5 @@ exports[`Section renders 1`] = `
       content
     </Col>
   </Strip>
-</main>
+</div>
 `;

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -147,6 +147,7 @@ const ControllerListTable = ({
           content: (
             <div className="u-flex">
               <GroupCheckbox
+                aria-label="all controllers"
                 data-testid="all-controllers-checkbox"
                 handleGroupCheckbox={handleGroupCheckbox}
                 items={controllerIDs}

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -158,6 +158,7 @@ const DeviceListTable = ({
           content: (
             <div className="u-flex">
               <GroupCheckbox
+                aria-label="all devices"
                 data-testid="all-devices-checkbox"
                 handleGroupCheckbox={handleGroupCheckbox}
                 items={deviceIDs}

--- a/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
+++ b/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`IncompleteCard renders 1`] = `
 <IncompleteCard>
   <IntroSection>
     <Section>
-      <main
+      <div
         className="section"
       >
         <Strip
@@ -139,7 +139,7 @@ exports[`IncompleteCard renders 1`] = `
             </Row>
           </section>
         </Strip>
-      </main>
+      </div>
     </Section>
   </IntroSection>
 </IncompleteCard>

--- a/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
+++ b/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
@@ -4,16 +4,16 @@ exports[`IncompleteCard renders 1`] = `
 <IncompleteCard>
   <IntroSection>
     <Section>
-      <div
+      <main
         className="section"
       >
         <Strip
-          element="main"
+          element="section"
           includeCol={false}
           rowClassName="section__content-wrapper"
           shallow={true}
         >
-          <main
+          <section
             className="p-strip is-shallow"
           >
             <Row
@@ -137,9 +137,9 @@ exports[`IncompleteCard renders 1`] = `
                 </Col>
               </div>
             </Row>
-          </main>
+          </section>
         </Strip>
-      </div>
+      </main>
     </Section>
   </IntroSection>
 </IncompleteCard>

--- a/ui/src/scss/_patterns_links.scss
+++ b/ui/src/scss/_patterns_links.scss
@@ -8,4 +8,11 @@
       color: $color-dark;
     }
   }
+  
+  // Make skip link work with the custom MAAS layout
+  .p-link--skip:focus {
+    position: absolute;
+    background-color: $color-x-light;
+    padding: $sph-inner;
+  }
 }


### PR DESCRIPTION
## Done

- fix "skip link" by using a consistent content id globally and [vanillaframwork.io skip link](https://vanillaframework.io/docs/patterns/links#skip-link)
- ensure all content is contained within landmarks - [region rule](https://dequeuniversity.com/rules/axe/4.3/region?application=axeAPI)
- fix all violations on:
  - "Controllers" page (/controllers)
  - "My preferences" page (/account/prefs/details)
  - "Devices" page (/devices)

## Screenshots
### Before
![Kapture 2022-02-24 at 16 50 20](https://user-images.githubusercontent.com/7452681/155558832-716b834f-3a46-40da-a4f8-e9a19d286769.gif)

### After 
![Kapture 2022-02-24 at 16 48 54](https://user-images.githubusercontent.com/7452681/155558574-56d7f211-d2a0-4695-85ad-8f597afe3c9a.gif)

## QA
- Use the `Tab` key to navigate between elements.
- The first element on the page should be the skip link which allows you to skip the navigation bar and go straight to the main content.

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #3645 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
