### PR TITLE
feat(ui): tag table

### DIFF
--- a/ui/src/app/tags/views/TagList/TagList.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import TagList, { Label } from "./TagList";
+
+import controllerURLs from "app/controllers/urls";
+import deviceURLs from "app/devices/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import {
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [
+        tagFactory({
+          name: "rad",
+        }),
+        tagFactory({
+          name: "cool",
+        }),
+      ],
+    }),
+  });
+});
+
+it("displays tags", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagList />
+      </MemoryRouter>
+    </Provider>
+  );
+  const names = screen.queryAllByRole("gridcell", {
+    name: Label.Name,
+  });
+  expect(names).toHaveLength(2);
+  expect(names.find((td) => td.textContent === "rad")).toBeInTheDocument();
+  expect(names.find((td) => td.textContent === "cool")).toBeInTheDocument();
+});
+
+it("shows an icon for automatic tags", () => {
+  state.tag.items = [tagFactory({ definition: "automatic" })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagList />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Auto,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).toBeInTheDocument();
+});
+
+it("does not show an icon for manual tags", () => {
+  state.tag.items = [tagFactory({ definition: undefined })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagList />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Auto,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).not.toBeInTheDocument();
+});
+
+it("shows an icon for kernel options", () => {
+  state.tag.items = [tagFactory({ kernel_opts: "i'm a kernel option" })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagList />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Options,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).toBeInTheDocument();
+});
+
+it("does not show an icon for tags without kernel options", () => {
+  state.tag.items = [tagFactory({ kernel_opts: undefined })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagList />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Options,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).not.toBeInTheDocument();
+});
+
+it("can link to nodes", () => {
+  state.tag.items = [
+    tagFactory({
+      machine_count: 1,
+      device_count: 2,
+      controller_count: 3,
+      name: "a-tag",
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagList />
+      </MemoryRouter>
+    </Provider>
+  );
+  const appliedTo = screen.getByRole("gridcell", {
+    name: Label.AppliedTo,
+  });
+  const machineLink = within(appliedTo).getByRole("link", {
+    name: "1 machine",
+  });
+  const deviceLink = within(appliedTo).getByRole("link", {
+    name: "2 devices",
+  });
+  const controllerLink = within(appliedTo).getByRole("link", {
+    name: "3 controllers",
+  });
+  expect(machineLink).toBeInTheDocument();
+  expect(controllerLink).toBeInTheDocument();
+  expect(deviceLink).toBeInTheDocument();
+  expect(machineLink).toHaveAttribute(
+    "href",
+    `${machineURLs.machines.index}?tags=a-tag`
+  );
+  expect(controllerLink).toHaveAttribute(
+    "href",
+    `${controllerURLs.controllers.index}?tags=a-tag`
+  );
+  expect(deviceLink).toHaveAttribute(
+    "href",
+    `${deviceURLs.devices.index}?tags=a-tag`
+  );
+});

--- a/ui/src/app/tags/views/TagList/TagList.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.tsx
@@ -1,0 +1,176 @@
+import { useEffect } from "react";
+
+import { Icon, MainTable, Tooltip } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import TableActions from "app/base/components/TableActions";
+import { useWindowTitle } from "app/base/hooks";
+import controllerURLs from "app/controllers/urls";
+import deviceURLs from "app/devices/urls";
+import machineURLs from "app/machines/urls";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import type { Tag } from "app/store/tag/types";
+import tagURLs from "app/tags/urls";
+import { breakLines, unindentString } from "app/utils";
+
+export enum Label {
+  Actions = "Actions",
+  AppliedTo = "Applied to",
+  Auto = "Auto",
+  Name = "Tag name",
+  Options = "Kernel options",
+  Updated = "Last update",
+}
+
+const generateRows = (tags: Tag[]) =>
+  tags.map((tag) => {
+    return {
+      key: `tag-row-${tag.id}`,
+      columns: [
+        {
+          "aria-label": Label.Name,
+          content: (
+            <Link to={tagURLs.tag.index({ id: tag.id })}>{tag.name}</Link>
+          ),
+        },
+        {
+          "aria-label": Label.Updated,
+          content: tag.updated,
+        },
+        {
+          "aria-label": Label.Auto,
+          content: !!tag.definition ? <Icon name="success-grey" /> : null,
+        },
+        {
+          "aria-label": Label.AppliedTo,
+          content: (
+            <>
+              {tag.machine_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${machineURLs.machines.index}?tags=${tag.name}`}
+                >
+                  {pluralize("machine", tag.machine_count, true)}
+                </Link>
+              ) : null}
+              {tag.controller_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${controllerURLs.controllers.index}?tags=${tag.name}`}
+                >
+                  {pluralize("controller", tag.controller_count, true)}
+                </Link>
+              ) : null}
+              {tag.device_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${deviceURLs.devices.index}?tags=${tag.name}`}
+                >
+                  {pluralize("device", tag.device_count, true)}
+                </Link>
+              ) : null}
+            </>
+          ),
+        },
+        {
+          "aria-label": Label.Options,
+          content: !!tag.kernel_opts ? <Icon name="success-grey" /> : null,
+        },
+        {
+          "aria-label": Label.Actions,
+          content: (
+            <TableActions
+              onDelete={() => {
+                // TODO: Implement the delete form:
+                // https://github.com/canonical-web-and-design/app-tribe/issues/701
+              }}
+              onEdit={() => {
+                // TODO: Implement tag edit form:
+                // https://github.com/canonical-web-and-design/app-tribe/issues/706
+              }}
+            />
+          ),
+          className: "u-align--right",
+        },
+      ],
+      sortData: {
+        name: tag.name,
+        updated: tag.updated,
+      },
+    };
+  });
+
+const TagList = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const tags = useSelector(tagSelectors.all);
+
+  useWindowTitle("Tags");
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <MainTable
+      className="p-table-expanding--light"
+      headers={[
+        {
+          content: Label.Name,
+          sortKey: "name",
+        },
+        {
+          content: Label.Updated,
+          sortKey: "updated",
+        },
+        {
+          content: (
+            <>
+              {Label.Auto}{" "}
+              <Tooltip
+                // TODO: add a link to the docs:
+                // https://github.com/canonical-web-and-design/app-tribe/issues/739
+                message={
+                  <>
+                    {breakLines(
+                      unindentString(
+                        `Automatic tags are automatically applied to every 
+                        machine that matches their definition.`
+                      )
+                    )}
+                    <br />
+                    <a href="#todo">
+                      Check the documentation about automatic tags.
+                    </a>
+                  </>
+                }
+                position="top-center"
+              >
+                <Icon name="information" />
+              </Tooltip>
+            </>
+          ),
+        },
+        {
+          content: Label.AppliedTo,
+        },
+        {
+          content: Label.Options,
+        },
+        {
+          content: Label.Actions,
+          className: "u-align--right",
+        },
+      ]}
+      rows={generateRows(tags)}
+      paginate={50}
+      sortable
+      defaultSort="name"
+      defaultSortDirection="ascending"
+    />
+  );
+};
+
+export default TagList;

--- a/ui/src/app/tags/views/TagList/index.ts
+++ b/ui/src/app/tags/views/TagList/index.ts
@@ -1,0 +1,1 @@
+export { default, Label } from "./TagList";

--- a/ui/src/app/tags/views/Tags.test.tsx
+++ b/ui/src/app/tags/views/Tags.test.tsx
@@ -33,6 +33,10 @@ describe("Tags", () => {
       path: tagURLs.tag.index({ id: 1 }),
     },
     {
+      component: "TagList",
+      path: tagURLs.tags.index,
+    },
+    {
       component: "NotFound",
       path: "/not/a/path",
     },

--- a/ui/src/app/tags/views/Tags.tsx
+++ b/ui/src/app/tags/views/Tags.tsx
@@ -1,6 +1,7 @@
 import { Route, Switch } from "react-router-dom";
 
 import TagDetails from "./TagDetails";
+import TagList from "./TagList";
 
 import NotFound from "app/base/views/NotFound";
 import tagsURLs from "app/tags/urls";
@@ -13,6 +14,7 @@ const Tags = (): JSX.Element => {
         path={tagsURLs.tag.index(null, true)}
         render={() => <TagDetails />}
       />
+      <Route exact path={tagsURLs.tags.index} render={() => <TagList />} />
       <Route path="*" render={() => <NotFound />} />
     </Switch>
   );


### PR DESCRIPTION
## Done

- Add the tag table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the tag list (machines -> tags).
- You should see a list of tags.
- Clicking links in the "Applied to" column should take you to a filtered node list.

## Fixes

Fixes: canonical-web-and-design/app-tribe#699.

## Screenshots

<img width="1249" alt="Screen Shot 2022-02-28 at 1 08 30 pm" src="https://user-images.githubusercontent.com/361637/155912656-5a585fa8-e9df-4db6-8418-e2c363043013.png">
