### PR TITLE
feat(ui): display tag details

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -136,6 +136,14 @@ const Routes = (): JSX.Element => (
       )}
     />
     <Route
+      path={tagURLs.tag.index(null, true)}
+      render={() => (
+        <ErrorBoundary>
+          <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
       path={settingsURLs.index}
       render={() => (
         <ErrorBoundary>

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -129,7 +129,9 @@ export const MachineListHeader = ({
           to: poolsURLs.pools,
         },
         {
-          active: location.pathname.startsWith(tagURLs.tags.index),
+          active:
+            location.pathname.startsWith(tagURLs.tags.index) ||
+            location.pathname.startsWith(tagURLs.tag.base),
           component: Link,
           label: `${pluralize("Tag", tags.length, true)}`,
           to: tagURLs.tags.index,

--- a/ui/src/app/machines/views/Machines.tsx
+++ b/ui/src/app/machines/views/Machines.tsx
@@ -92,6 +92,11 @@ const Machines = (): JSX.Element => {
           render={() => <PoolEdit />}
         />
         <Route exact path={tagURLs.tags.index} render={() => <Tags />} />
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          render={() => <Tags />}
+        />
         <Route path="*" render={() => <NotFound />} />
       </Switch>
     </Section>

--- a/ui/src/app/tags/urls.ts
+++ b/ui/src/app/tags/urls.ts
@@ -1,6 +1,13 @@
+import type { Tag, TagMeta } from "app/store/tag/types";
+import { argPath } from "app/utils";
+
 const urls = {
   tags: {
     index: "/tags",
+  },
+  tag: {
+    base: "/tag",
+    index: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id"),
   },
 };
 

--- a/ui/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import TagDetails, { Label } from "./TagDetails";
+
+import controllerURLs from "app/controllers/urls";
+import deviceURLs from "app/devices/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import tagURLs from "app/tags/urls";
+import {
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [
+        tagFactory({
+          name: "rad",
+        }),
+        tagFactory({
+          name: "cool",
+        }),
+      ],
+    }),
+  });
+});
+
+it("dispatches actions to fetch necessary data", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [tagActions.fetch()];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the tag does not exist", () => {
+  const state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText("Tag not found")).toBeInTheDocument();
+});
+
+it("shows a spinner if the tag has not loaded yet", () => {
+  const state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [],
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByTestId("Spinner")).toBeInTheDocument();
+});
+
+it("can link to nodes", () => {
+  state.tag.items = [
+    tagFactory({
+      id: 1,
+      machine_count: 1,
+      device_count: 2,
+      controller_count: 3,
+      name: "a-tag",
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagDetails />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const appliedTo = screen.getByLabelText(Label.AppliedTo);
+  const machineLink = within(appliedTo).getByRole("link", {
+    name: "1 machine",
+  });
+  const deviceLink = within(appliedTo).getByRole("link", {
+    name: "2 devices",
+  });
+  const controllerLink = within(appliedTo).getByRole("link", {
+    name: "3 controllers",
+  });
+  expect(machineLink).toBeInTheDocument();
+  expect(controllerLink).toBeInTheDocument();
+  expect(deviceLink).toBeInTheDocument();
+  expect(machineLink).toHaveAttribute(
+    "href",
+    `${machineURLs.machines.index}?tags=a-tag`
+  );
+  expect(controllerLink).toHaveAttribute(
+    "href",
+    `${controllerURLs.controllers.index}?tags=a-tag`
+  );
+  expect(deviceLink).toHaveAttribute(
+    "href",
+    `${deviceURLs.devices.index}?tags=a-tag`
+  );
+});

--- a/ui/src/app/tags/views/TagDetails/TagDetails.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.tsx
@@ -1,0 +1,158 @@
+import { useEffect } from "react";
+
+import {
+  Button,
+  CodeSnippet,
+  Col,
+  Icon,
+  Row,
+  Spinner,
+} from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import Definition from "app/base/components/Definition";
+import ModelNotFound from "app/base/components/ModelNotFound";
+import { useWindowTitle } from "app/base/hooks";
+import { useGetURLId } from "app/base/hooks/urls";
+import controllerURLs from "app/controllers/urls";
+import deviceURLs from "app/devices/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import { TagMeta } from "app/store/tag/types";
+import tagURLs from "app/tags/urls";
+import { isId } from "app/utils";
+
+export enum Label {
+  AppliedTo = "Applied to",
+  Comment = "Comment",
+  Definition = "Definition (automatic tag)",
+  Name = "Tag name",
+  Options = "Kernel options",
+  Update = "Last update",
+}
+
+const TagDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(TagMeta.PK);
+  const tag = useSelector((state: RootState) =>
+    tagSelectors.getById(state, id)
+  );
+  const tagsLoading = useSelector(tagSelectors.loading);
+
+  useWindowTitle(tag ? `Tag: ${tag.name}` : "Tag");
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
+
+  if (!isId(id) || (!tagsLoading && !tag)) {
+    return (
+      <ModelNotFound id={id} linkURL={tagURLs.tags.index} modelName="tag" />
+    );
+  }
+
+  if (!tag || tagsLoading) {
+    return (
+      <span data-testid="Spinner">
+        <Spinner />
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <Row>
+        <Col size={6}>
+          <Link to={tagURLs.tags.index}>&lsaquo; Back to all tags</Link>
+        </Col>
+        <Col className="u-align--right" size={6}>
+          <Button hasIcon>
+            <Icon className="is-light" name="edit" /> <span>Edit</span>
+          </Button>
+          <Button appearance="negative" hasIcon>
+            <Icon className="is-light" name="delete" /> <span>Delete</span>
+          </Button>
+        </Col>
+      </Row>
+      <hr />
+      <Row>
+        <Col size={2}>
+          <Definition description={tag.name} label={Label.Name} />
+        </Col>
+        <Col size={2}>
+          <Definition description={tag.updated} label={Label.Update} />
+        </Col>
+        <Col size={2}>
+          <Definition label={Label.AppliedTo}>
+            <>
+              {tag.machine_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${machineURLs.machines.index}?tags=${tag.name}`}
+                >
+                  {pluralize("machine", tag.machine_count, true)}
+                </Link>
+              ) : null}
+              {tag.controller_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${controllerURLs.controllers.index}?tags=${tag.name}`}
+                >
+                  {pluralize("controller", tag.controller_count, true)}
+                </Link>
+              ) : null}
+              {tag.device_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${deviceURLs.devices.index}?tags=${tag.name}`}
+                >
+                  {pluralize("device", tag.device_count, true)}
+                </Link>
+              ) : null}
+            </>
+          </Definition>
+        </Col>
+        <Col size={6}>
+          <Definition description={tag.comment} label={Label.Comment} />
+        </Col>
+      </Row>
+      <hr className="u-sv1" />
+      <Row>
+        <Col size={6}>
+          <p className="u-text--muted">{Label.Options}</p>
+          {tag.kernel_opts ? (
+            <CodeSnippet
+              blocks={[
+                {
+                  code: tag.kernel_opts,
+                },
+              ]}
+            />
+          ) : (
+            "None"
+          )}
+        </Col>
+        <Col size={6}>
+          <p className="u-text--muted">{Label.Definition}</p>
+          {tag.definition ? (
+            <CodeSnippet
+              blocks={[
+                {
+                  code: tag.definition,
+                },
+              ]}
+            />
+          ) : (
+            "None"
+          )}
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default TagDetails;

--- a/ui/src/app/tags/views/TagDetails/index.ts
+++ b/ui/src/app/tags/views/TagDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagDetails";

--- a/ui/src/app/tags/views/Tags.test.tsx
+++ b/ui/src/app/tags/views/Tags.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import Tags from "./Tags";
 
 import type { RootState } from "app/store/root/types";
+import tagURLs from "app/tags/urls";
 import {
   rootState as rootStateFactory,
   tag as tagFactory,
@@ -26,15 +27,26 @@ describe("Tags", () => {
     });
   });
 
-  it("displays a loading component if pools are loading", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-          <Tags />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.text().includes("Tags")).toBe(true);
+  [
+    {
+      component: "TagDetails",
+      path: tagURLs.tag.index({ id: 1 }),
+    },
+    {
+      component: "NotFound",
+      path: "/not/a/path",
+    },
+  ].forEach(({ component, path }) => {
+    it(`Displays: ${component} at: ${path}`, () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter initialEntries={[{ pathname: path }]}>
+            <Tags />
+          </MemoryRouter>
+        </Provider>
+      );
+      expect(wrapper.find(component).exists()).toBe(true);
+    });
   });
 });

--- a/ui/src/app/tags/views/Tags.tsx
+++ b/ui/src/app/tags/views/Tags.tsx
@@ -1,8 +1,21 @@
-import { useWindowTitle } from "app/base/hooks";
+import { Route, Switch } from "react-router-dom";
+
+import TagDetails from "./TagDetails";
+
+import NotFound from "app/base/views/NotFound";
+import tagsURLs from "app/tags/urls";
 
 const Tags = (): JSX.Element => {
-  useWindowTitle("Tags");
-  return <>Tags</>;
+  return (
+    <Switch>
+      <Route
+        exact
+        path={tagsURLs.tag.index(null, true)}
+        render={() => <TagDetails />}
+      />
+      <Route path="*" render={() => <NotFound />} />
+    </Switch>
+  );
 };
 
 export default Tags;


### PR DESCRIPTION
## Done

- Add the tag details page.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/tag/1 (or change the id if that doesn't exist).
- You should see the tag details.

## Fixes

Fixes: canonical-web-and-design/app-tribe#705.

## Screenshots

<img width="1521" alt="Screen Shot 2022-03-02 at 11 54 48 am" src="https://user-images.githubusercontent.com/361637/156274078-e26075b3-a42e-4439-b217-ab23640c1803.png">
