### PR TITLE
refactor(ui): make kvm action bar reusable

### DIFF
--- a/ui/src/app/base/components/ActionBar/ActionBar.test.tsx
+++ b/ui/src/app/base/components/ActionBar/ActionBar.test.tsx
@@ -2,19 +2,19 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import KVMActionBar from "./KVMActionBar";
+import ActionBar from "./ActionBar";
 
 import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
-describe("KVMActionBar", () => {
+describe("ActionBar", () => {
   it("displays provided actions", () => {
     const state = rootStateFactory();
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <KVMActionBar
+        <ActionBar
           actions={<span data-testid="actions">Actions</span>}
           currentPage={1}
           itemCount={10}

--- a/ui/src/app/base/components/ActionBar/ActionBar.tsx
+++ b/ui/src/app/base/components/ActionBar/ActionBar.tsx
@@ -3,8 +3,6 @@ import type { ReactNode } from "react";
 import type { SearchBoxProps } from "@canonical/react-components";
 import { SearchBox } from "@canonical/react-components";
 
-import { VMS_PER_PAGE } from "../LXDVMsTable";
-
 import ArrowPagination from "app/base/components/ArrowPagination";
 
 type Props = {
@@ -13,23 +11,25 @@ type Props = {
   loading?: boolean;
   itemCount: number;
   onSearchChange: SearchBoxProps["onChange"];
+  pageSize?: number;
   searchFilter: string;
   setCurrentPage: (page: number) => void;
 };
 
-const KVMActionBar = ({
+const ActionBar = ({
   actions,
   currentPage,
   loading,
   itemCount,
   onSearchChange,
+  pageSize = 50,
   searchFilter,
   setCurrentPage,
 }: Props): JSX.Element | null => {
   return (
-    <div className="kvm-action-bar">
-      <div className="kvm-action-bar__actions">{actions}</div>
-      <div className="kvm-action-bar__search">
+    <div className="action-bar">
+      <div className="action-bar__actions">{actions}</div>
+      <div className="action-bar__search">
         <SearchBox
           className="u-no-margin--bottom"
           externallyControlled
@@ -37,13 +37,13 @@ const KVMActionBar = ({
           value={searchFilter}
         />
       </div>
-      <div className="kvm-action-bar__pagination">
+      <div className="action-bar__pagination">
         <ArrowPagination
           className="u-display-inline-block"
           currentPage={currentPage}
           itemCount={itemCount}
           loading={loading}
-          pageSize={VMS_PER_PAGE}
+          pageSize={pageSize}
           setCurrentPage={setCurrentPage}
           showPageBounds
         />
@@ -52,4 +52,4 @@ const KVMActionBar = ({
   );
 };
 
-export default KVMActionBar;
+export default ActionBar;

--- a/ui/src/app/base/components/ActionBar/_index.scss
+++ b/ui/src/app/base/components/ActionBar/_index.scss
@@ -1,5 +1,5 @@
-@mixin KVMActionBar {
-  .kvm-action-bar {
+@mixin ActionBar {
+  .action-bar {
     display: grid;
     grid-template-areas:
       "act"
@@ -9,18 +9,18 @@
     grid-template-rows: min-content min-content min-content;
     padding: $spv-inner--medium 0;
 
-    .kvm-action-bar__actions {
+    .action-bar__actions {
       align-items: center;
       display: flex;
       grid-area: act;
     }
 
-    .kvm-action-bar__pagination {
+    .action-bar__pagination {
       grid-area: pag;
       margin-top: $spv-inner--small;
     }
 
-    .kvm-action-bar__search {
+    .action-bar__search {
       grid-area: sea;
       margin-top: $spv-inner--medium;
     }
@@ -32,7 +32,7 @@
       grid-template-columns: auto auto;
       grid-template-rows: min-content min-content;
 
-      .kvm-action-bar__pagination {
+      .action-bar__pagination {
         margin-top: 0;
         text-align: right;
       }
@@ -43,7 +43,7 @@
       grid-template-columns: max-content 1fr max-content;
       grid-template-rows: min-content;
 
-      .kvm-action-bar__search {
+      .action-bar__search {
         margin: 0 $sph-inner;
         max-width: 50rem;
       }

--- a/ui/src/app/base/components/ActionBar/index.ts
+++ b/ui/src/app/base/components/ActionBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActionBar";

--- a/ui/src/app/kvm/components/KVMActionBar/index.ts
+++ b/ui/src/app/kvm/components/KVMActionBar/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./KVMActionBar";

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -1,10 +1,10 @@
 import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import KVMActionBar from "../../KVMActionBar";
-
+import ActionBar from "app/base/components/ActionBar";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import type { SetSearchFilter } from "app/base/types";
+import { VMS_PER_PAGE } from "app/kvm/components/LXDVMsTable";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import { MachineHeaderViews } from "app/machines/constants";
 import machineSelectors from "app/store/machine/selectors";
@@ -35,7 +35,7 @@ const VMsActionBar = ({
   const vmActionsDisabled = selectedMachines.length === 0;
 
   return (
-    <KVMActionBar
+    <ActionBar
       actions={
         <>
           <NodeActionMenu
@@ -96,6 +96,7 @@ const VMsActionBar = ({
       itemCount={vms.length}
       loading={loading}
       onSearchChange={setSearchFilter}
+      pageSize={VMS_PER_PAGE}
       searchFilter={searchFilter}
       setCurrentPage={setCurrentPage}
     />

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsActionBar/LXDClusterHostsActionBar.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsActionBar/LXDClusterHostsActionBar.tsx
@@ -1,8 +1,9 @@
 import { Button, Icon } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import ActionBar from "app/base/components/ActionBar";
 import type { SetSearchFilter } from "app/base/types";
-import KVMActionBar from "app/kvm/components/KVMActionBar";
+import { VMS_PER_PAGE } from "app/kvm/components/LXDVMsTable";
 import { KVMHeaderViews } from "app/kvm/constants";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import type { Pod } from "app/store/pod/types";
@@ -43,7 +44,7 @@ const LXDClusterHostsActionBar = ({
   }
 
   return (
-    <KVMActionBar
+    <ActionBar
       actions={
         <Button
           className="u-rotate-right"
@@ -67,6 +68,7 @@ const LXDClusterHostsActionBar = ({
       itemCount={hosts.length}
       loading={loading}
       onSearchChange={setSearchFilter}
+      pageSize={VMS_PER_PAGE}
       searchFilter={searchFilter}
       setCurrentPage={setCurrentPage}
     />

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -71,6 +71,7 @@
 
 // Import and include MAAS component styles
 // base
+@import "~app/base/components/ActionBar";
 @import "~app/base/components/CertificateDownload";
 @import "~app/base/components/CertificateMetadata";
 @import "~app/base/components/ColumnToggle";
@@ -94,6 +95,7 @@
 @import "~app/base/components/Stepper";
 @import "~app/base/components/TableMenu";
 @import "~app/base/components/TagSelector";
+@include ActionBar;
 @include CertificateDownload;
 @include CertificateMetadata;
 @include ColumnToggle;
@@ -143,7 +145,6 @@
 // kvm
 @import "~app/kvm/components/CoreResources";
 @import "~app/kvm/components/CPUColumn/CPUPopover";
-@import "~app/kvm/components/KVMActionBar";
 @import "~app/kvm/components/KVMDetailsHeader";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect";
@@ -170,7 +171,6 @@
 @import "~app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard";
 @include CoreResources;
 @include CPUPopover;
-@include KVMActionBar;
 @include KVMComposeInterfacesTable;
 @include KVMComposeStorageTable;
 @include KVMDetailsHeader;


### PR DESCRIPTION
## Done

- Make the action bar used in the KVM pages reusable.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM host's virtual machines page.
- The take action/search/pagination row should appear as before.

## Fixes

Fixes: canonical-web-and-design/app-tribe#740.