### PR TITLE
Add tag sort, filter, search and pagination

### DIFF
--- a/ui/src/app/base/components/ActionBar/ActionBar.tsx
+++ b/ui/src/app/base/components/ActionBar/ActionBar.tsx
@@ -25,9 +25,10 @@ const ActionBar = ({
   pageSize = 50,
   searchFilter,
   setCurrentPage,
+  ...props
 }: Props): JSX.Element | null => {
   return (
-    <div className="action-bar">
+    <div className="action-bar" {...props}>
       <div className="action-bar__actions">{actions}</div>
       <div className="action-bar__search">
         <SearchBox

--- a/ui/src/app/base/components/SegmentToggle/SegmentToggle.test.tsx
+++ b/ui/src/app/base/components/SegmentToggle/SegmentToggle.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+
+import SegmentToggle from "./SegmentToggle";
+
+const options = [
+  {
+    title: "Red",
+    value: "#FF0000",
+  },
+  {
+    title: "Green",
+    value: "#00FF00",
+  },
+  {
+    title: "Blue",
+    value: "#0000FF",
+  },
+];
+
+it("renders a segment for each option", () => {
+  render(
+    <SegmentToggle onSelect={jest.fn()} options={options} selected="Green" />
+  );
+  expect(screen.getByRole("button", { name: "Red" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Green" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Blue" })).toBeInTheDocument();
+});
+
+it("highlights the active option", () => {
+  render(
+    <SegmentToggle onSelect={jest.fn()} options={options} selected="Green" />
+  );
+  expect(screen.getByRole("button", { name: "Green" })).toHaveClass(
+    "is-active"
+  );
+});
+
+it("calls the callback when clicking a button", () => {
+  const onSelect = jest.fn();
+  render(
+    <SegmentToggle onSelect={onSelect} options={options} selected="Green" />
+  );
+  screen.getByRole("button", { name: "Blue" }).click();
+  expect(onSelect).toHaveBeenCalledWith("blue");
+});

--- a/ui/src/app/base/components/SegmentToggle/SegmentToggle.test.tsx
+++ b/ui/src/app/base/components/SegmentToggle/SegmentToggle.test.tsx
@@ -19,7 +19,7 @@ const options = [
 
 it("renders a segment for each option", () => {
   render(
-    <SegmentToggle onSelect={jest.fn()} options={options} selected="Green" />
+    <SegmentToggle onSelect={jest.fn()} options={options} selected="#00FF00" />
   );
   expect(screen.getByRole("button", { name: "Red" })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Green" })).toBeInTheDocument();
@@ -28,18 +28,21 @@ it("renders a segment for each option", () => {
 
 it("highlights the active option", () => {
   render(
-    <SegmentToggle onSelect={jest.fn()} options={options} selected="Green" />
+    <SegmentToggle onSelect={jest.fn()} options={options} selected="#00FF00" />
   );
-  expect(screen.getByRole("button", { name: "Green" })).toHaveClass(
-    "is-active"
-  );
+  expect(
+    screen
+      .getByRole("button", { name: "Green" })
+      .getAttribute("class")
+      ?.includes("is-active")
+  ).toBe(true);
 });
 
 it("calls the callback when clicking a button", () => {
   const onSelect = jest.fn();
   render(
-    <SegmentToggle onSelect={onSelect} options={options} selected="Green" />
+    <SegmentToggle onSelect={onSelect} options={options} selected="#00FF00" />
   );
   screen.getByRole("button", { name: "Blue" }).click();
-  expect(onSelect).toHaveBeenCalledWith("blue");
+  expect(onSelect).toHaveBeenCalledWith("#0000FF");
 });

--- a/ui/src/app/base/components/SegmentToggle/SegmentToggle.test.tsx
+++ b/ui/src/app/base/components/SegmentToggle/SegmentToggle.test.tsx
@@ -21,21 +21,19 @@ it("renders a segment for each option", () => {
   render(
     <SegmentToggle onSelect={jest.fn()} options={options} selected="#00FF00" />
   );
-  expect(screen.getByRole("button", { name: "Red" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Green" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Blue" })).toBeInTheDocument();
+  expect(screen.getByRole("radio", { name: "Red" })).toBeInTheDocument();
+  expect(screen.getByRole("radio", { name: "Green" })).toBeInTheDocument();
+  expect(screen.getByRole("radio", { name: "Blue" })).toBeInTheDocument();
 });
 
-it("highlights the active option", () => {
+it("selects the active option", () => {
   render(
     <SegmentToggle onSelect={jest.fn()} options={options} selected="#00FF00" />
   );
-  expect(
-    screen
-      .getByRole("button", { name: "Green" })
-      .getAttribute("class")
-      ?.includes("is-active")
-  ).toBe(true);
+  expect(screen.getByRole("radio", { name: "Green" })).toHaveAttribute(
+    "aria-checked",
+    "true"
+  );
 });
 
 it("calls the callback when clicking a button", () => {
@@ -43,6 +41,6 @@ it("calls the callback when clicking a button", () => {
   render(
     <SegmentToggle onSelect={onSelect} options={options} selected="#00FF00" />
   );
-  screen.getByRole("button", { name: "Blue" }).click();
+  screen.getByRole("radio", { name: "Blue" }).click();
   expect(onSelect).toHaveBeenCalledWith("#0000FF");
 });

--- a/ui/src/app/base/components/SegmentToggle/SegmentToggle.tsx
+++ b/ui/src/app/base/components/SegmentToggle/SegmentToggle.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@canonical/react-components";
+import classNames from "classnames";
+
+type Segment<V> = {
+  title: string;
+  value: V;
+};
+
+type Props<V> = {
+  onSelect: (selected: V) => void;
+  options: Segment<V>[];
+  selected: V;
+};
+
+const SegmentToggle = <V,>({
+  onSelect,
+  options,
+  selected,
+}: Props<V>): JSX.Element => {
+  return (
+    <div className="p-segment-toggle">
+      {options.map(({ title, value }) => (
+        <Button
+          className={classNames("p-segment-toggle__button", {
+            "is-active": value === selected,
+          })}
+          key={title}
+          onClick={() => onSelect(value)}
+        >
+          {title}
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default SegmentToggle;

--- a/ui/src/app/base/components/SegmentToggle/SegmentToggle.tsx
+++ b/ui/src/app/base/components/SegmentToggle/SegmentToggle.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@canonical/react-components";
-import classNames from "classnames";
 
 type Segment<V> = {
   title: string;
@@ -16,20 +15,27 @@ const SegmentToggle = <V,>({
   onSelect,
   options,
   selected,
+  ...props
 }: Props<V>): JSX.Element => {
   return (
-    <div className="p-segment-toggle">
-      {options.map(({ title, value }) => (
-        <Button
-          className={classNames("p-segment-toggle__button", {
-            "is-active": value === selected,
-          })}
-          key={title}
-          onClick={() => onSelect(value)}
-        >
-          {title}
-        </Button>
-      ))}
+    <div
+      className="p-tab-buttons p-segment-toggle"
+      role="radiogroup"
+      {...props}
+    >
+      <div className="p-tab-buttons__list">
+        {options.map((button) => (
+          <Button
+            aria-checked={button.value === selected}
+            className="p-tab-buttons__button p-segment-toggle__button"
+            key={button.title}
+            onClick={() => onSelect(button.value)}
+            role="radio"
+          >
+            {button.title}
+          </Button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/ui/src/app/base/components/SegmentToggle/_index.scss
+++ b/ui/src/app/base/components/SegmentToggle/_index.scss
@@ -1,0 +1,34 @@
+@mixin SegmentToggle {
+  .p-segment-toggle {
+    border: 1px solid $colors--light-theme--border-high-contrast;
+    border-radius: $border-radius;
+    margin: 0 0 $input-margin-bottom 0;
+  }
+
+  .p-segment-toggle__button {
+    border-radius: 0;
+    margin: 0;
+
+    &,
+    &:hover {
+      border-color: $color-mid-light;
+      border-style: solid;
+      border-width: 0 1px 0 0;
+    }
+
+    &:first-child {
+      border-bottom-left-radius: $border-radius;
+      border-top-left-radius: $border-radius;
+    }
+
+    &:last-child {
+      border-bottom-right-radius: $border-radius;
+      border-right-width: 0;
+      border-top-right-radius: $border-radius;
+    }
+  }
+
+  .p-segment-toggle__button.is-active {
+    background-color: $colors--light-theme--background-active;
+  }
+}

--- a/ui/src/app/base/components/SegmentToggle/_index.scss
+++ b/ui/src/app/base/components/SegmentToggle/_index.scss
@@ -1,34 +1,5 @@
 @mixin SegmentToggle {
-  .p-segment-toggle {
-    border: 1px solid $colors--light-theme--border-high-contrast;
-    border-radius: $border-radius;
-    margin: 0 0 $input-margin-bottom 0;
-  }
-
-  .p-segment-toggle__button {
-    border-radius: 0;
-    margin: 0;
-
-    &,
-    &:hover {
-      border-color: $color-mid-light;
-      border-style: solid;
-      border-width: 0 1px 0 0;
-    }
-
-    &:first-child {
-      border-bottom-left-radius: $border-radius;
-      border-top-left-radius: $border-radius;
-    }
-
-    &:last-child {
-      border-bottom-right-radius: $border-radius;
-      border-right-width: 0;
-      border-top-right-radius: $border-radius;
-    }
-  }
-
-  .p-segment-toggle__button.is-active {
+  .p-segment-toggle__button[aria-checked="true"] {
     background-color: $colors--light-theme--background-active;
   }
 }

--- a/ui/src/app/base/components/SegmentToggle/index.ts
+++ b/ui/src/app/base/components/SegmentToggle/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SegmentToggle";

--- a/ui/src/app/store/tag/selectors.test.ts
+++ b/ui/src/app/store/tag/selectors.test.ts
@@ -1,4 +1,4 @@
-import tag from "./selectors";
+import tag, { TagSearchFilter } from "./selectors";
 
 import {
   rootState as rootStateFactory,
@@ -63,6 +63,63 @@ describe("tag selectors", () => {
         tag: tagStateFactory({ items: tags }),
       });
       expect(tag.getByIDs(state, [1, 2])).toStrictEqual([tags[0], tags[1]]);
+    });
+  });
+
+  describe("search", () => {
+    const tags = [
+      tagFactory({ id: 1, definition: undefined, name: "jacket" }),
+      tagFactory({ id: 2, definition: "denim", name: "jeans" }),
+      tagFactory({ id: 3, definition: undefined, name: "shirt" }),
+    ];
+
+    it("returns all tags if no filters or search are provided", () => {
+      const state = rootStateFactory({
+        tag: tagStateFactory({ items: tags }),
+      });
+      expect(tag.search(state, null, null)).toStrictEqual(tags);
+    });
+
+    it("returns all tags if the filter is set to 'All'", () => {
+      const state = rootStateFactory({
+        tag: tagStateFactory({ items: tags }),
+      });
+      expect(tag.search(state, null, TagSearchFilter.All)).toStrictEqual(tags);
+    });
+
+    it("filters automatic tags", () => {
+      const state = rootStateFactory({
+        tag: tagStateFactory({ items: tags }),
+      });
+      expect(tag.search(state, null, TagSearchFilter.Auto)).toStrictEqual([
+        tags[1],
+      ]);
+    });
+
+    it("filters manual tags", () => {
+      const state = rootStateFactory({
+        tag: tagStateFactory({ items: tags }),
+      });
+      expect(tag.search(state, null, TagSearchFilter.Manual)).toStrictEqual([
+        tags[0],
+        tags[2],
+      ]);
+    });
+
+    it("searches tags", () => {
+      const state = rootStateFactory({
+        tag: tagStateFactory({ items: tags }),
+      });
+      expect(tag.search(state, "j", null)).toStrictEqual([tags[0], tags[1]]);
+    });
+
+    it("searches and filters tags", () => {
+      const state = rootStateFactory({
+        tag: tagStateFactory({ items: tags }),
+      });
+      expect(tag.search(state, "j", TagSearchFilter.Manual)).toStrictEqual([
+        tags[0],
+      ]);
     });
   });
 });

--- a/ui/src/app/store/tag/selectors.ts
+++ b/ui/src/app/store/tag/selectors.ts
@@ -38,9 +38,48 @@ const getByIDs = createSelector(
   }
 );
 
+export enum TagSearchFilter {
+  All = "all",
+  Manual = "manual",
+  Auto = "auto",
+}
+
+/**
+ * Get machines that match search terms and filters.
+ * @param state - The redux state.
+ * @param terms - The terms to match against.
+ * @param filter - A .
+ * @returns A filtered list of machines.
+ */
+const search = createSelector(
+  [
+    defaultSelectors.all,
+    (
+      _state: RootState,
+      terms: string | null | undefined,
+      filter: TagSearchFilter | null | undefined
+    ) => ({
+      terms,
+      filter,
+    }),
+  ],
+  (tags: Tag[], { terms, filter }) => {
+    if (filter && filter !== TagSearchFilter.All) {
+      tags = tags.filter(({ definition }) =>
+        filter === TagSearchFilter.Auto ? !!definition : !definition
+      );
+    }
+    if (terms) {
+      tags = tags.filter((tag) => searchFunction(tag, terms));
+    }
+    return tags;
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
   getByIDs,
+  search,
 };
 
 export default selectors;

--- a/ui/src/app/tags/views/TagList/TagList.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import TagList, { TestId } from "./TagList";
+import TagList from "./TagList";
 
 import type { RootState } from "app/store/root/types";
 import {
@@ -39,6 +39,6 @@ it("renders", () => {
       </MemoryRouter>
     </Provider>
   );
-  expect(screen.getByTestId(TestId.TagListControls)).toBeInTheDocument();
-  expect(screen.getByTestId(TestId.TagTable)).toBeInTheDocument();
+  expect(screen.getByLabelText("tag list controls")).toBeInTheDocument();
+  expect(screen.getByRole("grid", { name: "tags" })).toBeInTheDocument();
 });

--- a/ui/src/app/tags/views/TagList/TagList.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.tsx
@@ -1,175 +1,50 @@
-import { useEffect } from "react";
+import { useState } from "react";
 
-import { Icon, MainTable, Tooltip } from "@canonical/react-components";
-import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 
-import TableActions from "app/base/components/TableActions";
+import TagListControls from "./TagListControls";
+import TagTable from "./TagTable";
+
 import { useWindowTitle } from "app/base/hooks";
-import controllerURLs from "app/controllers/urls";
-import deviceURLs from "app/devices/urls";
-import machineURLs from "app/machines/urls";
-import { actions as tagActions } from "app/store/tag";
-import tagSelectors from "app/store/tag/selectors";
-import type { Tag } from "app/store/tag/types";
-import tagURLs from "app/tags/urls";
-import { breakLines, unindentString } from "app/utils";
+import type { RootState } from "app/store/root/types";
+import tagSelectors, { TagSearchFilter } from "app/store/tag/selectors";
 
-export enum Label {
-  Actions = "Actions",
-  AppliedTo = "Applied to",
-  Auto = "Auto",
-  Name = "Tag name",
-  Options = "Kernel options",
-  Updated = "Last update",
+export enum TestId {
+  TagListControls = "TagListControls",
+  TagTable = "TagTable",
 }
 
-const generateRows = (tags: Tag[]) =>
-  tags.map((tag) => {
-    return {
-      key: `tag-row-${tag.id}`,
-      columns: [
-        {
-          "aria-label": Label.Name,
-          content: (
-            <Link to={tagURLs.tag.index({ id: tag.id })}>{tag.name}</Link>
-          ),
-        },
-        {
-          "aria-label": Label.Updated,
-          content: tag.updated,
-        },
-        {
-          "aria-label": Label.Auto,
-          content: !!tag.definition ? <Icon name="success-grey" /> : null,
-        },
-        {
-          "aria-label": Label.AppliedTo,
-          content: (
-            <>
-              {tag.machine_count > 0 ? (
-                <Link
-                  className="u-block"
-                  to={`${machineURLs.machines.index}?tags=${tag.name}`}
-                >
-                  {pluralize("machine", tag.machine_count, true)}
-                </Link>
-              ) : null}
-              {tag.controller_count > 0 ? (
-                <Link
-                  className="u-block"
-                  to={`${controllerURLs.controllers.index}?tags=${tag.name}`}
-                >
-                  {pluralize("controller", tag.controller_count, true)}
-                </Link>
-              ) : null}
-              {tag.device_count > 0 ? (
-                <Link
-                  className="u-block"
-                  to={`${deviceURLs.devices.index}?tags=${tag.name}`}
-                >
-                  {pluralize("device", tag.device_count, true)}
-                </Link>
-              ) : null}
-            </>
-          ),
-        },
-        {
-          "aria-label": Label.Options,
-          content: !!tag.kernel_opts ? <Icon name="success-grey" /> : null,
-        },
-        {
-          "aria-label": Label.Actions,
-          content: (
-            <TableActions
-              onDelete={() => {
-                // TODO: Implement the delete form:
-                // https://github.com/canonical-web-and-design/app-tribe/issues/701
-              }}
-              onEdit={() => {
-                // TODO: Implement tag edit form:
-                // https://github.com/canonical-web-and-design/app-tribe/issues/706
-              }}
-            />
-          ),
-          className: "u-align--right",
-        },
-      ],
-      sortData: {
-        name: tag.name,
-        updated: tag.updated,
-      },
-    };
-  });
-
 const TagList = (): JSX.Element => {
-  const dispatch = useDispatch();
-  const tags = useSelector(tagSelectors.all);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [filter, setFilter] = useState(TagSearchFilter.All);
+  const [searchText, setSearchText] = useState("");
+  const tags = useSelector((state: RootState) =>
+    tagSelectors.search(state, searchText, filter)
+  );
 
   useWindowTitle("Tags");
 
-  useEffect(() => {
-    dispatch(tagActions.fetch());
-  }, [dispatch]);
-
   return (
-    <MainTable
-      className="p-table-expanding--light"
-      headers={[
-        {
-          content: Label.Name,
-          sortKey: "name",
-        },
-        {
-          content: Label.Updated,
-          sortKey: "updated",
-        },
-        {
-          content: (
-            <>
-              {Label.Auto}{" "}
-              <Tooltip
-                // TODO: add a link to the docs:
-                // https://github.com/canonical-web-and-design/app-tribe/issues/739
-                message={
-                  <>
-                    {breakLines(
-                      unindentString(
-                        `Automatic tags are automatically applied to every 
-                        machine that matches their definition.`
-                      )
-                    )}
-                    <br />
-                    <a href="#todo">
-                      Check the documentation about automatic tags.
-                    </a>
-                  </>
-                }
-                position="top-center"
-              >
-                <Icon name="information" />
-              </Tooltip>
-            </>
-          ),
-        },
-        {
-          content: Label.AppliedTo,
-        },
-        {
-          content: Label.Options,
-        },
-        {
-          content: Label.Actions,
-          className: "u-align--right",
-        },
-      ]}
-      rows={generateRows(tags)}
-      paginate={50}
-      sortable
-      defaultSort="name"
-      defaultSortDirection="ascending"
-    />
+    <>
+      <TagListControls
+        data-testid="TagListControls"
+        filter={filter}
+        currentPage={currentPage}
+        setFilter={setFilter}
+        searchText={searchText}
+        setCurrentPage={setCurrentPage}
+        setSearchText={setSearchText}
+        tagCount={tags.length}
+      />
+      <TagTable
+        data-testid="TagTable"
+        currentPage={currentPage}
+        filter={filter}
+        searchText={searchText}
+        setCurrentPage={setCurrentPage}
+        tags={tags}
+      />
+    </>
   );
 };
 

--- a/ui/src/app/tags/views/TagList/TagList.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.tsx
@@ -6,13 +6,9 @@ import TagListControls from "./TagListControls";
 import TagTable from "./TagTable";
 
 import { useWindowTitle } from "app/base/hooks";
+import { useId } from "app/base/hooks/base";
 import type { RootState } from "app/store/root/types";
 import tagSelectors, { TagSearchFilter } from "app/store/tag/selectors";
-
-export enum TestId {
-  TagListControls = "TagListControls",
-  TagTable = "TagTable",
-}
 
 const TagList = (): JSX.Element => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -21,13 +17,15 @@ const TagList = (): JSX.Element => {
   const tags = useSelector((state: RootState) =>
     tagSelectors.search(state, searchText, filter)
   );
+  const tableId = useId();
 
   useWindowTitle("Tags");
 
   return (
     <>
       <TagListControls
-        data-testid="TagListControls"
+        aria-label="tag list controls"
+        aria-controls={tableId}
         filter={filter}
         currentPage={currentPage}
         setFilter={setFilter}
@@ -37,9 +35,10 @@ const TagList = (): JSX.Element => {
         tagCount={tags.length}
       />
       <TagTable
-        data-testid="TagTable"
+        aria-label="tags"
         currentPage={currentPage}
         filter={filter}
+        id={tableId}
         searchText={searchText}
         setCurrentPage={setCurrentPage}
         tags={tags}

--- a/ui/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
@@ -3,9 +3,10 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import TagList, { TestId } from "./TagList";
+import TagListControls, { Label } from "./TagListControls";
 
 import type { RootState } from "app/store/root/types";
+import { TagSearchFilter } from "app/store/tag/selectors";
 import {
   rootState as rootStateFactory,
   tag as tagFactory,
@@ -30,15 +31,24 @@ beforeEach(() => {
   });
 });
 
-it("renders", () => {
+it("can update the filter", () => {
+  const setFilter = jest.fn();
   const store = mockStore(state);
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagList />
+        <TagListControls
+          filter={TagSearchFilter.All}
+          setFilter={setFilter}
+          searchText={""}
+          setSearchText={jest.fn()}
+          currentPage={0}
+          setCurrentPage={jest.fn()}
+          tagCount={0}
+        />
       </MemoryRouter>
     </Provider>
   );
-  expect(screen.getByTestId(TestId.TagListControls)).toBeInTheDocument();
-  expect(screen.getByTestId(TestId.TagTable)).toBeInTheDocument();
+  screen.getByRole("button", { name: Label.Manual }).click(0);
+  expect(setFilter).toHaveBeenCalledWith(TagSearchFilter.Manual);
 });

--- a/ui/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
@@ -49,6 +49,6 @@ it("can update the filter", () => {
       </MemoryRouter>
     </Provider>
   );
-  screen.getByRole("button", { name: Label.Manual }).click(0);
+  screen.getByRole("radio", { name: Label.Manual }).click();
   expect(setFilter).toHaveBeenCalledWith(TagSearchFilter.Manual);
 });

--- a/ui/src/app/tags/views/TagList/TagListControls/TagListControls.tsx
+++ b/ui/src/app/tags/views/TagList/TagListControls/TagListControls.tsx
@@ -1,0 +1,71 @@
+import { useSelector } from "react-redux";
+
+import { TAGS_PER_PAGE } from "../constants";
+
+import ActionBar from "app/base/components/ActionBar";
+import SegmentToggle from "app/base/components/SegmentToggle";
+import type { SetSearchFilter } from "app/base/types";
+import tagSelectors, { TagSearchFilter } from "app/store/tag/selectors";
+
+type Props = {
+  filter: TagSearchFilter;
+  setFilter: (filter: TagSearchFilter) => void;
+  searchText: string;
+  setSearchText: SetSearchFilter;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  tagCount: number;
+};
+
+export enum Label {
+  All = "All tags",
+  Manual = "Manual tags",
+  Auto = "Automatic tags",
+}
+
+const TagListControls = ({
+  currentPage,
+  filter,
+  searchText,
+  setCurrentPage,
+  setFilter,
+  setSearchText,
+  tagCount,
+  ...actionBarProps
+}: Props): JSX.Element => {
+  const loading = useSelector(tagSelectors.loading);
+  return (
+    <ActionBar
+      {...actionBarProps}
+      actions={
+        <SegmentToggle
+          options={[
+            {
+              title: Label.All,
+              value: TagSearchFilter.All,
+            },
+            {
+              title: Label.Manual,
+              value: TagSearchFilter.Manual,
+            },
+            {
+              title: Label.Auto,
+              value: TagSearchFilter.Auto,
+            },
+          ]}
+          selected={filter}
+          onSelect={setFilter}
+        />
+      }
+      currentPage={currentPage}
+      itemCount={tagCount}
+      loading={loading}
+      onSearchChange={setSearchText}
+      pageSize={TAGS_PER_PAGE}
+      searchFilter={searchText}
+      setCurrentPage={setCurrentPage}
+    />
+  );
+};
+
+export default TagListControls;

--- a/ui/src/app/tags/views/TagList/TagListControls/TagListControls.tsx
+++ b/ui/src/app/tags/views/TagList/TagListControls/TagListControls.tsx
@@ -39,6 +39,7 @@ const TagListControls = ({
       {...actionBarProps}
       actions={
         <SegmentToggle
+          aria-label="tag filter"
           options={[
             {
               title: Label.All,

--- a/ui/src/app/tags/views/TagList/TagListControls/index.ts
+++ b/ui/src/app/tags/views/TagList/TagListControls/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagListControls";

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -1,0 +1,463 @@
+import { render, screen, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import TagTable, { Label, TestId } from "./TagTable";
+
+import controllerURLs from "app/controllers/urls";
+import deviceURLs from "app/devices/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import { TagSearchFilter } from "app/store/tag/selectors";
+import type { Tag } from "app/store/tag/types";
+import {
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+jest.mock("../constants", () => ({
+  __esModule: true,
+  // Mock the number of items per page to allow testing pagination.
+  TAGS_PER_PAGE: 2,
+}));
+
+const mockStore = configureStore();
+let state: RootState;
+let tags: Tag[];
+
+beforeEach(() => {
+  tags = [
+    tagFactory({
+      name: "rad",
+    }),
+    tagFactory({
+      name: "cool",
+    }),
+  ];
+  state = rootStateFactory({
+    tag: tagStateFactory({
+      items: tags,
+    }),
+  });
+});
+
+afterEach(() => {
+  // jest.resetModules();
+  // getTagsPerPage.mockReset()
+});
+
+it("displays tags", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const names = screen.queryAllByRole("gridcell", {
+    name: Label.Name,
+  });
+  expect(names).toHaveLength(2);
+  expect(names.find((td) => td.textContent === "rad")).toBeInTheDocument();
+  expect(names.find((td) => td.textContent === "cool")).toBeInTheDocument();
+});
+
+it("displays the tags in order", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const names = screen.queryAllByRole("gridcell", {
+    name: Label.Name,
+  });
+  expect(names[0].textContent).toBe("cool");
+  expect(names[1].textContent).toBe("rad");
+});
+
+it("can change the sort order", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  let names = screen.queryAllByRole("gridcell", {
+    name: Label.Name,
+  });
+  expect(names[0].textContent).toBe("cool");
+  expect(names[1].textContent).toBe("rad");
+  screen.getByRole("button", { name: Label.Name }).click();
+  names = screen.queryAllByRole("gridcell", {
+    name: Label.Name,
+  });
+  expect(names[0].textContent).toBe("rad");
+  expect(names[1].textContent).toBe("cool");
+});
+
+it("displays the tags for the current page", () => {
+  tags = [
+    tagFactory({
+      name: "rad",
+    }),
+    tagFactory({
+      name: "cool",
+    }),
+    tagFactory({
+      name: "hip",
+    }),
+    tagFactory({
+      name: "totes",
+    }),
+  ];
+
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={2}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const names = screen.queryAllByRole("gridcell", {
+    name: Label.Name,
+  });
+  expect(names).toHaveLength(2);
+  expect(names.find((td) => td.textContent === "rad")).toBeInTheDocument();
+  expect(names.find((td) => td.textContent === "totes")).toBeInTheDocument();
+});
+
+it("shows an icon for automatic tags", () => {
+  tags = [tagFactory({ definition: "automatic" })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Auto,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).toBeInTheDocument();
+});
+
+it("does not show an icon for manual tags", () => {
+  tags = [tagFactory({ definition: undefined })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Auto,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).not.toBeInTheDocument();
+});
+
+it("shows an icon for kernel options", () => {
+  tags = [tagFactory({ kernel_opts: "i'm a kernel option" })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Options,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).toBeInTheDocument();
+});
+
+it("does not show an icon for tags without kernel options", () => {
+  tags = [tagFactory({ kernel_opts: undefined })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const auto = screen.getByRole("gridcell", {
+    name: Label.Options,
+  });
+  expect(auto.querySelector(".p-icon--success-grey")).not.toBeInTheDocument();
+});
+
+it("can link to nodes", () => {
+  tags = [
+    tagFactory({
+      machine_count: 1,
+      device_count: 2,
+      controller_count: 3,
+      name: "a-tag",
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const cells = screen.queryAllByRole("gridcell", {
+    name: Label.AppliedTo,
+  });
+  const appliedTo = cells[cells.length - 1];
+  const machineLink = within(appliedTo).getByRole("link", {
+    name: "1 machine",
+  });
+  const deviceLink = within(appliedTo).getByRole("link", {
+    name: "2 devices",
+  });
+  const controllerLink = within(appliedTo).getByRole("link", {
+    name: "3 controllers",
+  });
+  expect(machineLink).toBeInTheDocument();
+  expect(controllerLink).toBeInTheDocument();
+  expect(deviceLink).toBeInTheDocument();
+  expect(machineLink).toHaveAttribute(
+    "href",
+    `${machineURLs.machines.index}?tags=a-tag`
+  );
+  expect(controllerLink).toHaveAttribute(
+    "href",
+    `${controllerURLs.controllers.index}?tags=a-tag`
+  );
+  expect(deviceLink).toHaveAttribute(
+    "href",
+    `${deviceURLs.devices.index}?tags=a-tag`
+  );
+});
+
+it("does not display a message if there are tags", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.queryByTestId(TestId.NoTags)).not.toBeInTheDocument();
+});
+
+it("displays a message if there are no automatic tags", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.Auto}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByTestId(TestId.NoTags).textContent).toBe(
+    "There are no automatic tags."
+  );
+});
+
+it("displays a message if there are no manual tags", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.Manual}
+          searchText=""
+          setCurrentPage={jest.fn()}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByTestId(TestId.NoTags).textContent).toBe(
+    "There are no manual tags."
+  );
+});
+
+it("displays a message if none match the search terms", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText="nothing"
+          setCurrentPage={jest.fn()}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByTestId(TestId.NoTags).textContent).toBe(
+    "No tags match the search criteria."
+  );
+});
+
+it("displays a message if none match the filter and search terms", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.Auto}
+          searchText="nothing"
+          setCurrentPage={jest.fn()}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByTestId(TestId.NoTags).textContent).toBe(
+    "No automatic tags match the search criteria."
+  );
+});
+
+it("returns to the first page if the search changes", () => {
+  const setCurrentPage = jest.fn();
+  const store = mockStore(state);
+  const { rerender } = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.Auto}
+          searchText=""
+          setCurrentPage={setCurrentPage}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  rerender(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.Auto}
+          searchText="new"
+          setCurrentPage={setCurrentPage}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(setCurrentPage).toHaveBeenCalledWith(1);
+});
+
+it("returns to the first page if the filter changes", () => {
+  const setCurrentPage = jest.fn();
+  const store = mockStore(state);
+  const { rerender } = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.All}
+          searchText=""
+          setCurrentPage={setCurrentPage}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  rerender(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <TagTable
+          currentPage={1}
+          filter={TagSearchFilter.Manual}
+          searchText=""
+          setCurrentPage={setCurrentPage}
+          tags={[]}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(setCurrentPage).toHaveBeenCalledWith(1);
+});

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -1,0 +1,270 @@
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { Icon, MainTable, Strip, Tooltip } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
+
+import { TAGS_PER_PAGE } from "../constants";
+
+import TableActions from "app/base/components/TableActions";
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
+import { SortDirection } from "app/base/types";
+import controllerURLs from "app/controllers/urls";
+import deviceURLs from "app/devices/urls";
+import machineURLs from "app/machines/urls";
+import { actions as tagActions } from "app/store/tag";
+import { TagSearchFilter } from "app/store/tag/selectors";
+import type { Tag } from "app/store/tag/types";
+import tagURLs from "app/tags/urls";
+import { breakLines, isComparable, unindentString } from "app/utils";
+
+type Props = {
+  currentPage: number;
+  filter: TagSearchFilter;
+  searchText: string;
+  setCurrentPage: (page: number) => void;
+  tags: Tag[];
+};
+
+export enum Label {
+  Actions = "Actions",
+  AppliedTo = "Applied to",
+  Auto = "Auto",
+  Name = "Tag name",
+  Options = "Kernel options",
+  Updated = "Last update",
+}
+
+export enum TestId {
+  NoTags = "no-tags",
+}
+
+type SortKey = keyof Tag;
+
+const getSortValue = (sortKey: SortKey, tag: Tag) => {
+  const value = tag[sortKey];
+  return isComparable(value) ? value : null;
+};
+
+const generateRows = (tags: Tag[]) =>
+  tags.map((tag) => {
+    return {
+      key: `tag-row-${tag.id}`,
+      columns: [
+        {
+          "aria-label": Label.Name,
+          content: (
+            <Link to={tagURLs.tag.index({ id: tag.id })}>{tag.name}</Link>
+          ),
+        },
+        {
+          "aria-label": Label.Updated,
+          content: tag.updated,
+        },
+        {
+          "aria-label": Label.Auto,
+          content: !!tag.definition ? <Icon name="success-grey" /> : null,
+        },
+        {
+          "aria-label": Label.AppliedTo,
+          content: (
+            <>
+              {tag.machine_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${machineURLs.machines.index}?tags=${tag.name}`}
+                >
+                  {pluralize("machine", tag.machine_count, true)}
+                </Link>
+              ) : null}
+              {tag.controller_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${controllerURLs.controllers.index}?tags=${tag.name}`}
+                >
+                  {pluralize("controller", tag.controller_count, true)}
+                </Link>
+              ) : null}
+              {tag.device_count > 0 ? (
+                <Link
+                  className="u-block"
+                  to={`${deviceURLs.devices.index}?tags=${tag.name}`}
+                >
+                  {pluralize("device", tag.device_count, true)}
+                </Link>
+              ) : null}
+            </>
+          ),
+        },
+        {
+          "aria-label": Label.Options,
+          content: !!tag.kernel_opts ? <Icon name="success-grey" /> : null,
+        },
+        {
+          "aria-label": Label.Actions,
+          content: (
+            <TableActions
+              onDelete={() => {
+                // TODO: Implement the delete form:
+                // https://github.com/canonical-web-and-design/app-tribe/issues/701
+              }}
+              onEdit={() => {
+                // TODO: Implement tag edit form:
+                // https://github.com/canonical-web-and-design/app-tribe/issues/706
+              }}
+            />
+          ),
+          className: "u-align--right",
+        },
+      ],
+      sortData: {
+        name: tag.name,
+        updated: tag.updated,
+      },
+    };
+  });
+
+const generateNoTagsMessage = (
+  noTags: boolean,
+  filter: TagSearchFilter,
+  searchText: string
+) => {
+  const hasFilter = filter !== TagSearchFilter.All;
+  let noTagsMessage: ReactNode = null;
+  if (noTags && (searchText || hasFilter)) {
+    let filterName: string | null = null;
+    if (hasFilter) {
+      filterName = filter === TagSearchFilter.Auto ? "automatic" : "manual";
+    }
+    let message: string | null = null;
+    if (hasFilter && !searchText) {
+      message = `There are no ${filterName} tags.`;
+    } else if (searchText) {
+      message = `No${
+        filterName ? ` ${filterName}` : ""
+      } tags match the search criteria.`;
+    }
+    if (message) {
+      noTagsMessage = (
+        <Strip
+          shallow
+          rowClassName="u-align--center"
+          data-testid={TestId.NoTags}
+        >
+          {message}
+        </Strip>
+      );
+    }
+  }
+  return noTagsMessage;
+};
+
+const TagTable = ({
+  currentPage,
+  filter,
+  searchText,
+  setCurrentPage,
+  tags,
+  ...tableProps
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const { currentSort, sortRows, updateSort } = useTableSort<Tag, SortKey>(
+    getSortValue,
+    {
+      key: "name",
+      direction: SortDirection.DESCENDING,
+    }
+  );
+  const sortedTags = sortRows(tags);
+  const paginatedTags = sortedTags.slice(
+    (currentPage - 1) * TAGS_PER_PAGE,
+    currentPage * TAGS_PER_PAGE
+  );
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
+
+  useEffect(() => {
+    // Go to the first page if the search text or filters are updated.
+    setCurrentPage(1);
+  }, [filter, searchText, setCurrentPage]);
+
+  return (
+    <>
+      <MainTable
+        {...tableProps}
+        className="p-table-expanding--light"
+        headers={[
+          {
+            content: (
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("name")}
+                sortKey="name"
+              >
+                {Label.Name}
+              </TableHeader>
+            ),
+          },
+          {
+            content: (
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("updated")}
+                sortKey="updated"
+              >
+                {Label.Updated}
+              </TableHeader>
+            ),
+          },
+          {
+            content: (
+              <>
+                {Label.Auto}{" "}
+                <Tooltip
+                  // TODO: add a link to the docs:
+                  // https://github.com/canonical-web-and-design/app-tribe/issues/739
+                  message={
+                    <>
+                      {breakLines(
+                        unindentString(
+                          `Automatic tags are automatically applied to every 
+                        machine that matches their definition.`
+                        )
+                      )}
+                      <br />
+                      <a href="#todo">
+                        Check the documentation about automatic tags.
+                      </a>
+                    </>
+                  }
+                  position="top-center"
+                >
+                  <Icon name="information" />
+                </Tooltip>
+              </>
+            ),
+          },
+          {
+            content: Label.AppliedTo,
+          },
+          {
+            content: Label.Options,
+          },
+          {
+            content: Label.Actions,
+            className: "u-align--right",
+          },
+        ]}
+        rows={generateRows(paginatedTags)}
+      />
+      {generateNoTagsMessage(tags.length === 0, filter, searchText)}
+    </>
+  );
+};
+
+export default TagTable;

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
+import type {
+  MainTableProps,
+  PropsWithSpread,
+} from "@canonical/react-components";
 import { Icon, MainTable, Strip, Tooltip } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch } from "react-redux";
@@ -21,13 +25,16 @@ import type { Tag } from "app/store/tag/types";
 import tagURLs from "app/tags/urls";
 import { breakLines, isComparable, unindentString } from "app/utils";
 
-type Props = {
-  currentPage: number;
-  filter: TagSearchFilter;
-  searchText: string;
-  setCurrentPage: (page: number) => void;
-  tags: Tag[];
-};
+type Props = PropsWithSpread<
+  {
+    currentPage: number;
+    filter: TagSearchFilter;
+    searchText: string;
+    setCurrentPage: (page: number) => void;
+    tags: Tag[];
+  },
+  MainTableProps
+>;
 
 export enum Label {
   Actions = "Actions",

--- a/ui/src/app/tags/views/TagList/TagTable/index.ts
+++ b/ui/src/app/tags/views/TagList/TagTable/index.ts
@@ -1,0 +1,1 @@
+export { default, Label } from "./TagTable";

--- a/ui/src/app/tags/views/TagList/constants.ts
+++ b/ui/src/app/tags/views/TagList/constants.ts
@@ -1,0 +1,1 @@
+export const TAGS_PER_PAGE = 50;

--- a/ui/src/app/tags/views/TagList/index.ts
+++ b/ui/src/app/tags/views/TagList/index.ts
@@ -1,1 +1,1 @@
-export { default, Label } from "./TagList";
+export { default } from "./TagList";

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -91,6 +91,7 @@
 @import "~app/base/components/Popover";
 @import "~app/base/components/Section";
 @import "~app/base/components/SectionHeader";
+@import "~app/base/components/SegmentToggle";
 @import "~app/base/components/SSHKeyList";
 @import "~app/base/components/Stepper";
 @import "~app/base/components/TableMenu";
@@ -115,6 +116,7 @@
 @include Popover;
 @include Section;
 @include SectionHeader;
+@include SegmentToggle;
 @include SSHKeyList;
 @include Stepper;
 @include TableMenu;


### PR DESCRIPTION
## Done

- Add a segmented button component.
- Add the action bar to Tags to sort, filter and search.
- Add pagination to the table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the tags tab under machines.
- Check that you can filter by automatic or manual tags.
- Check that you can search tags.
- Check that you can change the order of the name and updated columns.
- Check that you can paginate the table (you may have to reduce the `TAGS_PER_PAGE` value to less than the number of tags.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/703.
Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/698.
Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/697.
Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/696.

## Screenshots
<img width="1352" alt="Screen Shot 2022-03-04 at 12 07 35 pm" src="https://user-images.githubusercontent.com/361637/156686722-38b5b7ac-6e1b-4720-98e8-fa496ea9cf03.png">
