### PR TITLE
feat(ui): add tag create, update and delete actions

### DIFF
--- a/ui/src/app/store/tag/actions.test.ts
+++ b/ui/src/app/store/tag/actions.test.ts
@@ -11,4 +11,58 @@ describe("tag actions", () => {
       payload: null,
     });
   });
+
+  it("can create an action for creating a tag", () => {
+    const params = {
+      comment: "It's a tag",
+      definition: "tag def",
+      kernel_opts: "opts",
+      name: "tag1",
+    };
+    expect(actions.create(params)).toEqual({
+      type: "tag/create",
+      meta: {
+        model: "tag",
+        method: "create",
+      },
+      payload: {
+        params,
+      },
+    });
+  });
+
+  it("can create an action for deleting a tag", () => {
+    expect(actions.delete(1)).toEqual({
+      type: "tag/delete",
+      meta: {
+        model: "tag",
+        method: "delete",
+      },
+      payload: {
+        params: {
+          id: 1,
+        },
+      },
+    });
+  });
+
+  it("can create an action for updating a tag", () => {
+    const params = {
+      comment: "It's a tag",
+      definition: "tag def",
+      id: 1,
+      kernel_opts: "opts",
+      name: "tag1",
+    };
+    expect(actions.update(params)).toEqual({
+      type: "tag/update",
+      meta: {
+        model: "tag",
+        method: "update",
+      },
+      payload: {
+        params,
+      },
+    });
+  });
 });

--- a/ui/src/app/store/tag/reducers.test.ts
+++ b/ui/src/app/store/tag/reducers.test.ts
@@ -33,7 +33,7 @@ describe("tag reducer", () => {
     const tags = [tagFactory()];
 
     expect(reducers(state, actions.fetchSuccess(tags))).toEqual({
-      errors: {},
+      errors: null,
       items: tags,
       loading: false,
       loaded: true,
@@ -55,5 +55,174 @@ describe("tag reducer", () => {
         saving: false,
       }
     );
+  });
+
+  describe("create reducers", () => {
+    it("should correctly reduce createStart", () => {
+      const initialState = tagStateFactory({ saving: false });
+      expect(reducers(initialState, actions.createStart())).toEqual(
+        tagStateFactory({
+          saving: true,
+        })
+      );
+    });
+
+    it("should correctly reduce createError", () => {
+      const initialState = tagStateFactory({ saving: true });
+      expect(
+        reducers(
+          initialState,
+          actions.createError({ key: "Key already exists" })
+        )
+      ).toEqual(
+        tagStateFactory({
+          errors: { key: "Key already exists" },
+          saving: false,
+        })
+      );
+    });
+
+    it("should correctly reduce createSuccess", () => {
+      const initialState = tagStateFactory({
+        saved: false,
+        saving: true,
+      });
+      expect(reducers(initialState, actions.createSuccess())).toEqual(
+        tagStateFactory({
+          saved: true,
+          saving: false,
+        })
+      );
+    });
+
+    it("should correctly reduce createNotify", () => {
+      const items = [tagFactory(), tagFactory()];
+      const initialState = tagStateFactory({ items: [items[0]] });
+      expect(reducers(initialState, actions.createNotify(items[1]))).toEqual(
+        tagStateFactory({
+          items,
+        })
+      );
+    });
+  });
+
+  describe("update reducers", () => {
+    it("reduces updateStart", () => {
+      const tagState = tagStateFactory({ saved: true });
+
+      expect(reducers(tagState, actions.updateStart())).toEqual({
+        errors: null,
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: true,
+      });
+    });
+
+    it("reduces updateSuccess", () => {
+      const tagState = tagStateFactory({
+        saving: true,
+      });
+
+      expect(reducers(tagState, actions.updateSuccess())).toEqual({
+        errors: null,
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: true,
+        saving: false,
+      });
+    });
+
+    it("reduces updateError", () => {
+      const tagState = tagStateFactory({
+        saving: true,
+      });
+
+      expect(
+        reducers(tagState, actions.updateError("Could not update tag"))
+      ).toEqual({
+        errors: "Could not update tag",
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false,
+      });
+    });
+
+    it("reduces updateNotify", () => {
+      const tags = [tagFactory({ id: 1 })];
+      const updatedTag = tagFactory({
+        comment: "updated comment",
+        definition: "updated def",
+        id: 1,
+        kernel_opts: "updated opts",
+        name: "updated tag",
+      });
+
+      const tagState = tagStateFactory({
+        items: tags,
+      });
+
+      expect(reducers(tagState, actions.updateNotify(updatedTag))).toEqual({
+        errors: null,
+        items: [updatedTag],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false,
+      });
+    });
+  });
+
+  describe("delete reducers", () => {
+    it("should correctly reduce deleteStart", () => {
+      const initialState = tagStateFactory({
+        saved: true,
+        saving: false,
+      });
+      expect(reducers(initialState, actions.deleteStart())).toEqual(
+        tagStateFactory({
+          saved: false,
+          saving: true,
+        })
+      );
+    });
+
+    it("should correctly reduce deleteError", () => {
+      const initialState = tagStateFactory({
+        errors: null,
+        saving: true,
+      });
+      expect(
+        reducers(initialState, actions.deleteError("Could not delete"))
+      ).toEqual(
+        tagStateFactory({
+          errors: "Could not delete",
+          saving: false,
+        })
+      );
+    });
+
+    it("should correctly reduce deleteSuccess", () => {
+      const initialState = tagStateFactory({ saved: false });
+      expect(reducers(initialState, actions.deleteSuccess())).toEqual(
+        tagStateFactory({
+          saved: true,
+        })
+      );
+    });
+
+    it("should correctly reduce deleteNotify", () => {
+      const items = [tagFactory(), tagFactory()];
+      const initialState = tagStateFactory({ items });
+      expect(reducers(initialState, actions.deleteNotify(items[0].id))).toEqual(
+        tagStateFactory({
+          items: [items[1]],
+        })
+      );
+    });
   });
 });

--- a/ui/src/app/store/tag/slice.ts
+++ b/ui/src/app/store/tag/slice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 import { TagMeta } from "./types";
-import type { TagState } from "./types";
+import type { TagState, CreateParams, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
@@ -11,10 +11,12 @@ import {
 const tagSlice = createSlice({
   name: TagMeta.MODEL,
   initialState: genericInitialState as TagState,
-  reducers: generateCommonReducers<TagState, TagMeta.PK, void, void>(
-    TagMeta.MODEL,
-    TagMeta.PK
-  ),
+  reducers: generateCommonReducers<
+    TagState,
+    TagMeta.PK,
+    CreateParams,
+    UpdateParams
+  >(TagMeta.MODEL, TagMeta.PK),
 });
 
 export const { actions } = tagSlice;

--- a/ui/src/app/store/tag/types/actions.ts
+++ b/ui/src/app/store/tag/types/actions.ts
@@ -1,0 +1,13 @@
+import type { Tag } from "./base";
+import type { TagMeta } from "./enum";
+
+export type CreateParams = {
+  comment: Tag["comment"];
+  definition: Tag["definition"];
+  kernel_opts: Tag["kernel_opts"];
+  name: Tag["name"];
+};
+
+export type UpdateParams = CreateParams & {
+  [TagMeta.PK]: Tag[TagMeta.PK];
+};

--- a/ui/src/app/store/tag/types/index.ts
+++ b/ui/src/app/store/tag/types/index.ts
@@ -1,3 +1,4 @@
+export type { CreateParams, UpdateParams } from "./actions";
 export type { Tag, TagState } from "./base";
 
 export { TagMeta } from "./enum";

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -460,6 +460,7 @@ export const subnetState = define<SubnetState>({
 
 export const tagState = define<TagState>({
   ...defaultState,
+  errors: null,
 });
 
 export const vlanStatus = define<VLANStatus>(DEFAULT_VLAN_STATUSES);


### PR DESCRIPTION
## Done

- Add actions and reducers to the tag slice to support create, update and delete.

## QA

N/A code changes only.

## Fixes

Fixes: canonical-web-and-design/app-tribe#712.