### PR TITLE
refactor(ui): add ModularTable

### DIFF
--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -135,18 +135,11 @@ context("Subnets - Add", () => {
         cy.findByRole("rowheader").within(() =>
           cy.findByText(fabricName).should("not.be.visible")
         );
-        cy.findByRole("column", { name: "VLAN" }).should(
-          "have.text",
-          `${vid} (${vlanName})`
-        );
-        cy.findByRole("column", { name: "Subnet" }).should(
-          "contain.text",
-          subnetName
-        );
-        cy.findByRole("column", { name: "Space" }).should(
-          "have.text",
-          spaceName
-        );
+        cy.findAllByRole("gridcell")
+          .eq(0)
+          .should("have.text", `${vid} (${vlanName})`);
+        cy.findAllByRole("gridcell").eq(2).should("contain.text", subnetName);
+        cy.findAllByRole("gridcell").eq(4).should("have.text", spaceName);
       });
 
     // delete the subnet

--- a/ui/package.json
+++ b/ui/package.json
@@ -87,6 +87,7 @@
     "@testing-library/react": "12.1.4",
     "@testing-library/react-hooks": "7.0.2",
     "@types/path-parse": "1.0.19",
+    "@types/react-table": "7.7.9",
     "@typescript-eslint/eslint-plugin": "5.15.0",
     "@typescript-eslint/parser": "5.15.0",
     "@welldone-software/why-did-you-render": "6.2.3",

--- a/ui/src/app/base/components/ModularTable/ModularTable.tsx
+++ b/ui/src/app/base/components/ModularTable/ModularTable.tsx
@@ -1,0 +1,145 @@
+import type { ReactNode } from "react";
+
+import Icon from "@canonical/react-components/dist/components/Icon";
+import Table from "@canonical/react-components/dist/components/Table";
+import TableCell from "@canonical/react-components/dist/components/TableCell";
+import TableHeader from "@canonical/react-components/dist/components/TableHeader";
+import TableRow from "@canonical/react-components/dist/components/TableRow";
+import { useTable } from "react-table";
+import type {
+  Column,
+  TablePropGetter,
+  Cell,
+  UseTableOptions,
+} from "react-table";
+
+export type Props<D extends Record<string, unknown>> = {
+  /**
+   * The columns of the table.
+   */
+  columns: Column<D>[];
+  /**
+   * The data of the table.
+   */
+  data: D[];
+  /**
+   * A message to display if data is empty.
+   */
+  emptyMsg?: string;
+  /**
+   * Optional extra row to display underneath the main table content.
+   */
+  footer?: ReactNode;
+  getTableProps?: TablePropGetter<D>;
+  getHeaderProps?: (column: Column<D>) => Record<string, unknown>;
+  getColumnProps?: (column: Column<D>) => Record<string, unknown>;
+  getRowProps?: (column: Column<D>) => Record<string, unknown>;
+  getCellProps?: (cell: Cell<D>) => Record<string, unknown>;
+  getRowId?: UseTableOptions<D>["getRowId"];
+};
+
+const defaultPropGetter = () => ({});
+
+// TODO: Replace this component with a @canonical/react-components ModularTable
+// after upgrading to the lastest version that includes additional options for the MainTable
+// https://github.com/canonical-web-and-design/react-components/pull/723
+function ModularTable<D extends Record<string, unknown>>({
+  data,
+  columns,
+  emptyMsg,
+  footer,
+  getTableProps = defaultPropGetter,
+  getHeaderProps = defaultPropGetter,
+  getColumnProps = defaultPropGetter,
+  getRowProps = defaultPropGetter,
+  getCellProps = defaultPropGetter,
+  getRowId,
+}: Props<D>): JSX.Element {
+  const {
+    getTableProps: getBaseTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+  } = useTable<D>({ columns, data, getRowId: getRowId || undefined });
+
+  const showEmpty: boolean = !!emptyMsg && (!rows || rows.length === 0);
+
+  return (
+    <Table {...getBaseTableProps(getTableProps)}>
+      <thead>
+        {headerGroups.map((headerGroup) => (
+          <TableRow {...headerGroup.getHeaderGroupProps()}>
+            {headerGroup.headers.map((column) => (
+              <TableHeader
+                {...column.getHeaderProps([
+                  {
+                    className: column.className,
+                  },
+                  {
+                    className: column.getCellIcon
+                      ? "p-table__cell--icon-placeholder"
+                      : "",
+                  },
+                  getColumnProps(column),
+                  getHeaderProps(column),
+                ])}
+              >
+                {column.render("Header")}
+              </TableHeader>
+            ))}
+          </TableRow>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.map((row) => {
+          // This function is responsible for lazily preparing a row for rendering.
+          // Any row that you intend to render in your table needs to be passed to this function before every render.
+          // see: https://react-table.tanstack.com/docs/api/useTable#instance-properties
+          prepareRow(row);
+          return (
+            <TableRow {...row.getRowProps(getRowProps(row))}>
+              {row.cells.map((cell) => {
+                const hasColumnIcon = cell.column.getCellIcon;
+                const iconName =
+                  hasColumnIcon && cell.column.getCellIcon?.(cell);
+
+                return (
+                  <TableCell
+                    {...cell.getCellProps([
+                      {
+                        className: cell.column.className,
+                      },
+                      {
+                        className: hasColumnIcon
+                          ? "p-table__cell--icon-placeholder"
+                          : "",
+                      },
+                      getColumnProps(cell.column),
+                      getCellProps(cell),
+                    ])}
+                  >
+                    {iconName && <Icon name={iconName} />}
+                    {cell.render("Cell")}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          );
+        })}
+        {showEmpty && (
+          <TableRow>
+            <TableCell colSpan={columns.length}>{emptyMsg}</TableCell>
+          </TableRow>
+        )}
+        {footer && (
+          <TableRow>
+            <TableCell colSpan={columns.length}>{footer}</TableCell>
+          </TableRow>
+        )}
+      </tbody>
+    </Table>
+  );
+}
+
+export default ModularTable;

--- a/ui/src/app/base/components/ModularTable/ModularTable.tsx
+++ b/ui/src/app/base/components/ModularTable/ModularTable.tsx
@@ -11,6 +11,7 @@ import type {
   TablePropGetter,
   Cell,
   UseTableOptions,
+  Row,
 } from "react-table";
 
 export type Props<D extends Record<string, unknown>> = {
@@ -33,7 +34,7 @@ export type Props<D extends Record<string, unknown>> = {
   getTableProps?: TablePropGetter<D>;
   getHeaderProps?: (column: Column<D>) => Record<string, unknown>;
   getColumnProps?: (column: Column<D>) => Record<string, unknown>;
-  getRowProps?: (column: Column<D>) => Record<string, unknown>;
+  getRowProps?: (row: Row<D>) => Record<string, unknown>;
   getCellProps?: (cell: Cell<D>) => Record<string, unknown>;
   getRowId?: UseTableOptions<D>["getRowId"];
 };

--- a/ui/src/app/base/components/ModularTable/index.ts
+++ b/ui/src/app/base/components/ModularTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModularTable";

--- a/ui/src/app/base/components/ModularTable/react-table-config.d.ts
+++ b/ui/src/app/base/components/ModularTable/react-table-config.d.ts
@@ -1,0 +1,12 @@
+// check @types/react-table README for details on this config file:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-table/Readme.md
+
+import "react-table";
+
+declare module "react-table" {
+  export interface UseTableColumnOptions<D extends Record<string, unknown>>
+    extends UseTableColumnOptions<D> {
+    className?: string;
+    getCellIcon?: (cell: Cell<D>) => string | false;
+  }
+}

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
@@ -1,19 +1,19 @@
 import { useMemo } from "react";
 
-import { CellContents } from "../components";
-
 import ModularTable from "app/base/components/ModularTable";
+import { CellContents } from "app/subnets/views/SubnetsList/SubnetsTable/components";
+import {
+  subnetColumnLabels,
+  SubnetsColumns,
+} from "app/subnets/views/SubnetsList/SubnetsTable/constants";
 import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
 const FabricTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
   return (
     <ModularTable<SubnetsTableRow>
       emptyMsg="Loading..."
-      getTableProps={(tableProps) => ({
-        ...tableProps,
-        className: "subnets-table",
-        "aria-label": "Subnets",
-      })}
+      className="subnets-table"
+      aria-label="Subnets"
       getCellProps={({ value, column }) => ({
         className: `subnets-table__cell--${column.id}${
           value.isVisuallyHidden ? " u-no-border--top" : ""
@@ -29,33 +29,33 @@ const FabricTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
       columns={useMemo(
         () => [
           {
-            Header: "Fabric",
-            accessor: "fabric",
+            Header: subnetColumnLabels[SubnetsColumns.FABRIC],
+            accessor: SubnetsColumns.FABRIC,
             Cell: CellContents,
           },
           {
-            Header: "VLAN",
-            accessor: "vlan",
+            Header: subnetColumnLabels[SubnetsColumns.VLAN],
+            accessor: SubnetsColumns.VLAN,
             Cell: CellContents,
           },
           {
-            Header: "DHCP",
-            accessor: "dhcp",
+            Header: subnetColumnLabels[SubnetsColumns.DHCP],
+            accessor: SubnetsColumns.DHCP,
             Cell: CellContents,
           },
           {
-            Header: "Subnet",
-            accessor: "subnet",
+            Header: subnetColumnLabels[SubnetsColumns.SUBNET],
+            accessor: SubnetsColumns.SUBNET,
             Cell: CellContents,
           },
           {
-            Header: "Available IPs",
-            accessor: "ips",
+            Header: subnetColumnLabels[SubnetsColumns.IPS],
+            accessor: SubnetsColumns.IPS,
             Cell: CellContents,
           },
           {
-            Header: "Space",
-            accessor: "space",
+            Header: subnetColumnLabels[SubnetsColumns.SPACE],
+            accessor: SubnetsColumns.SPACE,
             className: "u-align--right",
             Cell: CellContents,
           },

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
@@ -12,14 +12,19 @@ const FabricTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
       getTableProps={(tableProps) => ({
         ...tableProps,
         className: "subnets-table",
+        "aria-label": "Subnets",
       })}
       getCellProps={({ value, column }) => ({
         className: `subnets-table__cell--${column.id}${
           value.isVisuallyHidden ? " u-no-border--top" : ""
         }`,
+        role: column.id === "fabric" ? "rowheader" : undefined,
       })}
       getHeaderProps={(header) => ({
         className: `subnets-table__cell--${header.id}`,
+      })}
+      getRowProps={(row) => ({
+        "aria-label": row.values.fabric.label,
       })}
       columns={useMemo(
         () => [

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
@@ -1,101 +1,64 @@
-import { memo } from "react";
+import { useMemo } from "react";
 
-import { Table, TableRow } from "@canonical/react-components";
+import { CellContents } from "../components";
 
-import { getRowPropsAreEqual } from "../utils";
-
-import {
-  TableHeader,
-  TableCell,
-} from "app/subnets/views/SubnetsList/SubnetsTable/components";
+import ModularTable from "app/base/components/ModularTable";
 import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
-export const FabricRow = memo(
-  ({ columns }: SubnetsTableRow): JSX.Element => (
-    <TableRow aria-label={columns.fabric.label || undefined}>
-      <TableCell
-        role="rowheader"
-        className="subnets-table__cell--fabric"
-        aria-label="Fabric"
-        cellData={columns.fabric}
-      >
-        {columns.fabric.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--vlan"
-        aria-label="VLAN"
-        cellData={columns.vlan}
-      >
-        {columns.vlan.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--dhcp"
-        aria-label="DHCP"
-        cellData={columns.dhcp}
-      >
-        {columns.dhcp.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--subnet"
-        aria-label="Subnet"
-        cellData={columns.subnet}
-      >
-        {columns.subnet.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--ips"
-        aria-label="IPs"
-        cellData={columns.ips}
-      >
-        {columns.ips.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--space u-align--right"
-        aria-label="Space"
-        cellData={columns.space}
-      >
-        {columns.space.label}
-      </TableCell>
-    </TableRow>
-  ),
-  getRowPropsAreEqual
-);
-
-const FabricTable = ({ rows }: { rows: SubnetsTableRow[] }): JSX.Element => {
+const FabricTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
   return (
-    <Table role="table" className="subnets-table" aria-label="Subnets">
-      <thead>
-        <tr>
-          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
-          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
-          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
-          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
-          <TableHeader
-            label="Available IPs"
-            className="subnets-table__cell--ips"
-          />
-          <TableHeader
-            label="Space"
-            className="subnets-table__cell--space u-align--right"
-          />
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, i) => {
-          return (
-            <FabricRow
-              key={`${row.sortData?.fabricId}-${row.sortData?.vlanId}-${i}`}
-              {...row}
-            />
-          );
-        })}
-      </tbody>
-    </Table>
+    <ModularTable<SubnetsTableRow>
+      emptyMsg="Loading..."
+      getTableProps={(tableProps) => ({
+        ...tableProps,
+        className: "subnets-table",
+      })}
+      getCellProps={({ value, column }) => ({
+        className: `subnets-table__cell--${column.id}${
+          value.isVisuallyHidden ? " u-no-border--top" : ""
+        }`,
+      })}
+      getHeaderProps={(header) => ({
+        className: `subnets-table__cell--${header.id}`,
+      })}
+      columns={useMemo(
+        () => [
+          {
+            Header: "Fabric",
+            accessor: "fabric",
+            Cell: CellContents,
+          },
+          {
+            Header: "VLAN",
+            accessor: "vlan",
+            Cell: CellContents,
+          },
+          {
+            Header: "DHCP",
+            accessor: "dhcp",
+            Cell: CellContents,
+          },
+          {
+            Header: "Subnet",
+            accessor: "subnet",
+            Cell: CellContents,
+          },
+          {
+            Header: "Available IPs",
+            accessor: "ips",
+            Cell: CellContents,
+          },
+          {
+            Header: "Space",
+            accessor: "space",
+            className: "u-align--right",
+            Cell: CellContents,
+          },
+        ],
+        []
+      )}
+      data={useMemo(() => data, [data])}
+    />
   );
 };
 

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
@@ -1,115 +1,65 @@
-import { memo, useState } from "react";
+import { useMemo } from "react";
 
-import { Table, TableRow, Button } from "@canonical/react-components";
-
-import { getRowPropsAreEqual } from "../utils";
-
+import ModularTable from "app/base/components/ModularTable";
 import {
-  TableHeader,
-  TableCell,
+  CellContents,
+  SpaceCellContents,
 } from "app/subnets/views/SubnetsList/SubnetsTable/components";
 import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
-export const SpaceRow = memo(({ columns }: SubnetsTableRow): JSX.Element => {
-  const [isWarningOpen, setIsWarningOpen] = useState(false);
+const SpaceTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
   return (
-    <TableRow aria-label={columns.space.label || undefined}>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--space"
-        aria-label="Space"
-        cellData={columns.space}
-      >
-        {columns.space.label === "No space" ? (
-          <Button
-            appearance="base"
-            dense
-            hasIcon
-            aria-label="No space - press to see more information"
-            onClick={() => setIsWarningOpen(!isWarningOpen)}
-          >
-            <i className="p-icon--warning"></i> <span>No space</span>
-          </Button>
-        ) : (
-          columns.space.label
-        )}
-        {isWarningOpen ? (
-          <div>
-            MAAS integrations require a space in order to determine the purpose
-            of a network. Define a space for each subnet by selecting the space
-            on the VLAN details page.
-          </div>
-        ) : null}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--vlan"
-        aria-label="VLAN"
-        cellData={columns.vlan}
-      >
-        {columns.vlan.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--dhcp"
-        aria-label="DHCP"
-        cellData={columns.dhcp}
-      >
-        {columns.dhcp.label}
-      </TableCell>
-      <TableCell
-        role="rowheader"
-        className="subnets-table__cell--fabric"
-        aria-label="Fabric"
-        cellData={columns.fabric}
-      >
-        {columns.fabric.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--subnet"
-        aria-label="Subnet"
-        cellData={columns.subnet}
-      >
-        {columns.subnet.label}
-      </TableCell>
-      <TableCell
-        role="column"
-        className="subnets-table__cell--ips u-align--right"
-        aria-label="IPs"
-        cellData={columns.ips}
-      >
-        {columns.ips.label}
-      </TableCell>
-    </TableRow>
-  );
-}, getRowPropsAreEqual);
-
-const SpaceTable = ({ rows }: { rows: SubnetsTableRow[] }): JSX.Element => {
-  return (
-    <Table role="table" className="subnets-table" aria-label="Subnets">
-      <thead>
-        <tr>
-          <TableHeader label="Space" className="subnets-table__cell--space" />
-          <TableHeader label="VLAN" className="subnets-table__cell--vlan" />
-          <TableHeader label="DHCP" className="subnets-table__cell--dhcp" />
-          <TableHeader label="Fabric" className="subnets-table__cell--fabric" />
-          <TableHeader label="Subnet" className="subnets-table__cell--subnet" />
-          <TableHeader
-            label="Available IPs"
-            className="subnets-table__cell--ips u-align--right"
-          />
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, i) => (
-          <SpaceRow
-            key={`${row.sortData?.spaceName}-${row.sortData?.vlanId}-${i}`}
-            {...row}
-          />
-        ))}
-      </tbody>
-    </Table>
+    <ModularTable<SubnetsTableRow>
+      emptyMsg="Loading..."
+      getTableProps={(tableProps) => ({
+        ...tableProps,
+        className: "subnets-table",
+      })}
+      getCellProps={({ value, column }) => ({
+        className: `subnets-table__cell--${column.id}${
+          value.isVisuallyHidden ? " u-no-border--top" : ""
+        }`,
+      })}
+      getHeaderProps={(header) => ({
+        className: `subnets-table__cell--${header.id}`,
+      })}
+      columns={useMemo(
+        () => [
+          {
+            Header: "Space",
+            accessor: "space",
+            Cell: SpaceCellContents,
+          },
+          {
+            Header: "VLAN",
+            accessor: "vlan",
+            Cell: CellContents,
+          },
+          {
+            Header: "DHCP",
+            accessor: "dhcp",
+            Cell: CellContents,
+          },
+          {
+            Header: "Fabric",
+            accessor: "fabric",
+            Cell: CellContents,
+          },
+          {
+            Header: "Subnet",
+            accessor: "subnet",
+            Cell: CellContents,
+          },
+          {
+            Header: "Available IPs",
+            accessor: "ips",
+            Cell: CellContents,
+          },
+        ],
+        []
+      )}
+      data={useMemo(() => data, [data])}
+    />
   );
 };
 

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
@@ -5,17 +5,18 @@ import {
   CellContents,
   SpaceCellContents,
 } from "app/subnets/views/SubnetsList/SubnetsTable/components";
+import {
+  subnetColumnLabels,
+  SubnetsColumns,
+} from "app/subnets/views/SubnetsList/SubnetsTable/constants";
 import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
 const SpaceTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
   return (
     <ModularTable<SubnetsTableRow>
       emptyMsg="Loading..."
-      getTableProps={(tableProps) => ({
-        ...tableProps,
-        className: "subnets-table",
-        "aria-label": "Subnets",
-      })}
+      className="subnets-table"
+      aria-label="Subnets"
       getCellProps={({ value, column }) => ({
         className: `subnets-table__cell--${column.id}${
           value.isVisuallyHidden ? " u-no-border--top" : ""
@@ -31,33 +32,33 @@ const SpaceTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
       columns={useMemo(
         () => [
           {
-            Header: "Space",
-            accessor: "space",
+            Header: subnetColumnLabels[SubnetsColumns.SPACE],
+            accessor: SubnetsColumns.SPACE,
             Cell: SpaceCellContents,
           },
           {
-            Header: "VLAN",
-            accessor: "vlan",
+            Header: subnetColumnLabels[SubnetsColumns.VLAN],
+            accessor: SubnetsColumns.VLAN,
             Cell: CellContents,
           },
           {
-            Header: "DHCP",
-            accessor: "dhcp",
+            Header: subnetColumnLabels[SubnetsColumns.DHCP],
+            accessor: SubnetsColumns.DHCP,
             Cell: CellContents,
           },
           {
-            Header: "Fabric",
-            accessor: "fabric",
+            Header: subnetColumnLabels[SubnetsColumns.FABRIC],
+            accessor: SubnetsColumns.FABRIC,
             Cell: CellContents,
           },
           {
-            Header: "Subnet",
-            accessor: "subnet",
+            Header: subnetColumnLabels[SubnetsColumns.SUBNET],
+            accessor: SubnetsColumns.SUBNET,
             Cell: CellContents,
           },
           {
-            Header: "Available IPs",
-            accessor: "ips",
+            Header: subnetColumnLabels[SubnetsColumns.IPS],
+            accessor: SubnetsColumns.IPS,
             Cell: CellContents,
           },
         ],

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
@@ -14,14 +14,19 @@ const SpaceTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
       getTableProps={(tableProps) => ({
         ...tableProps,
         className: "subnets-table",
+        "aria-label": "Subnets",
       })}
       getCellProps={({ value, column }) => ({
         className: `subnets-table__cell--${column.id}${
           value.isVisuallyHidden ? " u-no-border--top" : ""
         }`,
+        role: column.id === "space" ? "rowheader" : undefined,
       })}
       getHeaderProps={(header) => ({
         className: `subnets-table__cell--${header.id}`,
+      })}
+      getRowProps={(row) => ({
+        "aria-label": row.values.space.label,
       })}
       columns={useMemo(
         () => [

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
@@ -16,9 +16,9 @@ const SubnetsTable = ({
       <SubnetsControls groupBy={groupBy} setGroupBy={setGroupBy} />
 
       {groupBy === "fabric" ? (
-        <FabricTable rows={rows} />
+        <FabricTable data={rows} />
       ) : (
-        <SpaceTable rows={rows} />
+        <SpaceTable data={rows} />
       )}
     </>
   );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -1,44 +1,61 @@
-import type {
-  TableCellProps,
-  TableHeaderProps,
-} from "@canonical/react-components";
-import {
-  TableCell as TableCellComponent,
-  TableHeader as TableHeaderComponent,
-} from "@canonical/react-components";
+import type { PropsWithChildren } from "react";
+import { useState } from "react";
+
+import { Button } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
 import type { SubnetsTableColumn } from "./types";
 
-export const TableHeader = ({
-  label,
-  ...props
-}: TableHeaderProps & {
-  label: string;
-}): JSX.Element => (
-  <TableHeaderComponent {...props}>{label}</TableHeaderComponent>
-);
+export const SpaceCellContents = ({
+  value,
+}: PropsWithChildren<{
+  value: SubnetsTableColumn;
+}>): JSX.Element => {
+  const [isWarningOpen, setIsWarningOpen] = useState(false);
+  return (
+    <>
+      <span
+        className={
+          value.isVisuallyHidden ? "subnets-table__visually-hidden" : ""
+        }
+      >
+        {value.label === "No space" ? (
+          <Button
+            appearance="base"
+            dense
+            hasIcon
+            aria-label="No space - press to see more information"
+            onClick={() => setIsWarningOpen(!isWarningOpen)}
+          >
+            <i className="p-icon--warning"></i> <span>No space</span>
+          </Button>
+        ) : value.href ? (
+          <Link to={value.href}>{value.label}</Link>
+        ) : (
+          value.label
+        )}
+        {isWarningOpen ? (
+          <div>
+            MAAS integrations require a space in order to determine the purpose
+            of a network. Define a space for each subnet by selecting the space
+            on the VLAN details page.
+          </div>
+        ) : null}
+      </span>
+    </>
+  );
+};
 
-export const TableCell = ({
-  cellData,
-  children,
-  className,
-  ...props
-}: TableCellProps & {
-  cellData: SubnetsTableColumn;
+export const CellContents = ({
+  value,
+}: {
+  value: SubnetsTableColumn;
 }): JSX.Element => (
-  <TableCellComponent
-    className={`${className} ${
-      cellData.isVisuallyHidden ? "u-no-border--top" : ""
-    }`}
-    {...props}
-  >
+  <>
     <span
-      className={
-        cellData.isVisuallyHidden ? "subnets-table__visually-hidden" : ""
-      }
+      className={value.isVisuallyHidden ? "subnets-table__visually-hidden" : ""}
     >
-      {cellData.href ? <Link to={cellData.href}>{children}</Link> : children}
+      {value.href ? <Link to={value.href}>{value.label}</Link> : value.label}
     </span>
-  </TableCellComponent>
+  </>
 );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/constants.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/constants.ts
@@ -1,0 +1,17 @@
+export enum SubnetsColumns {
+  FABRIC = "fabric",
+  VLAN = "vlan",
+  DHCP = "dhcp",
+  SUBNET = "subnet",
+  IPS = "ips",
+  SPACE = "space",
+}
+
+export const subnetColumnLabels: Record<SubnetsColumns, string> = {
+  [SubnetsColumns.FABRIC]: "Fabric",
+  [SubnetsColumns.VLAN]: "VLAN",
+  [SubnetsColumns.DHCP]: "DHCP",
+  [SubnetsColumns.SUBNET]: "Subnet",
+  [SubnetsColumns.IPS]: "Available IPs",
+  [SubnetsColumns.SPACE]: "Space",
+};

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/types.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/types.ts
@@ -41,14 +41,11 @@ export type SortDataKey =
   | "cidr";
 
 export type SubnetsTableRow = {
-  columns: {
-    fabric: SubnetsTableColumn;
-    vlan: SubnetsTableColumn;
-    dhcp: SubnetsTableColumn;
-    subnet: SubnetsTableColumn;
-    ips: SubnetsTableColumn;
-    space: SubnetsTableColumn;
-  };
+  fabric: SubnetsTableColumn;
+  vlan: SubnetsTableColumn;
+  dhcp: SubnetsTableColumn;
+  subnet: SubnetsTableColumn;
+  ips: SubnetsTableColumn;
+  space: SubnetsTableColumn;
   sortData: SortData;
-  children?: React.ReactChildren[];
 };

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/types.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/types.ts
@@ -1,3 +1,5 @@
+import type { SubnetsColumns } from "./constants";
+
 import type { Fabric } from "app/store/fabric/types";
 import type { Space } from "app/store/space/types";
 import type { Subnet } from "app/store/subnet/types";
@@ -40,12 +42,6 @@ export type SortDataKey =
   | "spaceName"
   | "cidr";
 
-export type SubnetsTableRow = {
-  fabric: SubnetsTableColumn;
-  vlan: SubnetsTableColumn;
-  dhcp: SubnetsTableColumn;
-  subnet: SubnetsTableColumn;
-  ips: SubnetsTableColumn;
-  space: SubnetsTableColumn;
+export type SubnetsTableRow = Record<SubnetsColumns, SubnetsTableColumn> & {
   sortData: SortData;
 };

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
@@ -33,8 +33,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
   const spaces = [spaceFactory()];
 
   expect(
-    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[0]?.columns
-      .fabric
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[0]?.fabric
   ).toStrictEqual({
     href: "/fabric/1",
     isVisuallyHidden: false,
@@ -42,8 +41,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
   });
 
   expect(
-    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[1]?.columns
-      .fabric
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[1]?.fabric
   ).toStrictEqual({
     href: "/fabric/1",
     isVisuallyHidden: true,
@@ -51,8 +49,7 @@ test("getTableData returns grouped fabrics in a correct format", () => {
   });
 
   expect(
-    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[2]?.columns
-      .fabric
+    getTableData({ fabrics, vlans, subnets, spaces }, "fabric")[2]?.fabric
   ).toStrictEqual({
     href: "/fabric/2",
     isVisuallyHidden: false,

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.tsx
@@ -31,29 +31,6 @@ import {
 } from "app/subnets/urls";
 import { simpleSortByKey } from "app/utils";
 
-export const getRowPropsAreEqual = (
-  prevProps: SubnetsTableRow,
-  nextProps: SubnetsTableRow
-): boolean => {
-  return (
-    prevProps.columns.fabric.label === nextProps.columns.fabric.label &&
-    prevProps.columns.vlan.label === nextProps.columns.vlan.label &&
-    prevProps.columns.vlan.href === nextProps.columns.vlan.href &&
-    prevProps.columns.dhcp.label === nextProps.columns.dhcp.label &&
-    prevProps.columns.subnet.label === nextProps.columns.subnet.label &&
-    prevProps.columns.subnet.href === nextProps.columns.subnet.href &&
-    prevProps.columns.ips.label === nextProps.columns.ips.label &&
-    prevProps.columns.space.label === nextProps.columns.space.label &&
-    prevProps.columns.space.href === nextProps.columns.space.href &&
-    prevProps.columns.space.isVisuallyHidden ===
-      nextProps.columns.space.isVisuallyHidden &&
-    prevProps.columns.vlan.isVisuallyHidden ===
-      nextProps.columns.vlan.isVisuallyHidden &&
-    prevProps.columns.fabric.isVisuallyHidden ===
-      nextProps.columns.fabric.isVisuallyHidden
-  );
-};
-
 const sortBySortKey =
   (key: keyof SortData, { reverse } = { reverse: false }) =>
   (a: SubnetsTableRow, b: SubnetsTableRow): number => {
@@ -72,12 +49,12 @@ const markRepeatedFabricRows = (rows: SubnetsTableRow[]): SubnetsTableRow[] => {
   rows.forEach((row, index) => {
     const previousRow: SubnetsTableRow = rows[index - 1];
 
-    if (row.columns && index > 0) {
+    if (row && index > 0) {
       if (row.sortData?.fabricId === previousRow?.sortData?.fabricId) {
-        row.columns.fabric = { ...row.columns.fabric, isVisuallyHidden: true };
+        row.fabric = { ...row.fabric, isVisuallyHidden: true };
       }
       if (row.sortData?.vlanId === previousRow?.sortData?.vlanId) {
-        row.columns.vlan = { ...row.columns.vlan, isVisuallyHidden: true };
+        row.vlan = { ...row.vlan, isVisuallyHidden: true };
       }
     }
   });
@@ -89,8 +66,8 @@ const markRepeatedSpaceRows = (rows: SubnetsTableRow[]): SubnetsTableRow[] => {
   rows.forEach((row, index) => {
     const previousRow: SubnetsTableRow = rows[index - 1];
 
-    if (row.columns.space?.label === previousRow?.columns.space?.label) {
-      row.columns.space = { ...row.columns.space, isVisuallyHidden: true };
+    if (row.space?.label === previousRow?.space?.label) {
+      row.space = { ...row.space, isVisuallyHidden: true };
     }
   });
 
@@ -111,22 +88,20 @@ const getRowData = ({
   data?: SubnetsTableData;
 }): SubnetsTableRow => {
   return {
-    columns: {
-      fabric: getColumn(getFabricDisplay(fabric), getFabricLink(fabric?.id)),
-      vlan: getColumn(
-        getVLANDisplay(vlan),
-        vlan?.id ? getVLANLink(vlan?.id) : null
-      ),
-      dhcp: getColumn(
-        data ? getDHCPStatus(vlan, data.vlans, data.fabrics, true) : null
-      ),
-      subnet: getColumn(
-        subnet?.id ? getSubnetDisplay(subnet) : null,
-        subnet?.id ? getSubnetLink(subnet?.id) : null
-      ),
-      ips: getColumn(subnet ? getAvailableIPs(subnet) : null),
-      space: getColumn(getSpaceDisplay(space), getSpaceLink(space?.id)),
-    },
+    fabric: getColumn(getFabricDisplay(fabric), getFabricLink(fabric?.id)),
+    vlan: getColumn(
+      getVLANDisplay(vlan),
+      vlan?.id ? getVLANLink(vlan?.id) : null
+    ),
+    dhcp: getColumn(
+      data ? getDHCPStatus(vlan, data.vlans, data.fabrics, true) : null
+    ),
+    subnet: getColumn(
+      subnet?.id ? getSubnetDisplay(subnet) : null,
+      subnet?.id ? getSubnetLink(subnet?.id) : null
+    ),
+    ips: getColumn(subnet ? getAvailableIPs(subnet) : null),
+    space: getColumn(getSpaceDisplay(space), getSpaceLink(space?.id)),
     sortData: {
       fabricId: fabric?.id || "",
       fabricName: getFabricDisplay(fabric)?.toLowerCase() || "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3740,6 +3740,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-table@7.7.9":
+  version "7.7.9"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.9.tgz#ea82875775fc6ee71a28408dcc039396ae067c92"
+  integrity sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@>=16.9.0":
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"


### PR DESCRIPTION
## Done

- Replace custom Fabric and Space table implementations with a `ModularTable`
  - related PR adding changes to the ModularTable component in `react-components`: https://github.com/canonical-web-and-design/react-components/pull/723

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `MAAS/r/networks?by=fabric`,  `MAAS/r/networks?by=space` and make sure all rows are displayed exactly as before

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
