### PR TITLE
feat(ui): display new label for tag action

### DIFF
--- a/ui/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/ui/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -212,4 +212,23 @@ describe("NodeActionMenu", () => {
       "negative"
     );
   });
+
+  it("can override action titles", () => {
+    const nodes = [
+      machineFactory({
+        actions: [NodeActions.TAG],
+      }),
+    ];
+    const wrapper = mount(
+      <NodeActionMenu
+        getTitle={() => "Overridden"}
+        nodes={nodes}
+        onActionClick={jest.fn()}
+      />
+    );
+    openMenu(wrapper);
+    expect(
+      getActionButton(wrapper, NodeActions.TAG).text().includes("Overridden")
+    ).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/ui/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type {
   ButtonAppearance,
   ButtonProps,
@@ -21,6 +23,7 @@ type Props = {
   alwaysShowLifecycle?: boolean;
   disabledTooltipPosition?: "left" | "top-left";
   excludeActions?: NodeActions[];
+  getTitle?: (action: NodeActions) => ReactNode | null;
   menuPosition?: "left" | "right";
   nodeDisplay?: string;
   nodes: Node[];
@@ -76,7 +79,8 @@ const getTakeActionLinks = (
   nodes: Node[],
   onActionClick: (action: NodeActions) => void,
   excludeActions: NodeActions[],
-  alwaysShowLifecycle: boolean
+  alwaysShowLifecycle: boolean,
+  getTitle?: Props["getTitle"]
 ) => {
   return actionGroups.reduce<ActionLink[][]>((links, group) => {
     const groupLinks = group.actions.reduce<ActionLink[]>(
@@ -95,7 +99,10 @@ const getTakeActionLinks = (
           groupLinks.push({
             children: (
               <div className="u-flex--between">
-                <span>{getNodeActionTitle(action)}...</span>
+                <span>
+                  {getTitle?.(action) ?? getNodeActionTitle(action)}
+                  ...
+                </span>
                 {nodes.length > 1 && (
                   <span
                     className="u-nudge-right--small"
@@ -127,6 +134,7 @@ export const NodeActionMenu = ({
   alwaysShowLifecycle = false,
   disabledTooltipPosition = "left",
   excludeActions = [],
+  getTitle,
   menuPosition = "right",
   nodeDisplay = "node",
   nodes,
@@ -150,7 +158,8 @@ export const NodeActionMenu = ({
           nodes,
           onActionClick,
           excludeActions,
-          alwaysShowLifecycle
+          alwaysShowLifecycle,
+          getTitle
         )}
         position={menuPosition}
         toggleAppearance={toggleAppearance}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -14,6 +14,7 @@ import {
   machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { NodeActions } from "app/store/types/node";
 
 const mockStore = configureStore();
 
@@ -34,6 +35,10 @@ describe("MachineListHeader", () => {
         },
       }),
     });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it("displays a loader if machines have not loaded", () => {
@@ -167,5 +172,89 @@ describe("MachineListHeader", () => {
     expect(wrapper.find('[data-testid="section-header-title"]').text()).toBe(
       "Deploy"
     );
+  });
+
+  it("displays a new label for the tag action", () => {
+    // Set a selected machine so the take action menu becomes enabled.
+    state.machine.selected = ["abc123"];
+    // A machine needs the tag action for it to appear in the menu.
+    state.machine.items = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.TAG] }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the take action menu.
+    wrapper
+      .find(
+        '[data-testid="take-action-dropdown"] button.p-contextual-menu__toggle'
+      )
+      .simulate("click");
+    expect(
+      wrapper
+        .find("button[data-testid='action-link-tag']")
+        .text()
+        .includes("(NEW)")
+    ).toBe(true);
+  });
+
+  it("hides the tag action's new label after it has been clicked", () => {
+    // Set a selected machine so the take action menu becomes enabled.
+    state.machine.selected = ["abc123"];
+    // A machine needs the tag action for it to appear in the menu.
+    state.machine.items = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.TAG] }),
+    ];
+    const store = mockStore(state);
+    const Header = () => (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    let wrapper = mount(<Header />);
+    // Open the take action menu.
+    wrapper
+      .find(
+        '[data-testid="take-action-dropdown"] button.p-contextual-menu__toggle'
+      )
+      .simulate("click");
+    const tagAction = wrapper.find("button[data-testid='action-link-tag']");
+    // The new label should appear before being clicked.
+    expect(tagAction.text().includes("(NEW)")).toBe(true);
+    tagAction.simulate("click");
+    // Render the header again
+    wrapper = mount(<Header />);
+    // Open the take action menu.
+    wrapper
+      .find(
+        '[data-testid="take-action-dropdown"] button.p-contextual-menu__toggle'
+      )
+      .simulate("click");
+    // The new label should now be hidden.
+    expect(
+      wrapper
+        .find("button[data-testid='action-link-tag']")
+        .text()
+        .includes("(NEW)")
+    ).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -8,13 +8,13 @@ import MachineListHeader from "./MachineListHeader";
 
 import { MachineHeaderViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { NodeActions } from "app/store/types/node";
 
 const mockStore = configureStore();
 


### PR DESCRIPTION
## Done

- Add a new label to the tag action when it is first seen.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list.
- Tick a/some machines.
- Open the take action menu.
- The tag action should have "(NEW)" label next to it.
- Click on the tag action and then press cancel.
- Open the take action menu again and the "(NEW)" label should not be visible.

## Fixes

Fixes: canonical-web-and-design/app-tribe#692.