### PR TITLE
test: cleanup subnet tests

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -112,10 +112,8 @@ module.exports = {
       files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
       extends: ["plugin:testing-library/react"],
       rules: {
-        "testing-library/prefer-find-by": "warn",
-        "testing-library/prefer-presence-queries": "warn",
-        "testing-library/no-node-access": "warn",
-        "testing-library/no-wait-for-side-effects": "warn",
+        "testing-library/prefer-find-by": "off",
+        "testing-library/prefer-explicit-assert": "error",
       },
     },
   ],

--- a/ui/src/app/base/hooks/base.test.tsx
+++ b/ui/src/app/base/hooks/base.test.tsx
@@ -30,6 +30,7 @@ describe("hooks", () => {
 
     beforeEach(() => {
       global.innerHeight = 500;
+      // eslint-disable-next-line testing-library/no-node-access
       html = document.querySelector("html");
       scrollToSpy = jest.fn();
       global.scrollTo = scrollToSpy;

--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -136,7 +136,7 @@ describe("ReservedRangeForm", () => {
       screen.getByRole("textbox", { name: Labels.Comment }),
       "reserved"
     );
-    await waitFor(() => fireEvent.submit(screen.getByRole("form")));
+    fireEvent.submit(screen.getByRole("form"));
     const expected = ipRangeActions.create({
       comment: "reserved",
       end_ip: "1.1.1.2",
@@ -144,9 +144,11 @@ describe("ReservedRangeForm", () => {
       subnet: 1,
       type: IPRangeType.Reserved,
     });
-    expect(
-      store.getActions().find((action) => action.type === expected.type)
-    ).toStrictEqual(expected);
+    await waitFor(() =>
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected)
+    );
   });
 
   it("dispatches an action to update a reserved range", async () => {
@@ -160,16 +162,18 @@ describe("ReservedRangeForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    await waitFor(() => fireEvent.submit(screen.getByRole("form")));
+    fireEvent.submit(screen.getByRole("form"));
     const expected = ipRangeActions.update({
       comment: ipRange.comment,
       end_ip: ipRange.end_ip,
       id: ipRange.id,
       start_ip: ipRange.start_ip,
     });
-    expect(
-      store.getActions().find((action) => action.type === expected.type)
-    ).toStrictEqual(expected);
+    await waitFor(() =>
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected)
+    );
   });
 
   it("resets the comment when updating a dynamic range", async () => {
@@ -185,17 +189,21 @@ describe("ReservedRangeForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    await waitFor(() => fireEvent.submit(screen.getByRole("form")));
+    fireEvent.submit(screen.getByRole("form"));
     const expected = ipRangeActions.update({
       comment: ipRange.comment,
       end_ip: ipRange.end_ip,
       id: ipRange.id,
       start_ip: ipRange.start_ip,
     });
-    const actual = store
-      .getActions()
-      .find((action) => action.type === expected.type);
-    expect(actual.payload.params.comment).toBe(expected.payload.params.comment);
+    await waitFor(() => {
+      const actual = store
+        .getActions()
+        .find((action) => action.type === expected.type);
+      expect(actual.payload.params.comment).toBe(
+        expected.payload.params.comment
+      );
+    });
   });
 
   it("does not display the Comment field when creating a dynamic range", async () => {

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -75,14 +75,14 @@ it("renders for a subnet", () => {
   ).toHaveLength(2);
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.StartIP,
       })
       .find((td) => td.textContent === "11.1.1.1")
   ).toBeInTheDocument();
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.StartIP,
       })
       .find((td) => td.textContent === "11.1.1.2")
@@ -112,14 +112,14 @@ it("renders for a vlan", () => {
   ).toHaveLength(2);
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.StartIP,
       })
       .find((td) => td.textContent === "11.1.1.1")
   ).toBeInTheDocument();
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.StartIP,
       })
       .find((td) => td.textContent === "11.1.1.2")
@@ -236,12 +236,13 @@ it("displays an edit form", async () => {
       </MemoryRouter>
     </Provider>
   );
-  await waitFor(() => {
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-  });
-  expect(
-    screen.getByRole("form", { name: ReservedRangeFormLabels.EditRange })
-  ).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: ReservedRangeFormLabels.EditRange })
+    ).toBeInTheDocument()
+  );
 });
 
 it("displays confirm delete message", async () => {
@@ -253,14 +254,15 @@ it("displays confirm delete message", async () => {
       </MemoryRouter>
     </Provider>
   );
+  fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
   await waitFor(() => {
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(
+      screen.getByText(
+        new RegExp("Are you sure you want to remove this IP range?")
+      )
+    ).toBeInTheDocument();
   });
-  expect(
-    screen.getByText(
-      new RegExp("Are you sure you want to remove this IP range?")
-    )
-  ).toBeInTheDocument();
 });
 
 it("dispatches an action to delete a reserved range", async () => {
@@ -272,15 +274,17 @@ it("dispatches an action to delete a reserved range", async () => {
       </MemoryRouter>
     </Provider>
   );
-  await waitFor(() => {
-    fireEvent.click(screen.getByTestId("table-actions-delete"));
-    fireEvent.click(screen.getByTestId("action-confirm"));
-  });
+  fireEvent.click(screen.getByTestId("table-actions-delete"));
+  fireEvent.click(screen.getByTestId("action-confirm"));
+
   const expectedAction = ipRangeActions.delete(ipRange.id);
-  const actualAction = store
-    .getActions()
-    .find((action) => action.type === expectedAction.type);
-  expect(actualAction).toStrictEqual(expectedAction);
+
+  await waitFor(() => {
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
 });
 
 it("displays an add button when it is reserved", () => {
@@ -312,19 +316,20 @@ it("displays an add button when it is dynamic", async () => {
       </MemoryRouter>
     </Provider>
   );
+  fireEvent.click(
+    screen.queryAllByRole("button", {
+      name: Labels.ReserveRange,
+    })[0]
+  );
+  fireEvent.click(screen.getByTestId("reserve-dynamic-range-menu-item"));
+
   await waitFor(() => {
-    fireEvent.click(
-      screen.queryAllByRole("button", {
-        name: Labels.ReserveRange,
-      })[0]
-    );
-    fireEvent.click(screen.getByTestId("reserve-dynamic-range-menu-item"));
+    expect(
+      screen.getByRole("button", {
+        name: Labels.ReserveDynamicRange,
+      })
+    ).toBeInTheDocument();
   });
-  expect(
-    screen.getByRole("button", {
-      name: Labels.ReserveDynamicRange,
-    })
-  ).toBeInTheDocument();
 });
 
 it("disables the add button if there are no subnets in a VLAN", () => {
@@ -352,17 +357,20 @@ it("can display an add form", async () => {
       </MemoryRouter>
     </Provider>
   );
+  fireEvent.click(
+    screen.queryAllByRole("button", {
+      name: Labels.ReserveRange,
+    })[0]
+  );
+  fireEvent.click(screen.getByTestId("reserve-range-menu-item"));
+
   await waitFor(() => {
-    fireEvent.click(
-      screen.queryAllByRole("button", {
-        name: Labels.ReserveRange,
-      })[0]
-    );
-    fireEvent.click(screen.getByTestId("reserve-range-menu-item"));
+    expect(
+      screen.getByRole("form", {
+        name: ReservedRangeFormLabels.CreateRange,
+      })
+    ).toBeInTheDocument();
   });
-  expect(
-    screen.getByRole("form", { name: ReservedRangeFormLabels.CreateRange })
-  ).toBeInTheDocument();
 });
 
 it("displays the subnet column when the table is for a VLAN", () => {

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -71,7 +71,11 @@ it("can open and close the Edit fabric summary form", async () => {
   );
   const fabricSummary = screen.getByRole("region", { name: "Fabric summary" });
   userEvent.click(within(fabricSummary).getByRole("button", { name: "Edit" }));
-  await screen.findByRole("form", { name: "Edit fabric summary" });
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: "Edit fabric summary" })
+    ).toBeInTheDocument()
+  );
 
   userEvent.click(
     within(fabricSummary).getByRole("button", { name: "Cancel" })

--- a/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -57,7 +57,9 @@ it("correctly dispatches space create action on form submit", async () => {
   userEvent.type(screen.getByRole("textbox", { name: /CIDR/ }), cidr);
   userEvent.type(screen.getByRole("textbox", { name: /Name/ }), name);
 
-  await screen.findByRole("combobox", { name: "VLAN" });
+  await waitFor(() =>
+    expect(screen.getByRole("combobox", { name: "VLAN" })).toBeInTheDocument()
+  );
   userEvent.selectOptions(
     screen.getByRole("combobox", { name: "Fabric" }),
     fabric.name

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -33,7 +33,9 @@ it("displays validation messages for VID", async () => {
   userEvent.type(VidTextBox, "abc");
   userEvent.click(submitButton);
 
-  await screen.findByText(errorMessage);
+  await waitFor(() =>
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  );
 
   userEvent.clear(VidTextBox);
   userEvent.type(VidTextBox, "123");
@@ -45,7 +47,9 @@ it("displays validation messages for VID", async () => {
   userEvent.clear(VidTextBox);
   userEvent.type(VidTextBox, "99999");
 
-  await screen.findByText(errorMessage);
+  await waitFor(() =>
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  );
 });
 
 it("correctly dispatches VLAN create action on form submit", async () => {

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -53,7 +53,11 @@ it("can open and close the Edit space summary form", async () => {
   );
   const spaceSummary = screen.getByRole("region", { name: "Space summary" });
   userEvent.click(within(spaceSummary).getByRole("button", { name: "Edit" }));
-  await screen.findByRole("form", { name: "Edit space summary" });
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: "Edit space summary" })
+    ).toBeInTheDocument()
+  );
 
   userEvent.click(within(spaceSummary).getByRole("button", { name: "Cancel" }));
 

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -50,7 +50,11 @@ it("dispatches a correct action on add static route form submit", async () => {
     </Provider>
   );
 
-  await screen.findByRole("form", { name: "Add static route" });
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", { name: "Add static route" })
+    ).toBeInTheDocument()
+  );
 
   const addStaticRouteForm = screen.getByRole("form", {
     name: "Add static route",

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -50,20 +50,20 @@ it("renders for a subnet", () => {
     </Provider>
   );
   expect(
-    screen.queryAllByRole("gridcell", {
+    screen.getAllByRole("gridcell", {
       name: Labels.GatewayIp,
     })
   ).toHaveLength(2);
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.GatewayIp,
       })
       .find((td) => td.textContent === "11.1.1.1")
   ).toBeInTheDocument();
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.GatewayIp,
       })
       .find((td) => td.textContent === "11.1.1.2")
@@ -95,18 +95,25 @@ it("can open and close the add static route form", async () => {
       </MemoryRouter>
     </Provider>
   );
-  await screen.findByRole("button", {
-    name: AddStaticRouteFormLabels.AddStaticRoute,
-  });
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", {
+        name: AddStaticRouteFormLabels.AddStaticRoute,
+      })
+    ).toBeInTheDocument()
+  );
   userEvent.click(
     screen.getByRole("button", {
       name: AddStaticRouteFormLabels.AddStaticRoute,
     })
   );
-
-  await screen.findByRole("form", {
-    name: AddStaticRouteFormLabels.AddStaticRoute,
-  });
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", {
+        name: AddStaticRouteFormLabels.AddStaticRoute,
+      })
+    )
+  );
 
   userEvent.click(
     within(
@@ -156,9 +163,13 @@ it("can open and close the edit static route form", async () => {
     })
   );
 
-  await screen.findByRole("form", {
-    name: EditStaticRouteFormLabels.EditStaticRoute,
-  });
+  await waitFor(() =>
+    expect(
+      screen.getByRole("form", {
+        name: EditStaticRouteFormLabels.EditStaticRoute,
+      })
+    ).toBeInTheDocument()
+  );
 
   userEvent.click(
     within(

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -103,14 +103,12 @@ it("can update the arches to disable", async () => {
   );
   const nameCells = screen.getAllByRole("gridcell", { name: Headers.Name });
 
-  await waitFor(() => {
-    fireEvent.click(within(nameCells[0]).getByRole("checkbox"));
-  });
-  await waitFor(() => {
-    fireEvent.click(within(nameCells[1]).getByRole("checkbox"));
-  });
+  fireEvent.click(within(nameCells[0]).getByRole("checkbox"));
+  fireEvent.click(within(nameCells[1]).getByRole("checkbox"));
 
-  expect(within(nameCells[0]).getByRole("checkbox")).toBeChecked();
+  await waitFor(() =>
+    expect(within(nameCells[0]).getByRole("checkbox")).toBeChecked()
+  );
   expect(within(nameCells[1]).getByRole("checkbox")).not.toBeChecked();
 });
 
@@ -141,22 +139,20 @@ it("can dispatch an action to update subnet's disabled boot architectures", asyn
   );
   const nameCells = screen.getAllByRole("gridcell", { name: Headers.Name });
 
-  await waitFor(() => {
-    fireEvent.click(within(nameCells[0]).getByRole("checkbox"));
-  });
-  await waitFor(() => {
-    fireEvent.click(within(nameCells[1]).getByRole("checkbox"));
-  });
-  await waitFor(() => {
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-  });
+  fireEvent.click(within(nameCells[0]).getByRole("checkbox"));
+  fireEvent.click(within(nameCells[1]).getByRole("checkbox"));
+
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
   const expectedAction = subnetActions.update({
     id: subnet.id,
     disabled_boot_architectures: "arch1, arch2",
   });
-  const actualActions = store.getActions();
-  expect(
-    actualActions.find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+
+  await waitFor(() => {
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
@@ -62,13 +62,14 @@ it("can map an IPv4 subnet", async () => {
     </Provider>
   );
 
-  await waitFor(() => {
-    fireEvent.click(screen.getByRole("button", { name: "Map subnet" }));
-  });
+  fireEvent.click(screen.getByRole("button", { name: "Map subnet" }));
 
-  const expectedAction = subnetActions.scan(subnet.id);
-  const actualActions = store.getActions();
-  expect(
-    actualActions.find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  await waitFor(() => {
+    const expectedAction = subnetActions.scan(subnet.id);
+    const actualActions = store.getActions();
+
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
@@ -24,7 +24,7 @@ it("shows a spinner subtitle if the subnet is loading details", () => {
   render(<SubnetDetailsHeader subnet={subnet} />);
 
   expect(
-    screen.queryByTestId("section-header-subtitle-spinner")
+    screen.getByTestId("section-header-subtitle-spinner")
   ).toBeInTheDocument();
 });
 

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
@@ -30,6 +30,7 @@ jest.mock(
   "@canonical/react-components/dist/components/Tooltip",
   () => (props: PropsWithChildren<TooltipProps>) => {
     mockTooltip(props);
+    // eslint-disable-next-line testing-library/no-node-access
     return <span data-testid="Tooltip">{props.children}</span>;
   }
 );
@@ -109,7 +110,7 @@ it("renders correct section heading", async () => {
   ).toBeInTheDocument();
 });
 
-it("renders corrent values for static fields", async () => {
+it("renders current values for static fields", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -148,10 +149,10 @@ it("renders correct value for 'Managed allocation' if enabled", async () => {
       </MemoryRouter>
     </Provider>
   );
-  const label = "Managed allocation";
-  expect(screen.getByLabelText(label)).toHaveTextContent("Enabled");
+  const managedAllocation = screen.getByLabelText("Managed allocation");
+  expect(managedAllocation).toHaveTextContent("Enabled");
   expect(
-    within(screen.getByText(label)).queryByTestId("Tooltip")
+    within(managedAllocation).queryByTestId("Tooltip")
   ).not.toBeInTheDocument();
 });
 
@@ -210,10 +211,10 @@ it("renders correct value for 'Active discovery' if disabled", async () => {
       </MemoryRouter>
     </Provider>
   );
-  const label = "Active discovery";
-  expect(screen.getByLabelText(label)).toHaveTextContent("Disabled");
+  const activeDiscovery = screen.getByLabelText("Active discovery");
+  expect(activeDiscovery).toHaveTextContent("Disabled");
   expect(
-    within(screen.getByText(label)).queryByTestId("Tooltip")
+    within(activeDiscovery).queryByTestId("Tooltip")
   ).not.toBeInTheDocument();
 });
 
@@ -360,11 +361,9 @@ it("renders the correct value for 'Space' if it has an ID", async () => {
       </MemoryRouter>
     </Provider>
   );
-  const label = "Space";
-  expect(screen.getByLabelText(label)).toHaveTextContent("Test space");
-  expect(
-    within(screen.getByText(label)).queryByTestId("Tooltip")
-  ).not.toBeInTheDocument();
+  const space = screen.getByLabelText("Space");
+  expect(space).toHaveTextContent("Test space");
+  expect(within(space).queryByTestId("Tooltip")).not.toBeInTheDocument();
 });
 
 it("renders the correct value for 'Space' if no ID", async () => {

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -49,40 +49,35 @@ it("can dispatch an action to update the subnet", async () => {
     </Provider>
   );
 
-  await waitFor(() => {
-    fireEvent.input(screen.getByRole("textbox", { name: "CIDR" }), {
-      target: { value: "192.168.2.0/24" },
-    });
-    fireEvent.input(screen.getByRole("textbox", { name: "Name" }), {
-      target: { value: "New Name" },
-    });
-    fireEvent.input(screen.getByRole("textbox", { name: "Description" }), {
-      target: { value: "I'm a supernet" },
-    });
-    fireEvent.input(screen.getByRole("textbox", { name: "Gateway IP" }), {
-      target: { value: "192.168.2.1" },
-    });
-    fireEvent.input(screen.getByRole("textbox", { name: "DNS" }), {
-      target: { value: "fghij" },
-    });
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: "Managed allocation" })
-    );
-    fireEvent.click(screen.getByRole("checkbox", { name: "Active discovery" }));
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: "Allow DNS resolution" })
-    );
-    fireEvent.click(screen.getByRole("checkbox", { name: "Proxy access" }));
-    fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
-      target: { value: fabrics[1].id.toString() },
-    });
+  fireEvent.input(screen.getByRole("textbox", { name: "CIDR" }), {
+    target: { value: "192.168.2.0/24" },
   });
-  await waitFor(() => {
-    fireEvent.change(screen.getByRole("combobox", { name: "VLAN" }), {
-      target: { value: vlans[1].id.toString() },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  fireEvent.input(screen.getByRole("textbox", { name: "Name" }), {
+    target: { value: "New Name" },
   });
+  fireEvent.input(screen.getByRole("textbox", { name: "Description" }), {
+    target: { value: "I'm a supernet" },
+  });
+  fireEvent.input(screen.getByRole("textbox", { name: "Gateway IP" }), {
+    target: { value: "192.168.2.1" },
+  });
+  fireEvent.input(screen.getByRole("textbox", { name: "DNS" }), {
+    target: { value: "fghij" },
+  });
+  fireEvent.click(screen.getByRole("checkbox", { name: "Managed allocation" }));
+  fireEvent.click(screen.getByRole("checkbox", { name: "Active discovery" }));
+  fireEvent.click(
+    screen.getByRole("checkbox", { name: "Allow DNS resolution" })
+  );
+  fireEvent.click(screen.getByRole("checkbox", { name: "Proxy access" }));
+  fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
+    target: { value: fabrics[1].id.toString() },
+  });
+
+  fireEvent.change(screen.getByRole("combobox", { name: "VLAN" }), {
+    target: { value: vlans[1].id.toString() },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
   const expectedAction = subnetActions.update({
     active_discovery: true,
@@ -98,7 +93,10 @@ it("can dispatch an action to update the subnet", async () => {
     vlan: vlans[1].id,
   });
   const actualActions = store.getActions();
-  expect(
-    actualActions.find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+
+  await waitFor(() =>
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction)
+  );
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
@@ -38,11 +38,11 @@ it("updates to use the fabric's default VLAN on fabric change", async () => {
 
   expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("3");
 
-  await waitFor(() => {
-    fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
-      target: { value: fabrics[1].id.toString() },
-    });
+  fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
+    target: { value: fabrics[1].id.toString() },
   });
 
-  expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("5");
+  await waitFor(() =>
+    expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("5")
+  );
 });

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetUsedIPs/SubnetUsedIPs.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetUsedIPs/SubnetUsedIPs.test.tsx
@@ -50,14 +50,14 @@ it("displays correct IP addresses", () => {
   ).toHaveLength(2);
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.IpAddresses,
       })
       .find((td) => td.textContent === "11.1.1.1")
   ).toBeInTheDocument();
   expect(
     screen
-      .queryAllByRole("gridcell", {
+      .getAllByRole("gridcell", {
         name: Labels.IpAddresses,
       })
       .find((td) => td.textContent === "11.1.1.2")

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -169,18 +169,18 @@ it(`renders a subnet select field and prepopulated fields for a reserved range
     </Provider>
   );
 
-  await waitFor(() => {
-    fireEvent.change(screen.getByRole("combobox", { name: "Subnet" }), {
-      target: { value: subnet.id },
-    });
+  fireEvent.change(screen.getByRole("combobox", { name: "Subnet" }), {
+    target: { value: subnet.id },
   });
 
-  expect(
-    within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
-      "combobox",
-      { name: "Subnet" }
-    )
-  ).toBeInTheDocument();
+  await waitFor(() =>
+    expect(
+      within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
+        "combobox",
+        { name: "Subnet" }
+      )
+    ).toBeInTheDocument()
+  );
   expect(
     within(screen.getByRole("gridcell", { name: Headers.StartIP })).getByRole(
       "textbox",

--- a/ui/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
@@ -114,7 +114,7 @@ describe("EditVLAN", () => {
         </MemoryRouter>
       </Provider>
     );
-    await waitFor(() => fireEvent.submit(screen.getByRole("form")));
+    fireEvent.submit(screen.getByRole("form"));
     const expected = vlanActions.update({
       description: vlan.description,
       fabric: vlan.fabric,
@@ -124,9 +124,11 @@ describe("EditVLAN", () => {
       space: vlan.space,
       vid: vlan.vid,
     });
-    expect(
-      store.getActions().find((action) => action.type === expected.type)
-    ).toStrictEqual(expected);
+    await waitFor(() =>
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected)
+    );
   });
 
   it("allows the space to be unset", async () => {
@@ -140,16 +142,17 @@ describe("EditVLAN", () => {
         </MemoryRouter>
       </Provider>
     );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Space" }), {
+      target: { value: null },
+    });
     await waitFor(() =>
-      fireEvent.change(screen.getByRole("combobox", { name: "Space" }), {
-        target: { value: null },
-      })
+      expect(
+        within(screen.getByRole("combobox", { name: "Space" })).getByRole(
+          "option",
+          { name: "No space", selected: true }
+        )
+      ).toBeInTheDocument()
     );
-    expect(
-      within(screen.getByRole("combobox", { name: "Space" })).getByRole(
-        "option",
-        { name: "No space", selected: true }
-      )
-    ).toBeInTheDocument();
   });
 });

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -108,7 +108,7 @@ describe("VLANDetailsHeader", () => {
       </Provider>
     );
     expect(
-      screen.queryByTestId("section-header-subtitle-spinner")
+      screen.getByTestId("section-header-subtitle-spinner")
     ).toBeInTheDocument();
   });
 
@@ -121,7 +121,9 @@ describe("VLANDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.queryByTestId("section-header-subtitle-spinner")).toBeNull();
+    expect(
+      screen.queryByTestId("section-header-subtitle-spinner")
+    ).not.toBeInTheDocument();
   });
 
   it("shows the delete button when the user is an admin", () => {
@@ -138,7 +140,9 @@ describe("VLANDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.queryByTestId("delete-vlan")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete VLAN" })
+    ).toBeInTheDocument();
   });
 
   it("does not show the delete button if the user is not an admin", () => {
@@ -155,6 +159,8 @@ describe("VLANDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.queryByTestId("delete-vlan")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Delete VLAN" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -178,6 +178,7 @@ it("shows an icon for automatic tags", () => {
   const auto = screen.getByRole("gridcell", {
     name: Label.Auto,
   });
+  // eslint-disable-next-line testing-library/no-node-access
   expect(auto.querySelector(".p-icon--success-grey")).toBeInTheDocument();
 });
 
@@ -200,6 +201,7 @@ it("does not show an icon for manual tags", () => {
   const auto = screen.getByRole("gridcell", {
     name: Label.Auto,
   });
+  // eslint-disable-next-line testing-library/no-node-access
   expect(auto.querySelector(".p-icon--success-grey")).not.toBeInTheDocument();
 });
 
@@ -222,6 +224,7 @@ it("shows an icon for kernel options", () => {
   const auto = screen.getByRole("gridcell", {
     name: Label.Options,
   });
+  // eslint-disable-next-line testing-library/no-node-access
   expect(auto.querySelector(".p-icon--success-grey")).toBeInTheDocument();
 });
 
@@ -244,6 +247,7 @@ it("does not show an icon for tags without kernel options", () => {
   const auto = screen.getByRole("gridcell", {
     name: Label.Options,
   });
+  // eslint-disable-next-line testing-library/no-node-access
   expect(auto.querySelector(".p-icon--success-grey")).not.toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Done
### refactoring
 - refactor [subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/master...petermakowski:fix-testing-library-warnings?expand=1#diff-b9c3100dfc2b02c23bb0052d39511a69f801e78573b52cd2e644f99c6730b817) to use userEvent and test the component the way the user would use it (e.g. `userEvent.tab()` instead of `fireEvent.blur()`)
- refactor to not use `waitFor` to wrap around user interactions, and move it to to expect assertions instead (`testing-library/no-wait-for-side-effects` rule)

### eslint rules
- enable `testing-library/prefer-explicit-assert` (using explicit assertions is something that we already try to do anyway)
- enable `prefer-presence-queries`
- disable `testing-library/prefer-find-by` as it tends to conflict with `testing-library/prefer-explicit-assert`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/742

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
