### PR TITLE
add waitForPageToLoad cypress command

### DIFF
--- a/integration/cypress/integration/accessibility/accessibility.spec.ts
+++ b/integration/cypress/integration/accessibility/accessibility.spec.ts
@@ -28,19 +28,8 @@ pages.forEach(({ heading, url }: Page) => {
 
     cy.visit(pageUrl);
 
-    cy.waitUntil(
-      // using `Cypress.$` instead of `cy.get` to prevent test failure
-      // - `cy.get` itself is an assertion and would throw an error when element is not found
-      // https://github.com/NoriSte/cypress-wait-until/issues/75#issuecomment-572685623
-      () => Cypress.$("[data-testid='section-header-title-spinner']").length
-    );
-
+    cy.waitForPageToLoad();
     cy.get("[data-testid='section-header-title']").contains(heading);
-
-    cy.waitUntil(
-      () =>
-        Cypress.$("[data-testid='section-header-subtitle-spinner']").length < 1
-    );
 
     cy.testA11y({ url, title: heading });
   });

--- a/integration/cypress/support/commands.ts
+++ b/integration/cypress/support/commands.ts
@@ -65,3 +65,11 @@ Cypress.Commands.add("testA11y", (pageContext) => {
     Cypress.env("skipA11yFailures")
   );
 });
+
+Cypress.Commands.add("waitForPageToLoad", () => {
+  cy.get("[data-testid='section-header-title-spinner]").should("not.exist");
+  cy.get("[data-testid='section-header-subtitle-spinner']").should("not.exist");
+  cy.findByText("Loading...").should("not.exist");
+  cy.findByText("Failed to connect").should("not.exist");
+  cy.get("[data-testid='section-header-title']").should("be.visible");
+});

--- a/integration/cypress/support/index.ts
+++ b/integration/cypress/support/index.ts
@@ -15,6 +15,7 @@ declare global {
         shouldSkipSetupIntro?: boolean;
       }): void;
       testA11y(pageContext: A11yPageContext): void;
+      waitForPageToLoad(): void;
     }
   }
 }


### PR DESCRIPTION
## Done

- add waitForPageToLoad cypress command
  - use more reliable cypress queries for detecting appearance/disappearance

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: (https://github.com/canonical-web-and-design/app-tribe/issues/756)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
