### PR TITLE
feat: add pagination to subnets table

### DIFF
--- a/integration/cypress/integration/subnets/subnets.spec.ts
+++ b/integration/cypress/integration/subnets/subnets.spec.ts
@@ -35,7 +35,7 @@ context("Subnets", () => {
       "Space",
     ];
 
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: "Subnets by Fabric" }).within(() => {
       expectedHeaders.forEach((name) => {
         cy.findByRole("columnheader", { name }).should("exist");
       });
@@ -53,7 +53,7 @@ context("Subnets", () => {
   });
 
   it("allows grouping by fabric and space", () => {
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: "Subnets by Fabric" }).within(() => {
       cy.findAllByRole("columnheader").first().should("have.text", "Fabric");
     });
 
@@ -64,7 +64,7 @@ context("Subnets", () => {
 
     cy.findByRole("combobox", { name: "Group by" }).select("Space");
 
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: "Subnets by Space" }).within(() => {
       cy.findAllByRole("columnheader").first().should("have.text", "Space");
     });
 

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/FabricTable/FabricTable.tsx
@@ -1,5 +1,9 @@
 import { useMemo } from "react";
 
+import { Pagination } from "@canonical/react-components";
+
+import { usePagination } from "../hooks";
+
 import ModularTable from "app/base/components/ModularTable";
 import { CellContents } from "app/subnets/views/SubnetsList/SubnetsTable/components";
 import {
@@ -9,61 +13,66 @@ import {
 import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
 const FabricTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
+  const { pageData, ...paginationProps } = usePagination(data);
+
   return (
-    <ModularTable<SubnetsTableRow>
-      emptyMsg="Loading..."
-      className="subnets-table"
-      aria-label="Subnets"
-      getCellProps={({ value, column }) => ({
-        className: `subnets-table__cell--${column.id}${
-          value.isVisuallyHidden ? " u-no-border--top" : ""
-        }`,
-        role: column.id === "fabric" ? "rowheader" : undefined,
-      })}
-      getHeaderProps={(header) => ({
-        className: `subnets-table__cell--${header.id}`,
-      })}
-      getRowProps={(row) => ({
-        "aria-label": row.values.fabric.label,
-      })}
-      columns={useMemo(
-        () => [
-          {
-            Header: subnetColumnLabels[SubnetsColumns.FABRIC],
-            accessor: SubnetsColumns.FABRIC,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.VLAN],
-            accessor: SubnetsColumns.VLAN,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.DHCP],
-            accessor: SubnetsColumns.DHCP,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.SUBNET],
-            accessor: SubnetsColumns.SUBNET,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.IPS],
-            accessor: SubnetsColumns.IPS,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.SPACE],
-            accessor: SubnetsColumns.SPACE,
-            className: "u-align--right",
-            Cell: CellContents,
-          },
-        ],
-        []
-      )}
-      data={useMemo(() => data, [data])}
-    />
+    <>
+      <ModularTable<SubnetsTableRow>
+        emptyMsg="Loading..."
+        className="subnets-table"
+        aria-label="Subnets by Fabric"
+        getCellProps={({ value, column }) => ({
+          className: `subnets-table__cell--${column.id}${
+            value.isVisuallyHidden ? " u-no-border--top" : ""
+          }`,
+          role: column.id === "fabric" ? "rowheader" : undefined,
+        })}
+        getHeaderProps={(header) => ({
+          className: `subnets-table__cell--${header.id}`,
+        })}
+        getRowProps={(row) => ({
+          "aria-label": row.values.fabric.label,
+        })}
+        columns={useMemo(
+          () => [
+            {
+              Header: subnetColumnLabels[SubnetsColumns.FABRIC],
+              accessor: SubnetsColumns.FABRIC,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.VLAN],
+              accessor: SubnetsColumns.VLAN,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.DHCP],
+              accessor: SubnetsColumns.DHCP,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.SUBNET],
+              accessor: SubnetsColumns.SUBNET,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.IPS],
+              accessor: SubnetsColumns.IPS,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.SPACE],
+              accessor: SubnetsColumns.SPACE,
+              className: "u-align--right",
+              Cell: CellContents,
+            },
+          ],
+          []
+        )}
+        data={pageData}
+      />
+      <Pagination {...paginationProps} aria-label="pagination" />
+    </>
   );
 };
 

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SpaceTable/SpaceTable.tsx
@@ -1,5 +1,9 @@
 import { useMemo } from "react";
 
+import { Pagination } from "@canonical/react-components";
+
+import { usePagination } from "../hooks";
+
 import ModularTable from "app/base/components/ModularTable";
 import {
   CellContents,
@@ -12,60 +16,66 @@ import {
 import type { SubnetsTableRow } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
 const SpaceTable = ({ data }: { data: SubnetsTableRow[] }): JSX.Element => {
+  const { pageData, ...paginationProps } = usePagination(data);
+
   return (
-    <ModularTable<SubnetsTableRow>
-      emptyMsg="Loading..."
-      className="subnets-table"
-      aria-label="Subnets"
-      getCellProps={({ value, column }) => ({
-        className: `subnets-table__cell--${column.id}${
-          value.isVisuallyHidden ? " u-no-border--top" : ""
-        }`,
-        role: column.id === "space" ? "rowheader" : undefined,
-      })}
-      getHeaderProps={(header) => ({
-        className: `subnets-table__cell--${header.id}`,
-      })}
-      getRowProps={(row) => ({
-        "aria-label": row.values.space.label,
-      })}
-      columns={useMemo(
-        () => [
-          {
-            Header: subnetColumnLabels[SubnetsColumns.SPACE],
-            accessor: SubnetsColumns.SPACE,
-            Cell: SpaceCellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.VLAN],
-            accessor: SubnetsColumns.VLAN,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.DHCP],
-            accessor: SubnetsColumns.DHCP,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.FABRIC],
-            accessor: SubnetsColumns.FABRIC,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.SUBNET],
-            accessor: SubnetsColumns.SUBNET,
-            Cell: CellContents,
-          },
-          {
-            Header: subnetColumnLabels[SubnetsColumns.IPS],
-            accessor: SubnetsColumns.IPS,
-            Cell: CellContents,
-          },
-        ],
-        []
-      )}
-      data={useMemo(() => data, [data])}
-    />
+    <>
+      <ModularTable<SubnetsTableRow>
+        emptyMsg="Loading..."
+        className="subnets-table"
+        aria-label="Subnets by Space"
+        getCellProps={({ value, column }) => ({
+          className: `subnets-table__cell--${column.id}${
+            value.isVisuallyHidden ? " u-no-border--top" : ""
+          }`,
+          role: column.id === "space" ? "rowheader" : undefined,
+        })}
+        getHeaderProps={(header) => ({
+          className: `subnets-table__cell--${header.id}`,
+        })}
+        getRowProps={(row) => ({
+          "aria-label": row.values.space.label,
+        })}
+        columns={useMemo(
+          () => [
+            {
+              Header: subnetColumnLabels[SubnetsColumns.SPACE],
+              accessor: SubnetsColumns.SPACE,
+              Cell: SpaceCellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.VLAN],
+              accessor: SubnetsColumns.VLAN,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.DHCP],
+              accessor: SubnetsColumns.DHCP,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.FABRIC],
+              accessor: SubnetsColumns.FABRIC,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.SUBNET],
+              accessor: SubnetsColumns.SUBNET,
+              Cell: CellContents,
+            },
+            {
+              Header: subnetColumnLabels[SubnetsColumns.IPS],
+              accessor: SubnetsColumns.IPS,
+              className: "u-align--right",
+              Cell: CellContents,
+            },
+          ],
+          []
+        )}
+        data={pageData}
+      />
+      <Pagination {...paginationProps} aria-label="pagination" />
+    </>
   );
 };
 

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -1,0 +1,375 @@
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SubnetsTable from "./SubnetsTable";
+import { SUBNETS_TABLE_ITEMS_PER_PAGE } from "./constants";
+
+import urls from "app/subnets/urls";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  vlanState as vlanStateFactory,
+  subnetState as subnetStateFactory,
+  spaceState as spaceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const getMockState = ({ numberOfFabrics } = { numberOfFabrics: 50 }) => {
+  const fabrics = [
+    ...new Array(numberOfFabrics)
+      .fill(null)
+      .map((_value, index) =>
+        fabricFactory({ id: index + 1, name: `fabric-${index + 1}` })
+      ),
+  ];
+  return rootStateFactory({
+    fabric: fabricStateFactory({
+      loaded: true,
+      items: fabrics,
+    }),
+    vlan: vlanStateFactory({ loaded: true }),
+    subnet: subnetStateFactory({ loaded: true }),
+    space: spaceStateFactory({ loaded: true }),
+  });
+};
+
+it("renders a single table variant at a time", () => {
+  const state = getMockState();
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getAllByRole("table")).toHaveLength(1);
+});
+
+it("renders Subnets by Fabric table when grouping by Fabric", () => {
+  const state = getMockState();
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("table", { name: "Subnets by Fabric" })
+  ).toBeInTheDocument();
+});
+
+it("renders Subnets by Space table when grouping by Space", () => {
+  const state = getMockState();
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="space" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("table", { name: "Subnets by Space" })
+  ).toBeInTheDocument();
+});
+
+it("displays a correct number of pages", () => {
+  const state = getMockState();
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("table", { name: "Subnets by Fabric" })
+  ).toBeInTheDocument();
+
+  const numberOfPages =
+    state.fabric.items.length / SUBNETS_TABLE_ITEMS_PER_PAGE;
+  const numberOfNextAndPrevButtons = 2;
+  expect(
+    within(screen.getByRole("navigation")).getAllByRole("button")
+  ).toHaveLength(numberOfPages + numberOfNextAndPrevButtons);
+  expect(
+    within(screen.getByRole("navigation")).getByRole("button", { name: "1" })
+  ).toBeInTheDocument();
+  expect(
+    within(screen.getByRole("navigation")).getByRole("button", {
+      name: "2",
+    })
+  ).toBeInTheDocument();
+});
+
+it("updates the list of items correctly when navigating to another page", async () => {
+  const state = getMockState();
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+
+  expect(
+    within(tableBody).getByRole("link", {
+      name: "fabric-1",
+    })
+  ).toBeInTheDocument();
+  expect(
+    within(tableBody).getByRole("link", {
+      name: "fabric-25",
+    })
+  ).toBeInTheDocument();
+  await waitFor(() =>
+    expect(within(tableBody).getAllByRole("row")).toHaveLength(25)
+  );
+
+  userEvent.click(
+    within(screen.getByRole("navigation")).getByRole("button", {
+      name: "2",
+    })
+  );
+  await waitFor(() =>
+    expect(within(tableBody).getAllByRole("row")).toHaveLength(25)
+  );
+  await waitFor(() =>
+    expect(
+      within(tableBody).getByRole("link", {
+        name: "fabric-26",
+      })
+    ).toBeInTheDocument()
+  );
+  expect(
+    within(tableBody).getByRole("link", {
+      name: "fabric-50",
+    })
+  ).toBeInTheDocument();
+});
+
+it("doesn't display pagination if rows are within items per page limit", () => {
+  const numberOfFabrics = 1;
+  const state = getMockState({
+    numberOfFabrics,
+  });
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.queryByRole("navigation", { name: "Subnets by Fabric" })
+  ).not.toBeInTheDocument();
+});
+
+it("displays correctly paginated rows", async () => {
+  const numberOfFabrics = SUBNETS_TABLE_ITEMS_PER_PAGE * 2;
+  const state = getMockState({
+    numberOfFabrics,
+  });
+  const mockStore = configureStore();
+  const store = mockStore(state);
+  const firstPageFabrics = state.fabric.items.slice(
+    0,
+    SUBNETS_TABLE_ITEMS_PER_PAGE
+  );
+  const secondPageFabrics = state.fabric.items.slice(
+    SUBNETS_TABLE_ITEMS_PER_PAGE,
+    SUBNETS_TABLE_ITEMS_PER_PAGE * 2
+  );
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+
+  expect(within(tableBody).getAllByRole("row")).toHaveLength(
+    SUBNETS_TABLE_ITEMS_PER_PAGE
+  );
+
+  within(tableBody)
+    .getAllByRole("row")
+    .forEach((row, index) => {
+      expect(row.textContent).toEqual(
+        expect.stringContaining(firstPageFabrics[index].name)
+      );
+    });
+
+  userEvent.click(
+    screen.getByRole("button", {
+      name: "Next page",
+    })
+  );
+
+  /**
+   * TODO: replace querySelector with testing library method once react-components is fixed
+   * https://github.com/canonical-web-and-design/app-tribe/issues/764
+   */
+  await waitFor(() =>
+    expect(
+      screen
+        .getByRole("navigation", { name: "pagination" })
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector(".is-active")
+    ).toHaveTextContent("2")
+  );
+
+  expect(within(tableBody).getAllByRole("row")).toHaveLength(
+    SUBNETS_TABLE_ITEMS_PER_PAGE
+  );
+
+  within(tableBody)
+    .getAllByRole("row")
+    .forEach((row, index) => {
+      expect(row.textContent).toEqual(
+        expect.stringContaining(secondPageFabrics[index].name)
+      );
+    });
+});
+
+it("displays the last available page once the currently active has no items", async () => {
+  const numberOfFabrics = SUBNETS_TABLE_ITEMS_PER_PAGE * 3 + 1;
+  const state = getMockState({
+    numberOfFabrics,
+  });
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  const { rerender } = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+
+  userEvent.click(
+    within(screen.getByRole("navigation", { name: "pagination" })).getByRole(
+      "button",
+      {
+        name: "4",
+      }
+    )
+  );
+
+  await waitFor(() =>
+    expect(within(tableBody).getAllByRole("row")).toHaveLength(1)
+  );
+  expect(
+    within(tableBody).getByRole("link", {
+      name: `fabric-${numberOfFabrics}`,
+    })
+  ).toBeInTheDocument();
+
+  const updatedState = getMockState({
+    numberOfFabrics: SUBNETS_TABLE_ITEMS_PER_PAGE * 2,
+  });
+  const updatedMockStore = configureStore();
+  const updatedStore = updatedMockStore(updatedState);
+  rerender(
+    <Provider store={updatedStore}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() =>
+    expect(
+      screen
+        .getByRole("navigation", { name: "pagination" })
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector(".is-active")
+    ).toHaveTextContent("2")
+  );
+  expect(within(tableBody).getAllByRole("row")).toHaveLength(
+    SUBNETS_TABLE_ITEMS_PER_PAGE
+  );
+});
+
+it("remains on the same page once the data is updated and page is still available", async () => {
+  const numberOfFabrics = SUBNETS_TABLE_ITEMS_PER_PAGE * 2;
+  const state = getMockState({
+    numberOfFabrics,
+  });
+  const mockStore = configureStore();
+  const store = mockStore(state);
+
+  const { rerender } = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const pagination = screen.getByRole("navigation", { name: "pagination" });
+  userEvent.click(
+    within(pagination).getByRole("button", {
+      name: "2",
+    })
+  );
+
+  await waitFor(() =>
+    expect(
+      screen
+        .getByRole("navigation")
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector(".is-active")
+    ).toHaveTextContent("2")
+  );
+
+  const updatedState = getMockState({
+    numberOfFabrics: SUBNETS_TABLE_ITEMS_PER_PAGE * 2,
+  });
+  const updatedMockStore = configureStore();
+  const updatedStore = updatedMockStore(updatedState);
+  rerender(
+    <Provider store={updatedStore}>
+      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
+        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await waitFor(() =>
+    expect(
+      screen
+        .getByRole("navigation")
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector(".is-active")
+    ).toHaveTextContent("2")
+  );
+});

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/constants.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/constants.ts
@@ -15,3 +15,5 @@ export const subnetColumnLabels: Record<SubnetsColumns, string> = {
   [SubnetsColumns.IPS]: "Available IPs",
   [SubnetsColumns.SPACE]: "Space",
 };
+
+export const SUBNETS_TABLE_ITEMS_PER_PAGE = 25;

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/hooks.ts
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/hooks.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 
+import { SUBNETS_TABLE_ITEMS_PER_PAGE } from "./constants";
 import type { SubnetsTableRow, GroupByKey } from "./types";
 import { getTableData } from "./utils";
 
@@ -47,3 +48,41 @@ export const useSubnetsTable = (
 
   return { rows };
 };
+
+export function usePagination<D>(
+  data: Array<D>,
+  itemsPerPage = SUBNETS_TABLE_ITEMS_PER_PAGE
+): {
+  pageData: Array<D>;
+  currentPage: number;
+  paginate: (pageNumber: number) => void;
+  itemsPerPage: number;
+  totalItems: number;
+} {
+  const totalItems = data.length;
+  const [pageIndex, setPageIndex] = useState(0);
+  const startIndex = pageIndex * itemsPerPage;
+  const paginate = (pageNumber: number) => setPageIndex(pageNumber - 1);
+
+  useEffect(() => {
+    // go to the last available page if the current page is out of bounds
+    if (startIndex >= totalItems) {
+      totalItems / itemsPerPage > 0
+        ? setPageIndex(Math.floor(totalItems / itemsPerPage) - 1)
+        : setPageIndex(0);
+    }
+  }, [pageIndex, startIndex, setPageIndex, totalItems, itemsPerPage]);
+
+  const pageData = useMemo(
+    () => data?.slice(startIndex, startIndex + itemsPerPage),
+    [startIndex, data, itemsPerPage]
+  );
+
+  return {
+    pageData,
+    currentPage: pageIndex + 1,
+    paginate,
+    itemsPerPage,
+    totalItems,
+  };
+}

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
@@ -56,3 +56,37 @@ test("getTableData returns grouped fabrics in a correct format", () => {
     label: "test-fabric",
   });
 });
+
+test("getTableData returns fabrics sorted in a correct order", () => {
+  const fabrics = [
+    fabricFactory({ id: 1, name: "fabric-1" }),
+    fabricFactory({ id: 2, name: "1 fabric" }),
+    fabricFactory({ id: 10, name: "fabric-10" }),
+  ];
+  const expectedOrder = ["1 fabric", "fabric-1", "fabric-10"];
+  const tableData = getTableData(
+    { fabrics, vlans: [], subnets: [], spaces: [] },
+    "fabric"
+  );
+  expect(tableData).toHaveLength(3);
+  tableData.forEach((row, index) => {
+    expect(row.fabric.label).toEqual(expectedOrder[index]);
+  });
+});
+
+test("getTableData returns spaces sorted in a correct order", () => {
+  const spaces = [
+    spaceFactory({ id: 1, name: "space-1" }),
+    spaceFactory({ id: 2, name: "1 space" }),
+    spaceFactory({ id: 10, name: "space-10" }),
+  ];
+  const expectedOrder = ["1 space", "space-1", "space-10"];
+  const tableData = getTableData(
+    { fabrics: [], vlans: [], subnets: [], spaces },
+    "space"
+  );
+  expect(tableData).toHaveLength(3);
+  tableData.forEach((row, index) => {
+    expect(row.space.label).toEqual(expectedOrder[index]);
+  });
+});

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.tsx
@@ -31,14 +31,6 @@ import {
 } from "app/subnets/urls";
 import { simpleSortByKey } from "app/utils";
 
-const sortBySortKey =
-  (key: keyof SortData, { reverse } = { reverse: false }) =>
-  (a: SubnetsTableRow, b: SubnetsTableRow): number => {
-    if (a.sortData[key] > b.sortData[key]) return reverse ? -1 : 1;
-    if (a.sortData[key] < b.sortData[key]) return reverse ? 1 : -1;
-    return 0;
-  };
-
 const getColumn = (label: string | null, href?: string | null) => ({
   label,
   href: href ? href : null,
@@ -122,7 +114,14 @@ const getOrphanVLANs = (data: SubnetsTableData): SubnetsTableRow[] => {
     rows.push(getRowData({ fabric, vlan, subnet, space: undefined, data }));
   });
 
-  return markRepeatedSpaceRows(rows.sort(sortBySortKey("cidr")));
+  return markRepeatedSpaceRows(
+    rows.sort((a, b) =>
+      simpleSortByKey<SortData, "cidr">("cidr", { alphanumeric: true })(
+        a.sortData,
+        b.sortData
+      )
+    )
+  );
 };
 
 const getBySpaces = (data: SubnetsTableData): SubnetsTableRow[] => {
@@ -143,7 +142,13 @@ const getBySpaces = (data: SubnetsTableData): SubnetsTableRow[] => {
     });
   }
 
-  return markRepeatedSpaceRows(rows.sort(sortBySortKey("spaceName")));
+  return markRepeatedSpaceRows(
+    rows.sort((a, b) =>
+      simpleSortByKey<SortData, "spaceName">("spaceName", {
+        alphanumeric: true,
+      })(a.sortData, b.sortData)
+    )
+  );
 };
 
 const getByFabric = (data: SubnetsTableData): SubnetsTableRow[] => {
@@ -173,7 +178,13 @@ const getByFabric = (data: SubnetsTableData): SubnetsTableRow[] => {
     }
   });
 
-  return markRepeatedFabricRows(rows.sort(sortBySortKey("fabricName")));
+  return markRepeatedFabricRows(
+    rows.sort((a, b) =>
+      simpleSortByKey<SortData, "fabricName">("fabricName", {
+        alphanumeric: true,
+      })(a.sortData, b.sortData)
+    )
+  );
 };
 
 export const getTableData = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,6 +3747,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-table@7.7.9":
+  version "7.7.9"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.9.tgz#ea82875775fc6ee71a28408dcc039396ae067c92"
+  integrity sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@>=16.9.0":
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"


### PR DESCRIPTION
## Done

- add pagination to subnets table
- refactor to use the `localeCompare` alphanumeric sort via common `simpleSortByKey` util function
- add additional tests for subnets tables

## Before
### simple sort 

It's obvious what's changed by looking at tests, but adding for clarity

![image](https://user-images.githubusercontent.com/7452681/158652360-f5d6b6c6-d247-4ed5-a19a-6fb68c62da56.png)
## Before
### alphanumeric sort
![image](https://user-images.githubusercontent.com/7452681/158652365-c16fb432-64f8-4b2b-866f-63be7b7b263c.png)


### pagination
![image](https://user-images.githubusercontent.com/7452681/158653417-72a742ff-6760-483c-b738-7cbdb99be878.png)



## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/networks` and verify the table behaves correctly (e.g. when adding/removing rows)

## Fixes

Fixes:
- https://github.com/canonical-web-and-design/app-tribe/issues/758
- https://github.com/canonical-web-and-design/app-tribe/issues/761

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
