### PR TITLE
feat(ui): display manual and automatic tags in the tag form

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -85,7 +85,7 @@ export const TagForm = ({
       selectedCount={machines.length}
       validationSchema={TagFormSchema}
     >
-      <TagFormFields />
+      <TagFormFields machines={machines} />
     </ActionForm>
   );
 };

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import TagFormChanges, { Label, TestId } from "./TagFormChanges";
+
+import type { RootState } from "app/store/root/types";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machineFactory({ tags: [1] }), machineFactory({ tags: [1, 2] })],
+    }),
+    tag: tagStateFactory({
+      items: [tagFactory({ id: 1 }), tagFactory({ id: 2 })],
+    }),
+  });
+});
+
+it("displays a message if there are no tags", () => {
+  state.machine.items[0].tags = [];
+  state.machine.items[1].tags = [];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <TagFormChanges machines={state.machine.items} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByText(Label.NoTags)).toBeInTheDocument();
+  expect(screen.queryByLabelText(Label.Manual)).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(Label.Automatic)).not.toBeInTheDocument();
+});
+
+it("displays manual tags", () => {
+  state.tag.items[0].definition = "";
+  state.tag.items[1].definition = "";
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <TagFormChanges machines={state.machine.items} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByLabelText(Label.Manual)).toBeInTheDocument();
+  expect(screen.queryByTestId(TestId.Border)).not.toBeInTheDocument();
+});
+
+it("displays automatic tags", () => {
+  state.tag.items[0].definition = "def1";
+  state.tag.items[1].definition = "def2";
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <TagFormChanges machines={state.machine.items} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByLabelText(Label.Automatic)).toBeInTheDocument();
+  expect(screen.queryByTestId(TestId.Border)).not.toBeInTheDocument();
+});
+
+it("displays a border if there are both manual and automatic tags", () => {
+  state.tag.items[0].definition = "def1";
+  state.tag.items[1].definition = "";
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <TagFormChanges machines={state.machine.items} />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByLabelText(Label.Automatic)).toBeInTheDocument();
+  expect(screen.getByLabelText(Label.Manual)).toBeInTheDocument();
+  expect(screen.getByTestId(TestId.Border)).toBeInTheDocument();
+});

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -1,0 +1,79 @@
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import TagList from "../TagList";
+
+import type { Machine } from "app/store/machine/types";
+import { getTagCountsForMachines } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import tagSelectors from "app/store/tag/selectors";
+import tagsURLs from "app/tags/urls";
+
+type Props = {
+  machines: Machine[];
+};
+
+export enum Label {
+  Automatic = "Automatic tags",
+  Manual = "Manual tags",
+  NoTags = "Tags for selected machines will appear here.",
+}
+
+export enum TestId {
+  Border = "border",
+}
+
+export const TagFormChanges = ({ machines }: Props): JSX.Element => {
+  const tagIdsAndCounts = getTagCountsForMachines(machines);
+  const tagIds = Array.from(tagIdsAndCounts.keys());
+  const automaticTags = useSelector((state: RootState) =>
+    tagSelectors.getAutomaticByIDs(state, tagIds)
+  );
+  const manualTags = useSelector((state: RootState) =>
+    tagSelectors.getManualByIDs(state, tagIds)
+  );
+  const machineCount = machines.length;
+  const hasAutomaticTags = automaticTags.length > 0;
+  const hasManualTags = manualTags.length > 0;
+  if (!hasAutomaticTags && !hasManualTags) {
+    return <p className="u-text--muted">{Label.NoTags}</p>;
+  }
+  return (
+    <>
+      <h5>Tag changes</h5>
+      {hasManualTags ? (
+        <TagList
+          aria-label={Label.Manual}
+          chipAppearance="information"
+          // TODO: Implement removing tags from machines:
+          // https://github.com/canonical-web-and-design/app-tribe/issues/691
+          chipOnDismiss={() => null}
+          description="Currently assigned:"
+          machineCount={machineCount}
+          tagIdsAndCounts={tagIdsAndCounts}
+          tags={manualTags}
+        />
+      ) : null}
+      {hasAutomaticTags && hasManualTags ? (
+        <hr className="u-sv2" data-testid={TestId.Border} />
+      ) : null}
+      {hasAutomaticTags ? (
+        <TagList
+          aria-label={Label.Automatic}
+          description={
+            <>
+              Automatic tags (cannot be unassigned. Go to the{" "}
+              <Link to={tagsURLs.tags.index}>Tags tab</Link> to delete automatic
+              tags):
+            </>
+          }
+          machineCount={machineCount}
+          tagIdsAndCounts={tagIdsAndCounts}
+          tags={automaticTags}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default TagFormChanges;

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/index.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagFormChanges";

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -3,17 +3,23 @@ import type { ReactNode } from "react";
 import { Icon } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import TagFormChanges from "../TagFormChanges";
+
 import TagField from "app/base/components/TagField";
 import type { Tag as TagSelectorTag } from "app/base/components/TagSelector/TagSelector";
+import type { Machine } from "app/store/machine/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag } from "app/store/tag/types";
 
 const hasKernelOptions = (tags: Tag[], tag: TagSelectorTag) =>
   !!tags.find(({ id }) => tag.id === id)?.kernel_opts;
 
-export const TagFormFields = (): JSX.Element => {
-  const tags = useSelector(tagSelectors.getManual);
+type Props = {
+  machines: Machine[];
+};
 
+export const TagFormFields = ({ machines }: Props): JSX.Element => {
+  const tags = useSelector(tagSelectors.getManual);
   return (
     <div className="tag-form">
       <div className="tag-form__search">
@@ -46,9 +52,7 @@ export const TagFormFields = (): JSX.Element => {
         />
       </div>
       <div className="tag-form__changes">
-        <p className="u-text--muted">
-          Tags for selected machines will appear here.
-        </p>
+        <TagFormChanges machines={machines} />
       </div>
       <div className="tag-form__details">
         <p className="u-text--muted">

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/TagList.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/TagList.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, within } from "@testing-library/react";
+
+import TagList from "./TagList";
+
+import { tag as tagFactory } from "testing/factories";
+
+const tags = [
+  tagFactory({ name: "chip1", id: 1 }),
+  tagFactory({ name: "chip2", id: 2 }),
+];
+
+const tagMap = new Map([
+  [1, 2],
+  [2, 1],
+]);
+
+it("displays chips with counts", () => {
+  render(
+    <TagList
+      description=""
+      machineCount={10}
+      tags={tags}
+      tagIdsAndCounts={tagMap}
+    />
+  );
+  // These tests can't select by role and name because the text is inside an
+  // inner span which React Testing Library doesn't support and we can't
+  // currently apply additional aria labels to the button until react-components
+  // is updated with:
+  // https://github.com/canonical-web-and-design/react-components/pull/727
+  expect(screen.getByText("chip1 (2/10)")).toBeInTheDocument();
+  expect(screen.getByText("chip2 (1/10)")).toBeInTheDocument();
+});
+
+it("handles clicking on a chip", () => {
+  const chipOnClick = jest.fn();
+  render(
+    <TagList
+      chipOnClick={chipOnClick}
+      description=""
+      machineCount={10}
+      tags={tags}
+      tagIdsAndCounts={tagMap}
+    />
+  );
+  screen.getByText("chip1 (2/10)").click();
+  expect(chipOnClick).toHaveBeenCalled();
+});
+
+it("handles dismissing a chip", () => {
+  const chipOnDismiss = jest.fn();
+  render(
+    <TagList
+      chipOnDismiss={chipOnDismiss}
+      description=""
+      machineCount={10}
+      tags={tags}
+      tagIdsAndCounts={tagMap}
+    />
+  );
+  screen.getAllByRole("button", { name: "Dismiss" })[0].click();
+  expect(chipOnDismiss).toHaveBeenCalled();
+});
+
+it("can set the appearance of the chip", () => {
+  render(
+    <TagList
+      chipAppearance="caution"
+      description=""
+      machineCount={10}
+      tags={tags}
+      tagIdsAndCounts={tagMap}
+    />
+  );
+  expect(
+    screen.getAllByRole("button")[0]?.className.includes("p-chip--caution")
+  ).toBe(true);
+});
+
+it("can display a description", () => {
+  render(
+    <TagList
+      description="hot chips!"
+      machineCount={10}
+      tags={tags}
+      tagIdsAndCounts={tagMap}
+    />
+  );
+  expect(screen.getByText("hot chips!")).toBeInTheDocument();
+});

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/TagList.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/TagList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import TagList from "./TagList";
 

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/TagList.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/TagList.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import type { ChipProps } from "@canonical/react-components";
+import { Chip } from "@canonical/react-components";
+
+import type { TagIdCountMap } from "app/store/machine/utils";
+import type { Tag } from "app/store/tag/types";
+
+type Props = {
+  chipAppearance?: ChipProps["appearance"];
+  chipOnDismiss?: ChipProps["onDismiss"];
+  chipOnClick?: ChipProps["onClick"];
+  description: ReactNode;
+  machineCount: number;
+  tags: Tag[];
+  tagIdsAndCounts: TagIdCountMap;
+};
+
+export const TagList = ({
+  chipAppearance,
+  chipOnDismiss,
+  chipOnClick,
+  description,
+  machineCount,
+  tags,
+  tagIdsAndCounts,
+  ...props
+}: Props): JSX.Element => {
+  return (
+    <div {...props}>
+      <p className="u-no-margin--bottom">{description}</p>
+      {tags.map((tag) => {
+        const tagCount = tagIdsAndCounts.get(tag.id);
+        return (
+          <Chip
+            appearance={chipAppearance}
+            key={tag.id}
+            onDismiss={chipOnDismiss}
+            onClick={chipOnClick}
+            value={`${tag.name} (${tagCount}/${machineCount})`}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default TagList;

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/index.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagList";

--- a/ui/src/app/store/machine/utils/common.test.ts
+++ b/ui/src/app/store/machine/utils/common.test.ts
@@ -1,4 +1,4 @@
-import { isMachineDetails } from "./common";
+import { getTagCountsForMachines, isMachineDetails } from "./common";
 
 import {
   machine as machineFactory,
@@ -21,6 +21,23 @@ describe("common machine utils", () => {
 
     it("handles null", () => {
       expect(isMachineDetails(null)).toBe(false);
+    });
+  });
+
+  describe("getTagCountsForMachines", () => {
+    it("gets the tag ids and counts", () => {
+      const machines = [
+        machineFactory({ tags: [1, 2, 3] }),
+        machineFactory({ tags: [3, 1, 4] }),
+      ];
+      expect(getTagCountsForMachines(machines)).toStrictEqual(
+        new Map([
+          [1, 2],
+          [2, 1],
+          [3, 2],
+          [4, 1],
+        ])
+      );
     });
   });
 });

--- a/ui/src/app/store/machine/utils/common.ts
+++ b/ui/src/app/store/machine/utils/common.ts
@@ -1,4 +1,5 @@
 import type { Machine, MachineDetails } from "app/store/machine/types";
+import type { Tag, TagMeta } from "app/store/tag/types";
 
 /**
  * Whether a machine has a Machine or MachineDetails type.
@@ -9,3 +10,24 @@ export const isMachineDetails = (
   machine?: Machine | null
   // Use "metadata" as the canary as it only exists for MachineDetails.
 ): machine is MachineDetails => !!machine && "metadata" in machine;
+
+export type TagIdCountMap = Map<Tag[TagMeta.PK], number>;
+
+/**
+ * The tag ids for the given machines.
+ * @param machines - The machines to get the tag ids from.
+ * @returns A list of tag ids.
+ */
+export const getTagCountsForMachines = (machines: Machine[]): TagIdCountMap => {
+  const ids = machines.reduce<Tag[TagMeta.PK][]>(
+    (tagIds, machine) => tagIds.concat(machine.tags),
+    []
+  );
+  const tagCounts = new Map();
+  ids.forEach((id) => {
+    if (!tagCounts.has(id)) {
+      tagCounts.set(id, ids.filter((tagId) => tagId === id).length);
+    }
+  });
+  return tagCounts;
+};

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -1,4 +1,5 @@
-export { isMachineDetails } from "./common";
+export { isMachineDetails, getTagCountsForMachines } from "./common";
+export type { TagIdCountMap } from "./common";
 
 export {
   useCanAddVLAN,

--- a/ui/src/app/store/tag/selectors.test.ts
+++ b/ui/src/app/store/tag/selectors.test.ts
@@ -57,6 +57,19 @@ describe("tag selectors", () => {
     expect(tag.errors(state)).toStrictEqual("Data is incorrect");
   });
 
+  it("can get all automatic tags", () => {
+    const items = [
+      tagFactory({ definition: "def1" }),
+      tagFactory({ definition: "" }),
+    ];
+    const state = rootStateFactory({
+      tag: tagStateFactory({
+        items,
+      }),
+    });
+    expect(tag.getAutomatic(state)).toStrictEqual([items[0]]);
+  });
+
   describe("getByIDs", () => {
     const tags = [
       tagFactory({ id: 1 }),
@@ -98,6 +111,44 @@ describe("tag selectors", () => {
         tag: tagStateFactory({ items: tags }),
       });
       expect(tag.getByName(state, "tag2")).toStrictEqual(tags[1]);
+    });
+  });
+
+  describe("getAutomaticByIDs", () => {
+    const tags = [
+      tagFactory({ id: 1 }),
+      tagFactory({ definition: "def1", id: 2 }),
+      tagFactory({ id: 3 }),
+    ];
+    const state = rootStateFactory({
+      tag: tagStateFactory({ items: tags }),
+    });
+
+    it("handles the null case", () => {
+      expect(tag.getAutomaticByIDs(state, null)).toStrictEqual([]);
+    });
+
+    it("returns a list of tags given their IDs", () => {
+      expect(tag.getAutomaticByIDs(state, [1, 2])).toStrictEqual([tags[1]]);
+    });
+  });
+
+  describe("getManualByIDs", () => {
+    const tags = [
+      tagFactory({ id: 1 }),
+      tagFactory({ definition: "def1", id: 2 }),
+      tagFactory({ id: 3 }),
+    ];
+    const state = rootStateFactory({
+      tag: tagStateFactory({ items: tags }),
+    });
+
+    it("handles the null case", () => {
+      expect(tag.getManualByIDs(state, null)).toStrictEqual([]);
+    });
+
+    it("returns a list of tags given their IDs", () => {
+      expect(tag.getManualByIDs(state, [1, 2])).toStrictEqual([tags[0]]);
     });
   });
 

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -71,3 +71,12 @@ input[type="radio"] {
 .p-double-row__primary-row label.p-checkbox {
   padding-top: 0;
 }
+
+// 18-03-2022 Huw: Chips can't accept classnames to override the margin.
+// https://github.com/canonical-web-and-design/react-components/pull/727
+.tag-form__changes {
+  .p-chip,
+  [class^="p-chip--"] {
+    margin-bottom: $spv--x-small;
+  }
+}

--- a/ui/src/testing/factories/tag.ts
+++ b/ui/src/testing/factories/tag.ts
@@ -8,7 +8,7 @@ import type { TimestampedModel } from "app/store/types/model";
 export const tag = extend<TimestampedModel, Tag>(timestampedModel, {
   comment: "test comment",
   controller_count: 0,
-  definition: "test definition",
+  definition: "",
   device_count: 0,
   kernel_opts: null,
   machine_count: 0,


### PR DESCRIPTION
## Done

- Add the existing manual and automatic tags on the selected machines in the tag form in the machine list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and select some machines. I've created an automatic tag so if you select all machines, or one of the machines attached to the tag (http://bolla.internal:5240/MAAS/r/tag/74) you'll see automatic tags in the form.
- Use the take action menu to open the tag form.
- You should see the existing tags on the machines you selected.

## Fixes

Fixes: canonical-web-and-design/app-tribe#685.

## Screenshots

<img width="1143" alt="Screen Shot 2022-03-18 at 1 04 29 pm" src="https://user-images.githubusercontent.com/361637/158924813-71edfea4-918e-4ac8-96e3-2cf747bdcf3f.png">

