### PR TITLE
fix(ui): fix loading machine details

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -11,6 +11,7 @@ import { PowerState } from "app/store/types/enum";
 import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
+  machine as machineFactory,
   machineDetails as machineDetailsFactory,
   machineDevice as machineDeviceFactory,
   machineState as machineStateFactory,
@@ -39,6 +40,25 @@ describe("MachineHeader", () => {
 
   it("displays a spinner when loading", () => {
     state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineHeader
+            headerContent={null}
+            setHeaderContent={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a spinner when loading the details version of the machine", () => {
+    state.machine.items = [machineFactory({ system_id: "abc123" })];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -52,16 +52,16 @@ const MachineHeader = ({
     NodeActions.OFF,
     NodeActions.ON,
   ]);
+  const isDetails = isMachineDetails(machine);
 
   useEffect(() => {
     dispatch(machineActions.get(systemId));
   }, [dispatch, systemId]);
 
-  if (!machine) {
+  if (!machine || !isDetails) {
     return <SectionHeader loading />;
   }
 
-  const isDetails = isMachineDetails(machine);
   const urlBase = `/machine/${systemId}`;
   const checkingPower = statuses?.checkingPower;
 


### PR DESCRIPTION
## Done

- Display a spinner when waiting for the machine details to load.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list
- Reload so that the data in redux is fresh.
- Click on a machine
- You should get the machine details and it should not display an error.

## Fixes

Fixes: #3671.