### PR TITLE
fix(ui): Update machine types with latest shapes

### DIFF
--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -35,7 +35,6 @@ export type MachineActions = Exclude<NodeActions, NodeActions.IMPORT_IMAGES>;
 // pages.
 export type BaseMachine = BaseNode & {
   actions: MachineActions[];
-  commissioning_status: TestStatus;
   error_description: string;
   extra_macs: string[];
   fabrics: string[];
@@ -74,6 +73,7 @@ export type MachineDetails = BaseMachine &
     boot_disk: Disk | null;
     certificate?: CertificateMetadata;
     commissioning_start_time: string;
+    commissioning_status: TestStatus;
     cpu_test_status: TestStatus;
     current_commissioning_script_set: number;
     current_installation_script_set: number;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -196,7 +196,6 @@ const node = extend<SimpleNode, BaseNode>(simpleNode, {
 
 export const machine = extend<BaseNode, Machine>(node, {
   actions,
-  commissioning_status: testStatus,
   description: "a test machine",
   error_description: "",
   extra_macs,
@@ -305,6 +304,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   bmc: 190,
   boot_disk: null,
   commissioning_start_time: "Thu, 15 Oct. 2020 07:25:10",
+  commissioning_status: testStatus,
   created: "Thu, 15 Oct. 2020 07:25:10",
   current_commissioning_script_set: 6188,
   current_installation_script_set: 6174,


### PR DESCRIPTION
## Done

- Moved `commissioning_status` from `BaseMachine` to `MachineDetails`. It looks like the other params (`cpu_speed` and `commissioning_start_time`) were already in the right place, even though they were technically wrong before.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes #3691 

