### PR TITLE
feat(ui): tagged machines list

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -162,6 +162,7 @@ const generateRows = ({
 
     const columns = [
       {
+        "aria-label": columnLabels[MachineColumns.FQDN],
         key: MachineColumns.FQDN,
         className: "fqdn-col",
         content: (
@@ -179,6 +180,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.POWER],
         key: MachineColumns.POWER,
         className: "power-col",
         content: (
@@ -190,6 +192,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.STATUS],
         key: MachineColumns.STATUS,
         className: "status-col",
         content: (
@@ -201,6 +204,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.OWNER],
         key: MachineColumns.OWNER,
         className: "owner-col",
         content: (
@@ -212,6 +216,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.POOL],
         key: MachineColumns.POOL,
         className: "pool-col",
         content: (
@@ -223,6 +228,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.ZONE],
         key: MachineColumns.ZONE,
         className: "zone-col",
         content: (
@@ -234,6 +240,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.FABRIC],
         key: MachineColumns.FABRIC,
         className: "fabric-col",
         content: (
@@ -241,6 +248,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.CPU],
         key: MachineColumns.CPU,
         className: "cores-col",
         content: (
@@ -248,6 +256,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.MEMORY],
         key: MachineColumns.MEMORY,
         className: "ram-col",
         content: (
@@ -255,6 +264,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.DISKS],
         key: MachineColumns.DISKS,
         className: "disks-col",
         content: (
@@ -262,6 +272,7 @@ const generateRows = ({
         ),
       },
       {
+        "aria-label": columnLabels[MachineColumns.STORAGE],
         key: MachineColumns.STORAGE,
         className: "storage-col",
         content: (
@@ -275,8 +286,9 @@ const generateRows = ({
 
     return {
       key: row.system_id,
-      className: classNames("machine-list__machine", "truncated-border", {
+      className: classNames("machine-list__machine", {
         "machine-list__machine--active": isActive,
+        "truncated-border": showActions,
       }),
       columns: filterColumns(columns, hiddenColumns, showActions),
     };
@@ -520,6 +532,7 @@ export const MachineListTable = ({
   setHiddenGroups,
   setSearchFilter,
   showActions = true,
+  ...props
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const machinesLoaded = useSelector(machineSelectors.loaded);
@@ -527,6 +540,7 @@ export const MachineListTable = ({
   const { currentSort, sortRows, updateSort } = useTableSort<Machine, SortKey>(
     getSortValue,
     {
+      "aria-label": columnLabels[MachineColumns.FQDN],
       key: MachineColumns.FQDN,
       direction: SortDirection.DESCENDING,
     }
@@ -598,6 +612,7 @@ export const MachineListTable = ({
 
   const headers = [
     {
+      "aria-label": columnLabels[MachineColumns.FQDN],
       key: MachineColumns.FQDN,
       className: "fqdn-col",
       content: (
@@ -640,6 +655,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.POWER],
       key: MachineColumns.POWER,
       className: "power-col",
       content: (
@@ -655,6 +671,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.STATUS],
       key: MachineColumns.STATUS,
       className: "status-col",
       content: (
@@ -670,6 +687,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.OWNER],
       key: MachineColumns.OWNER,
       className: "owner-col",
       content: (
@@ -687,6 +705,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.POOL],
       key: MachineColumns.POOL,
       className: "pool-col",
       content: (
@@ -704,6 +723,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.ZONE],
       key: MachineColumns.ZONE,
       className: "zone-col",
       content: (
@@ -721,6 +741,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.FABRIC],
       key: MachineColumns.FABRIC,
       className: "fabric-col",
       content: (
@@ -738,6 +759,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.CPU],
       key: MachineColumns.CPU,
       className: "cores-col u-align--right",
       content: (
@@ -755,6 +777,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.MEMORY],
       key: MachineColumns.MEMORY,
       className: "ram-col u-align--right",
       content: (
@@ -769,6 +792,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.DISKS],
       key: MachineColumns.DISKS,
       className: "disks-col u-align--right",
       content: (
@@ -783,6 +807,7 @@ export const MachineListTable = ({
       ),
     },
     {
+      "aria-label": columnLabels[MachineColumns.STORAGE],
       key: MachineColumns.STORAGE,
       className: "storage-col u-align--right",
       content: (
@@ -839,6 +864,7 @@ export const MachineListTable = ({
             "No machines match the search criteria."
           ) : null
         }
+        {...props}
       />
     </>
   );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -540,7 +540,6 @@ export const MachineListTable = ({
   const { currentSort, sortRows, updateSort } = useTableSort<Machine, SortKey>(
     getSortValue,
     {
-      "aria-label": columnLabels[MachineColumns.FQDN],
       key: MachineColumns.FQDN,
       direction: SortDirection.DESCENDING,
     }

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -1,7 +1,7 @@
 import machine from "./selectors";
 
 import { NetworkInterfaceTypes } from "app/store/types/enum";
-import { NodeActions, NodeStatusCode } from "app/store/types/node";
+import { NodeActions, NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
@@ -452,5 +452,19 @@ describe("machine selectors", () => {
     expect(
       machine.getInterfaceById(state, node.system_id, null, link.id)
     ).toStrictEqual(nic);
+  });
+
+  it("can get deployed machines by tag", () => {
+    const items = [
+      machineFactory({ status: NodeStatus.DISK_ERASING, tags: [1] }),
+      machineFactory({ status: NodeStatus.DEPLOYED, tags: [1] }),
+      machineFactory({ status: NodeStatus.DEPLOYED, tags: [] }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items,
+      }),
+    });
+    expect(machine.getDeployedWithTag(state, 1)).toStrictEqual([items[1]]);
   });
 });

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -292,9 +292,10 @@ const getDeployedWithTag = createSelector(
     if (!isId(tagId)) {
       return [];
     }
-    return machines
-      .filter(({ status }) => status === NodeStatus.DEPLOYED)
-      .filter(({ tags }) => tags.includes(tagId));
+    return machines.filter(
+      ({ status, tags }) =>
+        status === NodeStatus.DEPLOYED && tags.includes(tagId)
+    );
   }
 );
 

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -1,6 +1,8 @@
 import type { Selector } from "@reduxjs/toolkit";
 import { createSelector } from "@reduxjs/toolkit";
 
+import type { Tag, TagMeta } from "../tag/types";
+
 import { ACTIONS } from "app/store/machine/slice";
 import { MachineMeta } from "app/store/machine/types";
 import type {
@@ -13,10 +15,12 @@ import { FilterMachines, isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { NetworkInterface } from "app/store/types/node";
+import { NodeStatus } from "app/store/types/node";
 import {
   generateBaseSelectors,
   getInterfaceById as getInterfaceByIdUtil,
 } from "app/store/utils";
+import { isId } from "app/utils";
 
 const defaultSelectors = generateBaseSelectors<
   MachineState,
@@ -273,6 +277,27 @@ const getByStatusCode = createSelector(
     machines.filter(({ status_code }) => status_code === statusCode)
 );
 
+/**
+ * Get the deployed machines with the provided tag.
+ * @param state - The redux state.
+ * @param tagId - The tag id.
+ * @returns The deployed machines with the tag.
+ */
+const getDeployedWithTag = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, tagId: Tag[TagMeta.PK] | null) => tagId,
+  ],
+  (machines, tagId) => {
+    if (!isId(tagId)) {
+      return [];
+    }
+    return machines
+      .filter(({ status }) => status === NodeStatus.DEPLOYED)
+      .filter(({ tags }) => tags.includes(tagId));
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
   aborting: statusSelectors["aborting"],
@@ -292,6 +317,7 @@ const selectors = {
   eventErrorsForIds,
   exitingRescueMode: statusSelectors["exitingRescueMode"],
   getByStatusCode,
+  getDeployedWithTag,
   getInterfaceById,
   getStatuses,
   getStatusForMachine,

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it("dispatches an action to create a tagrange", async () => {
+it("dispatches an action to create a tag", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,15 +1,21 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Router } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeleteTagForm from "./DeleteTagForm";
 
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
+import { NodeStatus } from "app/store/types/node";
+import tagsURLs from "app/tags/urls";
 import {
-  tag as tagFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
 
@@ -20,6 +26,14 @@ let scrollToSpy: jest.Mock;
 
 beforeEach(() => {
   state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [
+        machineFactory({
+          status: NodeStatus.DEPLOYED,
+          tags: [1],
+        }),
+      ],
+    }),
     tag: tagStateFactory({
       items: [tagFactory({ id: 1 })],
     }),
@@ -95,4 +109,71 @@ it("displays a message when deleting a tag not on a machine", async () => {
       name: "tag1 will be deleted. Are you sure?",
     })
   ).toBeInTheDocument();
+});
+
+it("can return to the list on cancel", async () => {
+  state.tag.items = [
+    tagFactory({
+      id: 1,
+      kernel_opts: "opts",
+      machine_count: 1,
+      name: "tag1",
+    }),
+  ];
+  const path = tagsURLs.tag.machines({ id: 1 });
+  const history = createMemoryHistory({
+    initialEntries: [{ pathname: path }],
+  });
+  const onClose = jest.fn();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <Router history={history}>
+        <Route
+          exact
+          path={path}
+          component={() => <DeleteTagForm id={1} onClose={onClose} />}
+        />
+      </Router>
+    </Provider>
+  );
+  userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  expect(history.location.pathname).toBe(tagsURLs.tags.index);
+  expect(onClose).toBeCalled();
+});
+
+it("can return to the details on cancel", async () => {
+  state.tag.items = [
+    tagFactory({
+      id: 1,
+      kernel_opts: "opts",
+      machine_count: 1,
+      name: "tag1",
+    }),
+  ];
+  const path = tagsURLs.tag.machines({ id: 1 });
+  const history = createMemoryHistory({
+    initialEntries: [{ pathname: path }],
+  });
+  const onClose = jest.fn();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <Router history={history}>
+        <Route
+          exact
+          path={path}
+          component={() => (
+            <DeleteTagForm fromDetails id={1} onClose={onClose} />
+          )}
+        />
+      </Router>
+    </Provider>
+  );
+  userEvent.click(
+    screen.getByRole("link", { name: "Show the deployed machine" })
+  );
+  userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  expect(history.location.pathname).toBe(tagsURLs.tag.index({ id: 1 }));
+  expect(onClose).toBeCalled();
 });

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
@@ -1,5 +1,6 @@
 import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 
 import DeleteTagFormWarnings from "./DeleteTagFormWarnings";
 
@@ -13,12 +14,18 @@ import type { Tag, TagMeta } from "app/store/tag/types";
 import tagsURLs from "app/tags/urls";
 
 type Props = {
+  fromDetails?: boolean;
   id: Tag[TagMeta.PK];
   onClose: () => void;
 };
 
-export const DeleteTagForm = ({ id, onClose }: Props): JSX.Element | null => {
+export const DeleteTagForm = ({
+  fromDetails = false,
+  id,
+  onClose,
+}: Props): JSX.Element | null => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const saved = useSelector(tagSelectors.saved);
   const saving = useSelector(tagSelectors.saving);
   const errors = useSelector(tagSelectors.errors);
@@ -26,6 +33,16 @@ export const DeleteTagForm = ({ id, onClose }: Props): JSX.Element | null => {
     tagSelectors.getById(state, id)
   );
   useScrollToTop();
+  const onCancel = () => {
+    onClose();
+    if (fromDetails) {
+      // Explicitly return to the page they user came from in case they have opened
+      // the list of machines.
+      history.push({ pathname: tagsURLs.tag.index({ id: id }) });
+    } else {
+      history.push({ pathname: tagsURLs.tags.index });
+    }
+  };
   if (!tag) {
     return null;
   }
@@ -37,7 +54,7 @@ export const DeleteTagForm = ({ id, onClose }: Props): JSX.Element | null => {
       cleanup={tagActions.cleanup}
       errors={errors}
       initialValues={{}}
-      onCancel={onClose}
+      onCancel={onCancel}
       onSaveAnalytics={{
         action: "Delete",
         category: "Delete tag form",

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
@@ -1,10 +1,13 @@
 import { Notification } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
+import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
+import tagsURLs from "app/tags/urls";
 
 type Props = {
   id: Tag[TagMeta.PK];
@@ -20,24 +23,36 @@ const generateWarning = (nodeType: string, count: number) => (
   </Notification>
 );
 
+const generateDeployedMessage = (count: number) =>
+  count === 1
+    ? `There is ${count} deployed machine with this tag and it will not be affected until it is redeployed.`
+    : `There are ${count} deployed machines with this tag and they will not be affected until they are redeployed.`;
+
 export const DeleteTagFormWarnings = ({ id }: Props): JSX.Element | null => {
   const tag = useSelector((state: RootState) =>
     tagSelectors.getById(state, id)
   );
+  const deployedMachines = useSelector((state: RootState) =>
+    machineSelectors.getDeployedWithTag(state, id)
+  );
+  const deployedCount = deployedMachines.length;
   if (!tag) {
     return null;
   }
   return (
     <div className="delete-tag-form-warnings">
-      {!!tag.kernel_opts && tag.machine_count > 0 ? (
+      {!!tag.kernel_opts && deployedCount > 0 ? (
         <Notification
           className="delete-tag-form-warnings__notification"
           severity="caution"
         >
-          You are deleting a tag with kernel options. There{" "}
-          {tag.machine_count === 1 ? "is" : "are"}{" "}
-          {pluralize("machine", tag.machine_count, true)} with this tag and they
-          will not be affected until they are redeployed.
+          <span className="u-block">
+            You are deleting a tag with kernel options.{" "}
+            {generateDeployedMessage(deployedCount)}
+          </span>
+          <Link to={tagsURLs.tag.machines({ id })}>
+            Show the deployed {pluralize("machine", deployedCount)}
+          </Link>
         </Notification>
       ) : null}
       {tag.device_count > 0

--- a/ui/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.test.tsx
@@ -13,6 +13,17 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
+let scrollToSpy: jest.Mock;
+
+beforeEach(() => {
+  // Mock the scrollTo method as jsdom doesn't support this and will error.
+  scrollToSpy = jest.fn();
+  global.scrollTo = scrollToSpy;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 it("can display the add tag form", () => {
   const store = mockStore(rootStateFactory());

--- a/ui/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.tsx
+++ b/ui/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.tsx
@@ -19,7 +19,16 @@ export const TagHeaderForms = ({
     case TagHeaderViews.DeleteTag:
       const id = headerContent?.extras?.id;
       if (id) {
-        return <DeleteTagForm id={id} onClose={() => setHeaderContent(null)} />;
+        return (
+          <DeleteTagForm
+            fromDetails={headerContent?.extras?.fromDetails}
+            id={id}
+            // Set a key so that if a different tag is click on while the form
+            // is open then it renders the form again and scrolls to the top.
+            key={id}
+            onClose={() => setHeaderContent(null)}
+          />
+        );
       }
       return null;
     default:

--- a/ui/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
@@ -13,6 +13,17 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
+let scrollToSpy: jest.Mock;
+
+beforeEach(() => {
+  // Mock the scrollTo method as jsdom doesn't support this and will error.
+  scrollToSpy = jest.fn();
+  global.scrollTo = scrollToSpy;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 it("can display the add tag form", () => {
   const store = mockStore(rootStateFactory());

--- a/ui/src/app/tags/types.ts
+++ b/ui/src/app/tags/types.ts
@@ -7,6 +7,9 @@ type HeaderViews = typeof TagHeaderViews;
 
 export type TagHeaderContent =
   | HeaderContent<HeaderViews["AddTag"]>
-  | HeaderContent<HeaderViews["DeleteTag"], { id: Tag[TagMeta.PK] }>;
+  | HeaderContent<
+      HeaderViews["DeleteTag"],
+      { id: Tag[TagMeta.PK]; fromDetails?: boolean }
+    >;
 
 export type TagSetHeaderContent = SetHeaderContent<TagHeaderContent>;

--- a/ui/src/app/tags/urls.ts
+++ b/ui/src/app/tags/urls.ts
@@ -8,6 +8,7 @@ const urls = {
   tag: {
     base: "/tag",
     index: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id"),
+    machines: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id/machines"),
   },
 };
 

--- a/ui/src/app/tags/views/TagDetails/TagDetails.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.tsx
@@ -37,7 +37,7 @@ export enum Label {
 }
 
 type Props = {
-  onDelete: (id: Tag[TagMeta.PK]) => void;
+  onDelete: (id: Tag[TagMeta.PK], fromDetails?: boolean) => void;
 };
 
 const TagDetails = ({ onDelete }: Props): JSX.Element => {
@@ -81,7 +81,7 @@ const TagDetails = ({ onDelete }: Props): JSX.Element => {
           <Button
             appearance="negative"
             hasIcon
-            onClick={() => onDelete(tag[TagMeta.PK])}
+            onClick={() => onDelete(tag[TagMeta.PK], true)}
           >
             <Icon className="is-light" name="delete" /> <span>Delete</span>
           </Button>

--- a/ui/src/app/tags/views/TagList/TagList.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.tsx
@@ -12,7 +12,7 @@ import tagSelectors, { TagSearchFilter } from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
 
 type Props = {
-  onDelete: (id: Tag[TagMeta.PK]) => void;
+  onDelete: (id: Tag[TagMeta.PK], fromDetails?: boolean) => void;
 };
 
 const TagList = ({ onDelete }: Props): JSX.Element => {

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -30,7 +30,7 @@ type Props = PropsWithSpread<
   {
     currentPage: number;
     filter: TagSearchFilter;
-    onDelete: (id: Tag[TagMeta.PK]) => void;
+    onDelete: (id: Tag[TagMeta.PK], fromDetails?: boolean) => void;
     searchText: string;
     setCurrentPage: (page: number) => void;
     tags: Tag[];

--- a/ui/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/ui/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import TagMachines, { Label } from "./TagMachines";
+
+import { columnLabels, MachineColumns } from "app/machines/constants";
+import { actions as machineActions } from "app/store/machine";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import { NodeStatus } from "app/store/types/node";
+import tagURLs from "app/tags/urls";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  modelRef as modelRefFactory,
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [
+        machineFactory({
+          domain: modelRefFactory({ id: 1, name: "test" }),
+          hostname: "deployed",
+          status: NodeStatus.DEPLOYED,
+          tags: [1],
+        }),
+      ],
+    }),
+    tag: tagStateFactory({
+      items: [
+        tagFactory({
+          id: 1,
+          machine_count: 1,
+          name: "rad",
+        }),
+      ],
+    }),
+  });
+});
+
+it("dispatches actions to fetch necessary data", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagMachines />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const expectedActions = [machineActions.fetch(), tagActions.fetch()];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the tag does not exist", () => {
+  const state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [],
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagMachines />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByText("Tag not found")).toBeInTheDocument();
+});
+
+it("shows a spinner if the tag has not loaded yet", () => {
+  const state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [],
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagMachines />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByTestId("Spinner")).toBeInTheDocument();
+});
+
+it("displays the machine list", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+      >
+        <Route
+          exact
+          path={tagURLs.tag.index(null, true)}
+          component={() => <TagMachines />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByRole("grid", { name: Label.Machines })
+  ).toBeInTheDocument();
+  const rows = screen.getAllByRole("gridcell", {
+    name: columnLabels[MachineColumns.FQDN],
+  });
+  expect(rows).toHaveLength(1);
+  expect(rows[0].textContent?.includes("deployed.test")).toBe(true);
+});

--- a/ui/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/ui/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import ModelNotFound from "app/base/components/ModelNotFound";
+import { useWindowTitle } from "app/base/hooks";
+import { useGetURLId } from "app/base/hooks/urls";
+import MachineListTable from "app/machines/views/MachineList/MachineListTable";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import { TagMeta } from "app/store/tag/types";
+import tagURLs from "app/tags/urls";
+import { isId } from "app/utils";
+
+export enum Label {
+  Machines = "Deployed machines",
+}
+
+const TagMachines = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(TagMeta.PK);
+  const tag = useSelector((state: RootState) =>
+    tagSelectors.getById(state, id)
+  );
+  const tagsLoading = useSelector(tagSelectors.loading);
+  const deployedMachines = useSelector((state: RootState) =>
+    machineSelectors.getDeployedWithTag(state, id)
+  );
+
+  useWindowTitle(tag ? `Deployed machines for: ${tag.name}` : "Tag");
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+    dispatch(machineActions.fetch());
+  }, [dispatch]);
+
+  if (!isId(id) || (!tagsLoading && !tag)) {
+    return (
+      <ModelNotFound id={id} linkURL={tagURLs.tags.index} modelName="tag" />
+    );
+  }
+
+  if (!tag || tagsLoading) {
+    return <Spinner data-testid="Spinner" />;
+  }
+
+  return (
+    <MachineListTable
+      aria-label={Label.Machines}
+      machines={deployedMachines}
+      showActions={false}
+    />
+  );
+};
+
+export default TagMachines;

--- a/ui/src/app/tags/views/TagMachines/index.ts
+++ b/ui/src/app/tags/views/TagMachines/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagMachines";

--- a/ui/src/app/tags/views/Tags.tsx
+++ b/ui/src/app/tags/views/Tags.tsx
@@ -8,6 +8,7 @@ import type { TagHeaderContent } from "../types";
 
 import TagDetails from "./TagDetails";
 import TagList from "./TagList";
+import TagMachines from "./TagMachines";
 
 import Section from "app/base/components/Section";
 import NotFound from "app/base/views/NotFound";
@@ -18,10 +19,10 @@ const Tags = (): JSX.Element => {
   const [headerContent, setHeaderContent] = useState<TagHeaderContent | null>(
     null
   );
-  const onDelete = (id: Tag[TagMeta.PK]) =>
+  const onDelete = (id: Tag[TagMeta.PK], fromDetails?: boolean) =>
     setHeaderContent({
       view: TagHeaderViews.DeleteTag,
-      extras: { id },
+      extras: { fromDetails, id },
     });
   return (
     <Section
@@ -37,6 +38,11 @@ const Tags = (): JSX.Element => {
           exact
           path={tagsURLs.tag.index(null, true)}
           render={() => <TagDetails onDelete={onDelete} />}
+        />
+        <Route
+          exact
+          path={tagsURLs.tag.machines(null, true)}
+          render={() => <TagMachines />}
         />
         <Route
           exact


### PR DESCRIPTION
## Done

- Display the list of deployed machines with a tag.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a tag with opts and add it to a deployed machine (it's a little hard to do that at the moment - you could do it with the CLI or set the definition when creating the tag to `//lshw:description[text() = "Computer"]` and it should get added to some machines).
- Click delete for the tag you just created.
- The tag form should open and there should be a warning about deployed machines.
- Click "Show the deployed machine" and the machine list should appear below with the deployed machine(s) that have the tag.
- Click delete and the tag should get removed and you should return to the tag list.

## Fixes

Fixes: canonical-web-and-design/app-tribe#766.

## Screenshot

<img width="1282" alt="Screen Shot 2022-03-23 at 12 41 40 pm" src="https://user-images.githubusercontent.com/361637/159632365-c60d7cc5-4123-4fff-9672-d21820f22727.png">
