### PR TITLE
feat(subnets): add search query to url params

### DIFF
--- a/ui/src/app/subnets/enum.ts
+++ b/ui/src/app/subnets/enum.ts
@@ -4,3 +4,8 @@ export enum SubnetForms {
   Space = "Space",
   Subnet = "Subnet",
 }
+
+export enum SubnetsUrlParams {
+  By = "by",
+  Q = "q",
+}

--- a/ui/src/app/subnets/types.ts
+++ b/ui/src/app/subnets/types.ts
@@ -1,3 +1,6 @@
+import type { GroupByKey } from "./views/SubnetsList/SubnetsTable/types";
+
 import type { SubnetForms } from "app/subnets/enum";
 
 export type SubnetForm = keyof typeof SubnetForms;
+export type SubnetsUrlParams = { by?: GroupByKey; q?: string };

--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -1,15 +1,15 @@
-import type { GroupByKey } from "./views/SubnetsList/SubnetsTable/types";
-
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import type { Space, SpaceMeta } from "app/store/space/types";
 import type { Subnet, SubnetMeta } from "app/store/subnet/types";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
+import type { SubnetsUrlParams } from "app/subnets/types";
 import { argPath, isId } from "app/utils";
 
 const urls = {
   index: "/networks",
-  indexBy: ({ by }: { by?: GroupByKey } = { by: "fabric" }): string =>
-    `/networks?by=${by}`,
+  indexWithParams: (
+    { by, q }: SubnetsUrlParams = { by: "fabric", q: "" }
+  ): string => `/networks?by=${by}&q=${q}`,
   fabric: {
     index: argPath<{ id: Fabric[FabricMeta.PK] }>("/fabric/:id"),
   },

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.tsx
@@ -49,7 +49,7 @@ const FabricDetails = (): JSX.Element => {
       return (
         <ModelNotFound
           id={id}
-          linkURL={subnetURLs.indexBy({ by: "fabric" })}
+          linkURL={subnetURLs.indexWithParams({ by: "fabric" })}
           modelName="fabric"
         />
       );

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.tsx
@@ -71,7 +71,7 @@ const FabricDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
         dispatch(cleanup());
         dispatch(fabricActions.delete(id));
       }}
-      savedRedirect={subnetURLs.indexBy({ by: "fabric" })}
+      savedRedirect={subnetURLs.indexWithParams({ by: "fabric" })}
       saved={saved}
       saving={saving}
       submitAppearance="negative"

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.tsx
@@ -47,7 +47,7 @@ const SpaceDetails = (): JSX.Element => {
       return (
         <ModelNotFound
           id={id}
-          linkURL={subnetURLs.indexBy({ by: "space" })}
+          linkURL={subnetURLs.indexWithParams({ by: "space" })}
           modelName="space"
         />
       );

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDelete/SpaceDelete.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDelete/SpaceDelete.tsx
@@ -39,7 +39,7 @@ export const SpaceDelete = ({
   };
   useCycled(saved, () => {
     if (saved) {
-      history.replace(urls.indexBy({ by: "space" }));
+      history.replace(urls.indexWithParams({ by: "space" }));
     }
   });
 

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -54,7 +54,7 @@ const SubnetDetails = (): JSX.Element => {
     return (
       <ModelNotFound
         id={id}
-        linkURL={subnetURLs.indexBy({ by: "fabric" })}
+        linkURL={subnetURLs.indexWithParams({ by: "fabric" })}
         modelName="subnet"
       />
     );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
@@ -12,11 +12,13 @@ import type {
 const SubnetsControls = ({
   groupBy,
   setGroupBy,
+  searchText: initialSearchText = "",
   handleSearch,
 }: SubnetGroupByProps & {
+  searchText?: string;
   handleSearch: (text: string) => void;
 }): JSX.Element => {
-  const [searchText, setSearchText] = useState("");
+  const [searchText, setSearchText] = useState(initialSearchText);
   const [isInfoOpen, setIsInfoOpen] = useState(false);
 
   return (

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
@@ -1,0 +1,109 @@
+import { screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import SubnetsList from "./SubnetsList";
+
+import urls from "app/subnets/urls";
+import {
+  fabricState as fabricStateFactory,
+  vlanState as vlanStateFactory,
+  subnetState as subnetStateFactory,
+  spaceState as spaceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { getUrlParam, renderWithBrowserRouter } from "testing/utils";
+
+const getMockState = () => {
+  return rootStateFactory({
+    fabric: fabricStateFactory({
+      loaded: true,
+    }),
+    vlan: vlanStateFactory({ loaded: true }),
+    subnet: subnetStateFactory({ loaded: true }),
+    space: spaceStateFactory({ loaded: true }),
+  });
+};
+
+it("displays loading text", async () => {
+  const state = getMockState();
+  state.fabric.loaded = false;
+  renderWithBrowserRouter(<SubnetsList />, {
+    wrapperProps: { state },
+    route: urls.index,
+  });
+
+  expect(screen.getAllByRole("table")).toHaveLength(1);
+  userEvent.type(screen.getByRole("searchbox"), "non-existent-fabric");
+  await waitFor(() =>
+    expect(screen.getByText(/Loading.../)).toBeInTheDocument()
+  );
+});
+
+it("displays correct text when there are no results for the search criteria", async () => {
+  const state = getMockState();
+  renderWithBrowserRouter(<SubnetsList />, {
+    wrapperProps: { state },
+    route: urls.index,
+  });
+
+  expect(screen.getAllByRole("table")).toHaveLength(1);
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+
+  userEvent.type(screen.getByRole("searchbox"), "non-existent-fabric");
+
+  await waitFor(() =>
+    expect(within(tableBody).getByText(/No results/)).toBeInTheDocument()
+  );
+  expect(within(tableBody).getAllByRole("row")).toHaveLength(1);
+});
+
+it("sets the options from the URL on load", async () => {
+  const state = getMockState();
+  renderWithBrowserRouter(<SubnetsList />, {
+    wrapperProps: { state },
+    route: urls.indexWithParams({ by: "space", q: "fabric-1" }),
+  });
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole<HTMLOptionElement>("option", { name: "Group by space" })
+        .selected
+    ).toBe(true)
+  );
+  await waitFor(() =>
+    expect(screen.getByRole<HTMLInputElement>("searchbox").value).toBe(
+      "fabric-1"
+    )
+  );
+});
+
+it("updates the URL on search", async () => {
+  const state = getMockState();
+  renderWithBrowserRouter(<SubnetsList />, {
+    wrapperProps: { state },
+    route: urls.index,
+  });
+
+  expect(getUrlParam("q")).toEqual("");
+
+  userEvent.type(screen.getByRole("searchbox"), "test-fabric");
+
+  await waitFor(() => expect(getUrlParam("q")).toEqual("test-fabric"));
+});
+
+it("updates the URL 'by' param once a new group by option is selected", async () => {
+  const state = getMockState();
+  renderWithBrowserRouter(<SubnetsList />, {
+    wrapperProps: { state },
+    route: urls.index,
+  });
+
+  expect(getUrlParam("by")).toEqual("fabric");
+
+  userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Group by" }),
+    "Group by space"
+  );
+
+  await waitFor(() => expect(getUrlParam("by")).toEqual("space"));
+});

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -10,7 +10,7 @@ import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
 import { useWindowTitle } from "app/base/hooks";
 import { useQuery } from "app/base/hooks/urls";
-import { SubnetForms } from "app/subnets/enum";
+import { SubnetForms, SubnetsUrlParams } from "app/subnets/enum";
 import type { SubnetForm } from "app/subnets/types";
 import FormActions from "app/subnets/views/FormActions";
 
@@ -19,14 +19,23 @@ const SubnetsList = (): JSX.Element => {
   const [activeForm, setActiveForm] = React.useState<SubnetForm | null>(null);
   const query = useQuery();
   const history = useHistory();
-  const groupBy = query.get("by");
+  const groupBy = query.get(SubnetsUrlParams.By);
+  const searchText = query.get(SubnetsUrlParams.Q) || "";
   const setGroupBy = useCallback(
     (group: GroupByKey) =>
       history.replace({
         pathname: "/networks",
-        search: `?by=${group}`,
+        search: `?${SubnetsUrlParams.By}=${group}&${SubnetsUrlParams.Q}=${searchText}`,
       }),
-    [history]
+    [history, searchText]
+  );
+  const setSearchText = useCallback(
+    (searchText) =>
+      history.replace({
+        pathname: "/networks",
+        search: `?${SubnetsUrlParams.By}=${groupBy}&${SubnetsUrlParams.Q}=${searchText}`,
+      }),
+    [history, groupBy]
   );
 
   const hasValidGroupBy = groupBy && ["fabric", "space"].includes(groupBy);
@@ -73,7 +82,12 @@ const SubnetsList = (): JSX.Element => {
       }
     >
       {hasValidGroupBy ? (
-        <SubnetsTable groupBy={groupBy as GroupByKey} setGroupBy={setGroupBy} />
+        <SubnetsTable
+          groupBy={groupBy as GroupByKey}
+          setGroupBy={setGroupBy}
+          searchText={searchText}
+          setSearchText={setSearchText}
+        />
       ) : null}
     </Section>
   );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -44,7 +44,12 @@ it("renders a single table variant at a time", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -60,7 +65,12 @@ it("renders Subnets by Fabric table when grouping by Fabric", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -77,7 +87,12 @@ it("renders Subnets by Space table when grouping by Space", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="space" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="space"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -94,7 +109,12 @@ it("displays a correct number of pages", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -126,7 +146,12 @@ it("updates the list of items correctly when navigating to another page", async 
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -179,7 +204,12 @@ it("doesn't display pagination if rows are within items per page limit", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -208,7 +238,12 @@ it("displays correctly paginated rows", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -269,7 +304,12 @@ it("displays the last available page once the currently active has no items", as
   const { rerender } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -301,7 +341,12 @@ it("displays the last available page once the currently active has no items", as
   rerender(
     <Provider store={updatedStore}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -330,7 +375,12 @@ it("remains on the same page once the data is updated and page is still availabl
   const { rerender } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -359,7 +409,12 @@ it("remains on the same page once the data is updated and page is still availabl
   rerender(
     <Provider store={updatedStore}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
+        <SubnetsTable
+          groupBy="fabric"
+          setGroupBy={jest.fn()}
+          searchText=""
+          setSearchText={jest.fn()}
+        />
       </MemoryRouter>
     </Provider>
   );
@@ -372,55 +427,4 @@ it("remains on the same page once the data is updated and page is still availabl
         .querySelector(".is-active")
     ).toHaveTextContent("2")
   );
-});
-
-it("displays loading text", async () => {
-  const state = rootStateFactory({
-    fabric: fabricStateFactory({
-      loaded: false,
-    }),
-    vlan: vlanStateFactory({ loaded: false }),
-    subnet: subnetStateFactory({ loaded: false }),
-    space: spaceStateFactory({ loaded: false }),
-  });
-  const mockStore = configureStore();
-  const store = mockStore(state);
-
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
-      </MemoryRouter>
-    </Provider>
-  );
-
-  expect(screen.getAllByRole("table")).toHaveLength(1);
-  userEvent.type(screen.getByRole("searchbox"), "non-existent-fabric");
-  await waitFor(() =>
-    expect(screen.getByText(/Loading.../)).toBeInTheDocument()
-  );
-});
-
-it("displays correct text when there are no results for the search criteria", async () => {
-  const state = getMockState();
-  const mockStore = configureStore();
-  const store = mockStore(state);
-
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable groupBy="fabric" setGroupBy={jest.fn()} />
-      </MemoryRouter>
-    </Provider>
-  );
-
-  expect(screen.getAllByRole("table")).toHaveLength(1);
-  const tableBody = screen.getAllByRole("rowgroup")[1];
-
-  userEvent.type(screen.getByRole("searchbox"), "non-existent-fabric");
-
-  await waitFor(() =>
-    expect(within(tableBody).getByText(/No results/)).toBeInTheDocument()
-  );
-  expect(within(tableBody).getAllByRole("row")).toHaveLength(1);
 });

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import FabricTable from "./FabricTable";
 import SpaceTable from "./SpaceTable";
 import { useSubnetsTable, useSubnetsTableSearch } from "./hooks";
@@ -10,14 +8,14 @@ import type { SubnetGroupByProps } from "app/subnets/views/SubnetsList/SubnetsTa
 const SubnetsTable = ({
   groupBy,
   setGroupBy,
-}: SubnetGroupByProps): JSX.Element | null => {
-  const [searchText, setSearchText] = useState("");
+  searchText,
+  setSearchText,
+}: SubnetGroupByProps & {
+  searchText: string;
+  setSearchText: (text: string) => void;
+}): JSX.Element | null => {
   const subnetsTable = useSubnetsTable(groupBy);
   const { data, loaded } = useSubnetsTableSearch(subnetsTable, searchText);
-
-  const handleSearch = (searchText: string): void => {
-    setSearchText(searchText);
-  };
 
   const emptyMsg = !loaded ? "Loading..." : "No results found";
 
@@ -26,7 +24,8 @@ const SubnetsTable = ({
       <SubnetsControls
         groupBy={groupBy}
         setGroupBy={setGroupBy}
-        handleSearch={handleSearch}
+        searchText={searchText}
+        handleSearch={setSearchText}
       />
 
       {groupBy === "fabric" ? (

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -55,7 +55,7 @@ const VLANDetails = (): JSX.Element => {
       return (
         <ModelNotFound
           id={id}
-          linkURL={subnetURLs.indexBy({ by: "fabric" })}
+          linkURL={subnetURLs.indexWithParams({ by: "fabric" })}
           modelName="VLAN"
         />
       );


### PR DESCRIPTION
## Done

- add search query to url params
  - add `renderWithBrowserRouter`, `getUrlParam` test helper utils

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/159982997-792b2688-da38-49e2-ba9b-fab4f0e23e56.png)



## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `MAAS/r/networks` and try various search text and group by options

## Fixes

Fixes: canonical-web-and-design/app-tribe#771 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
