### PR TITLE
feat(ui): add xpath analytics

### DIFF
--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import DefinitionField, { INVALID_XPATH_ERROR, Label } from "./DefinitionField";
 
+import * as hooks from "app/base/hooks/analytics";
 import type { RootState } from "app/store/root/types";
 import {
   tag as tagFactory,
@@ -28,6 +29,10 @@ beforeEach(() => {
       ],
     }),
   });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 it("overrides the xpath errors", async () => {
@@ -81,4 +86,59 @@ it("displays a warning when changing the definition", async () => {
       screen.getByText(/This tag will be unassigned/i)
     ).toBeInTheDocument();
   });
+});
+
+it("sends analytics when there is an xpath error", async () => {
+  const mockSendAnalytics = jest.fn();
+  jest
+    .spyOn(hooks, "useSendAnalytics")
+    .mockImplementation(() => mockSendAnalytics);
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik
+          initialErrors={{
+            definition: INVALID_XPATH_ERROR,
+          }}
+          initialValues={{}}
+          onSubmit={jest.fn()}
+        >
+          <DefinitionField />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(mockSendAnalytics).toHaveBeenCalled();
+  expect(mockSendAnalytics.mock.calls[0]).toEqual([
+    "XPath tagging",
+    "Invalid XPath",
+    "Save",
+  ]);
+});
+
+it("does not send xpath error analytics more than once", async () => {
+  const mockSendAnalytics = jest.fn();
+  jest
+    .spyOn(hooks, "useSendAnalytics")
+    .mockImplementation(() => mockSendAnalytics);
+  const store = mockStore(state);
+  const Field = () => (
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik
+          initialErrors={{
+            definition: INVALID_XPATH_ERROR,
+          }}
+          initialValues={{}}
+          onSubmit={jest.fn()}
+        >
+          <DefinitionField />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  const { rerender } = render(<Field />);
+  rerender(<Field />);
+  expect(mockSendAnalytics).toHaveBeenCalledTimes(1);
 });

--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useRef } from "react";
+
 import { CodeSnippet, Textarea } from "@canonical/react-components";
 import type { FormikErrors } from "formik";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
+import { useSendAnalytics } from "app/base/hooks";
 import { useId } from "app/base/hooks/base";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
@@ -50,9 +53,18 @@ export const DefinitionField = ({ id }: Props): JSX.Element => {
     tagSelectors.getById(state, id)
   );
   const definitionErrorId = useId();
+  const definitionAnalyticsSent = useRef(false);
+  const sendAnalytics = useSendAnalytics();
   const definitionError = getDefinitionError(errors, definitionErrorId);
   const hasChangedDefinition =
     !!tag?.definition && values.definition !== tag?.definition;
+
+  useEffect(() => {
+    if (definitionError && !definitionAnalyticsSent.current) {
+      sendAnalytics("XPath tagging", "Invalid XPath", "Save");
+      definitionAnalyticsSent.current = true;
+    }
+  }, [definitionError, sendAnalytics]);
   return (
     <>
       <FormikField

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -180,7 +180,7 @@ it("sends analytics when there is no definition", async () => {
   });
   expect(mockSendAnalytics.mock.calls[0]).toEqual([
     "Create Tag form",
-    "Tag created",
+    "Manual tag created",
     "Save",
   ]);
 });

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -66,9 +66,9 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
       }}
       onCancel={onClose}
       onSaveAnalytics={{
-        action: "Submit",
-        category: "Create tag form",
-        label: "Create tag",
+        action: "Valid XPath",
+        category: "XPath tagging",
+        label: "Save",
       }}
       onSubmit={(values) => {
         dispatch(tagActions.cleanup());

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -52,7 +52,7 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
       if (tag.definition) {
         sendAnalytics("XPath tagging", "Valid XPath", "Save");
       } else {
-        sendAnalytics("Create Tag form", "Tag created", "Save");
+        sendAnalytics("Create Tag form", "Manual tag created", "Save");
       }
       onClose();
     }

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
+import { useSendAnalytics } from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
@@ -43,13 +44,19 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
     // provided in this form.
     tagSelectors.getByName(state, savedName)
   );
+  const sendAnalytics = useSendAnalytics();
 
   useEffect(() => {
     if (tag) {
       history.push({ pathname: tagsURLs.tag.index({ id: tag.id }) });
+      if (tag.definition) {
+        sendAnalytics("XPath tagging", "Valid XPath", "Save");
+      } else {
+        sendAnalytics("Create Tag form", "Tag created", "Save");
+      }
       onClose();
     }
-  }, [history, onClose, tag]);
+  }, [history, onClose, tag, sendAnalytics]);
 
   return (
     <FormikForm<CreateParams>
@@ -65,11 +72,6 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
         name: "",
       }}
       onCancel={onClose}
-      onSaveAnalytics={{
-        action: "Valid XPath",
-        category: "XPath tagging",
-        label: "Save",
-      }}
       onSubmit={(values) => {
         dispatch(tagActions.cleanup());
         dispatch(tagActions.create(values));


### PR DESCRIPTION
## Done

- Add analytics to the add tag form for valid/invalid xpaths.

## QA

N/A

## Fixes

Fixes: canonical-web-and-design/app-tribe#754.