### PR TITLE
migrate FormikFormButtons.test to testing-library

### DIFF
--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -1,132 +1,116 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import FormikFormButtons from "./FormikFormButtons";
 
-describe("FormikFormButtons ", () => {
-  it("can display a cancel button", () => {
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons onCancel={jest.fn()} submitLabel="Save user" />
-      </Formik>
-    );
-    const button = wrapper.find("Button");
-    expect(button.exists()).toBe(true);
-    expect(button.children().text()).toBe("Cancel");
-  });
+it("can display a cancel button", () => {
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons onCancel={jest.fn()} submitLabel="Save user" />
+    </Formik>
+  );
+  expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+});
 
-  it("can perform a secondary submit action if function and label provided", () => {
-    const secondarySubmit = jest.fn();
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons
-          submitLabel="Save user"
-          secondarySubmit={secondarySubmit}
-          secondarySubmitLabel="Save and add another"
-        />
-      </Formik>
-    );
-    expect(wrapper.find("[data-testid='secondary-submit'] button").text()).toBe(
-      "Save and add another"
-    );
-    wrapper.find("[data-testid='secondary-submit'] button").simulate("click");
-    expect(secondarySubmit).toHaveBeenCalled();
-  });
+it("can perform a secondary submit action if function and label provided", () => {
+  const secondarySubmit = jest.fn();
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons
+        submitLabel="Save user"
+        secondarySubmit={secondarySubmit}
+        secondarySubmitLabel="Save and add another"
+      />
+    </Formik>
+  );
+  expect(screen.getByTestId("secondary-submit")).toHaveTextContent(
+    "Save and add another"
+  );
+  userEvent.click(screen.getByRole("button", { name: "Save and add another" }));
+  expect(secondarySubmit).toHaveBeenCalled();
+});
 
-  it("can generate a secondary submit label via a function", () => {
-    const secondarySubmit = jest.fn();
-    const wrapper = mount(
-      <Formik initialValues={{ name: "Koala" }} onSubmit={jest.fn()}>
-        <FormikFormButtons
-          submitLabel="Save user"
-          secondarySubmit={secondarySubmit}
-          secondarySubmitLabel={({ name }) => `Kool ${name}`}
-        />
-      </Formik>
-    );
-    expect(wrapper.find("button[data-testid='secondary-submit']").text()).toBe(
-      "Kool Koala"
-    );
-    wrapper.find("[data-testid='secondary-submit'] button").simulate("click");
-    expect(secondarySubmit).toHaveBeenCalled();
-  });
+it("can generate a secondary submit label via a function", () => {
+  const secondarySubmit = jest.fn();
+  render(
+    <Formik initialValues={{ name: "Koala" }} onSubmit={jest.fn()}>
+      <FormikFormButtons
+        submitLabel="Save user"
+        secondarySubmit={secondarySubmit}
+        secondarySubmitLabel={({ name }) => `Kool ${name}`}
+      />
+    </Formik>
+  );
+  expect(screen.getByTestId("secondary-submit")).toHaveTextContent(
+    "Kool Koala"
+  );
+  userEvent.click(screen.getByRole("button", { name: "Kool Koala" }));
+  expect(secondarySubmit).toHaveBeenCalled();
+});
 
-  it("can display a tooltip for the secondary submit action", () => {
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons
-          submitLabel="Save user"
-          secondarySubmit={jest.fn()}
-          secondarySubmitLabel="Save and add another"
-          secondarySubmitTooltip="Will add another"
-        />
-      </Formik>
-    );
-    expect(wrapper.find("Tooltip").exists()).toBe(true);
-  });
+it("can display a tooltip for the secondary submit action", async () => {
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons
+        submitLabel="Save user"
+        secondarySubmit={jest.fn()}
+        secondarySubmitLabel="Save and add another"
+        secondarySubmitTooltip="Will add another"
+      />
+    </Formik>
+  );
+  expect(screen.queryByText("Will add another")).not.toBeInTheDocument();
+  userEvent.hover(screen.getByRole("button", { name: "Save and add another" }));
+  expect(screen.getByText("Will add another")).toBeInTheDocument();
+});
 
-  it("displays a border if bordered is true", () => {
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons buttonsBordered submitLabel="Save" />
-      </Formik>
-    );
-    expect(
-      wrapper
-        .find("[data-testid='buttons-wrapper']")
-        .prop("className")
-        ?.includes("is-bordered")
-    ).toBe(true);
-  });
+it("displays a border if bordered is true", () => {
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons buttonsBordered submitLabel="Save" />
+    </Formik>
+  );
 
-  it("displays inline if inline is true", () => {
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons inline submitLabel="Save" />
-      </Formik>
-    );
-    expect(
-      wrapper
-        .find("[data-testid='buttons-wrapper']")
-        .prop("className")
-        ?.includes("is-inline")
-    ).toBe(true);
-  });
+  expect(screen.getByTestId("buttons-wrapper")).toHaveClass("is-bordered");
+});
 
-  it("displays help text if provided", () => {
-    const buttonsHelp = <p>Help!</p>;
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons buttonsHelp={buttonsHelp} submitLabel="Save" />
-      </Formik>
-    );
-    expect(wrapper.find("[data-testid='buttons-help']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='buttons-help']").text()).toBe("Help!");
-  });
+it("displays inline if inline is true", () => {
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons inline submitLabel="Save" />
+    </Formik>
+  );
+  expect(screen.getByTestId("buttons-wrapper")).toHaveClass("is-inline");
+});
 
-  it("can fire custom onCancel function", () => {
-    const onCancel = jest.fn();
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons onCancel={onCancel} submitLabel="Save" />
-      </Formik>
-    );
-    wrapper.find('[data-testid="cancel-action"] button').simulate("click");
-    expect(onCancel).toHaveBeenCalled();
-  });
+it("displays help text if provided", () => {
+  const buttonsHelp = <p>Help!</p>;
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons buttonsHelp={buttonsHelp} submitLabel="Save" />
+    </Formik>
+  );
+  expect(screen.getByTestId("buttons-help")).toBeInTheDocument();
+  expect(screen.getByTestId("buttons-help")).toHaveTextContent("Help!");
+});
 
-  it("can display a saving label", () => {
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FormikFormButtons
-          saving
-          savingLabel="Be patient!"
-          submitLabel="Save"
-        />
-      </Formik>
-    );
-    expect(wrapper.find('[data-testid="saving-label"]').text()).toBe(
-      "Be patient!"
-    );
-  });
+it("can fire custom onCancel function", () => {
+  const onCancel = jest.fn();
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons onCancel={onCancel} submitLabel="Save" />
+    </Formik>
+  );
+  userEvent.click(screen.getByTestId("cancel-action"));
+  expect(onCancel).toHaveBeenCalled();
+});
+
+it("can display a saving label", () => {
+  render(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <FormikFormButtons saving savingLabel="Be patient!" submitLabel="Save" />
+    </Formik>
+  );
+  expect(screen.getByTestId("saving-label")).toHaveTextContent("Be patient!");
 });


### PR DESCRIPTION
## Done

- migrate FormikFormButtons.test to testing-library

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #3712

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
