### PR TITLE
fix: deploy input options misaligned

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -126,16 +126,10 @@ export const DeployFormFields = (): JSX.Element => {
               disabled={!canBeKVMHost || noImages}
               id="deployVmHost"
               label={
-                <ul className="p-inline-list u-no-margin--bottom">
-                  <li className="p-inline-list__item">
-                    Register as MAAS KVM host.
-                  </li>
-                  <li className="p-inline-list__item">
-                    <a href="https://maas.io/docs/kvm-introduction">
-                      Read more
-                    </a>
-                  </li>
-                </ul>
+                <>
+                  Register as MAAS KVM host.{" "}
+                  <a href="https://maas.io/docs/kvm-introduction">KVM Docs</a>
+                </>
               }
               onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
                 const { checked } = evt.target;
@@ -173,16 +167,12 @@ export const DeployFormFields = (): JSX.Element => {
             <FormikField
               disabled={noImages}
               label={
-                <ul className="p-inline-list u-no-margin--bottom">
-                  <li className="p-inline-list__item">
-                    Cloud-init user-data&hellip;
-                  </li>
-                  <li className="p-inline-list__item">
-                    <a href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init">
-                      Read more
-                    </a>
-                  </li>
-                </ul>
+                <>
+                  Cloud-init user-data&hellip;{" "}
+                  <a href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init">
+                    Cloud-init docs
+                  </a>
+                </>
               }
               name="includeUserData"
               type="checkbox"

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -128,7 +128,7 @@ export const DeployFormFields = (): JSX.Element => {
               label={
                 <>
                   Register as MAAS KVM host.{" "}
-                  <a href="https://maas.io/docs/kvm-introduction">KVM Docs</a>
+                  <a href="https://maas.io/docs/kvm-introduction">KVM docs</a>
                 </>
               }
               onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Done

- fix: deploy input options misaligned
- add meaningful docs link labels (per new [Zeplin spec](https://zpl.io/O0M0kJX))

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/160437756-c4825679-a08b-48bb-b0f4-9793770f23f4.png)
### After
![image](https://user-images.githubusercontent.com/7452681/160437722-0f032467-f1c1-4f7b-bd36-4f3a81d50375.png)



## QA
### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- using bolla.internal MAAS go to `MAAS/r/machine/7c7ya3/summary` and verify that labels are displayed in a single line 


## Fixes

Fixes: canonical-web-and-design/maas-ui#3716 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
