### PR TITLE
Fix cypress failures

### DIFF
--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://0.0.0.0:8400",
-  "defaultCommandTimeout": 6000,
+  "defaultCommandTimeout": 10000,
   "env": {
     "username": "admin",
     "password": "test",

--- a/integration/cypress/integration/accessibility/accessibility.spec.ts
+++ b/integration/cypress/integration/accessibility/accessibility.spec.ts
@@ -4,7 +4,7 @@ import { pages } from "../../constants";
 pages.forEach(({ heading, url }) => {
   it(
     `"${heading}" page has no detectable accessibility violations on load`,
-    { defaultCommandTimeout: 10000, retries: 1 },
+    { retries: 1 },
     () => {
       if (url === "/intro/user") {
         cy.login({ shouldSkipIntro: false });

--- a/integration/cypress/integration/accessibility/accessibility.spec.ts
+++ b/integration/cypress/integration/accessibility/accessibility.spec.ts
@@ -2,18 +2,22 @@ import { generateNewURL } from "@maas-ui/maas-ui-shared";
 import { pages } from "../../constants";
 
 pages.forEach(({ heading, url }) => {
-  it(`"${heading}" page has no detectable accessibility violations on load`, () => {
-    if (url === "/intro/user") {
-      cy.login({ shouldSkipIntro: false });
-    } else if (url !== "/accounts/login") {
-      cy.login();
+  it(
+    `"${heading}" page has no detectable accessibility violations on load`,
+    { defaultCommandTimeout: 10000, retries: 1 },
+    () => {
+      if (url === "/intro/user") {
+        cy.login({ shouldSkipIntro: false });
+      } else if (url !== "/accounts/login") {
+        cy.login();
+      }
+      const pageUrl = generateNewURL(url);
+
+      cy.visit(pageUrl);
+      cy.waitForPageToLoad();
+      cy.findByRole("heading", { name: new RegExp(heading, "i") });
+
+      cy.testA11y({ url, title: heading });
     }
-    const pageUrl = generateNewURL(url);
-
-    cy.visit(pageUrl);
-    cy.waitForPageToLoad();
-    cy.get("[data-testid='section-header-title']").contains(heading);
-
-    cy.testA11y({ url, title: heading });
-  });
+  );
 });

--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -50,7 +50,7 @@ context("Login page", () => {
     cy.location("pathname").should("eq", generateNewURL("/intro"));
 
     // Log out.
-    cy.get(".p-navigation__link a:contains(Log out)").click();
+    cy.get(".p-navigation__link:contains(Log out)").click();
 
     // Set cookie to skip setup intro.
     cy.setCookie("skipsetupintro", "true");

--- a/integration/cypress/integration/subnets/add.spec.ts
+++ b/integration/cypress/integration/subnets/add.spec.ts
@@ -56,7 +56,7 @@ context("Subnets - Add", () => {
     const name = `cypress-${generateId()}`;
     completeForm("Fabric", name);
 
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: /Subnets/ }).within(() => {
       cy.findByRole("row", { name }).within(() =>
         cy.findByRole("link", { name }).click()
       );
@@ -74,7 +74,7 @@ context("Subnets - Add", () => {
 
     cy.url().should("include", generateNewURL("/networks?by=fabric"));
 
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: /Subnets/ }).within(() => {
       cy.findByRole("row", { name }).within(() =>
         cy.findByRole("link", { name }).should("not.exist")
       );
@@ -85,7 +85,7 @@ context("Subnets - Add", () => {
     cy.visit(generateNewURL("/networks?by=space"));
     const name = `cypress-${generateId()}`;
     completeForm("Space", name);
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: /Subnets/ }).within(() => {
       cy.findByRole("link", { name }).click();
     });
 
@@ -100,7 +100,7 @@ context("Subnets - Add", () => {
     cy.findByRole("button", { name: "Yes, delete space" }).click();
 
     cy.url().should("include", generateNewURL("/networks?by=space"));
-    cy.findByRole("table", { name: "Subnets" }).within(() => {
+    cy.findByRole("table", { name: /Subnets/ }).within(() => {
       cy.findByRole("link", { name }).should("not.exist");
     });
   });

--- a/integration/cypress/support/commands.ts
+++ b/integration/cypress/support/commands.ts
@@ -69,7 +69,6 @@ Cypress.Commands.add("testA11y", (pageContext) => {
 Cypress.Commands.add("waitForPageToLoad", () => {
   cy.get("[data-testid='section-header-title-spinner]").should("not.exist");
   cy.get("[data-testid='section-header-subtitle-spinner']").should("not.exist");
-  cy.findByText("Loading...").should("not.exist");
   cy.findByText("Failed to connect").should("not.exist");
   cy.get("[data-testid='section-header-title']").should("be.visible");
 });


### PR DESCRIPTION
## Done

- Fix cypress failures
  - increase the default command timeout and retries for the accessibility tests
  - update logout link selector (broke after upgrading to Vanilla 3)
  - update subnets table selectors

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3352

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
