### PR TITLE
feat(ui): upgrade react-components to 0.34.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/canonical-web-and-design/maas-ui/issues",
   "dependencies": {
     "@canonical/macaroon-bakery": "1.0.0",
-    "@canonical/react-components": "0.33.0",
+    "@canonical/react-components": "0.34.0",
     "@maas-ui/maas-ui-shared": "3.2.0",
     "@reduxjs/toolkit": "1.8.0",
     "@sentry/browser": "6.19.2",

--- a/ui/src/app/base/components/ArchitectureSelect/__snapshots__/ArchitectureSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ArchitectureSelect/__snapshots__/ArchitectureSelect.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`ArchitectureSelect renders a list of all architectures in state 1`] = `
 <select
+  aria-describedby={null}
+  aria-errormessage={null}
+  aria-invalid={false}
   aria-label="Architecture"
   className="p-form-validation__input"
   disabled={false}

--- a/ui/src/app/base/components/DomainSelect/__snapshots__/DomainSelect.test.tsx.snap
+++ b/ui/src/app/base/components/DomainSelect/__snapshots__/DomainSelect.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`DomainSelect renders a list of all domains in state 1`] = `
 <select
+  aria-describedby={null}
+  aria-errormessage={null}
+  aria-invalid={false}
   aria-label="Domain"
   className="p-form-validation__input"
   disabled={false}

--- a/ui/src/app/base/components/FormikField/__snapshots__/FormikField.test.tsx.snap
+++ b/ui/src/app/base/components/FormikField/__snapshots__/FormikField.test.tsx.snap
@@ -25,8 +25,10 @@ exports[`FormikField can render 1`] = `
       error={null}
       forId="username"
       help="Required."
+      helpId="mock-nanoid-2"
       label="Username"
       required={true}
+      validationId="mock-nanoid-1"
     >
       <div
         className="p-form__group p-form-validation"
@@ -46,10 +48,13 @@ exports[`FormikField can render 1`] = `
           className="p-form__control u-clearfix"
         >
           <input
+            aria-describedby="mock-nanoid-2"
+            aria-errormessage={null}
             aria-invalid={false}
             aria-label="Username"
             className="p-form-validation__input"
             id="username"
+            label="Username"
             name="username"
             onBlur={[Function]}
             onChange={[Function]}
@@ -58,6 +63,7 @@ exports[`FormikField can render 1`] = `
           />
           <p
             className="p-form-help-text"
+            id="mock-nanoid-2"
           >
             Required.
           </p>

--- a/ui/src/app/base/components/MinimumKernelSelect/__snapshots__/MinimumKernelSelect.test.tsx.snap
+++ b/ui/src/app/base/components/MinimumKernelSelect/__snapshots__/MinimumKernelSelect.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`MinimumKernelSelect renders a list of all hwe kernels in state 1`] = `
 <select
+  aria-describedby={null}
+  aria-errormessage={null}
+  aria-invalid={false}
   aria-label="Minimum kernel"
   className="p-form-validation__input"
   disabled={false}

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -37,7 +37,9 @@ exports[`NodeNameFields displays the fields 1`] = `
         className="u-nudge-left--small u-no-margin--right"
         error={null}
         forId="mock-redux-js-nanoid-1"
+        helpId="mock-nanoid-2"
         required={true}
+        validationId="mock-nanoid-1"
       >
         <div
           className="p-form__group p-form-validation u-nudge-left--small u-no-margin--right"
@@ -46,6 +48,8 @@ exports[`NodeNameFields displays the fields 1`] = `
             className="p-form__control u-clearfix"
           >
             <input
+              aria-describedby={null}
+              aria-errormessage={null}
               aria-invalid={false}
               className="p-form-validation__input node-name__hostname"
               id="mock-redux-js-nanoid-1"
@@ -124,9 +128,11 @@ exports[`NodeNameFields displays the fields 1`] = `
           className="u-nudge-left u-no-margin--right"
           error={null}
           forId="mock-redux-js-nanoid-2"
+          helpId="mock-nanoid-4"
           isSelect={true}
           label={null}
           required={true}
+          validationId="mock-nanoid-3"
         >
           <div
             className="p-form__group p-form-validation u-nudge-left u-no-margin--right"
@@ -138,6 +144,9 @@ exports[`NodeNameFields displays the fields 1`] = `
                 className="p-form-validation__select-wrapper"
               >
                 <select
+                  aria-describedby={null}
+                  aria-errormessage={null}
+                  aria-invalid={false}
                   aria-label={null}
                   className="p-form-validation__input u-no-margin--bottom"
                   disabled={false}

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -300,7 +300,9 @@ exports[`NodeName can display the form 1`] = `
                   className="u-nudge-left--small u-no-margin--right"
                   error={null}
                   forId="mock-redux-js-nanoid-1"
+                  helpId="mock-nanoid-2"
                   required={true}
+                  validationId="mock-nanoid-1"
                 >
                   <div
                     className="p-form__group p-form-validation u-nudge-left--small u-no-margin--right"
@@ -309,6 +311,8 @@ exports[`NodeName can display the form 1`] = `
                       className="p-form__control u-clearfix"
                     >
                       <input
+                        aria-describedby={null}
+                        aria-errormessage={null}
                         aria-invalid={false}
                         className="p-form-validation__input node-name__hostname"
                         id="mock-redux-js-nanoid-1"

--- a/ui/src/app/base/components/ResourcePoolSelect/__snapshots__/ResourcePoolSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ResourcePoolSelect/__snapshots__/ResourcePoolSelect.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`ResourcePoolSelect renders a list of all resource pools in state 1`] = `
 <select
+  aria-describedby={null}
+  aria-errormessage={null}
+  aria-invalid={false}
   aria-label="Resource pool"
   className="p-form-validation__input"
   disabled={false}

--- a/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
+++ b/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
@@ -85,7 +85,9 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
             value=""
           >
             <Field
+              helpId="mock-nanoid-2"
               required={false}
+              validationId="mock-nanoid-1"
             >
               <div
                 className="p-form__group p-form-validation"
@@ -94,6 +96,8 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
                   className="p-form__control u-clearfix"
                 >
                   <input
+                    aria-describedby={null}
+                    aria-errormessage={null}
                     aria-invalid={false}
                     className="p-form-validation__input tag-selector__input"
                     onChange={[Function]}
@@ -175,7 +179,9 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
             value=""
           >
             <Field
+              helpId="mock-nanoid-2"
               required={false}
+              validationId="mock-nanoid-1"
             >
               <div
                 className="p-form__group p-form-validation"
@@ -184,6 +190,8 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
                   className="p-form__control u-clearfix"
                 >
                   <input
+                    aria-describedby={null}
+                    aria-errormessage={null}
                     aria-invalid={false}
                     className="p-form-validation__input tag-selector__input"
                     onChange={[Function]}

--- a/ui/src/app/base/components/ZoneSelect/__snapshots__/ZoneSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ZoneSelect/__snapshots__/ZoneSelect.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`ZoneSelect renders a list of all zones in state 1`] = `
 <select
+  aria-describedby={null}
+  aria-errormessage={null}
+  aria-invalid={false}
   aria-label="Zone"
   className="p-form-validation__input"
   disabled={false}

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -17,6 +17,7 @@ import { submitFormikForm } from "testing/utils";
 const mockStore = configureStore();
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
+  useId: jest.fn(),
   usePrevious: jest.fn(),
 }));
 

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagChip/TagChip.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagChip/TagChip.test.tsx
@@ -16,10 +16,7 @@ const tagMap = new Map([
 
 it("displays chips with counts", () => {
   render(<TagChip machineCount={10} tag={tags[0]} tagIdsAndCounts={tagMap} />);
-  // These tests can't select by role and name because the text is inside an
-  // inner span which React Testing Library doesn't support and we can't
-  // currently apply additional aria labels to the button until react-components
-  // is updated with:
-  // https://github.com/canonical-web-and-design/react-components/pull/727
-  expect(screen.getByText("chip1 (2/10)")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "chip1 (2/10)" })
+  ).toBeInTheDocument();
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
@@ -95,8 +95,10 @@ exports[`NameColumn renders 1`] = `
                 <Field
                   className="u-no-margin--bottom u-nudge--checkbox"
                   forId="mock-redux-js-nanoid-1"
+                  helpId="mock-nanoid-2"
                   label=""
                   labelClassName="u-no-margin--bottom u-no-padding--top"
+                  validationId="mock-nanoid-1"
                 >
                   <div
                     className="p-form__group p-form-validation u-no-margin--bottom u-nudge--checkbox"
@@ -105,6 +107,9 @@ exports[`NameColumn renders 1`] = `
                       className="p-form__control u-clearfix"
                     >
                       <CheckboxInput
+                        aria-describedby={null}
+                        aria-errormessage={null}
+                        aria-invalid={false}
                         checked={false}
                         id="mock-redux-js-nanoid-1"
                         label={
@@ -127,6 +132,9 @@ exports[`NameColumn renders 1`] = `
                         onChange={[Function]}
                       >
                         <CheckableInput
+                          aria-describedby={null}
+                          aria-errormessage={null}
+                          aria-invalid={false}
                           checked={false}
                           id="mock-redux-js-nanoid-1"
                           indeterminate={false}
@@ -154,7 +162,10 @@ exports[`NameColumn renders 1`] = `
                             className="u-no-margin--bottom u-no-padding--top p-checkbox"
                           >
                             <input
-                              aria-labelledby="mock-nanoid-1"
+                              aria-describedby={null}
+                              aria-errormessage={null}
+                              aria-invalid={false}
+                              aria-labelledby="mock-nanoid-3"
                               checked={false}
                               className="p-checkbox__input"
                               id="mock-redux-js-nanoid-1"
@@ -163,7 +174,7 @@ exports[`NameColumn renders 1`] = `
                             />
                             <span
                               className="p-checkbox__label"
-                              id="mock-nanoid-1"
+                              id="mock-nanoid-3"
                             >
                               <Link
                                 title="test.maas"

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -64,13 +64,3 @@ input[type="radio"] {
     }
   }
 }
-
-// 18-03-2022 Huw: Chips can't accept classnames to override the margin.
-// https://github.com/canonical-web-and-design/react-components/pull/727
-.tag-form__changes {
-  .p-chip,
-  [class^="p-chip--"] {
-    margin-bottom: 0;
-    vertical-align: baseline;
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@
   dependencies:
     macaroon "3.0.4"
 
-"@canonical/react-components@0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.33.0.tgz#a9f0d6003bf43ddd9036f0a92e087c54a099d3a9"
-  integrity sha512-0ETyN5jGvnzoz6d/w65CDBQ9YX6QtC1uwaujmRCVwQbCTyTU/fgKGlOGMpoiFW432ixPFzL9lGu4KJmiT6QN4Q==
+"@canonical/react-components@0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.34.0.tgz#2258b7aea9ee92e57762dec84ba362647152680a"
+  integrity sha512-1C0LmLSA9xlwpEA98D8aeOKGnvcufqmOpRC3US1u94gLeanHFjeIP87vHLi7K+DEFlrdhgp+st+iUJR+K9pW+A==
   dependencies:
     "@types/jest" "27.4.1"
     "@types/node" "16.11.26"


### PR DESCRIPTION
## Done

- Upgrade to react-components to 0.34.0.
- Remove vanilla override for chips.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, select some machines that have tags and open the tag form.
- Check that the chips appear evenly spaced in the rows.
