### PR TITLE
feat(ui): display a confirmation message when tag successfully deleted

### DIFF
--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,3 +1,4 @@
+import { NotificationSeverity } from "@canonical/react-components";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
@@ -7,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import DeleteTagForm from "./DeleteTagForm";
 
+import * as baseHooks from "app/base/hooks/base";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { NodeStatus } from "app/store/types/node";
@@ -63,6 +65,25 @@ it("dispatches an action to delete a tag", async () => {
       store.getActions().find((action) => action.type === expected.type)
     ).toStrictEqual(expected)
   );
+});
+
+it("dispatches an action to add a notification when tag successfully deleted", async () => {
+  const useAddMessageMock = jest.spyOn(baseHooks, "useAddMessage");
+  state.tag.saved = true;
+  state.tag.errors = null;
+  state.tag.items[0].name = "tagalog";
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <DeleteTagForm id={1} onClose={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const mockArgs = useAddMessageMock.mock.calls[0];
+  expect(mockArgs[2]).toBe("Deleted tagalog from tag list.");
+  expect(mockArgs[4]).toBe(NotificationSeverity.POSITIVE);
 });
 
 it("displays a message when deleting a tag on a machine", async () => {

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
@@ -1,11 +1,13 @@
-import { Col, Row } from "@canonical/react-components";
+import { useState } from "react";
+
+import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 
 import DeleteTagFormWarnings from "./DeleteTagFormWarnings";
 
 import FormikForm from "app/base/components/FormikForm";
-import { useScrollToTop } from "app/base/hooks";
+import { useAddMessage, useScrollToTop } from "app/base/hooks";
 import type { EmptyObject } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -32,7 +34,17 @@ export const DeleteTagForm = ({
   const tag = useSelector((state: RootState) =>
     tagSelectors.getById(state, id)
   );
+  const [deletedTag, setDeletedTag] = useState<Tag["name"] | null>(
+    tag?.name || null
+  );
   useScrollToTop();
+  useAddMessage(
+    saved && !errors,
+    tagActions.cleanup,
+    `Deleted ${deletedTag || "tag"} from tag list.`,
+    onClose,
+    NotificationSeverity.POSITIVE
+  );
   const onCancel = () => {
     onClose();
     if (fromDetails) {
@@ -61,6 +73,7 @@ export const DeleteTagForm = ({
         label: "Delete tag",
       }}
       onSubmit={() => {
+        setDeletedTag(tag.name);
         dispatch(tagActions.cleanup());
         dispatch(tagActions.delete(tag.id));
       }}


### PR DESCRIPTION
## Done

- Displays a confirmation message when a tag is successfully deleted

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tag list and delete a tag
- Check that a notification shows up to confirm it was deleted

## Fixes

Fixes canonical-web-and-design/app-tribe#769

