### PR TITLE
feat(ui): show a confirmation when adding a new automatic tag

### DIFF
--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Col, Row } from "@canonical/react-components";
+import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
@@ -8,12 +8,14 @@ import * as Yup from "yup";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import { useSendAnalytics } from "app/base/hooks";
+import { actions as messageActions } from "app/store/message";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import type { CreateParams, Tag } from "app/store/tag/types";
 import DefinitionField from "app/tags/components/DefinitionField";
 import KernelOptionsField from "app/tags/components/KernelOptionsField";
+import { NewDefinitionMessage } from "app/tags/constants";
 import tagsURLs from "app/tags/urls";
 
 type Props = {
@@ -76,8 +78,16 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
         dispatch(tagActions.cleanup());
         dispatch(tagActions.create(values));
       }}
-      onSuccess={({ name }) => {
+      onSuccess={({ definition, name }) => {
         setSavedName(name);
+        if (!!definition) {
+          dispatch(
+            messageActions.add(
+              `Created ${name}. ${NewDefinitionMessage}`,
+              NotificationSeverity.POSITIVE
+            )
+          );
+        }
       }}
       saved={saved}
       saving={saving}

--- a/ui/src/app/tags/constants.ts
+++ b/ui/src/app/tags/constants.ts
@@ -2,3 +2,6 @@ export const TagHeaderViews = {
   AddTag: ["addTagForm", "addTag"],
   DeleteTag: ["deleteTagForm", "deleteTag"],
 } as const;
+
+export const NewDefinitionMessage =
+  "MAAS will automatically tag every machine that matches the new definition in the background. This can take some time.";

--- a/ui/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -11,6 +11,7 @@ import * as baseHooks from "app/base/hooks/base";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { Label as KernelOptionsLabel } from "app/tags/components/KernelOptionsField";
+import { NewDefinitionMessage } from "app/tags/constants";
 import tagURLs from "app/tags/urls";
 import { Label } from "app/tags/views/TagDetails";
 import {
@@ -227,8 +228,6 @@ it("shows a confirmation when a tag's definition is updated", async () => {
       .getActions()
       .find((action) => action.type === "message/add");
     const strippedMessage = action.payload.message.replace(/\s+/g, " ").trim();
-    expect(strippedMessage).toBe(
-      "Updated baggage. MAAS will automatically tag every machine that matches the new definition in the background. This can take some time."
-    );
+    expect(strippedMessage).toBe(`Updated baggage. ${NewDefinitionMessage}`);
   });
 });

--- a/ui/src/app/tags/views/TagUpdate/TagUpdate.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdate.tsx
@@ -13,6 +13,7 @@ import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, UpdateParams, TagMeta } from "app/store/tag/types";
+import { NewDefinitionMessage } from "app/tags/constants";
 import tagURLs from "app/tags/urls";
 
 type Props = {
@@ -96,9 +97,7 @@ const TagUpdate = ({ id }: Props): JSX.Element => {
         if (isAuto && values.definition !== tag.definition) {
           dispatch(
             messageActions.add(
-              `Updated ${tag.name}. MAAS will automatically tag every machine
-              that matches the new definition in the background. This can take
-              some time.`,
+              `Updated ${tag.name}. ${NewDefinitionMessage}`,
               NotificationSeverity.POSITIVE
             )
           );


### PR DESCRIPTION
## Done

- Show a confirmation when adding a new automatic tag

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tag list and click "Create tag"
- Do not enter a definition and submit the form
- Check that you do not see a notification
- Open the create tag form again, this time entering a definition before submitting the form
- Check that a notification appears

## Fixes

Fixes canonical-web-and-design/app-tribe#777

