### PR TITLE
[Periodic hardware sync] -  machine details - add statusbar sync information

### DIFF
--- a/shared/src/components/StatusBar/StatusBar.test.tsx
+++ b/shared/src/components/StatusBar/StatusBar.test.tsx
@@ -3,25 +3,30 @@ import React from "react";
 
 import StatusBar from "./StatusBar";
 
-describe("StatusBar", () => {
-  it("shows the MAAS name", () => {
-    render(<StatusBar maasName="foo" version="2.7.5" />);
-    expect(screen.getByTestId("status-bar-maas-name")).toHaveTextContent(
-      "foo MAAS"
-    );
-  });
+it("displays a status bar", () => {
+  render(<StatusBar maasName="foo" version="2.7.5" />);
+  expect(
+    screen.getByRole("complementary", { name: "status bar" })
+  ).toBeInTheDocument();
+});
 
-  it("shows the MAAS version", () => {
-    render(<StatusBar maasName="foo" version="2.7.5" />);
-    expect(screen.getByTestId("status-bar-version")).toHaveTextContent("2.7.5");
-  });
+it("shows the MAAS name", () => {
+  render(<StatusBar maasName="foo" version="2.7.5" />);
+  expect(screen.getByTestId("status-bar-maas-name")).toHaveTextContent(
+    "foo MAAS"
+  );
+});
 
-  it("can show a status", () => {
-    render(
-      <StatusBar maasName="foo" status="Activating charcoal" version="2.7.5" />
-    );
-    expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-      "Activating charcoal"
-    );
-  });
+it("shows the MAAS version", () => {
+  render(<StatusBar maasName="foo" version="2.7.5" />);
+  expect(screen.getByTestId("status-bar-version")).toHaveTextContent("2.7.5");
+});
+
+it("can show a status", () => {
+  render(
+    <StatusBar maasName="foo" status="Activating charcoal" version="2.7.5" />
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "Activating charcoal"
+  );
 });

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -15,12 +15,12 @@ export const StatusBar = ({
   return (
     <aside className="p-status-bar" aria-label="status bar">
       <div className="row">
-        <div className="col-6">
+        <div className="col-4">
           <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
           <span data-testid="status-bar-version">{version}</span>
         </div>
         {status && (
-          <div className="col-6 u-align--right" data-testid="status-bar-status">
+          <div className="col-8 u-align--right" data-testid="status-bar-status">
             {status}
           </div>
         )}

--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -104,7 +104,7 @@ it("can handle an incorrectly formatted commissioning timestamp", () => {
   );
 });
 
-it("For deployed machines with hardware sync enabled displays Last and Next sync instead of Last commissioned date", () => {
+it("displays Last and Next sync instead of Last commissioned date for deployed machines with hardware sync enabled ", () => {
   state.machine.items = [
     machineDetailsFactory({
       commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
@@ -117,9 +117,7 @@ it("For deployed machines with hardware sync enabled displays Last and Next sync
     }),
   ];
 
-  renderWithMockStore(<StatusBar />, {
-    state,
-  });
+  renderWithMockStore(<StatusBar />, { state: state });
 
   expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
     /Last commissioned/
@@ -135,7 +133,35 @@ it("For deployed machines with hardware sync enabled displays Last and Next sync
   );
 });
 
-it("Displays correct text for machines with hardware sync enabled and no last_sync or next_sync", () => {
+it("doesn't display last or next sync for deploying machines with hardware sync enabled", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYING,
+      system_id: "abc123",
+      enable_hw_sync: true,
+      last_sync: "Thu, 31 Dec. 2020 22:00:00",
+      next_sync: "Thu, 31 Dec. 2020 23:01:00",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, {
+    state,
+  });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Last commissioned/
+  );
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Last synced/
+  );
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Next sync/
+  );
+});
+
+it("displays correct text for machines with hardware sync enabled and no last_sync or next_sync", () => {
   state.machine.items = [
     machineDetailsFactory({
       commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",

--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -15,95 +15,153 @@ import {
 } from "testing/factories";
 import { renderWithMockStore } from "testing/utils";
 
-describe("StatusBar", () => {
-  let state: RootState;
-  beforeEach(() => {
-    jest.useFakeTimers("modern");
-    // Thu, 31 Dec. 2020 23:00:00 UTC
-    jest.setSystemTime(new Date(Date.UTC(2020, 11, 31, 23, 0, 0)));
-    state = rootStateFactory({
-      config: configStateFactory({
-        items: [configFactory({ name: "maas_name", value: "bolla" })],
-      }),
-      general: generalStateFactory({
-        version: versionStateFactory({ data: "2.10.0" }),
-      }),
-      machine: machineStateFactory({
-        active: "abc123",
-        items: [],
-      }),
-    });
+let state: RootState;
+beforeEach(() => {
+  jest.useFakeTimers("modern");
+  // Thu, 31 Dec. 2020 23:00:00 UTC
+  jest.setSystemTime(new Date(Date.UTC(2020, 11, 31, 23, 0, 0)));
+  state = rootStateFactory({
+    config: configStateFactory({
+      items: [configFactory({ name: "maas_name", value: "bolla" })],
+    }),
+    general: generalStateFactory({
+      version: versionStateFactory({ data: "2.10.0" }),
+    }),
+    machine: machineStateFactory({
+      active: "abc123",
+      items: [],
+    }),
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+it("can show if a machine is currently commissioning", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      fqdn: "test.maas",
+      status: NodeStatus.COMMISSIONING,
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Commissioning in progress..."
+  );
+});
+
+it("can show if a machine has not been commissioned yet", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "",
+      fqdn: "test.maas",
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Not yet commissioned"
+  );
+});
+
+it("can show the last time a machine was commissioned", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Last commissioned 1 minute ago"
+  );
+});
+
+it("can handle an incorrectly formatted commissioning timestamp", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "2020-03-01 09:12:43",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
+  );
+});
+
+it("For deployed machines with hardware sync enabled displays Last and Next sync instead of Last commissioned date", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+      enable_hw_sync: true,
+      last_sync: "Thu, 31 Dec. 2020 22:00:00",
+      next_sync: "Thu, 31 Dec. 2020 23:01:00",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, {
+    state,
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Last commissioned/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /test.maas/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Last synced: about 1 hour ago/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Next sync: in 1 minute/
+  );
+});
+
+it("Displays correct text for machines with hardware sync enabled and no last_sync or next_sync", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+      enable_hw_sync: true,
+      last_sync: "",
+      next_sync: "",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, {
+    state,
   });
 
-  describe("active machine status", () => {
-    it("can show if a machine is currently commissioning", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          fqdn: "test.maas",
-          status: NodeStatus.COMMISSIONING,
-          system_id: "abc123",
-        }),
-      ];
-
-      renderWithMockStore(<StatusBar />, { state });
-
-      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-        "test.maas: Commissioning in progress..."
-      );
-    });
-
-    it("can show if a machine has not been commissioned yet", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          commissioning_start_time: "",
-          fqdn: "test.maas",
-          system_id: "abc123",
-        }),
-      ];
-
-      renderWithMockStore(<StatusBar />, { state });
-
-      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-        "test.maas: Not yet commissioned"
-      );
-    });
-
-    it("can show the last time a machine was commissioned", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
-          fqdn: "test.maas",
-          status: NodeStatus.DEPLOYED,
-          system_id: "abc123",
-        }),
-      ];
-
-      renderWithMockStore(<StatusBar />, { state });
-
-      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-        "test.maas: Last commissioned 1 minute ago"
-      );
-    });
-
-    it("can handle an incorrectly formatted commissioning timestamp", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          commissioning_start_time: "2020-03-01 09:12:43",
-          fqdn: "test.maas",
-          status: NodeStatus.DEPLOYED,
-          system_id: "abc123",
-        }),
-      ];
-
-      renderWithMockStore(<StatusBar />, { state });
-
-      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-        "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
-      );
-    });
-  });
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Last commissioned/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /test.maas/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Last synced: Never/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Next sync: Never/
+  );
 });

--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -1,6 +1,4 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
+import { screen } from "@testing-library/react";
 
 import StatusBar from "./StatusBar";
 
@@ -15,12 +13,10 @@ import {
   rootState as rootStateFactory,
   versionState as versionStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithMockStore } from "testing/utils";
 
 describe("StatusBar", () => {
   let state: RootState;
-
   beforeEach(() => {
     jest.useFakeTimers("modern");
     // Thu, 31 Dec. 2020 23:00:00 UTC
@@ -53,14 +49,9 @@ describe("StatusBar", () => {
         }),
       ];
 
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
+      renderWithMockStore(<StatusBar />, { state });
 
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
+      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
         "test.maas: Commissioning in progress..."
       );
     });
@@ -74,14 +65,9 @@ describe("StatusBar", () => {
         }),
       ];
 
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
+      renderWithMockStore(<StatusBar />, { state });
 
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
+      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
         "test.maas: Not yet commissioned"
       );
     });
@@ -96,14 +82,9 @@ describe("StatusBar", () => {
         }),
       ];
 
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
+      renderWithMockStore(<StatusBar />, { state });
 
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
+      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
         "test.maas: Last commissioned 1 minute ago"
       );
     });
@@ -118,14 +99,9 @@ describe("StatusBar", () => {
         }),
       ];
 
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
+      renderWithMockStore(<StatusBar />, { state });
 
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
+      expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
         "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
       );
     });

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -8,6 +8,7 @@ import configSelectors from "app/store/config/selectors";
 import { version as versionSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
+import { isMachineDetails } from "app/store/machine/utils";
 import { NodeStatus } from "app/store/types/node";
 
 const getTimeDistanceString = (utcTimeString: string) =>
@@ -54,17 +55,17 @@ export const StatusBar = (): JSX.Element | null => {
   const activeMachine = useSelector(machineSelectors.active);
   const version = useSelector(versionSelectors.get);
   const maasName = useSelector(configSelectors.maasName);
-  const isHardwareSyncEnabled =
-    activeMachine &&
-    "enable_hw_sync" in activeMachine &&
-    activeMachine.enable_hw_sync === true;
 
   if (!(maasName && version)) {
     return null;
   }
 
   let status: ReactNode = "";
-  if (isHardwareSyncEnabled) {
+  if (
+    isMachineDetails(activeMachine) &&
+    activeMachine?.status === NodeStatus.DEPLOYED &&
+    activeMachine.enable_hw_sync === true
+  ) {
     status = (
       <ul className="p-inline-list u-no-margin--bottom">
         <li className="p-inline-list__item">

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -82,6 +82,7 @@ export type MachineDetails = BaseMachine &
     devices: NodeDeviceRef[];
     dhcp_on: boolean;
     disks: Disk[];
+    enable_hw_sync: boolean;
     error: string;
     events: NodeEvent[];
     grouped_storages: GroupedStorage[];
@@ -91,11 +92,13 @@ export type MachineDetails = BaseMachine &
     installation_status: number;
     interface_test_status: TestStatus;
     interfaces: NetworkInterface[];
+    last_sync: string;
     license_key: string;
     memory_test_status: TestStatus;
     metadata: NodeMetadata;
     min_hwe_kernel: string;
     network_test_status: TestStatus;
+    next_sync: string;
     node_type: number;
     numa_nodes: NodeNumaNode[];
     on_network: boolean;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -313,6 +313,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   devices: () => [],
   dhcp_on: false,
   disks: () => [],
+  enable_hw_sync: false,
   error_description: "",
   error: "",
   events: () => [],
@@ -322,6 +323,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   installation_start_time: "Thu, 15 Oct. 2020 07:25:10",
   installation_status: 3,
   interfaces: () => [],
+  last_sync: "",
   license_key: "",
   metadata: () => ({
     cpu_model: "Intel(R) Xeon(R) CPU E5620",
@@ -339,6 +341,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
     chassis_version: "pc-q35-5.1",
   }),
   min_hwe_kernel: "",
+  next_sync: "",
   node_type: 0,
   numa_nodes: () => [],
   on_network: false,

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -118,6 +118,17 @@ const BrowserRouterWithProvider = ({
   );
 };
 
+const WithMockStoreProvider = ({
+  children,
+  state,
+}: WrapperProps & { children: React.ReactElement }) => {
+  const getMockStore = (state: RootState) => {
+    const mockStore = configureStore();
+    return mockStore(state);
+  };
+  return <Provider store={getMockStore(state)}>{children}</Provider>;
+};
+
 export const renderWithBrowserRouter = (
   ui: React.ReactElement,
   options: RenderOptions & {
@@ -134,6 +145,14 @@ export const renderWithBrowserRouter = (
     ...options,
   });
 };
+
+export const renderWithMockStore = (
+  ui: React.ReactElement,
+  wrapperProps: WrapperProps
+): RenderResult =>
+  render(ui, {
+    wrapper: (props) => <WithMockStoreProvider {...props} {...wrapperProps} />,
+  });
 
 export const getUrlParam: URLSearchParams["get"] = (param: string) =>
   new URLSearchParams(window.location.search).get(param);

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -148,11 +148,20 @@ export const renderWithBrowserRouter = (
 
 export const renderWithMockStore = (
   ui: React.ReactElement,
-  wrapperProps: WrapperProps
-): RenderResult =>
-  render(ui, {
-    wrapper: (props) => <WithMockStoreProvider {...props} {...wrapperProps} />,
+  options: RenderOptions & {
+    state: RootState;
+  }
+): RenderResult => {
+  const rendered = render(ui, {
+    wrapper: (props) => (
+      <WithMockStoreProvider {...props} state={options.state} />
+    ),
+    ...options,
   });
+  return {
+    ...rendered,
+  };
+};
 
 export const getUrlParam: URLSearchParams["get"] = (param: string) =>
   new URLSearchParams(window.location.search).get(param);


### PR DESCRIPTION
## Done

- add sync information to the statusbar - more details in https://github.com/canonical-web-and-design/app-tribe/issues/783
  - adjust statusbar columns to allow for more space for status
  - add `enable_hw_sync`, `last_sync`, `next_sync` to `MachineDetails`
- add `renderWithMockStore` helper util

## Screenshots
### large breakpoint
![image](https://user-images.githubusercontent.com/7452681/160831021-74d3467a-c613-4c8a-90eb-19af850f4c70.png)

### medium breakpoint
![image](https://user-images.githubusercontent.com/7452681/160831036-fa509f80-9637-49d2-ba40-efd1312b1df4.png)


## QA
- deploy a machine with hardware sync enabled, e.g. via maas CLI: `machine deploy [node-id] enable_hw_sync=True`
- view the machine in the UI and verify that sync information is displayed correctly (both fields can read "Never")

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: canonical-web-and-design/app-tribe#783 
Fixes: canonical-web-and-design/app-tribe#784 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
