### PR TITLE
feat(ui): build read-only machine tags section in config tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineConfiguration.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineConfiguration.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 
 import MachineForm from "./MachineForm";
 import PowerForm from "./PowerForm";
+import TagForm from "./TagForm";
 
 import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
@@ -26,6 +27,10 @@ const MachineConfiguration = (): JSX.Element => {
     <>
       <Strip shallow>
         <MachineForm systemId={machine.system_id} />
+      </Strip>
+      <hr />
+      <Strip shallow>
+        <TagForm systemId={machine.system_id} />
       </Strip>
       <hr />
       <Strip shallow>

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import TagForm from "./TagForm";
+
+import machineURLs from "app/machines/urls";
+import { FilterMachines } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("TagForm", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            permissions: ["edit"],
+            system_id: "abc123",
+            tags: [1, 2],
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+      tag: tagStateFactory({
+        items: [
+          tagFactory({ id: 1, name: "tag-1" }),
+          tagFactory({ id: 2, name: "tag-2" }),
+        ],
+      }),
+    });
+  });
+
+  it("is not editable if machine does not have edit permission", () => {
+    state.machine.items[0].permissions = [];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <TagForm systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Edit" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("is editable if machine has edit permission", () => {
+    state.machine.items[0].permissions = ["edit"];
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <TagForm systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(screen.getAllByRole("button", { name: "Edit" }).length).not.toBe(0);
+  });
+
+  it("renders list of tag links until edit button is pressed", () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <TagForm systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(screen.queryByLabelText("tag-form")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "tag-1" })).toHaveAttribute(
+      "href",
+      `${machineURLs.machines.index}${FilterMachines.filtersToQueryString({
+        tags: ["=tag-1"],
+      })}`
+    );
+    expect(screen.getByRole("link", { name: "tag-2" })).toHaveAttribute(
+      "href",
+      `${machineURLs.machines.index}${FilterMachines.filtersToQueryString({
+        tags: ["=tag-2"],
+      })}`
+    );
+
+    userEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+
+    expect(screen.getByLabelText("tag-form")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Button, Col, Row, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikForm from "app/base/components/FormikForm";
+import TagLinks from "app/base/components/TagLinks";
+import { useCanEdit } from "app/base/hooks";
+import type { EmptyObject } from "app/base/types";
+import machineURLs from "app/machines/urls";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { MachineDetails } from "app/store/machine/types";
+import { FilterMachines, isMachineDetails } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+
+type Props = { systemId: MachineDetails["system_id"] };
+
+const TagForm = ({ systemId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const tags = useSelector((state: RootState) =>
+    tagSelectors.getByIDs(state, machine?.tags || [])
+  );
+  const tagsLoading = useSelector(tagSelectors.loading);
+  const errors = useSelector(machineSelectors.errors);
+  const saved = useSelector(machineSelectors.saved);
+  const saving = useSelector(machineSelectors.saving);
+  const cleanup = useCallback(() => machineActions.cleanup(), []);
+  const [editing, setEditing] = useState(false);
+  const canEdit = useCanEdit(machine, true);
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
+
+  if (!isMachineDetails(machine) || tagsLoading) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return (
+    <Row>
+      <Col size={3}>
+        <div className="u-flex--between u-flex--wrap">
+          <h4>Tags</h4>
+          {canEdit && !editing && (
+            <Button
+              className="u-no-margin--bottom u-hide--large"
+              onClick={() => setEditing(true)}
+            >
+              Edit
+            </Button>
+          )}
+        </div>
+      </Col>
+      <Col size={editing ? 9 : 6}>
+        {editing ? (
+          <FormikForm<EmptyObject>
+            aria-label="tag-form"
+            cleanup={cleanup}
+            errors={errors}
+            initialValues={{}}
+            onSaveAnalytics={{
+              action: "Update machine tags",
+              category: "Machine details",
+              label: "Save changes",
+            }}
+            onCancel={() => setEditing(false)}
+            onSubmit={() => {
+              return;
+            }}
+            onSuccess={() => setEditing(false)}
+            saved={saved}
+            saving={saving}
+            submitDisabled
+            submitLabel="Save changes"
+          />
+        ) : (
+          <p>
+            <TagLinks
+              getLinkURL={(tag) => {
+                const filter = FilterMachines.filtersToQueryString({
+                  tags: [`=${tag.name}`],
+                });
+                return `${machineURLs.machines.index}${filter}`;
+              }}
+              tags={tags}
+            />
+          </p>
+        )}
+      </Col>
+      {canEdit && !editing && (
+        <Col className="u-align--right" size={3}>
+          <Button
+            className="u-no-margin--bottom u-hide--small u-hide--medium"
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </Button>
+        </Col>
+      )}
+    </Row>
+  );
+};
+
+export default TagForm;

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagForm";


### PR DESCRIPTION
## Done

- Added read-only "Tags" section to machine config tab (actual form to come later)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Configuration tab of a machine
- Check that there is a "Tags" section that shows a list of tags links
- Check that the tag links filter the machine list appropriately

## Fixes

Fixes canonical-web-and-design/app-tribe#709

## Screenshot

![2022-03-31_12-42](https://user-images.githubusercontent.com/25733845/160965522-c5fec99f-a278-43cf-965f-38b83a63c550.png)

