### PR TITLE
feat: periodic hardware sync

### DIFF
--- a/shared/src/components/StatusBar/StatusBar.test.tsx
+++ b/shared/src/components/StatusBar/StatusBar.test.tsx
@@ -3,25 +3,30 @@ import React from "react";
 
 import StatusBar from "./StatusBar";
 
-describe("StatusBar", () => {
-  it("shows the MAAS name", () => {
-    render(<StatusBar maasName="foo" version="2.7.5" />);
-    expect(screen.getByTestId("status-bar-maas-name")).toHaveTextContent(
-      "foo MAAS"
-    );
-  });
+it("displays a status bar", () => {
+  render(<StatusBar maasName="foo" version="2.7.5" />);
+  expect(
+    screen.getByRole("complementary", { name: "status bar" })
+  ).toBeInTheDocument();
+});
 
-  it("shows the MAAS version", () => {
-    render(<StatusBar maasName="foo" version="2.7.5" />);
-    expect(screen.getByTestId("status-bar-version")).toHaveTextContent("2.7.5");
-  });
+it("shows the MAAS name", () => {
+  render(<StatusBar maasName="foo" version="2.7.5" />);
+  expect(screen.getByTestId("status-bar-maas-name")).toHaveTextContent(
+    "foo MAAS"
+  );
+});
 
-  it("can show a status", () => {
-    render(
-      <StatusBar maasName="foo" status="Activating charcoal" version="2.7.5" />
-    );
-    expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-      "Activating charcoal"
-    );
-  });
+it("shows the MAAS version", () => {
+  render(<StatusBar maasName="foo" version="2.7.5" />);
+  expect(screen.getByTestId("status-bar-version")).toHaveTextContent("2.7.5");
+});
+
+it("can show a status", () => {
+  render(
+    <StatusBar maasName="foo" status="Activating charcoal" version="2.7.5" />
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "Activating charcoal"
+  );
 });

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -15,12 +15,12 @@ export const StatusBar = ({
   return (
     <aside className="p-status-bar" aria-label="status bar">
       <div className="row">
-        <div className="col-6">
+        <div className="col-4">
           <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
           <span data-testid="status-bar-version">{version}</span>
         </div>
         {status && (
-          <div className="col-6 u-align--right" data-testid="status-bar-status">
+          <div className="col-8 u-align--right" data-testid="status-bar-status">
             {status}
           </div>
         )}

--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -1,6 +1,4 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
+import { screen } from "@testing-library/react";
 
 import StatusBar from "./StatusBar";
 
@@ -15,119 +13,181 @@ import {
   rootState as rootStateFactory,
   versionState as versionStateFactory,
 } from "testing/factories";
+import { renderWithMockStore } from "testing/utils";
 
-const mockStore = configureStore();
+let state: RootState;
+beforeEach(() => {
+  jest.useFakeTimers("modern");
+  // Thu, 31 Dec. 2020 23:00:00 UTC
+  jest.setSystemTime(new Date(Date.UTC(2020, 11, 31, 23, 0, 0)));
+  state = rootStateFactory({
+    config: configStateFactory({
+      items: [configFactory({ name: "maas_name", value: "bolla" })],
+    }),
+    general: generalStateFactory({
+      version: versionStateFactory({ data: "2.10.0" }),
+    }),
+    machine: machineStateFactory({
+      active: "abc123",
+      items: [],
+    }),
+  });
+});
 
-describe("StatusBar", () => {
-  let state: RootState;
+afterEach(() => {
+  jest.useRealTimers();
+});
 
-  beforeEach(() => {
-    jest.useFakeTimers("modern");
-    // Thu, 31 Dec. 2020 23:00:00 UTC
-    jest.setSystemTime(new Date(Date.UTC(2020, 11, 31, 23, 0, 0)));
-    state = rootStateFactory({
-      config: configStateFactory({
-        items: [configFactory({ name: "maas_name", value: "bolla" })],
-      }),
-      general: generalStateFactory({
-        version: versionStateFactory({ data: "2.10.0" }),
-      }),
-      machine: machineStateFactory({
-        active: "abc123",
-        items: [],
-      }),
-    });
+it("can show if a machine is currently commissioning", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      fqdn: "test.maas",
+      status: NodeStatus.COMMISSIONING,
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Commissioning in progress..."
+  );
+});
+
+it("can show if a machine has not been commissioned yet", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "",
+      fqdn: "test.maas",
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Not yet commissioned"
+  );
+});
+
+it("can show the last time a machine was commissioned", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Last commissioned 1 minute ago"
+  );
+});
+
+it("can handle an incorrectly formatted commissioning timestamp", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "2020-03-01 09:12:43",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
+  );
+});
+
+it("displays Last and Next sync instead of Last commissioned date for deployed machines with hardware sync enabled ", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+      enable_hw_sync: true,
+      last_sync: "Thu, 31 Dec. 2020 22:00:00",
+      next_sync: "Thu, 31 Dec. 2020 23:01:00",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, { state: state });
+
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Last commissioned/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /test.maas/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Last synced: about 1 hour ago/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Next sync: in 1 minute/
+  );
+});
+
+it("doesn't display last or next sync for deploying machines with hardware sync enabled", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYING,
+      system_id: "abc123",
+      enable_hw_sync: true,
+      last_sync: "Thu, 31 Dec. 2020 22:00:00",
+      next_sync: "Thu, 31 Dec. 2020 23:01:00",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, {
+    state,
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Last commissioned/
+  );
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Last synced/
+  );
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Next sync/
+  );
+});
+
+it("displays correct text for machines with hardware sync enabled and no last_sync or next_sync", () => {
+  state.machine.items = [
+    machineDetailsFactory({
+      commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+      fqdn: "test.maas",
+      status: NodeStatus.DEPLOYED,
+      system_id: "abc123",
+      enable_hw_sync: true,
+      last_sync: "",
+      next_sync: "",
+    }),
+  ];
+
+  renderWithMockStore(<StatusBar />, {
+    state,
   });
 
-  describe("active machine status", () => {
-    it("can show if a machine is currently commissioning", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          fqdn: "test.maas",
-          status: NodeStatus.COMMISSIONING,
-          system_id: "abc123",
-        }),
-      ];
-
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
-
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
-        "test.maas: Commissioning in progress..."
-      );
-    });
-
-    it("can show if a machine has not been commissioned yet", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          commissioning_start_time: "",
-          fqdn: "test.maas",
-          system_id: "abc123",
-        }),
-      ];
-
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
-
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
-        "test.maas: Not yet commissioned"
-      );
-    });
-
-    it("can show the last time a machine was commissioned", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
-          fqdn: "test.maas",
-          status: NodeStatus.DEPLOYED,
-          system_id: "abc123",
-        }),
-      ];
-
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
-
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
-        "test.maas: Last commissioned 1 minute ago"
-      );
-    });
-
-    it("can handle an incorrectly formatted commissioning timestamp", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          commissioning_start_time: "2020-03-01 09:12:43",
-          fqdn: "test.maas",
-          status: NodeStatus.DEPLOYED,
-          system_id: "abc123",
-        }),
-      ];
-
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <StatusBar />
-        </Provider>
-      );
-
-      expect(wrapper.find("[data-testid='status-bar-status']").text()).toBe(
-        "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
-      );
-    });
-  });
+  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+    /Last commissioned/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /test.maas/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Last synced: Never/
+  );
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    /Next sync: Never/
+  );
 });

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -8,7 +8,19 @@ import configSelectors from "app/store/config/selectors";
 import { version as versionSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
+import { isMachineDetails } from "app/store/machine/utils";
 import { NodeStatus } from "app/store/types/node";
+
+const getTimeDistanceString = (utcTimeString: string) =>
+  formatDistance(
+    parse(
+      `${utcTimeString} +00`, // let parse fn know it's UTC
+      "E, dd LLL. yyyy HH:mm:ss x",
+      new Date()
+    ),
+    new Date(),
+    { addSuffix: true }
+  );
 
 const getLastCommissionedString = (machine: MachineDetails) => {
   if (machine.status === NodeStatus.COMMISSIONING) {
@@ -17,18 +29,23 @@ const getLastCommissionedString = (machine: MachineDetails) => {
     return "Not yet commissioned";
   }
   try {
-    const distance = formatDistance(
-      parse(
-        `${machine.commissioning_start_time} +00`, // let parse fn know it's UTC
-        "E, dd LLL. yyyy HH:mm:ss x",
-        new Date()
-      ),
-      new Date(),
-      { addSuffix: true }
-    );
+    const distance = getTimeDistanceString(machine.commissioning_start_time);
     return `Last commissioned ${distance}`;
   } catch (error) {
     return `Unable to parse commissioning timestamp (${
+      error instanceof Error ? error.message : error
+    })`;
+  }
+};
+
+const getSyncStatusString = (syncStatus: string) => {
+  if (syncStatus === "") {
+    return "Never";
+  }
+  try {
+    return getTimeDistanceString(syncStatus);
+  } catch (error) {
+    return `Unable to parse sync timestamp (${
       error instanceof Error ? error.message : error
     })`;
   }
@@ -44,7 +61,25 @@ export const StatusBar = (): JSX.Element | null => {
   }
 
   let status: ReactNode = "";
-  if (activeMachine && "commissioning_start_time" in activeMachine) {
+  if (
+    isMachineDetails(activeMachine) &&
+    activeMachine?.status === NodeStatus.DEPLOYED &&
+    activeMachine.enable_hw_sync === true
+  ) {
+    status = (
+      <ul className="p-inline-list u-no-margin--bottom">
+        <li className="p-inline-list__item">
+          <strong>{activeMachine.fqdn}</strong>
+        </li>
+        <li className="p-inline-list__item">
+          Last synced: {getSyncStatusString(activeMachine.last_sync)}
+        </li>
+        <li className="p-inline-list__item">
+          Next sync: {getSyncStatusString(activeMachine.next_sync)}
+        </li>
+      </ul>
+    );
+  } else if (activeMachine && "commissioning_start_time" in activeMachine) {
     const lastCommissioned = getLastCommissionedString(activeMachine);
     status = (
       <>

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -2,6 +2,8 @@ import type { ValueOf } from "@canonical/react-components";
 
 export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+export type Seconds = number;
+
 export const SortDirection = {
   ASCENDING: "ascending",
   DESCENDING: "descending",

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,13 +1,19 @@
-import { Tooltip } from "@canonical/react-components";
+import { Button, Icon, Tooltip } from "@canonical/react-components";
+import { formatDuration, intervalToDuration } from "date-fns";
 import { useSelector } from "react-redux";
 
+import type { Seconds } from "app/base/types";
 import { PowerTypeNames } from "app/store/general/constants";
 import type { MachineDetails } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag } from "app/store/tag/types";
-import { NodeStatusCode, TestStatusStatus } from "app/store/types/node";
+import {
+  NodeStatus,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "app/store/types/node";
 import { breakLines } from "app/utils";
 
 type Props = {
@@ -35,6 +41,14 @@ const showFailedTestsWarning = (machine: MachineDetails) => {
 
   return machine.testing_status.status === TestStatusStatus.FAILED;
 };
+
+const formatSyncInterval = (syncInterval: Seconds) =>
+  formatDuration(
+    intervalToDuration({
+      start: 0,
+      end: syncInterval * 1000,
+    })
+  );
 
 const StatusCard = ({ machine }: Props): JSX.Element => {
   const formattedOS = useFormattedOS(machine);
@@ -80,6 +94,40 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
               {machine.error_description}
             </Tooltip>
           </p>
+        ) : null}
+        {machine.status === NodeStatus.DEPLOYED && machine.enable_hw_sync ? (
+          <>
+            <hr />
+            <p className="u-text--muted">
+              Periodic hardware sync enabled{" "}
+              {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
+              {/* TODO: use actual `sync_interval` value from the back-end https://github.com/canonical-web-and-design/app-tribe/issues/782 */}
+              <Tooltip
+                position="right"
+                message={
+                  <>
+                    This machine hardware info is synced every{" "}
+                    {formatSyncInterval(machine.sync_interval)}.{"\n"}
+                    You can check it at the bottom, in the status bar.{"\n"}More
+                    about this in the{" "}
+                    <a className="p-link--inverted" href="#todo">
+                      Hardware sync docs
+                    </a>
+                    .
+                  </>
+                }
+              >
+                <Button
+                  aria-label="more about periodic hardware sync"
+                  appearance="base"
+                  dense
+                  hasIcon
+                >
+                  <Icon name="help" />
+                </Button>
+              </Tooltip>
+            </p>
+          </>
         ) : null}
       </div>
       {showFailedTestsWarning(machine) ? (

--- a/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.tsx
@@ -22,14 +22,19 @@ const DeployForm = (): JSX.Element => {
 
   const defaultOSystem = useSelector(configSelectors.defaultOSystem);
   const defaultDistroSeries = useSelector(configSelectors.defaultDistroSeries);
+  const hardwareSyncInterval = useSelector(
+    configSelectors.hardwareSyncInterval
+  );
 
   return (
     <FormikForm<DeployFormValues>
+      aria-label="deploy configuration"
       buttonsAlign="left"
       buttonsBordered={false}
       initialValues={{
         default_osystem: defaultOSystem || "",
         default_distro_series: defaultDistroSeries || "",
+        hardware_sync_interval: hardwareSyncInterval || "",
       }}
       onSaveAnalytics={{
         action: "Saved",

--- a/ui/src/app/settings/views/Configuration/DeployForm/types.ts
+++ b/ui/src/app/settings/views/Configuration/DeployForm/types.ts
@@ -1,4 +1,5 @@
 export type DeployFormValues = {
   default_osystem: string;
   default_distro_series: string;
+  hardware_sync_interval: string;
 };

--- a/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme";
+import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -61,15 +61,54 @@ describe("DeployFormFields", () => {
     });
   });
 
-  it("can render", () => {
+  it("displays the deploy configuration form with correct fields", () => {
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
           <DeployForm />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("DeployFormFields").exists()).toBe(true);
+
+    const form = screen.getByRole("form", { name: "deploy configuration" });
+    expect(form).toBeInTheDocument();
+
+    expect(
+      within(form).getByRole("combobox", {
+        name: /Default operating system used for deployment/,
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(form).getByRole("combobox", {
+        name: /Default OS release used for deployment/,
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(form).getByRole("textbox", {
+        name: /Default hardware sync interval/,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("displays the default hardware sync interval option with a correct value", () => {
+    const syncIntervalValue = "1h";
+    // TODO: Investigate mutating state in integration tests https://github.com/canonical-web-and-design/app-tribe/issues/794
+    state.config.items.push({
+      name: "hardware_sync_interval",
+      value: syncIntervalValue,
+    });
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DeployForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: /Default hardware sync interval/ })
+    ).toHaveValue(syncIntervalValue);
   });
 });

--- a/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.tsx
@@ -46,6 +46,11 @@ const DeployFormFields = (): JSX.Element => {
         options={distroSeriesOptions}
         name="default_distro_series"
       />
+      <FormikField
+        label="Default hardware sync interval (hours)"
+        name="hardware_sync_interval"
+        type="text"
+      />
     </>
   );
 };

--- a/ui/src/app/store/config/selectors.ts
+++ b/ui/src/app/store/config/selectors.ts
@@ -514,6 +514,10 @@ const bootImagesAutoImport = createSelector([all], (configs) =>
   getValueFromName<boolean>(configs, "boot_images_auto_import")
 );
 
+const hardwareSyncInterval = createSelector([all], (configs) =>
+  getValueFromName<string>(configs, "hardware_sync_interval")
+);
+
 const config = {
   activeDiscoveryInterval,
   all,
@@ -536,6 +540,7 @@ const config = {
   enableDiskErasing,
   enableHttpProxy,
   errors,
+  hardwareSyncInterval,
   httpProxy,
   kernelParams,
   loaded,

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -1,6 +1,6 @@
 import type { MachineMeta } from "./enum";
 
-import type { APIError } from "app/base/types";
+import type { APIError, Seconds } from "app/base/types";
 import type { CloneError } from "app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults";
 import type { CertificateMetadata, PowerType } from "app/store/general/types";
 import type { PowerState, StorageLayout } from "app/store/types/enum";
@@ -110,6 +110,7 @@ export type MachineDetails = BaseMachine &
     storage_layout_issues: string[];
     storage_test_status: TestStatus;
     supported_filesystems: SupportedFilesystem[];
+    sync_interval: Seconds;
     swap_size: number | null;
     testing_start_time: string;
   };

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -82,6 +82,7 @@ export type MachineDetails = BaseMachine &
     devices: NodeDeviceRef[];
     dhcp_on: boolean;
     disks: Disk[];
+    enable_hw_sync: boolean;
     error: string;
     events: NodeEvent[];
     grouped_storages: GroupedStorage[];
@@ -91,11 +92,13 @@ export type MachineDetails = BaseMachine &
     installation_status: number;
     interface_test_status: TestStatus;
     interfaces: NetworkInterface[];
+    last_sync: string;
     license_key: string;
     memory_test_status: TestStatus;
     metadata: NodeMetadata;
     min_hwe_kernel: string;
     network_test_status: TestStatus;
+    next_sync: string;
     node_type: number;
     numa_nodes: NodeNumaNode[];
     on_network: boolean;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -313,6 +313,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   devices: () => [],
   dhcp_on: false,
   disks: () => [],
+  enable_hw_sync: false,
   error_description: "",
   error: "",
   events: () => [],
@@ -322,6 +323,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   installation_start_time: "Thu, 15 Oct. 2020 07:25:10",
   installation_status: 3,
   interfaces: () => [],
+  last_sync: "",
   license_key: "",
   metadata: () => ({
     cpu_model: "Intel(R) Xeon(R) CPU E5620",
@@ -339,6 +341,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
     chassis_version: "pc-q35-5.1",
   }),
   min_hwe_kernel: "",
+  next_sync: "",
   node_type: 0,
   numa_nodes: () => [],
   on_network: false,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -356,6 +356,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   storage_layout_issues: () => [],
   supported_filesystems: () => [],
   swap_size: null,
+  sync_interval: 900,
   testing_start_time: "Thu, 15 Oct. 2020 07:25:10",
   updated: "Fri, 23 Oct. 2020 05:24:41",
 });

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -118,6 +118,17 @@ const BrowserRouterWithProvider = ({
   );
 };
 
+const WithMockStoreProvider = ({
+  children,
+  state,
+}: WrapperProps & { children: React.ReactElement }) => {
+  const getMockStore = (state: RootState) => {
+    const mockStore = configureStore();
+    return mockStore(state);
+  };
+  return <Provider store={getMockStore(state)}>{children}</Provider>;
+};
+
 export const renderWithBrowserRouter = (
   ui: React.ReactElement,
   options: RenderOptions & {
@@ -133,6 +144,23 @@ export const renderWithBrowserRouter = (
     ),
     ...options,
   });
+};
+
+export const renderWithMockStore = (
+  ui: React.ReactElement,
+  options: RenderOptions & {
+    state: RootState;
+  }
+): RenderResult => {
+  const rendered = render(ui, {
+    wrapper: (props) => (
+      <WithMockStoreProvider {...props} state={options.state} />
+    ),
+    ...options,
+  });
+  return {
+    ...rendered,
+  };
 };
 
 export const getUrlParam: URLSearchParams["get"] = (param: string) =>


### PR DESCRIPTION
## Done

- Feature branch for periodic hardware sync
  - https://github.com/canonical-web-and-design/maas-ui/pull/3737

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
