### PR TITLE
[Hardware sync] add machine feature status 

### DIFF
--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -2,6 +2,8 @@ import type { ValueOf } from "@canonical/react-components";
 
 export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+export type Seconds = number;
+
 export const SortDirection = {
   ASCENDING: "ascending",
   DESCENDING: "descending",

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -1,4 +1,5 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -39,7 +40,7 @@ describe("StatusCard", () => {
     machine.locked = true;
     const store = mockStore(state);
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -49,7 +50,7 @@ describe("StatusCard", () => {
       </Provider>
     );
 
-    expect(wrapper.find("[data-testid='locked']").exists()).toEqual(true);
+    expect(screen.getByTestId("locked")).toBeInTheDocument();
   });
 
   it("renders os info", () => {
@@ -62,7 +63,7 @@ describe("StatusCard", () => {
     });
     const store = mockStore(state);
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -72,7 +73,7 @@ describe("StatusCard", () => {
       </Provider>
     );
 
-    expect(wrapper.find("[data-testid='os-info']").text()).toEqual(
+    expect(screen.getByTestId("os-info")).toHaveTextContent(
       'Ubuntu 20.04 LTS "Focal Fossa"'
     );
   });
@@ -83,7 +84,7 @@ describe("StatusCard", () => {
 
     const store = mockStore(state);
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -93,7 +94,7 @@ describe("StatusCard", () => {
       </Provider>
     );
 
-    expect(wrapper.find("[data-testid='failed-test-warning']").text()).toEqual(
+    expect(screen.getByTestId("failed-test-warning")).toHaveTextContent(
       "Warning: Some tests failed, use with caution."
     );
   });
@@ -106,7 +107,7 @@ describe("StatusCard", () => {
     });
     const store = mockStore(state);
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
@@ -116,8 +117,56 @@ describe("StatusCard", () => {
       </Provider>
     );
 
-    expect(wrapper.find("[data-testid='error-description']").text()).toBe(
+    expect(screen.getByTestId("error-description")).toHaveTextContent(
       "machine is on fire"
     );
+  });
+
+  it("displays a message when the hardware sync is enabled", () => {
+    const machine = machineDetailsFactory({
+      enable_hw_sync: true,
+    });
+    const store = mockStore(state);
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      screen.getByText("Periodic hardware sync enabled")
+    ).toBeInTheDocument();
+  });
+
+  it("displays deployed hardware sync interval and link to docs in the hardware sync tooltip", () => {
+    const machine = machineDetailsFactory({
+      enable_hw_sync: true,
+    });
+    const store = mockStore(state);
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    userEvent.click(
+      screen.getByRole("button", { name: "more about periodic hardware sync" })
+    );
+    expect(
+      screen.getByText(/This machine hardware info is synced every 24 hours/)
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Hardware sync docs" })
+    ).toBeVisible();
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -122,9 +122,32 @@ describe("StatusCard", () => {
     );
   });
 
-  it("displays a message when the hardware sync is enabled", () => {
+  it("does not display a sync status for deployed machines with hardware sync disabled", () => {
+    const machine = machineDetailsFactory({
+      enable_hw_sync: false,
+      status: NodeStatus.DEPLOYED,
+    });
+    const store = mockStore(state);
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      screen.queryByText(/Periodic hardware sync/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays a sync status and link to docs for deployed machines with hardware sync enabled", () => {
     const machine = machineDetailsFactory({
       enable_hw_sync: true,
+      status: NodeStatus.DEPLOYED,
     });
     const store = mockStore(state);
 
@@ -141,12 +164,23 @@ describe("StatusCard", () => {
     expect(
       screen.getByText("Periodic hardware sync enabled")
     ).toBeInTheDocument();
+    userEvent.click(
+      screen.getByRole("button", {
+        name: "more about periodic hardware sync",
+      })
+    );
+    expect(
+      screen.getByRole("link", { name: "Hardware sync docs" })
+    ).toBeVisible();
   });
 
-  it("displays deployed hardware sync interval and link to docs in the hardware sync tooltip", () => {
+  it("displays deployed hardware sync interval in a correct format", () => {
     const machine = machineDetailsFactory({
       enable_hw_sync: true,
+      status: NodeStatus.DEPLOYED,
+      sync_interval: 900,
     });
+
     const store = mockStore(state);
 
     render(
@@ -163,10 +197,7 @@ describe("StatusCard", () => {
       screen.getByRole("button", { name: "more about periodic hardware sync" })
     );
     expect(
-      screen.getByText(/This machine hardware info is synced every 24 hours/)
-    ).toBeVisible();
-    expect(
-      screen.getByRole("link", { name: "Hardware sync docs" })
+      screen.getByText(/This machine hardware info is synced every 15 minutes./)
     ).toBeVisible();
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -2,6 +2,7 @@ import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { formatDuration, intervalToDuration } from "date-fns";
 import { useSelector } from "react-redux";
 
+import type { Seconds } from "app/base/types";
 import { PowerTypeNames } from "app/store/general/constants";
 import type { MachineDetails } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
@@ -41,7 +42,7 @@ const showFailedTestsWarning = (machine: MachineDetails) => {
   return machine.testing_status.status === TestStatusStatus.FAILED;
 };
 
-const formatSyncInterval = (syncInterval: number) =>
+const formatSyncInterval = (syncInterval: Seconds) =>
   formatDuration(
     intervalToDuration({
       start: 0,

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -110,7 +110,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
                     {formatSyncInterval(machine.sync_interval)}.{"\n"}
                     You can check it at the bottom, in the status bar.{"\n"}More
                     about this in the{" "}
-                    <a className="p-link--inverted" href="#">
+                    <a className="p-link--inverted" href="#todo">
                       Hardware sync docs
                     </a>
                     .

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon, Tooltip } from "@canonical/react-components";
+import { formatDuration, intervalToDuration } from "date-fns";
 import { useSelector } from "react-redux";
 
 import { PowerTypeNames } from "app/store/general/constants";
@@ -7,7 +8,11 @@ import { useFormattedOS } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag } from "app/store/tag/types";
-import { NodeStatusCode, TestStatusStatus } from "app/store/types/node";
+import {
+  NodeStatus,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "app/store/types/node";
 import { breakLines } from "app/utils";
 
 type Props = {
@@ -35,6 +40,14 @@ const showFailedTestsWarning = (machine: MachineDetails) => {
 
   return machine.testing_status.status === TestStatusStatus.FAILED;
 };
+
+const formatSyncInterval = (syncInterval: number) =>
+  formatDuration(
+    intervalToDuration({
+      start: 0,
+      end: syncInterval * 1000,
+    })
+  );
 
 const StatusCard = ({ machine }: Props): JSX.Element => {
   const formattedOS = useFormattedOS(machine);
@@ -81,7 +94,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
             </Tooltip>
           </p>
         ) : null}
-        {machine.enable_hw_sync ? (
+        {machine.status === NodeStatus.DEPLOYED && machine.enable_hw_sync ? (
           <>
             <hr />
             <p className="u-text--muted">
@@ -92,7 +105,8 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
                 position="right"
                 message={
                   <>
-                    This machine hardware info is synced every 24 hours.{"\n"}
+                    This machine hardware info is synced every{" "}
+                    {formatSyncInterval(machine.sync_interval)}.{"\n"}
                     You can check it at the bottom, in the status bar.{"\n"}More
                     about this in the{" "}
                     <a className="p-link--inverted" href="#">

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@canonical/react-components";
+import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import { PowerTypeNames } from "app/store/general/constants";
@@ -80,6 +80,39 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
               {machine.error_description}
             </Tooltip>
           </p>
+        ) : null}
+        {machine.enable_hw_sync ? (
+          <>
+            <hr />
+            <p className="u-text--muted">
+              Periodic hardware sync enabled{" "}
+              {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
+              {/* TODO: use actual `sync_interval` value from the back-end https://github.com/canonical-web-and-design/app-tribe/issues/782 */}
+              <Tooltip
+                position="right"
+                message={
+                  <>
+                    This machine hardware info is synced every 24 hours.{"\n"}
+                    You can check it at the bottom, in the status bar.{"\n"}More
+                    about this in the{" "}
+                    <a className="p-link--inverted" href="#">
+                      Hardware sync docs
+                    </a>
+                    .
+                  </>
+                }
+              >
+                <Button
+                  aria-label="more about periodic hardware sync"
+                  appearance="base"
+                  dense
+                  hasIcon
+                >
+                  <Icon name="help" />
+                </Button>
+              </Tooltip>
+            </p>
+          </>
         ) : null}
       </div>
       {showFailedTestsWarning(machine) ? (

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -110,6 +110,7 @@ export type MachineDetails = BaseMachine &
     storage_layout_issues: string[];
     storage_test_status: TestStatus;
     supported_filesystems: SupportedFilesystem[];
+    sync_interval: number;
     swap_size: number | null;
     testing_start_time: string;
   };

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -1,6 +1,6 @@
 import type { MachineMeta } from "./enum";
 
-import type { APIError } from "app/base/types";
+import type { APIError, Seconds } from "app/base/types";
 import type { CloneError } from "app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults";
 import type { CertificateMetadata, PowerType } from "app/store/general/types";
 import type { PowerState, StorageLayout } from "app/store/types/enum";
@@ -110,7 +110,7 @@ export type MachineDetails = BaseMachine &
     storage_layout_issues: string[];
     storage_test_status: TestStatus;
     supported_filesystems: SupportedFilesystem[];
-    sync_interval: number;
+    sync_interval: Seconds;
     swap_size: number | null;
     testing_start_time: string;
   };

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -356,6 +356,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   storage_layout_issues: () => [],
   supported_filesystems: () => [],
   swap_size: null,
+  sync_interval: 900,
   testing_start_time: "Thu, 15 Oct. 2020 07:25:10",
   updated: "Fri, 23 Oct. 2020 05:24:41",
 });


### PR DESCRIPTION
## Done

- add machine feature status
- refactor StatusCard.test.tsx to testing library

---

- **Note:** Tooltip's behaviour will be improved in https://github.com/canonical-web-and-design/react-components/issues/697

## Screenshots

![image](https://user-images.githubusercontent.com/7452681/161040551-fa595a89-9de4-4515-a39a-b6079d65d216.png)


## QA
### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- using bolla, go to `machine/xxn6s7/summary`
  - if this doesn't work, in file `app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx` replace line `97` with `{!machine.enable_hw_sync ? (` 
- go to the machine details page and verify the message and tooltip are displayed correctly

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/781
Fixes: canonical-web-and-design/app-tribe/issues/782
Fixes: #3741

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
