### PR TITLE
[Hardware sync] settings - default hardware sync interval option

### DIFF
--- a/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.tsx
@@ -22,14 +22,19 @@ const DeployForm = (): JSX.Element => {
 
   const defaultOSystem = useSelector(configSelectors.defaultOSystem);
   const defaultDistroSeries = useSelector(configSelectors.defaultDistroSeries);
+  const hardwareSyncInterval = useSelector(
+    configSelectors.hardwareSyncInterval
+  );
 
   return (
     <FormikForm<DeployFormValues>
+      aria-label="deploy configuration"
       buttonsAlign="left"
       buttonsBordered={false}
       initialValues={{
         default_osystem: defaultOSystem || "",
         default_distro_series: defaultDistroSeries || "",
+        hardware_sync_interval: hardwareSyncInterval || "",
       }}
       onSaveAnalytics={{
         action: "Saved",

--- a/ui/src/app/settings/views/Configuration/DeployForm/types.ts
+++ b/ui/src/app/settings/views/Configuration/DeployForm/types.ts
@@ -1,4 +1,5 @@
 export type DeployFormValues = {
   default_osystem: string;
   default_distro_series: string;
+  hardware_sync_interval: string;
 };

--- a/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme";
+import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -61,15 +61,54 @@ describe("DeployFormFields", () => {
     });
   });
 
-  it("can render", () => {
+  it("displays the deploy configuration form with correct fields", () => {
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
           <DeployForm />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("DeployFormFields").exists()).toBe(true);
+
+    const form = screen.getByRole("form", { name: "deploy configuration" });
+    expect(form).toBeInTheDocument();
+
+    expect(
+      within(form).getByRole("combobox", {
+        name: /Default operating system used for deployment/,
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(form).getByRole("combobox", {
+        name: /Default OS release used for deployment/,
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(form).getByRole("textbox", {
+        name: /Default hardware sync interval/,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("displays the default hardware sync interval option with a correct value", () => {
+    const syncIntervalValue = "1h";
+    // TODO: Investigate mutating state in integration tests https://github.com/canonical-web-and-design/app-tribe/issues/794
+    state.config.items.push({
+      name: "hardware_sync_interval",
+      value: syncIntervalValue,
+    });
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DeployForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: /Default hardware sync interval/ })
+    ).toHaveValue(syncIntervalValue);
   });
 });

--- a/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployFormFields/DeployFormFields.tsx
@@ -46,6 +46,11 @@ const DeployFormFields = (): JSX.Element => {
         options={distroSeriesOptions}
         name="default_distro_series"
       />
+      <FormikField
+        label="Default hardware sync interval (hours)"
+        name="hardware_sync_interval"
+        type="text"
+      />
     </>
   );
 };

--- a/ui/src/app/store/config/selectors.ts
+++ b/ui/src/app/store/config/selectors.ts
@@ -514,6 +514,10 @@ const bootImagesAutoImport = createSelector([all], (configs) =>
   getValueFromName<boolean>(configs, "boot_images_auto_import")
 );
 
+const hardwareSyncInterval = createSelector([all], (configs) =>
+  getValueFromName<string>(configs, "hardware_sync_interval")
+);
+
 const config = {
   activeDiscoveryInterval,
   all,
@@ -536,6 +540,7 @@ const config = {
   enableDiskErasing,
   enableHttpProxy,
   errors,
+  hardwareSyncInterval,
   httpProxy,
   kernelParams,
   loaded,


### PR DESCRIPTION
## Done

- add default hardware sync interval option to settings
- refactor DeployFormFields.test.tsx to testing library

## Notes
- Back-end has a default of `15m` but the design only allows specifying the interval in hours. expects a string value with appended `m` for minutes or `h` for hours, and we only allow.
- once we resolve this front-end implementation will be updated accordingly in https://github.com/canonical-web-and-design/app-tribe/issues/795

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/161056339-7af71d13-2c01-480f-ae01-fb27ef59cce3.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to settings -> deploy and modify the value by submitting the form
  - make sure you append `m` for minutes or `h` for hours to the end of the value as that's the format accepted by the back-end currently

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/785
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3744

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
