### PR TITLE
[Hardware sync] - deployment form - add periodic hardware sync checkbox ui

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -427,4 +427,29 @@ describe("DeployFormFields", () => {
     // Previous kernel selection should be cleared.
     expect(wrapper.find("Select[name='kernel']").prop("value")).toBe("");
   });
+
+  it("displays 'periodically sync hardware' checkbox", async () => {
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm
+            clearHeaderContent={jest.fn()}
+            machines={[]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("FormikField[name='enable_hw_sync']").exists()).toBe(
+      true
+    );
+  });
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -429,9 +429,6 @@ describe("DeployFormFields", () => {
   });
 
   it("displays 'periodically sync hardware' checkbox", async () => {
-    if (state.general.osInfo.data) {
-      state.general.osInfo.data.default_release = "bionic";
-    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -211,7 +211,7 @@ export const DeployFormFields = (): JSX.Element => {
                     </Button>
                   </Tooltip>
                   {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
-                  <a href="#">Hardware sync docs</a>
+                  <a href="#todo">Hardware sync docs</a>
                 </>
               }
               help="Hardware sync interval: 6 hours - Admins can change this in the global settings."

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -10,6 +10,7 @@ import {
   Row,
   Select,
   Tooltip,
+  useId,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
@@ -34,6 +35,8 @@ export const DeployFormFields = (): JSX.Element => {
   const [userDataVisible, setUserDataVisible] = useState(false);
   const formikProps = useFormikContext<DeployFormValues>();
   const { handleChange, setFieldValue, values } = formikProps;
+  const deployVmHostHelpText = useId();
+  const enableHwSyncHelpText = useId();
 
   const user = useSelector(authSelectors.get);
   const osOptions = useSelector(configSelectors.defaultOSystemOptions);
@@ -126,6 +129,9 @@ export const DeployFormFields = (): JSX.Element => {
           </Col>
           <Col size={9}>
             <Input
+              // TODO: use an Input help text prop instead once the bug below is resolved
+              // https://github.com/canonical-web-and-design/react-components/issues/748
+              aria-describedby={deployVmHostHelpText}
               checked={deployVmHost}
               disabled={!canBeKVMHost || noImages}
               id="deployVmHost"
@@ -146,7 +152,11 @@ export const DeployFormFields = (): JSX.Element => {
               }}
               type="checkbox"
             />
-            <p className="p-form-help-text" style={{ paddingLeft: "2rem" }}>
+            <p
+              id={deployVmHostHelpText}
+              className="p-form-help-text"
+              style={{ paddingLeft: "2rem" }}
+            >
               Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially
               supported.
             </p>
@@ -192,6 +202,9 @@ export const DeployFormFields = (): JSX.Element => {
               disabled
               type="checkbox"
               name="enable_hw_sync"
+              // TODO: use an Input help text prop instead once the bug below is resolved
+              // https://github.com/canonical-web-and-design/react-components/issues/748
+              aria-describedby={enableHwSyncHelpText}
               label={
                 <>
                   Periodically sync hardware{" "}
@@ -205,18 +218,26 @@ export const DeployFormFields = (): JSX.Element => {
                       type="button"
                       appearance="base"
                       aria-label="more about periodically sync hardware"
-                      className="u-no-margin--bottom"
+                      className="u-no-margin--bottom u-no-padding"
                     >
                       <Icon name="information" />
                     </Button>
                   </Tooltip>
-                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
+                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}{" "}
                   <a href="#todo">Hardware sync docs</a>
                 </>
               }
-              // TODO: use real sync interval https://github.com/canonical-web-and-design/app-tribe/issues/780
-              help="Hardware sync interval: 6 hours - Admins can change this in the global settings."
             />
+            {/* TODO: use real sync interval
+                https://github.com/canonical-web-and-design/app-tribe/issues/780 */}
+            <p
+              id={enableHwSyncHelpText}
+              className="p-form-help-text"
+              style={{ paddingLeft: "2rem" }}
+            >
+              Hardware sync interval: 6 hours - Admins can change this in the
+              global settings.
+            </p>
             {userDataVisible && (
               <UploadTextArea
                 label="Upload script"

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -214,6 +214,7 @@ export const DeployFormFields = (): JSX.Element => {
                   <a href="#todo">Hardware sync docs</a>
                 </>
               }
+              // TODO: use real sync interval https://github.com/canonical-web-and-design/app-tribe/issues/780
               help="Hardware sync interval: 6 hours - Admins can change this in the global settings."
             />
             {userDataVisible && (

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -2,11 +2,14 @@ import { useState } from "react";
 import * as React from "react";
 
 import {
+  Button,
   Col,
+  Icon,
   Input,
   Notification,
   Row,
   Select,
+  Tooltip,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
@@ -24,6 +27,7 @@ import configSelectors from "app/store/config/selectors";
 import { osInfo as osInfoSelectors } from "app/store/general/selectors";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
+import { breakLines } from "app/utils";
 
 export const DeployFormFields = (): JSX.Element => {
   const [deployVmHost, setDeployVmHost] = useState(false);
@@ -183,6 +187,34 @@ export const DeployFormFields = (): JSX.Element => {
               wrapperClassName={classNames({
                 "u-sv2": userDataVisible,
               })}
+            />
+            <FormikField
+              disabled
+              type="checkbox"
+              name="enable_hw_sync"
+              label={
+                <>
+                  Periodically sync hardware{" "}
+                  <Tooltip
+                    positionElementClassName="u-display-inline-important"
+                    message={breakLines(
+                      "Enable this to make MAAS periodically check the hardware configuration of this machine and reflect any possible change after the deployment."
+                    )}
+                  >
+                    <Button
+                      type="button"
+                      appearance="base"
+                      aria-label="more about periodically sync hardware"
+                      className="u-no-margin--bottom"
+                    >
+                      <Icon name="information" />
+                    </Button>
+                  </Tooltip>
+                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
+                  <a href="#">Hardware sync docs</a>
+                </>
+              }
+              help="Hardware sync interval: 6 hours - Admins can change this in the global settings."
             />
             {userDataVisible && (
               <UploadTextArea


### PR DESCRIPTION
## Done

- add periodic hardware sync checkbox to the deployment form
  - redux and api integration will be done separately https://github.com/canonical-web-and-design/app-tribe/issues/780 - this will include additional tests

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/161094087-46b5157c-ce73-4e93-a293-5081467d7767.png)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to any machine that can be deployed, e.g. on bolla: `/MAAS/r/machine/7c7ya3/summary`
- verify that the checkbox is displayed properly (it's disabled for now)

## Fixes

Fixes: canonical-web-and-design/app-tribe/issues/779

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
