### PR TITLE
fix(ui): fix required tag selectors

### DIFF
--- a/ui/src/app/base/components/node/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/base/components/node/TestForm/TestFormFields/TestFormFields.tsx
@@ -49,7 +49,6 @@ export const TestFormFields = ({
             setFieldValue("scripts", selectedScripts);
           }}
           placeholder="Select scripts"
-          required
           tags={scripts.map(({ id, name }) => ({
             id,
             name,

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.tsx
@@ -60,7 +60,6 @@ export const CommissionFormFields = ({
             setFieldValue("commissioningScripts", selectedScripts);
           }}
           placeholder="Select additional scripts"
-          required
           tags={commissioningScripts}
           disabledTags={commissioningScripts.filter(
             (script) => script.default === true
@@ -77,7 +76,6 @@ export const CommissionFormFields = ({
             setFieldValue("testingScripts", selectedScripts);
           }}
           placeholder="Select additional scripts"
-          required
           tags={testingScripts}
         />
         {urlScriptsSelected.map((script) => (


### PR DESCRIPTION
## Done

- Remove required from the tag selector components as the required prop was being spread on the field used to search for tags (or in this case scripts).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and tick a machine that can be commissioned.
- Open the commission form and submit. It should not show a warning about the testing scripts being required.
- Now tick a machine that can be tested and open the testing form.
- You should be able to submit without a warning that the tests field is required.

## Fixes

Fixes: #3699.