### PR TITLE
feat(ui): create tag form

### DIFF
--- a/ui/src/app/base/components/TagSelector/TagSelector.test.tsx
+++ b/ui/src/app/base/components/TagSelector/TagSelector.test.tsx
@@ -157,6 +157,28 @@ describe("TagSelector", () => {
     ).toBe("new-tag");
   });
 
+  it("can call a provide function to create a new tag", () => {
+    const onAddNewTag = jest.fn();
+    const component = shallow(
+      <TagSelector
+        allowNewTags
+        onAddNewTag={onAddNewTag}
+        label="Tags"
+        placeholder="Select or create tags"
+        onTagsUpdate={jest.fn()}
+        tags={tags}
+      />
+    );
+    component.find(".tag-selector__input").simulate("focus");
+    component
+      .find(".tag-selector__input")
+      .simulate("change", { target: { value: "new-tag" } });
+    component.find('[data-testid="new-tag"]').simulate("click");
+    expect(onAddNewTag).toHaveBeenCalledWith("new-tag");
+    // The input should get cleared.
+    expect(component.find(".tag-selector__input").prop("value")).toBe("");
+  });
+
   it("sanitises text when creating new tag", () => {
     const component = shallow(
       <TagSelector

--- a/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
+++ b/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`TagSelector renders and matches the snapshot when closed 1`] = `
 <Field
+  forId="mock-nanoid-1"
   label={
     <span
       onClick={[Function]}
@@ -15,6 +16,7 @@ exports[`TagSelector renders and matches the snapshot when closed 1`] = `
   >
     <Input
       className="tag-selector__input"
+      id="mock-nanoid-1"
       onChange={[Function]}
       onFocus={[Function]}
       onKeyPress={[Function]}
@@ -46,6 +48,7 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
   }
 >
   <Field
+    forId="mock-nanoid-1"
     label={
       <span
         onClick={[Function]}
@@ -57,9 +60,12 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
     <div
       className="p-form__group p-form-validation"
     >
-      <Label>
+      <Label
+        forId="mock-nanoid-1"
+      >
         <label
           className="p-form__label"
+          htmlFor="mock-nanoid-1"
         >
           <span
             onClick={[Function]}
@@ -76,6 +82,7 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
         >
           <Input
             className="tag-selector__input"
+            id="mock-nanoid-1"
             onChange={[Function]}
             onFocus={[Function]}
             onKeyPress={[Function]}
@@ -85,9 +92,10 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
             value=""
           >
             <Field
-              helpId="mock-nanoid-2"
+              forId="mock-nanoid-1"
+              helpId="mock-nanoid-3"
               required={false}
-              validationId="mock-nanoid-1"
+              validationId="mock-nanoid-2"
             >
               <div
                 className="p-form__group p-form-validation"
@@ -100,6 +108,7 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
                     aria-errormessage={null}
                     aria-invalid={false}
                     className="p-form-validation__input tag-selector__input"
+                    id="mock-nanoid-1"
                     onChange={[Function]}
                     onFocus={[Function]}
                     onKeyPress={[Function]}
@@ -140,6 +149,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
   }
 >
   <Field
+    forId="mock-nanoid-1"
     label={
       <span
         onClick={[Function]}
@@ -151,9 +161,12 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
     <div
       className="p-form__group p-form-validation"
     >
-      <Label>
+      <Label
+        forId="mock-nanoid-1"
+      >
         <label
           className="p-form__label"
+          htmlFor="mock-nanoid-1"
         >
           <span
             onClick={[Function]}
@@ -170,6 +183,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
         >
           <Input
             className="tag-selector__input"
+            id="mock-nanoid-1"
             onChange={[Function]}
             onFocus={[Function]}
             onKeyPress={[Function]}
@@ -179,9 +193,10 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
             value=""
           >
             <Field
-              helpId="mock-nanoid-2"
+              forId="mock-nanoid-1"
+              helpId="mock-nanoid-3"
               required={false}
-              validationId="mock-nanoid-1"
+              validationId="mock-nanoid-2"
             >
               <div
                 className="p-form__group p-form-validation"
@@ -194,6 +209,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
                     aria-errormessage={null}
                     aria-invalid={false}
                     className="p-form-validation__input tag-selector__input"
+                    id="mock-nanoid-1"
                     onChange={[Function]}
                     onFocus={[Function]}
                     onKeyPress={[Function]}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
@@ -39,7 +39,7 @@ it("dispatches an action to create a tag", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm machines={[]} name="new-tag" onClose={jest.fn()} />
+        <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />
       </MemoryRouter>
     </Provider>
   );
@@ -65,7 +65,7 @@ it("dispatches an action to create a tag", async () => {
 });
 
 it("returns the newly created tag on save", async () => {
-  const onClose = jest.fn();
+  const onTagCreated = jest.fn();
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -74,7 +74,11 @@ it("returns the newly created tag on save", async () => {
           exact
           path={tagsURLs.tags.index}
           component={() => (
-            <AddTagForm machines={[]} name="new-tag" onClose={onClose} />
+            <AddTagForm
+              machines={[]}
+              name="new-tag"
+              onTagCreated={onTagCreated}
+            />
           )}
         />
       </MemoryRouter>
@@ -93,5 +97,5 @@ it("returns the newly created tag on save", async () => {
     saved: true,
   });
   fireEvent.submit(screen.getByRole("form"));
-  await waitFor(() => expect(onClose).toHaveBeenCalledWith(newTag));
+  await waitFor(() => expect(onTagCreated).toHaveBeenCalledWith(newTag));
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddTagForm, { Label } from "./AddTagForm";
+
+import * as baseHooks from "app/base/hooks/base";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import { Label as KernelOptionsLabel } from "app/tags/components/KernelOptionsField";
+import tagsURLs from "app/tags/urls";
+import {
+  tag as tagFactory,
+  rootState as rootStateFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    tag: tagStateFactory(),
+  });
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [false, () => null]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("dispatches an action to create a tag", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <AddTagForm machines={[]} name="new-tag" onClose={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  userEvent.type(
+    screen.getByRole("textbox", { name: Label.Comment }),
+    "comment1"
+  );
+  userEvent.type(
+    screen.getByRole("textbox", { name: KernelOptionsLabel.KernelOptions }),
+    "options1"
+  );
+  fireEvent.submit(screen.getByRole("form"));
+  const expected = tagActions.create({
+    comment: "comment1",
+    kernel_opts: "options1",
+    name: "new-tag",
+  });
+  await waitFor(() =>
+    expect(
+      store.getActions().find((action) => action.type === expected.type)
+    ).toStrictEqual(expected)
+  );
+});
+
+it("returns the newly created tag on save", async () => {
+  const onClose = jest.fn();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <Route
+          exact
+          path={tagsURLs.tags.index}
+          component={() => (
+            <AddTagForm machines={[]} name="new-tag" onClose={onClose} />
+          )}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  // Simulate the state.tag.saved state going from `save: false` to `saved:
+  // true` which happens when the tag is successfully saved. This in turn will
+  // mean that the form `onSuccess` prop will get called so that the component
+  // knows that the tag was created.
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [true, () => null]);
+  const newTag = tagFactory({ id: 8, name: "new-tag" });
+  state.tag = tagStateFactory({
+    items: [newTag],
+    saved: true,
+  });
+  fireEvent.submit(screen.getByRole("form"));
+  await waitFor(() => expect(onClose).toHaveBeenCalledWith(newTag));
+});

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+
+import { Col, Row } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import type { CreateParams, Tag } from "app/store/tag/types";
+import { NodeStatus } from "app/store/types/node";
+import KernelOptionsField from "app/tags/components/KernelOptionsField";
+
+type Props = {
+  machines: Machine[];
+  name: string | null;
+  onClose: (tag: Tag | null) => void;
+};
+
+export enum Label {
+  Form = "Create tag",
+  Comment = "Comment",
+  Name = "Tag name",
+}
+
+const AddTagFormSchema = Yup.object().shape({
+  comment: Yup.string(),
+  kernel_opts: Yup.string(),
+  name: Yup.string().required("Name is required."),
+});
+
+export const AddTagForm = ({ machines, name, onClose }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const [savedName, setSavedName] = useState<Tag["name"] | null>(null);
+  const saved = useSelector(tagSelectors.saved);
+  const saving = useSelector(tagSelectors.saving);
+  const errors = useSelector(tagSelectors.errors);
+  const tag = useSelector((state: RootState) =>
+    // Tag names are unique so fetch the newly created tag using the name
+    // provided in this form.
+    tagSelectors.getByName(state, savedName)
+  );
+
+  useEffect(() => {
+    if (tag) {
+      onClose(tag);
+    }
+  }, [onClose, tag]);
+
+  return (
+    <FormikForm<CreateParams>
+      aria-label={Label.Form}
+      allowUnchanged
+      buttonsAlign="left"
+      buttonsBordered={false}
+      cleanup={tagActions.cleanup}
+      errors={errors}
+      initialValues={{
+        comment: "",
+        kernel_opts: "",
+        name: name ?? "",
+      }}
+      onSaveAnalytics={{
+        action: "Manual tag created",
+        category: "Machine list create tag form",
+        label: "Save",
+      }}
+      onSubmit={(values) => {
+        dispatch(tagActions.cleanup());
+        dispatch(tagActions.create(values));
+      }}
+      onSuccess={({ name }) => {
+        setSavedName(name);
+      }}
+      saved={saved}
+      saving={saving}
+      submitAppearance="neutral"
+      submitLabel="Create and add to tag changes"
+      validationSchema={AddTagFormSchema}
+    >
+      <Row className="u-no-padding">
+        <Col size={12}>
+          <FormikField
+            label={Label.Name}
+            name="name"
+            placeholder="Enter a name for the tag."
+            type="text"
+            required
+          />
+          <FormikField
+            label={Label.Comment}
+            name="comment"
+            placeholder="Add a comment as an explanation for this tag."
+            type="text"
+          />
+          <KernelOptionsField
+            generateDeployedMessage={(count: number) =>
+              count === 1
+                ? `${count} selected machine is deployed. The new kernel options will not be applied to this machine until it is redeployed.`
+                : `${count} selected machines are deployed. The new kernel options will not be applied to these machines until they are redeployed.`
+            }
+            deployedMachines={machines.filter(
+              ({ status }) => status === NodeStatus.DEPLOYED
+            )}
+          />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default AddTagForm;

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -17,7 +17,7 @@ import KernelOptionsField from "app/tags/components/KernelOptionsField";
 type Props = {
   machines: Machine[];
   name: string | null;
-  onClose: (tag: Tag | null) => void;
+  onTagCreated: (tag: Tag) => void;
 };
 
 export enum Label {
@@ -32,7 +32,11 @@ const AddTagFormSchema = Yup.object().shape({
   name: Yup.string().required("Name is required."),
 });
 
-export const AddTagForm = ({ machines, name, onClose }: Props): JSX.Element => {
+export const AddTagForm = ({
+  machines,
+  name,
+  onTagCreated,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [savedName, setSavedName] = useState<Tag["name"] | null>(null);
   const saved = useSelector(tagSelectors.saved);
@@ -46,9 +50,9 @@ export const AddTagForm = ({ machines, name, onClose }: Props): JSX.Element => {
 
   useEffect(() => {
     if (tag) {
-      onClose(tag);
+      onTagCreated(tag);
     }
-  }, [onClose, tag]);
+  }, [onTagCreated, tag]);
 
   return (
     <FormikForm<CreateParams>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/index.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddTagForm";

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -27,6 +27,7 @@ type Props = {
 };
 
 export enum Label {
+  Table = "Tag changes",
   Added = "To be added",
   Automatic = "Automatic tags",
   Manual = "Currently assigned",
@@ -150,6 +151,7 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
   return (
     <>
       <ModularTable
+        aria-label={Label.Table}
         className="tag-form__changes"
         columns={columns}
         data={[
@@ -218,7 +220,11 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
       />
       {isOpen && tagDetails ? (
         <Portal>
-          <Modal close={() => toggleTagDetails(null)} title={tagDetails.name}>
+          <Modal
+            className="tag-form__modal"
+            close={() => toggleTagDetails(null)}
+            title={tagDetails.name}
+          >
             <TagDetails id={tagDetails.id} narrow />
           </Modal>
         </Portal>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -1,37 +1,64 @@
-import { render } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import TagFormFields from "./TagFormFields";
+import { Label as AddTagFormLabel } from "../AddTagForm/AddTagForm";
+import { Label as TagFormChangesLabel } from "../TagFormChanges/TagFormChanges";
 
-import type { Props as TagFieldProps } from "app/base/components/TagField/TagField";
+import TagFormFields, { Label } from "./TagFormFields";
+
+import * as baseHooks from "app/base/hooks/base";
+import type { RootState } from "app/store/root/types";
+import type { Tag, TagMeta } from "app/store/tag/types";
 import {
-  tag as tagFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
-const mockTagField = jest.fn();
-jest.mock("app/base/components/TagField", () => (props: TagFieldProps) => {
-  mockTagField(props);
-  return null;
+let state: RootState;
+let tags: Tag[];
+
+beforeEach(() => {
+  tags = [
+    tagFactory({ id: 1, name: "tag1" }),
+    tagFactory({ id: 2, name: "tag2" }),
+    tagFactory({ id: 3, name: "tag3" }),
+  ];
+  state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [
+        machineFactory({
+          tags: [],
+        }),
+      ],
+    }),
+    tag: tagStateFactory({
+      items: tags,
+    }),
+  });
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [false, () => null]);
 });
 
 afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it("passes the selected tag objects", () => {
-  const tags = [tagFactory(), tagFactory(), tagFactory()];
-  const state = rootStateFactory({
-    tag: tagStateFactory({
-      items: tags,
-      loading: false,
-    }),
-  });
+it("displays the new tags", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -40,19 +67,81 @@ it("passes the selected tag objects", () => {
           initialValues={{ tags: [tags[0].id, tags[2].id] }}
           onSubmit={jest.fn()}
         >
+          <TagFormFields machines={state.machine.items} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  const changes = screen.getByRole("table", {
+    name: TagFormChangesLabel.Table,
+  });
+  expect(
+    within(changes).getByRole("button", { name: "tag1 (1/1)" })
+  ).toBeInTheDocument();
+  expect(
+    within(changes).getByRole("button", { name: "tag3 (1/1)" })
+  ).toBeInTheDocument();
+});
+
+it("can open a create tag form", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={{ tags: [] }} onSubmit={jest.fn()}>
           <TagFormFields machines={[]} />
         </Formik>
       </MemoryRouter>
     </Provider>
   );
-  expect(mockTagField).toHaveBeenCalledWith(
-    expect.objectContaining({
-      externalSelectedTags: [tags[0], tags[2]],
-      tags: [
-        { id: tags[0].id, name: tags[0].name },
-        { id: tags[1].id, name: tags[1].name },
-        { id: tags[2].id, name: tags[2].name },
-      ],
-    })
+  userEvent.type(
+    screen.getByRole("textbox", { name: Label.TagInput }),
+    "name1{enter}"
+  );
+  await waitFor(() =>
+    expect(
+      screen.getByRole("dialog", { name: Label.AddTag })
+    ).toBeInTheDocument()
+  );
+});
+
+it("updates the new tags after creating a tag", async () => {
+  const store = mockStore(state);
+  const Form = ({ tags }: { tags: Tag[TagMeta.PK][] }) => (
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={{ tags }} onSubmit={jest.fn()}>
+          <TagFormFields machines={state.machine.items} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  const { rerender } = render(<Form tags={[]} />);
+  expect(
+    screen.queryByRole("button", { name: /new-tag/i })
+  ).not.toBeInTheDocument();
+  userEvent.type(
+    screen.getByRole("textbox", { name: Label.TagInput }),
+    "new-tag{enter}"
+  );
+  // Simulate the state.tag.saved state going from `save: false` to `saved:
+  // true` which happens when the tag is successfully saved. This in turn will
+  // mean that the form `onSuccess` prop will get called so that the component
+  // knows that the tag was created.
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [true, () => null]);
+  const newTag = tagFactory({ id: 8, name: "new-tag" });
+  state.tag.saved = true;
+  state.tag.items.push(newTag);
+  fireEvent.submit(screen.getByRole("form", { name: AddTagFormLabel.Form }));
+  rerender(<Form tags={[newTag.id]} />);
+  const changes = screen.getByRole("table", {
+    name: TagFormChangesLabel.Table,
+  });
+  await waitFor(() =>
+    expect(
+      within(changes).getByRole("button", { name: /new-tag/i })
+    ).toBeInTheDocument()
   );
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -90,13 +90,8 @@ export const TagFormFields = ({ machines }: Props): JSX.Element => {
             <AddTagForm
               machines={machines}
               name={newTagName}
-              onClose={(tag) => {
-                if (tag) {
-                  setFieldValue(
-                    "tags",
-                    values.tags.concat([tag.id.toString()])
-                  );
-                }
+              onTagCreated={(tag) => {
+                setFieldValue("tags", values.tags.concat([tag.id.toString()]));
                 setNewTagName(null);
                 closePortal(NULL_EVENT);
               }}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -1,10 +1,15 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 
-import { Col, Icon, Row } from "@canonical/react-components";
+import { Col, Icon, Modal, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
+import usePortal from "react-useportal";
 
+import AddTagForm from "../AddTagForm";
 import TagFormChanges from "../TagFormChanges";
 import { useSelectedTags } from "../hooks";
+import type { TagFormValues } from "../types";
 
 import TagField from "app/base/components/TagField";
 import type { Tag as TagSelectorTag } from "app/base/components/TagSelector/TagSelector";
@@ -19,43 +24,87 @@ type Props = {
   machines: Machine[];
 };
 
+export enum Label {
+  AddTag = "Create a new tag",
+  TagInput = "Search existing or add new tags",
+}
+
+// usePortal was originally design to work with click events, so to open the
+// portal programmatically we need to fake the event. This workaround can be
+// removed when this issue is resolved:
+// https://github.com/alex-cory/react-useportal/issues/36
+const NULL_EVENT = { currentTarget: { contains: () => false } };
+
 export const TagFormFields = ({ machines }: Props): JSX.Element => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const [newTagName, setNewTagName] = useState<string | null>(null);
+  const { setFieldValue, values } = useFormikContext<TagFormValues>();
   const selectedTags = useSelectedTags();
   const tags = useSelector(tagSelectors.getManual);
   return (
-    <Row>
-      <Col size={6} className="col-start-large-4">
-        <TagField
-          externalSelectedTags={selectedTags}
-          generateDropdownEntry={(
-            tag: TagSelectorTag,
-            highlightedName: ReactNode
-          ) => (
-            <div className="u-flex--between">
-              <span>{highlightedName}</span>
-              {hasKernelOptions(tags, tag) ? (
-                <span className="u-nudge-left--small">
-                  <Icon name="tick" />
-                </span>
-              ) : null}
-            </div>
-          )}
-          header={
-            <div className="u-flex--between p-text--x-small-capitalised">
-              <span>Tag name</span>
-              <span>Kernel options</span>
-            </div>
-          }
-          label="Search existing or add new tags"
-          name="tags"
-          placeholder=""
-          showSelectedTags={false}
-          storedValue="id"
-          tags={tags.map(({ id, name }) => ({ id, name }))}
-        />
-        <TagFormChanges machines={machines} />
-      </Col>
-    </Row>
+    <>
+      <Row>
+        <Col size={6} className="col-start-large-4">
+          <TagField
+            externalSelectedTags={selectedTags}
+            generateDropdownEntry={(
+              tag: TagSelectorTag,
+              highlightedName: ReactNode
+            ) => (
+              <div className="u-flex--between">
+                <span>{highlightedName}</span>
+                {hasKernelOptions(tags, tag) ? (
+                  <span className="u-nudge-left--small">
+                    <Icon name="tick" />
+                  </span>
+                ) : null}
+              </div>
+            )}
+            header={
+              <div className="u-flex--between p-text--x-small-capitalised u-nudge-down--x-small">
+                <span>Tag name</span>
+                <span>Kernel options</span>
+              </div>
+            }
+            label={Label.TagInput}
+            name="tags"
+            onAddNewTag={(name) => {
+              setNewTagName(name);
+              openPortal(NULL_EVENT);
+            }}
+            placeholder=""
+            showSelectedTags={false}
+            storedValue="id"
+            tags={tags.map(({ id, name }) => ({ id, name }))}
+          />
+          <TagFormChanges machines={machines} />
+        </Col>
+      </Row>
+      {isOpen ? (
+        <Portal>
+          <Modal
+            className="tag-form__modal"
+            close={() => closePortal(NULL_EVENT)}
+            title={Label.AddTag}
+          >
+            <AddTagForm
+              machines={machines}
+              name={newTagName}
+              onClose={(tag) => {
+                if (tag) {
+                  setFieldValue(
+                    "tags",
+                    values.tags.concat([tag.id.toString()])
+                  );
+                }
+                setNewTagName(null);
+                closePortal(NULL_EVENT);
+              }}
+            />
+          </Modal>
+        </Portal>
+      ) : null}
+    </>
   );
 };
 

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/_index.scss
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/_index.scss
@@ -16,4 +16,10 @@
       @include breakpoint-widths(20%, 20%, 20%, 20%, 20%);
     }
   }
+
+  @media (min-width: $breakpoint-large) {
+    .tag-form__modal .p-modal__dialog {
+      width: 50%;
+    }
+  }
 }

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
@@ -83,3 +83,60 @@ it("displays a deployed machines message when updating a tag", async () => {
     ).toBeInTheDocument();
   });
 });
+
+it("displays a deployed machines message when passed machines", async () => {
+  const machines = [
+    machineFactory({
+      status: NodeStatus.DEPLOYED,
+      tags: [1],
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={{}} onSubmit={jest.fn()}>
+          <KernelOptionsField deployedMachines={machines} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  userEvent.type(
+    screen.getByRole("textbox", { name: Label.KernelOptions }),
+    "options2"
+  );
+  await waitFor(() => {
+    expect(
+      screen.getByText(/The new kernel options will not be applied/i)
+    ).toBeInTheDocument();
+  });
+});
+
+it("can display a provided deployed machines message", async () => {
+  const machines = [
+    machineFactory({
+      status: NodeStatus.DEPLOYED,
+      tags: [1],
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={{}} onSubmit={jest.fn()}>
+          <KernelOptionsField
+            deployedMachines={machines}
+            generateDeployedMessage={(count) => `${count} deployed machine`}
+          />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  userEvent.type(
+    screen.getByRole("textbox", { name: Label.KernelOptions }),
+    "options2"
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/1 deployed machine/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -153,6 +153,9 @@
   .u-nudge-up--x-small {
     margin-top: -$sp-x-small !important;
   }
+  .u-nudge-down--x-small {
+    margin-bottom: $sp-x-small !important;
+  }
 
   .u-rotate-left {
     transform: rotate(-90deg) !important;


### PR DESCRIPTION
## Done

- Add a form to create new tags in the machine list tag form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list and tick some machines and open the tag form.
- Type a new tag name in the input and click "Create tag".
- Enter some details in the modal and submit.
- The new tag should appear as a green chip.

## Fixes

Fixes: canonical-web-and-design/app-tribe#690.

## Screenshot

<img width="749" alt="Screen Shot 2022-04-01 at 11 52 18 am" src="https://user-images.githubusercontent.com/361637/161182927-d5521bb3-1c07-4d2e-a159-6296be731186.png">
