### PR TITLE
feat(ui): build read-only machine power config section

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
@@ -8,16 +8,6 @@ import { powerField as powerFieldFactory } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
 
 describe("BasePowerField", () => {
-  it("can be disabled", () => {
-    const field = powerFieldFactory();
-    const wrapper = mount(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <BasePowerField disabled field={field} />
-      </Formik>
-    );
-    expect(wrapper.find("input").prop("disabled")).toBe(true);
-  });
-
   it("can be given a custom power parameters name", () => {
     const field = powerFieldFactory({ name: "field-name" });
     const wrapper = mount(

--- a/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
@@ -8,13 +8,11 @@ import type { PowerField } from "app/store/general/types";
 import type { PowerParameters } from "app/store/types/node";
 
 type Props = {
-  disabled?: boolean;
   field: PowerField;
   powerParametersValueName?: string;
 };
 
 export const BasePowerField = <V extends AnyObject>({
-  disabled = false,
   field,
   powerParametersValueName = "power_parameters",
 }: Props): JSX.Element => {
@@ -38,7 +36,6 @@ export const BasePowerField = <V extends AnyObject>({
             <Input
               checked={checked}
               data-testid="multi-choice-checkbox"
-              disabled={disabled}
               id={id}
               key={id}
               label={label}
@@ -59,7 +56,6 @@ export const BasePowerField = <V extends AnyObject>({
   return (
     <FormikField
       component={field_type === PowerFieldType.CHOICE ? Select : Input}
-      disabled={disabled}
       key={fieldName}
       label={label}
       name={fieldName}

--- a/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.tsx
@@ -11,7 +11,6 @@ import type { PowerField as PowerFieldType } from "app/store/general/types";
 import type { PowerParameters } from "app/store/types/node";
 
 type Props = {
-  disabled?: boolean;
   fields: PowerFieldType[];
   powerParametersValueName?: string;
 };
@@ -21,7 +20,6 @@ export const WORKAROUNDS_FIELD_NAME = "workaround_flags";
 export const NONE_WORKAROUND_VALUE = "";
 
 export const IPMIPowerFields = <V extends AnyObject>({
-  disabled = false,
   fields,
   powerParametersValueName = "power_parameters",
 }: Props): JSX.Element | null => {
@@ -67,7 +65,6 @@ export const IPMIPowerFields = <V extends AnyObject>({
                   return (
                     <Input
                       checked={checked}
-                      disabled={disabled}
                       id={id}
                       key={id}
                       label={label}
@@ -92,7 +89,6 @@ export const IPMIPowerFields = <V extends AnyObject>({
         } else {
           content.push(
             <BasePowerField
-              disabled={disabled}
               field={field}
               key={field.name}
               powerParametersValueName={powerParametersValueName}

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.test.tsx
@@ -7,8 +7,6 @@ import LXDPowerFields from "./LXDPowerFields";
 
 import type { RootState } from "app/store/root/types";
 import {
-  certificateMetadata as certMetadataFactory,
-  machineDetails as machineFactory,
   powerField as powerFieldFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -22,21 +20,6 @@ describe("LXDPowerFields", () => {
     state = rootStateFactory();
   });
 
-  it("can be disabled", () => {
-    const field = powerFieldFactory({ name: "field" });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <LXDPowerFields disabled fields={[field]} />
-        </Formik>
-      </Provider>
-    );
-    expect(
-      wrapper.find("input[name='power_parameters.field']").prop("disabled")
-    ).toBe(true);
-  });
-
   it("can be given a custom power parameters name", () => {
     const field = powerFieldFactory({ name: "field" });
     const store = mockStore(state);
@@ -44,7 +27,6 @@ describe("LXDPowerFields", () => {
       <Provider store={store}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <LXDPowerFields
-            disabled
             fields={[field]}
             powerParametersValueName="custom-power-parameters"
           />
@@ -56,63 +38,16 @@ describe("LXDPowerFields", () => {
     ).toBe(true);
   });
 
-  it(`renders certificate data if provided machine has certificate data and the
-      user is not currently editing the form`, () => {
-    const machine = machineFactory({
-      certificate: certMetadataFactory(),
-      power_parameters: {
-        certificate: "certificate",
-        key: "key",
-      },
-    });
+  it("renders certificate fields if the user can edit them", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <LXDPowerFields
-            disabled
-            editing={false}
-            fields={[]}
-            machine={machine}
-          />
+          <LXDPowerFields canEditCertificate fields={[]} />
         </Formik>
       </Provider>
     );
-    expect(wrapper.find("CertificateDetails").exists()).toBe(true);
-    expect(wrapper.find("CertificateFields").exists()).toBe(false);
-  });
 
-  it(`renders certificate fields if provided machine has certificate data and
-      the user is currently editing the form`, () => {
-    const machine = machineFactory({
-      certificate: certMetadataFactory(),
-      power_parameters: {
-        certificate: "certificate",
-        key: "key",
-      },
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <LXDPowerFields editing fields={[]} machine={machine} />
-        </Formik>
-      </Provider>
-    );
-    expect(wrapper.find("CertificateDetails").exists()).toBe(false);
-    expect(wrapper.find("CertificateFields").exists()).toBe(true);
-  });
-
-  it("renders certificate fields if machine is not provided", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <LXDPowerFields fields={[]} />
-        </Formik>
-      </Provider>
-    );
-    expect(wrapper.find("CertificateDetails").exists()).toBe(false);
     expect(wrapper.find("CertificateFields").exists()).toBe(true);
   });
 
@@ -125,7 +60,7 @@ describe("LXDPowerFields", () => {
         </Formik>
       </Provider>
     );
-    expect(wrapper.find("CertificateDetails").exists()).toBe(false);
+
     expect(wrapper.find("CertificateFields").exists()).toBe(false);
   });
 });

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/LXDPowerFields.tsx
@@ -5,40 +5,38 @@ import { useFormikContext } from "formik";
 
 import BasePowerField from "../BasePowerField";
 
-import CertificateDetails from "app/base/components/CertificateDetails";
 import CertificateFields from "app/base/components/CertificateFields";
 import type { AnyObject } from "app/base/types";
 import type { PowerField as PowerFieldType } from "app/store/general/types";
-import type { MachineDetails } from "app/store/machine/types";
+import type { PowerParameters } from "app/store/types/node";
 
 export type Props = {
   canEditCertificate?: boolean;
-  disabled?: boolean;
-  editing?: boolean;
   fields: PowerFieldType[];
-  machine?: MachineDetails;
+  initialShouldGenerateCert?: boolean;
   powerParametersValueName?: string;
 };
 
-const CustomFields = {
+export const CustomFields = {
   CERTIFICATE: "certificate",
   KEY: "key",
 } as const;
 
 export const LXDPowerFields = <V extends AnyObject>({
   canEditCertificate = true,
-  disabled = false,
-  editing = false,
   fields,
-  machine,
+  initialShouldGenerateCert = true,
   powerParametersValueName = "power_parameters",
 }: Props): JSX.Element => {
   const [shouldGenerateCert, setShouldGenerateCert] = useState(
-    !machine?.certificate
+    initialShouldGenerateCert
   );
-  const { setFieldValue } = useFormikContext<V>();
+  const { initialValues, setFieldValue } = useFormikContext<V>();
   const certFieldName = `${powerParametersValueName}.${CustomFields.CERTIFICATE}`;
   const privateKeyFieldName = `${powerParametersValueName}.${CustomFields.KEY}`;
+  const initialParameters = initialValues[
+    powerParametersValueName
+  ] as PowerParameters;
 
   const baseFields = fields.reduce<ReactNode[]>((content, field) => {
     const isCustom = Object.values(CustomFields).some(
@@ -47,7 +45,6 @@ export const LXDPowerFields = <V extends AnyObject>({
     if (!isCustom) {
       content.push(
         <BasePowerField
-          disabled={disabled}
           field={field}
           key={field.name}
           powerParametersValueName={powerParametersValueName}
@@ -56,51 +53,29 @@ export const LXDPowerFields = <V extends AnyObject>({
     }
     return content;
   }, []);
-
-  let customFields: ReactNode;
-  if (
-    machine?.certificate &&
-    machine?.power_parameters.certificate &&
-    machine?.power_parameters.key &&
-    !editing
-  ) {
-    // If certificate details exist and the user is not currently editing power
-    // configuration, we display a custom read-only set of certificate data.
-    customFields = (
-      <CertificateDetails
-        certificate={machine.power_parameters.certificate as string}
-        eventCategory="Machine configuration"
-        metadata={machine.certificate}
-      />
-    );
-  } else if (canEditCertificate) {
-    // Otherwise we display the fields for generating/providing a certificate
-    // and key if the user is able to edit them.
-    customFields = (
-      <CertificateFields
-        certificateFieldName={certFieldName}
-        onShouldGenerateCert={(shouldGenerateCert) => {
-          setShouldGenerateCert(shouldGenerateCert);
-          if (shouldGenerateCert) {
-            setFieldValue(certFieldName, "");
-            setFieldValue(privateKeyFieldName, "");
-          } else {
-            setFieldValue(
-              certFieldName,
-              machine?.power_parameters[CustomFields.CERTIFICATE] || ""
-            );
-            setFieldValue(
-              privateKeyFieldName,
-              machine?.power_parameters[CustomFields.KEY] || ""
-            );
-          }
-        }}
-        privateKeyFieldName={privateKeyFieldName}
-        shouldGenerateCert={shouldGenerateCert}
-      />
-    );
-  }
-
+  const customFields = canEditCertificate ? (
+    <CertificateFields
+      certificateFieldName={certFieldName}
+      onShouldGenerateCert={(shouldGenerateCert) => {
+        setShouldGenerateCert(shouldGenerateCert);
+        if (shouldGenerateCert) {
+          setFieldValue(certFieldName, "");
+          setFieldValue(privateKeyFieldName, "");
+        } else {
+          setFieldValue(
+            certFieldName,
+            initialParameters[CustomFields.CERTIFICATE] || ""
+          );
+          setFieldValue(
+            privateKeyFieldName,
+            initialParameters[CustomFields.KEY] || ""
+          );
+        }
+      }}
+      privateKeyFieldName={privateKeyFieldName}
+      shouldGenerateCert={shouldGenerateCert}
+    />
+  ) : null;
   return (
     <>
       {baseFields}

--- a/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/index.ts
+++ b/ui/src/app/base/components/PowerTypeFields/LXDPowerFields/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./LXDPowerFields";
+export { default, CustomFields } from "./LXDPowerFields";
 export type { Props as LXDPowerFieldsProps } from "./LXDPowerFields";

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
@@ -256,34 +256,6 @@ describe("PowerTypeFields", () => {
     );
   });
 
-  it("can disable the power type fields", () => {
-    const powerTypes = [
-      powerTypeFactory({
-        fields: [powerFieldFactory({ name: "parameter1" })],
-        name: PowerTypeNames.MANUAL,
-      }),
-    ];
-    state.general.powerTypes.data = powerTypes;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{
-            power_parameters: {},
-            power_type: PowerTypeNames.MANUAL,
-          }}
-          onSubmit={jest.fn()}
-        >
-          <PowerTypeFields disableFields />
-        </Formik>
-      </Provider>
-    );
-
-    expect(
-      wrapper.find("input[name='power_parameters.parameter1']").prop("disabled")
-    ).toBe(true);
-  });
-
   it("resets the fields of the selected power type on change", async () => {
     // Mock two power types that share a power parameter "parameter1"
     const powerTypes = [
@@ -317,7 +289,7 @@ describe("PowerTypeFields", () => {
           }}
           onSubmit={jest.fn()}
         >
-          <PowerTypeFields disableFields />
+          <PowerTypeFields />
         </Formik>
       </Provider>
     );
@@ -365,13 +337,15 @@ describe("PowerTypeFields", () => {
           onSubmit={jest.fn()}
         >
           <PowerTypeFields
-            customFieldProps={{ lxd: { forConfiguration: true } }}
+            customFieldProps={{ lxd: { initialShouldGenerateCert: false } }}
           />
         </Formik>
       </Provider>
     );
 
     expect(wrapper.find(LXDPowerFields).exists()).toBe(true);
-    expect(wrapper.find(LXDPowerFields).prop("forConfiguration")).toBe(true);
+    expect(wrapper.find(LXDPowerFields).prop("initialShouldGenerateCert")).toBe(
+      false
+    );
   });
 });

--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -25,7 +25,6 @@ type Props = {
   customFieldProps?: {
     [PowerTypeNames.LXD]?: Partial<LXDPowerFieldsProps>;
   };
-  disableFields?: boolean;
   disableSelect?: boolean;
   forChassis?: boolean;
   powerParametersValueName?: string;
@@ -36,7 +35,6 @@ type Props = {
 
 export const PowerTypeFields = <V extends AnyObject>({
   customFieldProps,
-  disableFields = false,
   disableSelect = false,
   forChassis = false,
   powerParametersValueName = "power_parameters",
@@ -79,7 +77,6 @@ export const PowerTypeFields = <V extends AnyObject>({
       case PowerTypeNames.IPMI:
         fieldContent = (
           <IPMIPowerFields
-            disabled={disableFields}
             fields={fieldsInScope}
             powerParametersValueName={powerParametersValueName}
           />
@@ -88,7 +85,6 @@ export const PowerTypeFields = <V extends AnyObject>({
       case PowerTypeNames.LXD:
         fieldContent = (
           <LXDPowerFields
-            disabled={disableFields}
             fields={fieldsInScope}
             powerParametersValueName={powerParametersValueName}
             {...(customFieldProps?.lxd || {})}
@@ -98,7 +94,6 @@ export const PowerTypeFields = <V extends AnyObject>({
       default:
         fieldContent = fieldsInScope.map((field) => (
           <BasePowerField
-            disabled={disableFields}
             field={field}
             key={field.name}
             powerParametersValueName={powerParametersValueName}

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -98,6 +98,25 @@ it("is editable if machine has edit permission", () => {
   );
 });
 
+it("renders read-only text fields until edit button is pressed", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerForm systemId="abc123" />
+    </Provider>
+  );
+
+  expect(
+    screen.queryByRole("combobox", { name: "Power type" })
+  ).not.toBeInTheDocument();
+
+  userEvent.click(screen.getAllByRole("button", { name: Labels.Edit })[0]);
+
+  expect(
+    screen.getByRole("combobox", { name: "Power type" })
+  ).toBeInTheDocument();
+});
+
 it("correctly dispatches an action to update a machine's power", async () => {
   const machine = machineDetailsFactory({
     permissions: ["edit"],

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.test.tsx
@@ -32,107 +32,6 @@ describe("PowerFormFields", () => {
     });
   });
 
-  it("shows an error if no rack controller is connected", () => {
-    state.general.powerTypes.data = [];
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{
-            powerParameters: {},
-            powerType: "power-type",
-          }}
-          onSubmit={jest.fn()}
-        >
-          <PowerFormFields editing={false} machine={machine} />
-        </Formik>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-testid='no-rack-controller']").exists()).toBe(
-      true
-    );
-  });
-
-  it("shows an error if a power type has not been set", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{
-            powerParameters: {},
-            powerType: "",
-          }}
-          onSubmit={jest.fn()}
-        >
-          <PowerFormFields editing={false} machine={machine} />
-        </Formik>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-testid='no-power-type']").exists()).toBe(true);
-  });
-
-  it("shows a warning if the power type is set to manual", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{
-            powerParameters: {},
-            powerType: "manual",
-          }}
-          onSubmit={jest.fn()}
-        >
-          <PowerFormFields editing={false} machine={machine} />
-        </Formik>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-testid='manual-power-type']").exists()).toBe(
-      true
-    );
-  });
-
-  it("shows an error if editing and the selected power type is missing packages", () => {
-    state.general.powerTypes.data = [
-      powerTypeFactory({
-        description: "the Infinity gauntlet",
-        missing_packages: ["green-infinity-stone", "red-infinity-stone"],
-        name: "ultimate-power",
-      }),
-    ];
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{
-            powerParameters: {},
-            powerType: "ultimate-power",
-          }}
-          onSubmit={jest.fn()}
-        >
-          <PowerFormFields editing machine={machine} />
-        </Formik>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-testid='missing-packages']").exists()).toBe(
-      true
-    );
-    expect(
-      wrapper
-        .find("[data-testid='missing-packages'] .p-notification__message")
-        .text()
-    ).toBe(
-      "Power control software for the Infinity gauntlet is missing from the rack controller. To proceed, install the following packages on the rack controller: green-infinity-stone, red-infinity-stone"
-    );
-  });
-
   it("disables the power select and limits field scopes to node if machine is in a pod", () => {
     state.general.powerTypes.data = [
       powerTypeFactory({
@@ -146,7 +45,7 @@ describe("PowerFormFields", () => {
             scope: PowerFieldScope.BMC,
           }),
         ],
-        name: "power-type",
+        name: "manual",
       }),
     ];
     const machine = machineDetailsFactory({
@@ -155,7 +54,7 @@ describe("PowerFormFields", () => {
         name: "pod",
       },
       power_bmc_node_count: 1,
-      power_type: "power-type",
+      power_type: "manual",
       system_id: "abc123",
     });
     const store = mockStore(state);
@@ -164,11 +63,11 @@ describe("PowerFormFields", () => {
         <Formik
           initialValues={{
             powerParameters: {},
-            powerType: "power-type",
+            powerType: "manual",
           }}
           onSubmit={jest.fn()}
         >
-          <PowerFormFields editing machine={machine} />
+          <PowerFormFields machine={machine} />
         </Formik>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
@@ -1,67 +1,31 @@
-import { Col, Notification, Row } from "@canonical/react-components";
-import { useFormikContext } from "formik";
-import { useSelector } from "react-redux";
+import { Col, Row } from "@canonical/react-components";
 
 import type { PowerFormValues } from "../PowerForm";
 
 import PowerTypeFields from "app/base/components/PowerTypeFields";
-import { useIsRackControllerConnected } from "app/base/hooks";
 import { PowerTypeNames } from "app/store/general/constants";
-import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
-import { getPowerTypeFromName } from "app/store/general/utils";
 import type { MachineDetails } from "app/store/machine/types";
 import { getMachineFieldScopes } from "app/store/machine/utils";
 
 type Props = {
-  editing: boolean;
   machine: MachineDetails;
 };
 
-const PowerFormFields = ({ editing, machine }: Props): JSX.Element => {
-  const powerTypes = useSelector(powerTypesSelectors.get);
-  const { values } = useFormikContext<PowerFormValues>();
-  const isRackControllerConnected = useIsRackControllerConnected();
-  const powerType = getPowerTypeFromName(powerTypes, values.powerType);
-  const machineInPod = Boolean(machine.pod);
+const PowerFormFields = ({ machine }: Props): JSX.Element => {
+  const isMachineInPod = Boolean(machine.pod);
   const fieldScopes = getMachineFieldScopes(machine);
 
   return (
     <Row>
       <Col size={6}>
-        {!isRackControllerConnected && (
-          <Notification data-testid="no-rack-controller" severity="negative">
-            Power configuration is currently disabled because no rack controller
-            is currently connected to the region.
-          </Notification>
-        )}
-        {isRackControllerConnected && !values.powerType && (
-          <Notification data-testid="no-power-type" severity="negative">
-            This node does not have a power type set and MAAS will be unable to
-            control it. Update the power information below.
-          </Notification>
-        )}
-        {values.powerType === "manual" && (
-          <Notification data-testid="manual-power-type" severity="caution">
-            Power control for this power type will need to be handled manually.
-          </Notification>
-        )}
-        {editing && powerType && powerType?.missing_packages.length > 0 && (
-          <Notification data-testid="missing-packages" severity="negative">
-            Power control software for {powerType?.description} is missing from
-            the rack controller. To proceed, install the following packages on
-            the rack controller: {powerType.missing_packages.join(", ") || ""}
-          </Notification>
-        )}
         <PowerTypeFields<PowerFormValues>
           customFieldProps={{
             [PowerTypeNames.LXD]: {
-              canEditCertificate: !machineInPod,
-              editing,
-              machine,
+              canEditCertificate: !isMachineInPod,
+              initialShouldGenerateCert: !machine.certificate,
             },
           }}
-          disableFields={!editing}
-          disableSelect={!editing || machineInPod}
+          disableSelect={isMachineInPod}
           fieldScopes={fieldScopes}
           powerParametersValueName="powerParameters"
           powerTypeValueName="powerType"

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameterDefinition/PowerParameterDefinition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameterDefinition/PowerParameterDefinition.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+
+import PowerParameterDefinition from "./PowerParameterDefinition";
+
+import { PowerFieldType } from "app/store/general/types";
+import { powerField as powerFieldFactory } from "testing/factories";
+
+it("renders the value of a power parameter", () => {
+  const field = powerFieldFactory({
+    field_type: PowerFieldType.STRING,
+  });
+  render(<PowerParameterDefinition field={field} powerParameter="parameter" />);
+
+  expect(screen.getByText(/parameter/)).toBeInTheDocument();
+});
+
+it("handles 'choice' power fields", () => {
+  const field = powerFieldFactory({
+    choices: [
+      ["choice1", "Choice 1"],
+      ["choice2", "Choice 2"],
+    ],
+    field_type: PowerFieldType.CHOICE,
+  });
+  render(<PowerParameterDefinition field={field} powerParameter="choice1" />);
+
+  expect(screen.getByText(/Choice 1/)).toBeInTheDocument();
+});
+
+it("handles 'multiple_choice' power fields", () => {
+  const field = powerFieldFactory({
+    choices: [
+      ["choice1", "Choice 1"],
+      ["choice2", "Choice 2"],
+      ["choice3", "Choice 3"],
+    ],
+    field_type: PowerFieldType.MULTIPLE_CHOICE,
+  });
+  render(
+    <PowerParameterDefinition
+      field={field}
+      powerParameter={["choice1", "choice2"]}
+    />
+  );
+
+  expect(screen.getByText(/Choice 1, Choice 2/)).toBeInTheDocument();
+});
+
+it("handles 'password' power fields", () => {
+  const field = powerFieldFactory({
+    field_type: PowerFieldType.PASSWORD,
+  });
+  render(<PowerParameterDefinition field={field} powerParameter="password" />);
+
+  expect(screen.getByText("********")).toBeInTheDocument();
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameterDefinition/PowerParameterDefinition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameterDefinition/PowerParameterDefinition.tsx
@@ -1,0 +1,58 @@
+import Definition from "app/base/components/Definition";
+import type { PowerField } from "app/store/general/types";
+import { PowerFieldType } from "app/store/general/types";
+import type { PowerParameter } from "app/store/types/node";
+
+type Props = {
+  field: PowerField;
+  powerParameter: PowerParameter;
+};
+
+const getParameterDescription = (
+  field: PowerField,
+  powerParameter: PowerParameter
+) => {
+  if (
+    field.field_type === PowerFieldType.CHOICE &&
+    typeof powerParameter === "string"
+  ) {
+    const selectedChoice = field.choices.find(
+      ([choiceValue]) => choiceValue === powerParameter
+    );
+    if (selectedChoice) {
+      const [, choiceLabel] = selectedChoice;
+      return choiceLabel;
+    }
+  } else if (
+    field.field_type === PowerFieldType.MULTIPLE_CHOICE &&
+    Array.isArray(powerParameter)
+  ) {
+    return field.choices
+      .reduce<string[]>((labels, [choiceValue, choiceLabel]) => {
+        if (powerParameter.includes(choiceValue)) {
+          labels.push(choiceLabel);
+        }
+        return labels;
+      }, [])
+      .join(", ");
+  } else if (field.field_type === PowerFieldType.PASSWORD) {
+    return powerParameter.toString().replace(/./g, "*");
+  }
+  return powerParameter.toString();
+};
+
+const PowerParameterDefinition = ({
+  field,
+  powerParameter,
+}: Props): JSX.Element => {
+  const description = getParameterDescription(field, powerParameter);
+  return (
+    <Definition
+      description={description}
+      key={field.name}
+      label={field.label}
+    />
+  );
+};
+
+export default PowerParameterDefinition;

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameterDefinition/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameterDefinition/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PowerParameterDefinition";

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameters.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameters.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import PowerParameters from "./PowerParameters";
+
+import { PowerTypeNames } from "app/store/general/constants";
+import { PowerFieldScope } from "app/store/general/types";
+import type { RootState } from "app/store/root/types";
+import {
+  certificateMetadata as certificateMetadataFactory,
+  generalState as generalStateFactory,
+  machineDetails as machineDetailsFactory,
+  modelRef as modelRefFactory,
+  powerField as powerFieldFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+let state: RootState;
+beforeEach(() => {
+  state = rootStateFactory({
+    general: generalStateFactory({
+      powerTypes: powerTypesStateFactory({
+        data: [powerTypeFactory({ fields: [], name: PowerTypeNames.MANUAL })],
+        loaded: true,
+      }),
+    }),
+  });
+});
+
+it("shows an error if no rack controller is connected", () => {
+  state.general.powerTypes.data = [];
+  const machine = machineDetailsFactory({ system_id: "abc123" });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(/no rack controller is currently connected/)
+  ).toBeInTheDocument();
+});
+
+it("shows an error if a power type has not been set", () => {
+  const machine = machineDetailsFactory({
+    power_type: "",
+    system_id: "abc123",
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(/This node does not have a power type set/)
+  ).toBeInTheDocument();
+});
+
+it("shows a warning if the power type is set to manual", () => {
+  const machine = machineDetailsFactory({
+    power_type: PowerTypeNames.MANUAL,
+    system_id: "abc123",
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(
+      /Power control for this power type will need to be handled manually/
+    )
+  ).toBeInTheDocument();
+});
+
+it("shows an error if the power type is missing packages", () => {
+  state.general.powerTypes.data = [
+    powerTypeFactory({
+      description: "AMT",
+      missing_packages: ["package1", "package2"],
+      name: PowerTypeNames.AMT,
+    }),
+  ];
+  const machine = machineDetailsFactory({
+    power_type: PowerTypeNames.AMT,
+    system_id: "abc123",
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(
+      /Power control software for AMT is missing from the rack controller/
+    )
+  ).toBeInTheDocument();
+});
+
+it("renders power parameters for all scopes if machine is not in a pod", () => {
+  state.general.powerTypes.data = [
+    powerTypeFactory({
+      fields: [
+        powerFieldFactory({ name: "node-field", scope: PowerFieldScope.NODE }),
+        powerFieldFactory({ name: "bmc-field", scope: PowerFieldScope.BMC }),
+      ],
+      name: PowerTypeNames.LXD,
+    }),
+  ];
+  const machine = machineDetailsFactory({
+    pod: undefined,
+    power_parameters: {
+      "node-field": "node field",
+      "bmc-field": "bmc field",
+    },
+    power_type: PowerTypeNames.LXD,
+    system_id: "abc123",
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(screen.getByText("node field")).toBeInTheDocument();
+  expect(screen.getByText("bmc field")).toBeInTheDocument();
+});
+
+it("renders power parameters only for node scope if machine is in a pod", () => {
+  state.general.powerTypes.data = [
+    powerTypeFactory({
+      fields: [
+        powerFieldFactory({ name: "node-field", scope: PowerFieldScope.NODE }),
+        powerFieldFactory({ name: "bmc-field", scope: PowerFieldScope.BMC }),
+      ],
+      name: PowerTypeNames.LXD,
+    }),
+  ];
+  const machine = machineDetailsFactory({
+    pod: modelRefFactory(),
+    power_parameters: {
+      "node-field": "node field",
+      "bmc-field": "bmc field",
+    },
+    power_type: PowerTypeNames.LXD,
+    system_id: "abc123",
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(screen.getByText("node field")).toBeInTheDocument();
+  expect(screen.queryByText("bmc field")).not.toBeInTheDocument();
+});
+
+it("renders certificate power parameters with metadata", () => {
+  const certificateMetadata = certificateMetadataFactory();
+  state.general.powerTypes.data = [
+    powerTypeFactory({
+      fields: [powerFieldFactory({ name: "certificate" })],
+      name: PowerTypeNames.LXD,
+    }),
+  ];
+  const machine = machineDetailsFactory({
+    certificate: certificateMetadata,
+    power_parameters: {
+      certificate: "abc",
+    },
+    power_type: PowerTypeNames.LXD,
+    system_id: "abc123",
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <PowerParameters machine={machine} />
+    </Provider>
+  );
+
+  expect(screen.getByText(certificateMetadata.CN)).toBeInTheDocument();
+  expect(screen.getByText(certificateMetadata.expiration)).toBeInTheDocument();
+  expect(screen.getByText(certificateMetadata.fingerprint)).toBeInTheDocument();
+  expect(screen.getByRole("textbox")).toHaveValue("abc");
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameters.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/PowerParameters.tsx
@@ -1,0 +1,98 @@
+import { Notification } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import PowerParameterDefinition from "./PowerParameterDefinition";
+
+import CertificateDetails from "app/base/components/CertificateDetails";
+import Definition from "app/base/components/Definition";
+import { useIsRackControllerConnected } from "app/base/hooks";
+import { PowerTypeNames } from "app/store/general/constants";
+import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
+import type { PowerField } from "app/store/general/types";
+import {
+  getFieldsInScope,
+  getPowerTypeFromName,
+} from "app/store/general/utils";
+import type { MachineDetails } from "app/store/machine/types";
+import { getMachineFieldScopes } from "app/store/machine/utils";
+
+type Props = {
+  machine: MachineDetails;
+};
+
+const generateParameters = (machine: MachineDetails, fields: PowerField[]) => {
+  const { certificate, power_parameters } = machine;
+  const baseParameters = fields.reduce<React.ReactNode[]>(
+    (parameters, field) => {
+      const isCertificateField = ["certificate", "key"].includes(field.name);
+      if (!isCertificateField && field.name in power_parameters) {
+        const powerParameter = power_parameters[field.name];
+        parameters.push(
+          <PowerParameterDefinition
+            field={field}
+            key={field.name}
+            powerParameter={powerParameter}
+          />
+        );
+      }
+      return parameters;
+    },
+    []
+  );
+  const certificateParameters = certificate ? (
+    <CertificateDetails
+      certificate={power_parameters.certificate as string}
+      eventCategory="Machine configuration"
+      metadata={certificate}
+    />
+  ) : null;
+  return (
+    <>
+      {baseParameters}
+      {certificateParameters}
+    </>
+  );
+};
+
+const PowerParameters = ({ machine }: Props): JSX.Element => {
+  const powerTypes = useSelector(powerTypesSelectors.get);
+  const isRackControllerConnected = useIsRackControllerConnected();
+  const powerType = getPowerTypeFromName(powerTypes, machine.power_type);
+  const fieldScopes = getMachineFieldScopes(machine);
+  const fieldsInScope = getFieldsInScope(powerType, fieldScopes);
+
+  return (
+    <>
+      {!isRackControllerConnected && (
+        <Notification data-testid="no-rack-controller" severity="negative">
+          Power configuration is currently disabled because no rack controller
+          is currently connected to the region.
+        </Notification>
+      )}
+      {isRackControllerConnected && !powerType && (
+        <Notification data-testid="no-power-type" severity="negative">
+          This node does not have a power type set and MAAS will be unable to
+          control it. Update the power information below.
+        </Notification>
+      )}
+      {powerType?.name === PowerTypeNames.MANUAL && (
+        <Notification data-testid="manual-power-type" severity="caution">
+          Power control for this power type will need to be handled manually.
+        </Notification>
+      )}
+      {powerType && powerType.missing_packages.length > 0 && (
+        <Notification data-testid="missing-packages" severity="negative">
+          Power control software for {powerType.description} is missing from the
+          rack controller. To proceed, install the following packages on the
+          rack controller: {powerType.missing_packages.join(", ")}
+        </Notification>
+      )}
+      <Definition label="Power type">
+        {powerType?.description || "None"}
+      </Definition>
+      {generateParameters(machine, fieldsInScope)}
+    </>
+  );
+};
+
+export default PowerParameters;

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerParameters/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PowerParameters";

--- a/ui/src/app/store/machine/types/actions.ts
+++ b/ui/src/app/store/machine/types/actions.ts
@@ -2,7 +2,6 @@ import type { Machine, MachineStatus } from "./base";
 import type { MachineMeta } from "./enum";
 
 import type { Domain } from "app/store/domain/types";
-import type { PowerType } from "app/store/general/types";
 import type { LicenseKeys } from "app/store/licensekeys/types";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import type { Script } from "app/store/script/types";
@@ -127,7 +126,7 @@ export type CreateParams = {
   osystem?: Machine["osystem"];
   pool?: { name: ResourcePool["name"] };
   power_parameters: PowerParameters;
-  power_type: PowerType["name"];
+  power_type: Machine["power_type"];
   pxe_mac: Machine["pxe_mac"];
   swap_size?: string;
   zone?: { name: Zone["name"] };

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -49,7 +49,7 @@ export type BaseMachine = BaseNode & {
   pod?: ModelRef;
   pool: ModelRef;
   power_state: PowerState;
-  power_type: PowerType["name"];
+  power_type: PowerType["name"] | "";
   pxe_mac_vendor?: string;
   pxe_mac?: string;
   spaces: string[];

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -372,8 +372,10 @@ export type NodeNumaNode = Model & {
 };
 
 // Power parameters are dynamic and depend on the power type of the node.
+export type PowerParameter = string | number | string[];
+
 export type PowerParameters = {
-  [x: string]: string | number | string[];
+  [x: string]: PowerParameter;
 };
 
 export type SupportedFilesystem = {


### PR DESCRIPTION
## Done

- Built read-only machine power config section
  - This replaces the old functionality of it always being a form, with form fields being enabled depending on whether the user was in edit mode.
  - Added new components for the read-only section, with common utils being extracted from PowerTypeFields
- Removed "disabled" functionality for PowerTypeFields, since now this can't be done anywhere in the UI

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the config tab of a machine that is not in a pod
- Check that the power parameters render as a list and not as form fields
- Click "Edit" and check that the section is now a form
- Change the power type to LXD and choose to generate a certificate
- Submit the form and check that it closes after success, and the generated certificate is displayed with its metadata and a download button
- Go to the config tab of a LXD machine that is in a pod
- Check that there are only node-scoped fields displayed
- Click "Edit" and check that you do not get the option to change the certificate

## Fixes

Fixes canonical-web-and-design/app-tribe#745

## Screenshot
![Peek 2022-04-01 13-58](https://user-images.githubusercontent.com/25733845/161192412-46f2c010-4899-4b38-a513-aa8a1989e38e.gif)

