### PR TITLE
feat(ui): center machine power form and create utils for common functions

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -16,6 +16,10 @@ import { actions as generalActions } from "app/store/general";
 import { PowerTypeNames } from "app/store/general/constants";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import { PowerFieldScope } from "app/store/general/types";
+import {
+  getFieldsInScope,
+  getPowerTypeFromName,
+} from "app/store/general/utils";
 
 type Props = {
   customFieldProps?: {
@@ -70,9 +74,7 @@ export const PowerTypeFields = <V extends AnyObject>({
   if (!powerTypesLoaded) {
     fieldContent = <Spinner text="Loading..." />;
   } else if (selectedPowerType) {
-    const fieldsInScope = selectedPowerType.fields.filter((field) =>
-      fieldScopes.includes(field.scope)
-    );
+    const fieldsInScope = getFieldsInScope(selectedPowerType, fieldScopes);
     switch (selectedPowerType.name) {
       case PowerTypeNames.IPMI:
         fieldContent = (
@@ -128,9 +130,7 @@ export const PowerTypeFields = <V extends AnyObject>({
             setErrors(initialErrors);
             setTouched(initialTouched);
 
-            const powerType = powerTypes.find(
-              (type) => type.name === e.target.value
-            );
+            const powerType = getPowerTypeFromName(powerTypes, e.target.value);
             // Explicitly set the fields of the selected power type to defaults.
             // This is necessary because some field names are shared across
             // power types (e.g. "power_address"), meaning the value would otherwise

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { Button, Col, Row, Spinner } from "@canonical/react-components";
-import { usePrevious } from "@canonical/react-components/dist/hooks";
+import {
+  Button,
+  Col,
+  Row,
+  Spinner,
+  usePrevious,
+} from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { SchemaOf } from "yup";
 import * as Yup from "yup";
@@ -12,23 +17,30 @@ import FormikForm from "app/base/components/FormikForm";
 import { useCanEdit } from "app/base/hooks";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import type { PowerType } from "app/store/general/types";
-import { PowerFieldScope } from "app/store/general/types";
 import {
   formatPowerParameters,
   generatePowerParametersSchema,
+  getPowerTypeFromName,
   useInitialPowerParameters,
 } from "app/store/general/utils";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
-import { isMachineDetails } from "app/store/machine/utils";
+import {
+  getMachineFieldScopes,
+  isMachineDetails,
+} from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
-import type { PowerParameters } from "app/store/types/node";
+import type { PowerParameters as PowerParametersType } from "app/store/types/node";
 
 export type PowerFormValues = {
   powerType: Machine["power_type"];
-  powerParameters: PowerParameters;
+  powerParameters: PowerParametersType;
 };
+
+export enum Labels {
+  Edit = "Edit",
+}
 
 type Props = { systemId: Machine["system_id"] };
 
@@ -40,17 +52,19 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
   const errors = useSelector(machineSelectors.errors);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
+  const previousSaving = usePrevious(saving);
   const powerTypes = useSelector(powerTypesSelectors.get);
-  const powerTypesLoaded = useSelector(powerTypesSelectors.loaded);
+  const powerTypesLoading = useSelector(powerTypesSelectors.loading);
   const cleanup = useCallback(() => machineActions.cleanup(), []);
   const [editing, setEditing] = useState(false);
   const canEdit = useCanEdit(machine, true);
-  const previousSaving = usePrevious(saving);
-  const [powerType, setPowerType] = useState<PowerType>();
-  const setPowerTypeFromName = (name: string) => {
-    const powerType = powerTypes.find((type) => type.name === name);
-    setPowerType(powerType);
-  };
+  const [selectedPowerType, setSelectedPowerType] = useState<PowerType | null>(
+    null
+  );
+  const isDetails = isMachineDetails(machine);
+  const initialPowerParameters = useInitialPowerParameters(
+    (isDetails && machine.power_parameters) || {}
+  );
 
   // Close the form if saving was successfully completed.
   useEffect(() => {
@@ -59,15 +73,22 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
     }
   }, [previousSaving, saved, saving]);
 
-  const machineInPod = Boolean(machine?.pod);
-  const fieldScopes = machineInPod
-    ? [PowerFieldScope.NODE]
-    : [PowerFieldScope.BMC, PowerFieldScope.NODE];
-  const initialPowerParameters = useInitialPowerParameters(
-    (isMachineDetails(machine) && machine.power_parameters) || {}
-  );
+  useEffect(() => {
+    // We set the selected power type outside the scope of the form as its used
+    // to generate the form's validation schema.
+    if (machine?.power_type) {
+      const powerType = getPowerTypeFromName(powerTypes, machine.power_type);
+      setSelectedPowerType(powerType);
+    }
+  }, [machine?.power_type, powerTypes]);
+
+  if (!isDetails || powerTypesLoading) {
+    return <Spinner text="Loading..." />;
+  }
+
+  const fieldScopes = getMachineFieldScopes(machine);
   const powerParametersSchema = generatePowerParametersSchema(
-    powerType,
+    selectedPowerType,
     fieldScopes
   );
   const PowerFormSchema: SchemaOf<PowerFormValues> = Yup.object()
@@ -77,25 +98,22 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
     })
     .defined();
 
-  if (isMachineDetails(machine) && powerTypesLoaded) {
-    return (
-      <>
-        <Row>
-          <Col small={4} medium={4} size={6}>
-            <h4>Power configuration</h4>
-          </Col>
-          <Col small={4} medium={2} size={6} className="u-align--right">
-            {canEdit && !editing && (
-              <Button
-                className="u-no-margin--bottom"
-                data-testid="edit-power-config"
-                onClick={() => setEditing(true)}
-              >
-                Edit
-              </Button>
-            )}
-          </Col>
-        </Row>
+  return (
+    <Row>
+      <Col size={3}>
+        <div className="u-flex--between u-flex--wrap">
+          <h4>Power configuration</h4>
+          {canEdit && !editing && (
+            <Button
+              className="u-no-margin--bottom u-hide--large"
+              onClick={() => setEditing(true)}
+            >
+              {Labels.Edit}
+            </Button>
+          )}
+        </div>
+      </Col>
+      <Col size={editing ? 9 : 6}>
         <FormikForm<PowerFormValues>
           allowAllEmpty
           allowUnchanged
@@ -104,7 +122,7 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
           // Only show machine errors if form is in editing state.
           errors={editing ? errors : null}
           initialValues={{
-            powerType: powerType?.name || machine.power_type,
+            powerType: machine.power_type,
             powerParameters: initialPowerParameters,
           }}
           onSaveAnalytics={{
@@ -113,7 +131,11 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
             label: "Save changes",
           }}
           onCancel={(_, { initialValues, resetForm }) => {
-            setPowerTypeFromName(machine.power_type);
+            const powerType = getPowerTypeFromName(
+              powerTypes,
+              machine.power_type
+            );
+            setSelectedPowerType(powerType);
             resetForm({ values: initialValues });
             setEditing(false);
             dispatch(machineActions.cleanup());
@@ -122,7 +144,7 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
             const params = {
               extra_macs: machine.extra_macs,
               power_parameters: formatPowerParameters(
-                powerType || null,
+                selectedPowerType,
                 values.powerParameters,
                 fieldScopes
               ),
@@ -133,7 +155,11 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
             dispatch(machineActions.update(params));
           }}
           onValuesChanged={(values) => {
-            setPowerTypeFromName(values.powerType);
+            const powerType = getPowerTypeFromName(
+              powerTypes,
+              values.powerType
+            );
+            setSelectedPowerType(powerType);
           }}
           saved={saved}
           saving={saving}
@@ -142,10 +168,19 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
         >
           <PowerFormFields editing={editing} machine={machine} />
         </FormikForm>
-      </>
-    );
-  }
-  return <Spinner text="Loading..." />;
+      </Col>
+      {canEdit && !editing && (
+        <Col className="u-align--right" size={3}>
+          <Button
+            className="u-no-margin--bottom u-hide--small u-hide--medium"
+            onClick={() => setEditing(true)}
+          >
+            {Labels.Edit}
+          </Button>
+        </Col>
+      )}
+    </Row>
+  );
 };
 
 export default PowerForm;

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.tsx
@@ -8,8 +8,9 @@ import PowerTypeFields from "app/base/components/PowerTypeFields";
 import { useIsRackControllerConnected } from "app/base/hooks";
 import { PowerTypeNames } from "app/store/general/constants";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
-import { PowerFieldScope } from "app/store/general/types";
+import { getPowerTypeFromName } from "app/store/general/utils";
 import type { MachineDetails } from "app/store/machine/types";
+import { getMachineFieldScopes } from "app/store/machine/utils";
 
 type Props = {
   editing: boolean;
@@ -20,12 +21,9 @@ const PowerFormFields = ({ editing, machine }: Props): JSX.Element => {
   const powerTypes = useSelector(powerTypesSelectors.get);
   const { values } = useFormikContext<PowerFormValues>();
   const isRackControllerConnected = useIsRackControllerConnected();
-
-  const powerType = powerTypes.find((type) => type.name === values.powerType);
+  const powerType = getPowerTypeFromName(powerTypes, values.powerType);
   const machineInPod = Boolean(machine.pod);
-  const fieldScopes = machineInPod
-    ? [PowerFieldScope.NODE]
-    : [PowerFieldScope.BMC, PowerFieldScope.NODE];
+  const fieldScopes = getMachineFieldScopes(machine);
 
   return (
     <Row>

--- a/ui/src/app/store/general/utils/index.ts
+++ b/ui/src/app/store/general/utils/index.ts
@@ -5,4 +5,6 @@ export { useInitialPowerParameters } from "./hooks";
 export {
   formatPowerParameters,
   generatePowerParametersSchema,
+  getFieldsInScope,
+  getPowerTypeFromName,
 } from "./powerTypes";

--- a/ui/src/app/store/general/utils/powerTypes.test.ts
+++ b/ui/src/app/store/general/utils/powerTypes.test.ts
@@ -1,6 +1,8 @@
 import {
   formatPowerParameters,
   generatePowerParametersSchema,
+  getFieldsInScope,
+  getPowerTypeFromName,
 } from "./powerTypes";
 
 import { PowerFieldScope } from "app/store/general/types";
@@ -124,6 +126,30 @@ describe("powerTypes utils", () => {
       ]);
       expect("power_address" in schema).toBe(true);
       expect("power_pass" in schema).toBe(false);
+    });
+  });
+
+  describe("getFieldsInScope", () => {
+    it("can get a list of power fields that are in the given field scopes", () => {
+      const fields = [
+        powerFieldFactory({ scope: PowerFieldScope.BMC }),
+        powerFieldFactory({ scope: PowerFieldScope.NODE }),
+      ];
+      const powerType = powerTypeFactory({ fields });
+
+      expect(getFieldsInScope(powerType, [PowerFieldScope.BMC])).toStrictEqual([
+        fields[0],
+      ]);
+      expect(getFieldsInScope(null, [PowerFieldScope.BMC])).toStrictEqual([]);
+    });
+  });
+
+  describe("getPowerTypeFromName", () => {
+    it("can get a power type from its name", () => {
+      const powerTypes = [powerTypeFactory({ name: "manual" })];
+
+      expect(getPowerTypeFromName(powerTypes, "manual")).toBe(powerTypes[0]);
+      expect(getPowerTypeFromName(powerTypes, "other")).toBe(null);
     });
   });
 });

--- a/ui/src/app/store/general/utils/powerTypes.ts
+++ b/ui/src/app/store/general/utils/powerTypes.ts
@@ -1,7 +1,7 @@
 import * as Yup from "yup";
 import type { ObjectShape } from "yup/lib/object";
 
-import type { PowerType } from "app/store/general/types";
+import type { PowerField, PowerType } from "app/store/general/types";
 import { PowerFieldScope, PowerFieldType } from "app/store/general/types";
 import type { PowerParameters } from "app/store/types/node";
 
@@ -74,3 +74,26 @@ export const generatePowerParametersSchema = (
     }
     return schema;
   }, {}) || {};
+
+/**
+ * Get a list of power fields that are included in the given field scopes.
+ * @param powerType - Power type whose fields to check.
+ * @param fieldScopes - The scopes of the fields to be included.
+ * @returns List of power fields included in given field scopes.
+ */
+export const getFieldsInScope = (
+  powerType: PowerType | null,
+  fieldScopes: PowerFieldScope[]
+): PowerField[] =>
+  powerType?.fields.filter((field) => fieldScopes.includes(field.scope)) || [];
+
+/**
+ * Get a power type from its name.
+ * @param powerTypes - List of power types to check.
+ * @param name - Name of the power type to find.
+ * @returns Power type that matches given name.
+ */
+export const getPowerTypeFromName = (
+  powerTypes: PowerType[],
+  name: string
+): PowerType | null => powerTypes.find((type) => type.name === name) || null;

--- a/ui/src/app/store/machine/utils/common.test.ts
+++ b/ui/src/app/store/machine/utils/common.test.ts
@@ -1,8 +1,14 @@
-import { getTagCountsForMachines, isMachineDetails } from "./common";
+import {
+  getMachineFieldScopes,
+  getTagCountsForMachines,
+  isMachineDetails,
+} from "./common";
 
+import { PowerFieldScope } from "app/store/general/types";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
+  modelRef as modelRefFactory,
 } from "testing/factories";
 
 describe("common machine utils", () => {
@@ -38,6 +44,25 @@ describe("common machine utils", () => {
           [4, 1],
         ])
       );
+    });
+  });
+
+  describe("getMachineFieldScopes", () => {
+    it("gets the field scopes for a machine in a pod", () => {
+      const machine = machineFactory({ pod: modelRefFactory() });
+
+      expect(getMachineFieldScopes(machine)).toStrictEqual([
+        PowerFieldScope.NODE,
+      ]);
+    });
+
+    it("gets the field scopes for a machine not in a pod", () => {
+      const machine = machineFactory({ pod: undefined });
+
+      expect(getMachineFieldScopes(machine)).toStrictEqual([
+        PowerFieldScope.BMC,
+        PowerFieldScope.NODE,
+      ]);
     });
   });
 });

--- a/ui/src/app/store/machine/utils/common.ts
+++ b/ui/src/app/store/machine/utils/common.ts
@@ -1,3 +1,4 @@
+import { PowerFieldScope } from "app/store/general/types";
 import type { Machine, MachineDetails } from "app/store/machine/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
 
@@ -30,4 +31,16 @@ export const getTagCountsForMachines = (machines: Machine[]): TagIdCountMap => {
     }
   });
   return tagCounts;
+};
+
+/**
+ * Get the power field scopes that are applicable to a machine.
+ * @param machine - The machine to get the applicable field scopes.
+ * @returns A list of applicable field scopes.
+ */
+export const getMachineFieldScopes = (machine: Machine): PowerFieldScope[] => {
+  if (machine.pod) {
+    return [PowerFieldScope.NODE];
+  }
+  return [PowerFieldScope.BMC, PowerFieldScope.NODE];
 };

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -1,4 +1,8 @@
-export { isMachineDetails, getTagCountsForMachines } from "./common";
+export {
+  isMachineDetails,
+  getMachineFieldScopes,
+  getTagCountsForMachines,
+} from "./common";
 export type { TagIdCountMap } from "./common";
 
 export {


### PR DESCRIPTION
## Done

- Center power config form
- Created common utils for machine power type functions

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the config tab of a machine and check that the form is centered
- Check that you can still submit the form successfully as before.

## Fixes

Fixes canonical-web-and-design/app-tribe#746
