### PR TITLE
feat(ui): increase space for tag names in machine tag form

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -193,14 +193,7 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
             automaticTags,
             machineCount,
             tagIdsAndCounts,
-            <>
-              {Label.Automatic}
-              <p className="u-text--muted u-nudge-left">
-                Automatic tags (cannot be unassigned. Go to the{" "}
-                <Link to={tagsURLs.tags.index}>Tags tab</Link> to delete
-                automatic tags).
-              </p>
-            </>,
+            Label.Automatic,
             toggleTagDetails
           ),
         ]}
@@ -218,6 +211,13 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
           return {};
         }}
       />
+      {hasAutomaticTags && (
+        <p className="u-text--muted u-nudge-right--small">
+          These tags cannot be unassigned. Go to the{" "}
+          <Link to={tagsURLs.tags.index}>Tags tab</Link> to manage automatic
+          tags.
+        </p>
+      )}
       {isOpen && tagDetails ? (
         <Portal>
           <Modal

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/_index.scss
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/_index.scss
@@ -1,19 +1,21 @@
 @mixin TagForm {
   .tag-form__changes {
+    margin-bottom: $spv--small;
+
     .label-col {
-      @include breakpoint-widths(35%, 35%, 35%, 35%, 35%);
+      width: 40%;
     }
 
     .name-col {
-      @include breakpoint-widths(25%, 25%, 25%, 25%, 25%);
+      width: 60%;
     }
 
     .options-col {
-      @include breakpoint-widths(20%, 20%, 20%, 20%, 20%);
+      @include breakpoint-widths(0, 7.5rem, 7.5rem, 7.5rem, 7.5rem);
     }
 
     .action-col {
-      @include breakpoint-widths(20%, 20%, 20%, 20%, 20%);
+      width: 7rem;
     }
   }
 


### PR DESCRIPTION
## Done

- Increased space for tag names in machine tag form
- Moved Automatic tags help text underneath the table, otherwise it gets super squished. @huwshimi the Zeplin wireframe shows this version as well as the version where it's in the table cell - not sure which one has the right text?

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, select some machines and select "Tag" from the action menu
- Check that the tag name has more space than before at all screen sizes

## Fixes

Fixes canonical-web-and-design/app-tribe#792

## Screenshot

![Screenshot 2022-04-04 at 11-21-37 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/161459131-9d8a77b5-ed12-483f-9757-222682eba126.png)
