### PR TITLE
feat(ui): remove existing tags

### DIFF
--- a/ui/src/app/base/components/TagSelector/TagSelector.tsx
+++ b/ui/src/app/base/components/TagSelector/TagSelector.tsx
@@ -123,11 +123,14 @@ const generateDropdownItems = ({
         <li className="tag-selector__dropdown-item" key={tag.name}>
           <Button
             appearance="base"
+            aria-label={tag.displayName}
+            aria-selected={false}
             className="tag-selector__dropdown-button u-break-word"
             data-testid="existing-tag"
             onClick={() => {
               updateTags([...selectedTags, tag]);
             }}
+            role="option"
             type="button"
           >
             {generateDropdownEntry?.(tag, highlightedName) ?? (
@@ -274,6 +277,7 @@ export const TagSelector = ({
           </ul>
         )}
         <Input
+          aria-haspopup="listbox"
           className={classNames("tag-selector__input", {
             "tags-selected": hasSelectedTags,
           })}
@@ -301,7 +305,7 @@ export const TagSelector = ({
           value={filter}
         />
         {dropdownOpen && dropdownItems.length >= 1 && (
-          <div className="tag-selector__dropdown">
+          <div className="tag-selector__dropdown" role="listbox">
             {header ? (
               <div className="tag-selector__dropdown-header">{header}</div>
             ) : null}

--- a/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
+++ b/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`TagSelector renders and matches the snapshot when closed 1`] = `
     className="tag-selector"
   >
     <Input
+      aria-haspopup="listbox"
       className="tag-selector__input"
       id="mock-nanoid-1"
       onChange={[Function]}
@@ -81,6 +82,7 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
           className="tag-selector"
         >
           <Input
+            aria-haspopup="listbox"
             className="tag-selector__input"
             id="mock-nanoid-1"
             onChange={[Function]}
@@ -106,6 +108,7 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
                   <input
                     aria-describedby={null}
                     aria-errormessage={null}
+                    aria-haspopup="listbox"
                     aria-invalid={false}
                     className="p-form-validation__input tag-selector__input"
                     id="mock-nanoid-1"
@@ -182,6 +185,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
           className="tag-selector"
         >
           <Input
+            aria-haspopup="listbox"
             className="tag-selector__input"
             id="mock-nanoid-1"
             onChange={[Function]}
@@ -207,6 +211,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
                   <input
                     aria-describedby={null}
                     aria-errormessage={null}
+                    aria-haspopup="listbox"
                     aria-invalid={false}
                     className="p-form-validation__input tag-selector__input"
                     id="mock-nanoid-1"

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -73,7 +73,7 @@ describe("TagForm", () => {
 
     act(() =>
       submitFormikForm(wrapper, {
-        tags: ["tag1", "tag2"],
+        added: ["tag1", "tag2"],
       })
     );
     expect(

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -16,10 +16,8 @@ import { NodeActions } from "app/store/types/node";
 type Props = MachineActionFormProps;
 
 const TagFormSchema = Yup.object().shape({
-  tags: Yup.array()
-    .of(Yup.string())
-    .min(1)
-    .required("You must select at least one tag."),
+  added: Yup.array().of(Yup.string()),
+  removed: Yup.array().of(Yup.string()),
 });
 
 export const TagForm = ({
@@ -30,16 +28,13 @@ export const TagForm = ({
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const [initialValues, setInitialValues] = useState<TagFormValues>({
-    tags: [],
-  });
   const tagsLoaded = useSelector(tagSelectors.loaded);
 
   let formErrors: Record<string, string | string[]> | null = null;
   if (errors && typeof errors === "object" && "name" in errors) {
     formErrors = {
       ...errors,
-      tags: errors.name,
+      added: errors.name,
     } as Record<string, string | string[]>;
     delete formErrors.name;
   }
@@ -53,7 +48,10 @@ export const TagForm = ({
       actionName={NodeActions.TAG}
       cleanup={machineActions.cleanup}
       errors={formErrors}
-      initialValues={initialValues}
+      initialValues={{
+        added: [],
+        removed: [],
+      }}
       loaded={tagsLoaded}
       modelName="machine"
       onCancel={clearHeaderContent}
@@ -64,17 +62,16 @@ export const TagForm = ({
       }}
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
-        if (values.tags && values.tags.length) {
+        if (values.added.length) {
           machines.forEach((machine) => {
             dispatch(
               machineActions.tag({
                 systemId: machine.system_id,
-                tags: values.tags,
+                tags: values.added,
               })
             );
           });
         }
-        setInitialValues(values);
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -212,7 +212,7 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
             },
             <>
               <span className="u-nudge-left--small">{Label.Discard}</span>
-              <Icon name="close" />
+              <Icon aria-hidden="true" name="close" />
             </>
           ),
           ...generateRows(
@@ -231,7 +231,7 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
             },
             <>
               <span className="u-nudge-left--small">{Label.Remove}</span>
-              <Icon name="delete" />
+              <Icon aria-hidden="true" name="delete" />
             </>
           ),
           ...generateRows(

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -58,13 +58,49 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+it("displays available tags in the dropdown", async () => {
+  state.machine.items[0].tags = [3];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
+          <TagFormFields machines={state.machine.items} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+  const changes = screen.getByRole("table", {
+    name: TagFormChangesLabel.Table,
+  });
+  const tagRow = within(changes).getByRole("row", {
+    name: "tag3",
+  });
+  // Set a tag to be removed.
+  userEvent.click(
+    within(tagRow).getByRole("button", { name: TagFormChangesLabel.Remove })
+  );
+  // Open the tag selector dropdown.
+  screen.getByRole("textbox", { name: Label.TagInput }).focus();
+  // Set a tag to be added.
+  userEvent.click(
+    screen.getByRole("option", {
+      name: "tag1",
+    })
+  );
+  expect(screen.getAllByRole("option")).toHaveLength(1);
+  await waitFor(() =>
+    expect(screen.getByRole("option", { name: "tag2" })).toBeInTheDocument()
+  );
+});
+
 it("displays the new tags", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
       <MemoryRouter>
         <Formik
-          initialValues={{ tags: [tags[0].id, tags[2].id] }}
+          initialValues={{ added: [tags[0].id, tags[2].id], removed: [] }}
           onSubmit={jest.fn()}
         >
           <TagFormFields machines={state.machine.items} />
@@ -88,7 +124,7 @@ it("can open a create tag form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ tags: [] }} onSubmit={jest.fn()}>
+        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
           <TagFormFields machines={[]} />
         </Formik>
       </MemoryRouter>
@@ -110,7 +146,10 @@ it("updates the new tags after creating a tag", async () => {
   const Form = ({ tags }: { tags: Tag[TagMeta.PK][] }) => (
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ tags }} onSubmit={jest.fn()}>
+        <Formik
+          initialValues={{ added: tags, removed: [] }}
+          onSubmit={jest.fn()}
+        >
           <TagFormFields machines={state.machine.items} />
         </Formik>
       </MemoryRouter>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/hooks.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/hooks.test.tsx
@@ -5,7 +5,7 @@ import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import { useSelectedTags } from "./hooks";
+import { useSelectedTags, useUnchangedTags } from "./hooks";
 
 import {
   tag as tagFactory,
@@ -15,26 +15,73 @@ import {
 
 const mockStore = configureStore();
 
-it("gets and sets active tag", () => {
-  const tags = [tagFactory(), tagFactory(), tagFactory()];
-  const state = rootStateFactory({
-    tag: tagStateFactory({
-      items: tags,
-      loading: false,
-    }),
+describe("useSelectedTags", () => {
+  it("gets tags that have been added", () => {
+    const tags = [tagFactory(), tagFactory(), tagFactory()];
+    const state = rootStateFactory({
+      tag: tagStateFactory({
+        items: tags,
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useSelectedTags("added"), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <Provider store={store}>
+          <Formik
+            initialValues={{ added: [tags[0].id, tags[2].id] }}
+            onSubmit={jest.fn()}
+          >
+            {children}
+          </Formik>
+        </Provider>
+      ),
+    });
+    expect(result.current).toStrictEqual([tags[0], tags[2]]);
   });
-  const store = mockStore(state);
-  const { result } = renderHook(() => useSelectedTags(), {
-    wrapper: ({ children }: { children: ReactNode }) => (
-      <Provider store={store}>
+
+  it("gets tags that have been removed", () => {
+    const tags = [tagFactory(), tagFactory(), tagFactory()];
+    const state = rootStateFactory({
+      tag: tagStateFactory({
+        items: tags,
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const { result } = renderHook(() => useSelectedTags("removed"), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <Provider store={store}>
+          <Formik
+            initialValues={{ removed: [tags[0].id, tags[2].id] }}
+            onSubmit={jest.fn()}
+          >
+            {children}
+          </Formik>
+        </Provider>
+      ),
+    });
+    expect(result.current).toStrictEqual([tags[0], tags[2]]);
+  });
+});
+
+describe("useUnchangedTags", () => {
+  it("gets tags that have been added", () => {
+    const tags = [
+      tagFactory({ id: 1 }),
+      tagFactory({ id: 2 }),
+      tagFactory({ id: 3 }),
+    ];
+    const { result } = renderHook(() => useUnchangedTags(tags), {
+      wrapper: ({ children }: { children: ReactNode }) => (
         <Formik
-          initialValues={{ tags: [tags[0].id, tags[2].id] }}
+          initialValues={{ added: [tags[0].id], removed: [tags[1].id] }}
           onSubmit={jest.fn()}
         >
           {children}
         </Formik>
-      </Provider>
-    ),
+      ),
+    });
+    expect(result.current).toStrictEqual([tags[2]]);
   });
-  expect(result.current).toStrictEqual([tags[0], tags[2]]);
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/hooks.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/hooks.ts
@@ -11,11 +11,11 @@ import { toFormikNumber } from "app/utils";
 /**
  * Get the tag objects for the tag ids that have been selected in the form.
  */
-export const useSelectedTags = (): Tag[] => {
+export const useSelectedTags = (key: keyof TagFormValues): Tag[] => {
   const { values } = useFormikContext<TagFormValues>();
   // The Formik values are strings so we need to convert these into numbers so
   // they can be used in the selector.
-  const tagIds = values.tags.reduce<Tag[TagMeta.PK][]>((tagList, id) => {
+  const tagIds = values[key].reduce<Tag[TagMeta.PK][]>((tagList, id) => {
     const idNumber = toFormikNumber(id);
     if (idNumber) {
       tagList.push(idNumber);
@@ -26,4 +26,21 @@ export const useSelectedTags = (): Tag[] => {
     tagSelectors.getByIDs(state, tagIds)
   );
   return selectedTags;
+};
+
+/**
+ * Filter tags for those that have not been added or removed.
+ * @param tags A list of tags to filter.
+ * @returns A list of unchanged tags.
+ */
+export const useUnchangedTags = (tags: Tag[]): Tag[] => {
+  const { values } = useFormikContext<TagFormValues>();
+  // Use `find` instead of `includes` as we need to convert the stored values
+  // to numbers (Formik returns either strings or numbers depending on the
+  // render cycle).
+  return tags.filter(
+    (tag) =>
+      !values.added.find((tagId) => toFormikNumber(tagId) === tag.id) &&
+      !values.removed.find((tagId) => toFormikNumber(tagId) === tag.id)
+  );
 };

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/types.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/types.ts
@@ -1,3 +1,4 @@
 export type TagFormValues = {
-  tags: string[];
+  added: string[];
+  removed: string[];
 };


### PR DESCRIPTION
## Done

- Display removed tags in the machine list tag form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list, tick some machines with tags and open the tag form.
- Click the "Remove" button for a tag and it should become a red tag in the "To be removed" section.
Note: the tags won't actually get removed from the machine when the form is submitted (support for that will be in https://github.com/canonical-web-and-design/app-tribe/issues/682).

## Fixes

Fixes: canonical-web-and-design/app-tribe#687.

## Screenshot

<img width="755" alt="Screen Shot 2022-04-04 at 12 06 49 pm" src="https://user-images.githubusercontent.com/361637/161482827-1d2713bc-68e2-42f7-a5ad-66a954ede131.png">
