### PR TITLE
[Hardware sync] periodic sync checkbox redux & api integration

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -247,6 +247,81 @@ describe("DeployForm", () => {
     ]);
   });
 
+  it("ignores enable_hw_sync if checkbox is not checked", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm
+            clearHeaderContent={jest.fn()}
+            machines={[state.machine.items[0]]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      submitFormikForm(wrapper, {
+        includeUserData: false,
+        kernel: "",
+        oSystem: "ubuntu",
+        release: "bionic",
+        userData: "",
+        vmHostType: "",
+        enableHwSync: false,
+      })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "machine/deploy")
+        .payload.params.extra
+    ).toStrictEqual({
+      osystem: "ubuntu",
+      distro_series: "bionic",
+      hwe_kernel: "",
+    });
+  });
+
+  it("adds enable_hw_sync if checkbox is checked", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm
+            clearHeaderContent={jest.fn()}
+            machines={[state.machine.items[0]]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      submitFormikForm(wrapper, {
+        includeUserData: false,
+        kernel: "",
+        oSystem: "ubuntu",
+        release: "bionic",
+        userData: "",
+        vmHostType: "",
+        enableHwSync: true,
+      })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "machine/deploy")
+        .payload.params.extra
+    ).toStrictEqual({
+      osystem: "ubuntu",
+      distro_series: "bionic",
+      hwe_kernel: "",
+      enable_hw_sync: true,
+    });
+  });
+
   it("ignores user-data if the cloud-init option is not checked", () => {
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -14,7 +14,7 @@ import {
   osInfo as osInfoSelectors,
 } from "app/store/general/selectors";
 import { actions as machineActions } from "app/store/machine";
-import type { MachineEventErrors } from "app/store/machine/types";
+import type { DeployParams, MachineEventErrors } from "app/store/machine/types";
 import { PodType } from "app/store/pod/constants";
 import { NodeActions } from "app/store/types/node";
 
@@ -23,6 +23,7 @@ const DeploySchema = Yup.object().shape({
   release: Yup.string().required("Release is required"),
   kernel: Yup.string(),
   includeUserData: Yup.boolean(),
+  enableHwSync: Yup.boolean(),
   vmHostType: Yup.string().oneOf([PodType.LXD, PodType.VIRSH, ""]),
 });
 
@@ -33,6 +34,7 @@ export type DeployFormValues = {
   release: string;
   userData?: string;
   vmHostType: string;
+  enableHwSync: boolean;
 };
 
 type Props = MachineActionFormProps;
@@ -90,6 +92,7 @@ export const DeployForm = ({
         includeUserData: false,
         userData: "",
         vmHostType: "",
+        enableHwSync: false,
       }}
       loaded={defaultMinHweKernelLoaded && osInfoLoaded}
       modelName="machine"
@@ -103,10 +106,11 @@ export const DeployForm = ({
         dispatch(machineActions.cleanup());
         const hasUserData =
           values.includeUserData && values.userData && values.userData !== "";
-        const extra = {
+        const extra: DeployParams["extra"] = {
           osystem: values.oSystem,
           distro_series: values.release,
           hwe_kernel: values.kernel,
+          ...(values.enableHwSync && { enable_hw_sync: true }),
           ...(values.vmHostType === PodType.LXD && { register_vmhost: true }),
           ...(values.vmHostType === PodType.VIRSH && { install_kvm: true }),
           ...(hasUserData && { user_data: values.userData }),

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -231,11 +231,6 @@ describe("DeployFormFields", () => {
         screen.getByRole("checkbox", { name: /Register as MAAS KVM host/ })
       ).toBeEnabled()
     );
-    await waitFor(() =>
-      expect(
-        screen.getByRole("checkbox", { name: /Register as MAAS KVM host/ })
-      ).toBeEnabled()
-    );
   });
 
   it("enables KVM host checkbox when switching to Ubuntu 18.04 from a different OS/Release", async () => {

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -427,4 +427,29 @@ describe("DeployFormFields", () => {
     // Previous kernel selection should be cleared.
     expect(wrapper.find("Select[name='kernel']").prop("value")).toBe("");
   });
+
+  it("displays 'periodically sync hardware' checkbox", async () => {
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm
+            clearHeaderContent={jest.fn()}
+            machines={[]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("FormikField[name='enable_hw_sync']").exists()).toBe(
+      true
+    );
+  });
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -428,7 +428,7 @@ describe("DeployFormFields", () => {
     expect(wrapper.find("Select[name='kernel']").prop("value")).toBe("");
   });
 
-  it("displays 'periodically sync hardware' checkbox", async () => {
+  it("displays the global setting for hardware sync interval", async () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -449,4 +449,6 @@ describe("DeployFormFields", () => {
       true
     );
   });
+
+  it("adds an additional enable_hw_sync field in the request on submit", () => {});
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -429,9 +429,6 @@ describe("DeployFormFields", () => {
   });
 
   it("displays 'periodically sync hardware' checkbox", async () => {
-    if (state.general.osInfo.data) {
-      state.general.osInfo.data.default_release = "bionic";
-    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -54,6 +54,9 @@ export const DeployFormFields = (): JSX.Element => {
     setDeployVmHost(false);
     setFieldValue("vmHostType", "");
   };
+  const hardwareSyncInterval = useSelector(
+    configSelectors.hardwareSyncInterval
+  );
 
   return (
     <>
@@ -228,15 +231,13 @@ export const DeployFormFields = (): JSX.Element => {
                 </>
               }
             />
-            {/* TODO: use real sync interval
-                https://github.com/canonical-web-and-design/app-tribe/issues/780 */}
             <p
               id={enableHwSyncHelpText}
               className="p-form-help-text"
               style={{ paddingLeft: "2rem" }}
             >
-              Hardware sync interval: 6 hours - Admins can change this in the
-              global settings.
+              Hardware sync interval: {hardwareSyncInterval} - Admins can change
+              this in the global settings.
             </p>
             {userDataVisible && (
               <UploadTextArea

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -211,7 +211,7 @@ export const DeployFormFields = (): JSX.Element => {
                     </Button>
                   </Tooltip>
                   {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
-                  <a href="#">Hardware sync docs</a>
+                  <a href="#todo">Hardware sync docs</a>
                 </>
               }
               help="Hardware sync interval: 6 hours - Admins can change this in the global settings."

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -202,9 +202,8 @@ export const DeployFormFields = (): JSX.Element => {
               })}
             />
             <FormikField
-              disabled
               type="checkbox"
-              name="enable_hw_sync"
+              name="enableHwSync"
               // TODO: use an Input help text prop instead once the bug below is resolved
               // https://github.com/canonical-web-and-design/react-components/issues/748
               aria-describedby={enableHwSyncHelpText}

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -10,6 +10,7 @@ import {
   Row,
   Select,
   Tooltip,
+  useId,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
@@ -34,6 +35,8 @@ export const DeployFormFields = (): JSX.Element => {
   const [userDataVisible, setUserDataVisible] = useState(false);
   const formikProps = useFormikContext<DeployFormValues>();
   const { handleChange, setFieldValue, values } = formikProps;
+  const deployVmHostHelpText = useId();
+  const enableHwSyncHelpText = useId();
 
   const user = useSelector(authSelectors.get);
   const osOptions = useSelector(configSelectors.defaultOSystemOptions);
@@ -126,6 +129,9 @@ export const DeployFormFields = (): JSX.Element => {
           </Col>
           <Col size={9}>
             <Input
+              // TODO: use an Input help text prop instead once the bug below is resolved
+              // https://github.com/canonical-web-and-design/react-components/issues/748
+              aria-describedby={deployVmHostHelpText}
               checked={deployVmHost}
               disabled={!canBeKVMHost || noImages}
               id="deployVmHost"
@@ -146,7 +152,11 @@ export const DeployFormFields = (): JSX.Element => {
               }}
               type="checkbox"
             />
-            <p className="p-form-help-text" style={{ paddingLeft: "2rem" }}>
+            <p
+              id={deployVmHostHelpText}
+              className="p-form-help-text"
+              style={{ paddingLeft: "2rem" }}
+            >
               Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially
               supported.
             </p>
@@ -192,6 +202,9 @@ export const DeployFormFields = (): JSX.Element => {
               disabled
               type="checkbox"
               name="enable_hw_sync"
+              // TODO: use an Input help text prop instead once the bug below is resolved
+              // https://github.com/canonical-web-and-design/react-components/issues/748
+              aria-describedby={enableHwSyncHelpText}
               label={
                 <>
                   Periodically sync hardware{" "}
@@ -205,18 +218,26 @@ export const DeployFormFields = (): JSX.Element => {
                       type="button"
                       appearance="base"
                       aria-label="more about periodically sync hardware"
-                      className="u-no-margin--bottom"
+                      className="u-no-margin--bottom u-no-padding"
                     >
                       <Icon name="information" />
                     </Button>
                   </Tooltip>
-                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
+                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}{" "}
                   <a href="#todo">Hardware sync docs</a>
                 </>
               }
-              // TODO: use real sync interval https://github.com/canonical-web-and-design/app-tribe/issues/780
-              help="Hardware sync interval: 6 hours - Admins can change this in the global settings."
             />
+            {/* TODO: use real sync interval
+                https://github.com/canonical-web-and-design/app-tribe/issues/780 */}
+            <p
+              id={enableHwSyncHelpText}
+              className="p-form-help-text"
+              style={{ paddingLeft: "2rem" }}
+            >
+              Hardware sync interval: 6 hours - Admins can change this in the
+              global settings.
+            </p>
             {userDataVisible && (
               <UploadTextArea
                 label="Upload script"

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -157,8 +157,7 @@ export const DeployFormFields = (): JSX.Element => {
             />
             <p
               id={deployVmHostHelpText}
-              className="p-form-help-text"
-              style={{ paddingLeft: "2rem" }}
+              className="p-form-help-text is-tick-element"
             >
               Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially
               supported.
@@ -232,8 +231,7 @@ export const DeployFormFields = (): JSX.Element => {
             />
             <p
               id={enableHwSyncHelpText}
-              className="p-form-help-text"
-              style={{ paddingLeft: "2rem" }}
+              className="p-form-help-text is-tick-element"
             >
               Hardware sync interval: {hardwareSyncInterval} - Admins can change
               this in the global settings.

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -214,6 +214,7 @@ export const DeployFormFields = (): JSX.Element => {
                   <a href="#todo">Hardware sync docs</a>
                 </>
               }
+              // TODO: use real sync interval https://github.com/canonical-web-and-design/app-tribe/issues/780
               help="Hardware sync interval: 6 hours - Admins can change this in the global settings."
             />
             {userDataVisible && (

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -2,11 +2,14 @@ import { useState } from "react";
 import * as React from "react";
 
 import {
+  Button,
   Col,
+  Icon,
   Input,
   Notification,
   Row,
   Select,
+  Tooltip,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
@@ -24,6 +27,7 @@ import configSelectors from "app/store/config/selectors";
 import { osInfo as osInfoSelectors } from "app/store/general/selectors";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
+import { breakLines } from "app/utils";
 
 export const DeployFormFields = (): JSX.Element => {
   const [deployVmHost, setDeployVmHost] = useState(false);
@@ -183,6 +187,34 @@ export const DeployFormFields = (): JSX.Element => {
               wrapperClassName={classNames({
                 "u-sv2": userDataVisible,
               })}
+            />
+            <FormikField
+              disabled
+              type="checkbox"
+              name="enable_hw_sync"
+              label={
+                <>
+                  Periodically sync hardware{" "}
+                  <Tooltip
+                    positionElementClassName="u-display-inline-important"
+                    message={breakLines(
+                      "Enable this to make MAAS periodically check the hardware configuration of this machine and reflect any possible change after the deployment."
+                    )}
+                  >
+                    <Button
+                      type="button"
+                      appearance="base"
+                      aria-label="more about periodically sync hardware"
+                      className="u-no-margin--bottom"
+                    >
+                      <Icon name="information" />
+                    </Button>
+                  </Tooltip>
+                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
+                  <a href="#">Hardware sync docs</a>
+                </>
+              }
+              help="Hardware sync interval: 6 hours - Admins can change this in the global settings."
             />
             {userDataVisible && (
               <UploadTextArea

--- a/ui/src/app/store/machine/types/actions.ts
+++ b/ui/src/app/store/machine/types/actions.ts
@@ -228,6 +228,7 @@ export type DeployParams = {
     register_vmhost?: boolean;
     install_kvm?: boolean;
     user_data?: string;
+    enable_hw_sync?: boolean;
   };
 };
 


### PR DESCRIPTION
## Done

- periodic sync checkbox redux & api integration
- refactor DeployFormFields.test.tsx to testing-library

Review https://github.com/canonical-web-and-design/maas-ui/pull/3745 first

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to any machine that can be deployed, e.g. on bolla: `/MAAS/r/machine/7c7ya3/summary`
- verify that the checkbox is displayed properly and if checked `enable_hw_sync` is set to true

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/780
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3758

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
