### PR TITLE
fix: default value for subnets search query

### DIFF
--- a/ui/src/app/subnets/urls.ts
+++ b/ui/src/app/subnets/urls.ts
@@ -7,9 +7,11 @@ import { argPath, isId } from "app/utils";
 
 const urls = {
   index: "/networks",
-  indexWithParams: (
-    { by, q }: SubnetsUrlParams = { by: "fabric", q: "" }
-  ): string => `/networks?by=${by}&q=${q}`,
+  indexWithParams: (options: SubnetsUrlParams): string => {
+    const defaults = { by: "fabric", q: "" };
+    const { by, q } = { ...defaults, ...options };
+    return `/networks?by=${by}&q=${q}`;
+  },
   fabric: {
     index: argPath<{ id: Fabric[FabricMeta.PK] }>("/fabric/:id"),
   },


### PR DESCRIPTION
## Done

- fix: default value for subnets search query
  - search query value on after deleting a fabric would read `q=undefined` prior to this change

## Before
![image](https://user-images.githubusercontent.com/7452681/161586538-8d51df21-f5d8-4a21-99ce-d65709d5fbd5.png)

## After
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/7452681/161586685-f3f8e9b4-2c19-4919-a61f-7e84ed27fcfa.png">


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3723

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
