### PR TITLE
feat(ui): add support for untag machine action

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -84,7 +84,8 @@ const getLabel = (
     case NodeActions.SET_ZONE:
       return `${processing ? "Setting" : "Set"} zone for ${modelString}`;
     case NodeActions.TAG:
-      return `${processing ? "Tagging" : "Tag"} ${modelString}`;
+    case NodeActions.UNTAG:
+      return `${processing ? "Updating" : "Update"} tags for ${modelString}`;
     case NodeActions.TEST:
       return `${processing ? "Starting" : "Start"} tests for ${modelString}`;
     case NodeActions.UNLOCK:

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -1,4 +1,5 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -8,41 +9,84 @@ import ActionFormWrapper from "./ActionFormWrapper";
 import { actions as machineActions } from "app/store/machine";
 import { NodeActions } from "app/store/types/node";
 import {
+  machineEventError as machineEventErrorFactory,
   machine as machineFactory,
+  machineState as machineStateFactory,
   rootState as rootStateFactory,
+  tagState as tagStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
-describe("ActionFormWrapper", () => {
-  it("can set selected machines to those that can perform action", () => {
-    const state = rootStateFactory();
-    const machines = [
-      machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
-      machineFactory({ system_id: "def456", actions: [] }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <ActionFormWrapper
-            action={NodeActions.ABORT}
-            clearHeaderContent={jest.fn()}
-            machines={machines}
-            viewingDetails={false}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
+it("can set selected machines to those that can perform action", () => {
+  const state = rootStateFactory();
+  const machines = [
+    machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
+    machineFactory({ system_id: "def456", actions: [] }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <ActionFormWrapper
+          action={NodeActions.ABORT}
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          viewingDetails={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
 
-    wrapper.find('button[data-testid="on-update-selected"]').simulate("click");
+  userEvent.click(
+    screen.getByRole("button", { name: /update your selection/ })
+  );
 
-    const expectedAction = machineActions.setSelected(["abc123"]);
-    const actualActions = store.getActions();
-    expect(
-      actualActions.find((action) => action.type === expectedAction.type)
-    ).toStrictEqual(expectedAction);
+  const expectedAction = machineActions.setSelected(["abc123"]);
+  const actualActions = store.getActions();
+  expect(
+    actualActions.find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});
+
+it("can show untag errors when the tag form is open", async () => {
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      eventErrors: [
+        machineEventErrorFactory({
+          id: "abc123",
+          error: "Untagging failed",
+          event: NodeActions.UNTAG,
+        }),
+      ],
+    }),
+    tag: tagStateFactory({
+      loaded: true,
+    }),
   });
+  const machines = [
+    machineFactory({
+      system_id: "abc123",
+      actions: [NodeActions.TAG, NodeActions.UNTAG],
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <ActionFormWrapper
+          action={NodeActions.TAG}
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          viewingDetails={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText("Untagging failed")).toBeInTheDocument();
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -1,116 +1,174 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagForm from "./TagForm";
+import { Label as TagFormChangesLabel } from "./TagFormChanges";
+import { Label as TagFormFieldsLabel } from "./TagFormFields";
 
+import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
-import { NodeActions } from "app/store/types/node";
 import {
   machine as machineFactory,
   rootState as rootStateFactory,
+  tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
 
 const mockStore = configureStore();
 
-describe("TagForm", () => {
-  let state: RootState;
-
-  beforeEach(() => {
-    state = rootStateFactory({
-      tag: tagStateFactory({
-        loaded: true,
-      }),
-    });
+let state: RootState;
+beforeEach(() => {
+  state = rootStateFactory({
+    tag: tagStateFactory({
+      items: [
+        tagFactory({ id: 1, name: "tag1" }),
+        tagFactory({ id: 2, name: "tag2" }),
+      ],
+      loaded: true,
+    }),
   });
+});
 
-  it("dispatches action to fetch tags on load", () => {
-    const store = mockStore(state);
-    mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <TagForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
+it("dispatches action to fetch tags on load", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <TagForm
+          clearHeaderContent={jest.fn()}
+          machines={[]}
+          processingCount={0}
+          viewingDetails={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
 
-    expect(
-      store.getActions().some((action) => action.type === "tag/fetch")
-    ).toBe(true);
-  });
+  expect(store.getActions().some((action) => action.type === "tag/fetch")).toBe(
+    true
+  );
+});
 
-  it("correctly dispatches actions to tag machines", () => {
-    const machines = [
-      machineFactory({ system_id: "abc123" }),
-      machineFactory({ system_id: "def456" }),
+it("correctly dispatches actions to tag machines", async () => {
+  const machines = [
+    machineFactory({ system_id: "abc123", tags: [] }),
+    machineFactory({ system_id: "def456", tags: [] }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <TagForm
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          processingCount={0}
+          viewingDetails={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  userEvent.click(screen.getByLabelText(TagFormFieldsLabel.TagInput));
+  userEvent.click(screen.getByRole("option", { name: "tag1" }));
+  userEvent.click(screen.getByRole("option", { name: "tag2" }));
+  userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+  await waitFor(() => {
+    const expectedActions = [
+      machineActions.tag({ systemId: "abc123", tags: [1, 2] }),
+      machineActions.tag({ systemId: "def456", tags: [1, 2] }),
     ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <TagForm
-            clearHeaderContent={jest.fn()}
-            machines={machines}
-            processingCount={0}
-            viewingDetails={false}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
+    const actualActions = store
+      .getActions()
+      .filter((action) => action.type === expectedActions[0].type);
+    expect(actualActions).toStrictEqual(expectedActions);
+  });
+});
 
-    act(() =>
-      submitFormikForm(wrapper, {
-        added: ["tag1", "tag2"],
-      })
-    );
-    expect(
-      store.getActions().filter((action) => action.type === "machine/tag")
-    ).toStrictEqual([
-      {
-        type: "machine/tag",
-        meta: {
-          model: "machine",
-          method: "action",
-        },
-        payload: {
-          params: {
-            action: NodeActions.TAG,
-            extra: {
-              tags: ["tag1", "tag2"],
-            },
-            system_id: "abc123",
-          },
-        },
-      },
-      {
-        type: "machine/tag",
-        meta: {
-          model: "machine",
-          method: "action",
-        },
-        payload: {
-          params: {
-            action: NodeActions.TAG,
-            extra: {
-              tags: ["tag1", "tag2"],
-            },
-            system_id: "def456",
-          },
-        },
-      },
-    ]);
+it("correctly dispatches actions to untag machines", async () => {
+  const machines = [
+    machineFactory({ system_id: "abc123", tags: [1, 2] }),
+    machineFactory({ system_id: "def456", tags: [1, 2] }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <TagForm
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          processingCount={0}
+          viewingDetails={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const deleteButtons = screen.getAllByRole("button", {
+    name: TagFormChangesLabel.Remove,
+  });
+  userEvent.click(deleteButtons[0]);
+  userEvent.click(deleteButtons[1]);
+  userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+  await waitFor(() => {
+    const expectedActions = [
+      machineActions.untag({ systemId: "abc123", tags: [1, 2] }),
+      machineActions.untag({ systemId: "def456", tags: [1, 2] }),
+    ];
+    const actualActions = store
+      .getActions()
+      .filter((action) => action.type === expectedActions[0].type);
+    expect(actualActions).toStrictEqual(expectedActions);
+  });
+});
+
+it("correctly dispatches actions to tag and untag a machine", async () => {
+  const machines = [machineFactory({ system_id: "abc123", tags: [1] })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <TagForm
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          processingCount={0}
+          viewingDetails={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  userEvent.click(screen.getByLabelText(TagFormFieldsLabel.TagInput));
+  userEvent.click(screen.getByRole("option", { name: "tag2" }));
+  userEvent.click(
+    screen.getByRole("button", { name: TagFormChangesLabel.Remove })
+  );
+  userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+  await waitFor(() => {
+    const expectedActions = [
+      machineActions.tag({ systemId: "abc123", tags: [2] }),
+      machineActions.untag({ systemId: "abc123", tags: [1] }),
+    ];
+    const actualActions = store
+      .getActions()
+      .filter(
+        (action) =>
+          action.type === expectedActions[0].type ||
+          action.type === expectedActions[1].type
+      );
+    expect(actualActions).toStrictEqual(expectedActions);
   });
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -9,6 +9,7 @@ import type { TagFormValues } from "./types";
 import ActionForm from "app/base/components/ActionForm";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
+import type { MachineEventErrors } from "app/store/machine/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import { NodeActions } from "app/store/types/node";
@@ -44,10 +45,10 @@ export const TagForm = ({
   }, [dispatch]);
 
   return (
-    <ActionForm<TagFormValues>
+    <ActionForm<TagFormValues, MachineEventErrors>
       actionName={NodeActions.TAG}
       cleanup={machineActions.cleanup}
-      errors={formErrors}
+      errors={formErrors || errors}
       initialValues={{
         added: [],
         removed: [],
@@ -67,7 +68,17 @@ export const TagForm = ({
             dispatch(
               machineActions.tag({
                 systemId: machine.system_id,
-                tags: values.added,
+                tags: values.added.map((id) => Number(id)),
+              })
+            );
+          });
+        }
+        if (values.removed.length) {
+          machines.forEach((machine) => {
+            dispatch(
+              machineActions.untag({
+                systemId: machine.system_id,
+                tags: values.removed.map((id) => Number(id)),
               })
             );
           });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/index.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TagFormChanges";
+export { default, Label } from "./TagFormChanges";

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/index.ts
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TagFormFields";
+export { default, Label } from "./TagFormFields";

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -1,5 +1,6 @@
 import { actions } from "./slice";
 
+import { PowerTypeNames } from "app/store/general/constants";
 import {
   BondLacpRate,
   BondMode,
@@ -65,6 +66,8 @@ describe("machine actions", () => {
         hostname: "machine1",
         description: "a machine",
         extra_macs: [],
+        power_parameters: {},
+        power_type: PowerTypeNames.MANUAL,
         pxe_mac: "",
       })
     ).toEqual({
@@ -78,6 +81,8 @@ describe("machine actions", () => {
           hostname: "machine1",
           description: "a machine",
           extra_macs: [],
+          power_parameters: {},
+          power_type: PowerTypeNames.MANUAL,
           pxe_mac: "",
         },
       },
@@ -561,22 +566,37 @@ describe("machine actions", () => {
   });
 
   it("can handle tagging a machine", () => {
-    expect(actions.tag({ systemId: "abc123", tags: ["tag1", "tag2"] })).toEqual(
-      {
-        type: "machine/tag",
-        meta: {
-          model: "machine",
-          method: "action",
+    expect(actions.tag({ systemId: "abc123", tags: [1, 2] })).toEqual({
+      type: "machine/tag",
+      meta: {
+        model: "machine",
+        method: "action",
+      },
+      payload: {
+        params: {
+          action: NodeActions.TAG,
+          extra: { tags: [1, 2] },
+          system_id: "abc123",
         },
-        payload: {
-          params: {
-            action: NodeActions.TAG,
-            extra: { tags: ["tag1", "tag2"] },
-            system_id: "abc123",
-          },
+      },
+    });
+  });
+
+  it("can handle untagging a machine", () => {
+    expect(actions.untag({ systemId: "abc123", tags: [1, 2] })).toEqual({
+      type: "machine/untag",
+      meta: {
+        model: "machine",
+        method: "action",
+      },
+      payload: {
+        params: {
+          action: NodeActions.UNTAG,
+          extra: { tags: [1, 2] },
+          system_id: "abc123",
         },
-      }
-    );
+      },
+    });
   });
 
   it("can handle cloning a machine", () => {

--- a/ui/src/app/store/machine/reducers.test.ts
+++ b/ui/src/app/store/machine/reducers.test.ts
@@ -611,4 +611,93 @@ describe("machine reducer", () => {
       );
     });
   });
+
+  describe("untag", () => {
+    it("reduces untagStart", () => {
+      const machine = machineFactory({ system_id: "abc123" });
+      const initialState = machineStateFactory({
+        items: [machine],
+        statuses: { abc123: machineStatusFactory({ untagging: false }) },
+      });
+
+      expect(
+        reducers(
+          initialState,
+          actions.untagStart({
+            item: machine,
+          })
+        )
+      ).toEqual(
+        machineStateFactory({
+          items: [machine],
+          statuses: {
+            abc123: machineStatusFactory({
+              untagging: true,
+            }),
+          },
+        })
+      );
+    });
+
+    it("reduces untagSuccess", () => {
+      const machine = machineFactory({ system_id: "abc123" });
+      const initialState = machineStateFactory({
+        items: [machine],
+        statuses: { abc123: machineStatusFactory({ untagging: true }) },
+      });
+
+      expect(
+        reducers(
+          initialState,
+          actions.untagSuccess({
+            item: machine,
+          })
+        )
+      ).toEqual(
+        machineStateFactory({
+          items: [machine],
+          statuses: {
+            abc123: machineStatusFactory({
+              untagging: false,
+            }),
+          },
+        })
+      );
+    });
+
+    it("reduces untagError", () => {
+      const machine = machineFactory({ system_id: "abc123" });
+      const initialState = machineStateFactory({
+        items: [machine],
+        statuses: { abc123: machineStatusFactory({ untagging: true }) },
+      });
+
+      expect(
+        reducers(
+          initialState,
+          actions.untagError({
+            item: machine,
+            payload: "Untagging failed.",
+          })
+        )
+      ).toEqual(
+        machineStateFactory({
+          errors: "Untagging failed.",
+          eventErrors: [
+            machineEventErrorFactory({
+              error: "Untagging failed.",
+              event: NodeActions.UNTAG,
+              id: "abc123",
+            }),
+          ],
+          items: [machine],
+          statuses: {
+            abc123: machineStatusFactory({
+              untagging: false,
+            }),
+          },
+        })
+      );
+    });
+  });
 });

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -81,6 +81,20 @@ ACTIONS.forEach(({ status }) => {
 });
 
 /**
+ * Get the machines that are either tagging or untagging.
+ * @param state - The redux state.
+ * @returns Machines that are either tagging or untagging.
+ */
+const updatingTags = createSelector(
+  [defaultSelectors.all, statuses],
+  (machines: Machine[], statuses: MachineStatuses) =>
+    machines.filter(
+      ({ system_id }) =>
+        statuses[system_id]?.["tagging"] || statuses[system_id]?.["untagging"]
+    )
+);
+
+/**
  * Get the statuses for a machine.
  * @param state - The redux state.
  * @param id - A machine's system id.
@@ -202,7 +216,7 @@ const eventErrorsForIds = createSelector(
     (
       _state: RootState,
       ids: Machine[MachineMeta.PK] | Machine[MachineMeta.PK][],
-      event?: string | null
+      event?: string[] | string | null
     ) => ({
       ids,
       event,
@@ -220,7 +234,9 @@ const eventErrorsForIds = createSelector(
       // If an event has been provided as `null` then filter for errors with
       // a null event.
       if (event || event === null) {
-        match = matchesId && error.event === event;
+        const eventArray = Array.isArray(event) ? event : [event];
+        const matchesEvent = eventArray.some((e) => error.event === e);
+        match = matchesId && matchesEvent;
       } else {
         match = matchesId;
       }
@@ -341,7 +357,9 @@ const selectors = {
   turningOn: statusSelectors["turningOn"],
   unlocking: statusSelectors["unlocking"],
   unlinkingSubnet: statusSelectors["unlinkingSubnet"],
+  untagging: statusSelectors["untagging"],
   unselected,
+  updatingTags,
 };
 
 export default selectors;

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -41,6 +41,7 @@ import type {
   TestParams,
   UnlinkSubnetParams,
   UnmountSpecialParams,
+  UntagParams,
   UpdateDiskParams,
   UpdateFilesystemParams,
   UpdateParams,
@@ -245,6 +246,10 @@ export const ACTIONS: Action[] = [
     status: "unmountingSpecial",
   },
   {
+    name: NodeActions.UNTAG,
+    status: "untagging",
+  },
+  {
     name: "update-disk",
     status: "updatingDisk",
   },
@@ -309,6 +314,7 @@ export const DEFAULT_STATUSES = {
   unlocking: false,
   unlinkingSubnet: false,
   unmountingSpecial: false,
+  untagging: false,
   updatingDisk: false,
   updatingFilesystem: false,
   updatingInterface: false,
@@ -1561,6 +1567,27 @@ const machineSlice = createSlice({
         // No state changes need to be handled for this action.
       },
     },
+    [NodeActions.UNTAG]: {
+      prepare: (params: UntagParams) => ({
+        meta: {
+          model: MachineMeta.MODEL,
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: NodeActions.UNTAG,
+            extra: { tags: params.tags },
+            system_id: params.systemId,
+          },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    untagError: statusHandlers.untag.error,
+    untagStart: statusHandlers.untag.start,
+    untagSuccess: statusHandlers.untag.success,
     updateDisk: {
       prepare: (params: UpdateDiskParams) => ({
         meta: {

--- a/ui/src/app/store/machine/types/actions.ts
+++ b/ui/src/app/store/machine/types/actions.ts
@@ -6,6 +6,7 @@ import type { LicenseKeys } from "app/store/licensekeys/types";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import type { Script } from "app/store/script/types";
 import type { Subnet } from "app/store/subnet/types";
+import type { Tag, TagMeta } from "app/store/tag/types";
 import type {
   DiskTypes,
   NetworkLinkMode,
@@ -298,7 +299,7 @@ export type SetZoneParams = {
 
 export type TagParams = {
   systemId: Machine[MachineMeta.PK];
-  tags: string[];
+  tags: Tag[TagMeta.PK][];
 };
 
 export type TestParams = {
@@ -317,6 +318,11 @@ export type UnlinkSubnetParams = {
 export type UnmountSpecialParams = {
   mountPoint: string;
   systemId: Machine[MachineMeta.PK];
+};
+
+export type UntagParams = {
+  systemId: Machine[MachineMeta.PK];
+  tags: Tag[TagMeta.PK][];
 };
 
 export type UpdateDiskParams = {

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -166,6 +166,7 @@ export type MachineStatus = {
   unlocking: boolean;
   unlinkingSubnet: boolean;
   unmountingSpecial: boolean;
+  untagging: boolean;
   updatingDisk: boolean;
   updatingFilesystem: boolean;
   updatingInterface: boolean;

--- a/ui/src/app/store/machine/types/index.ts
+++ b/ui/src/app/store/machine/types/index.ts
@@ -35,6 +35,7 @@ export type {
   TestParams,
   UnlinkSubnetParams,
   UnmountSpecialParams,
+  UntagParams,
   UpdateDiskParams,
   UpdateFilesystemParams,
   UpdateParams,

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -149,6 +149,7 @@ export enum NodeActions {
   TAG = "tag",
   TEST = "test",
   UNLOCK = "unlock",
+  UNTAG = "untag",
 }
 
 export enum TestStatusStatus {


### PR DESCRIPTION
## Done

- Add support for "untag" machine action
- Handle untagging machines when submitting tag form
- Migrate a couple of tests to RTL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, select a few machines and select "Tag" from the action menu
- Add and remove some tags then submit the form
- Check that the form closes automatically
- Keep the same machines selected and reopen the "Tag" form
- The "Currently assigned" tags should match what was added/removed in the previous form submissions

## Fixes

Fixes canonical-web-and-design/app-tribe#682
Fixes canonical-web-and-design/app-tribe#691

## Screenshot

![Peek 2022-04-05 13-55](https://user-images.githubusercontent.com/25733845/161675918-cff07e75-8da6-4efd-b7e5-06997f1d2cd2.gif)

