### PR TITLE
use standard link variant in hardware sync tooltip

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -109,11 +109,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
                     This machine hardware info is synced every{" "}
                     {formatSyncInterval(machine.sync_interval)}.{"\n"}
                     You can check it at the bottom, in the status bar.{"\n"}More
-                    about this in the{" "}
-                    <a className="p-link--inverted" href="#todo">
-                      Hardware sync docs
-                    </a>
-                    .
+                    about this in the <a href="#todo">Hardware sync docs</a>.
                   </>
                 }
               >

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -109,7 +109,11 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
                     This machine hardware info is synced every{" "}
                     {formatSyncInterval(machine.sync_interval)}.{"\n"}
                     You can check it at the bottom, in the status bar.{"\n"}More
-                    about this in the <a href="#todo">Hardware sync docs</a>.
+                    about this in the{" "}
+                    <a href="#todo" className="is-on-dark">
+                      Hardware sync docs
+                    </a>
+                    .
                   </>
                 }
               >

--- a/ui/src/scss/_patterns_links.scss
+++ b/ui/src/scss/_patterns_links.scss
@@ -15,4 +15,9 @@
     background-color: $color-x-light;
     padding: $sph--large;
   }
+
+  // TODO: remove once https://github.com/canonical-web-and-design/vanilla-framework/issues/4368 is released
+  a.is-on-dark {
+     color: #3097FF;
+  }
 }


### PR DESCRIPTION
## Done

- use a standard (blue) link variant in hardware sync tooltip
  - source: https://chat.canonical.com/canonical/pl/bk669n8wwfywudgtbmr11xtgph

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/161706188-1896356b-cd6a-44a8-a22f-7d970d4396f8.png)

### After
![image](https://user-images.githubusercontent.com/7452681/161920173-8d1b7b6e-ea4e-40b9-b608-dbfae731ba63.png)



## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/799

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
