### PR TITLE
feat(ui): machine list tag notification

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { NotificationSeverity } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -10,11 +11,16 @@ import ActionForm from "app/base/components/ActionForm";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import type { MachineEventErrors } from "app/store/machine/types";
+import { actions as messageActions } from "app/store/message";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import { NodeActions } from "app/store/types/node";
 
 type Props = MachineActionFormProps;
+
+export enum Label {
+  Saved = "Saved all tag changes.",
+}
 
 const TagFormSchema = Yup.object().shape({
   added: Yup.array().of(Yup.string()),
@@ -84,7 +90,12 @@ export const TagForm = ({
           });
         }
       }}
-      onSuccess={clearHeaderContent}
+      onSuccess={() => {
+        clearHeaderContent();
+        dispatch(
+          messageActions.add(Label.Saved, NotificationSeverity.POSITIVE)
+        );
+      }}
       processingCount={processingCount}
       submitLabel="Save"
       selectedCount={machines.length}


### PR DESCRIPTION
## Done

- Display a notification when tag changes have been saved in the machine list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and tick some machines and open the tag form.
- Add or remove some tags and submit.
- When the tag form closes you should see a success notification.

## Fixes

Fixes: canonical-web-and-design/app-tribe#693

## Screenshot

<img width="1462" alt="Screen Shot 2022-04-06 at 11 13 02 am" src="https://user-images.githubusercontent.com/361637/161876120-cd7e64ab-def0-4bc3-86aa-3813886d3682.png">
