### PR TITLE
feat(ui): show tag action form in machine config page

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -126,4 +126,25 @@ describe("ActionForm", () => {
       "Processing 0 of 2 machines..."
     );
   });
+
+  it("can override showing the processing count", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActionForm
+          actionName="action"
+          initialValues={{}}
+          modelName="machine"
+          onSubmit={jest.fn()}
+          processingCount={1}
+          selectedCount={2}
+          showProcessingCount={false}
+        />
+      </Provider>
+    );
+    submitFormikForm(wrapper);
+    wrapper.update();
+
+    expect(wrapper.find("[data-testid='saving-label']").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -104,6 +104,7 @@ export type Props<V, E = null> = Omit<
   modelName: string;
   processingCount: number;
   selectedCount: number;
+  showProcessingCount?: boolean;
   submitLabel?: string;
 };
 
@@ -117,6 +118,7 @@ const ActionForm = <V, E = null>({
   onSubmit,
   processingCount,
   selectedCount,
+  showProcessingCount = true,
   submitLabel,
   ...formikFormProps
 }: Props<V, E>): JSX.Element | null => {
@@ -148,12 +150,16 @@ const ActionForm = <V, E = null>({
       }}
       saved={processingComplete}
       saving={processingCount > 0}
-      savingLabel={`${getLabel(
-        modelName,
-        actionName,
-        selectedOnSubmit,
-        processingCount
-      )}...`}
+      savingLabel={
+        showProcessingCount
+          ? `${getLabel(
+              modelName,
+              actionName,
+              selectedOnSubmit,
+              processingCount
+            )}...`
+          : null
+      }
       submitLabel={
         submitLabel ?? getLabel(modelName, actionName, selectedCount)
       }

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -181,6 +181,56 @@ it("correctly dispatches actions to tag and untag a machine", async () => {
   });
 });
 
+it("shows saving label if not viewing from machine config page", () => {
+  const machines = [
+    machineFactory({ system_id: "abc123", tags: [] }),
+    machineFactory({ system_id: "def456", tags: [] }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <TagForm
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          processingCount={1}
+          viewingDetails={false}
+          viewingMachineConfig={false}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByTestId("saving-label")).toBeInTheDocument();
+});
+
+it("does not show saving label if viewing from machine config page", () => {
+  const machines = [
+    machineFactory({ system_id: "abc123", tags: [] }),
+    machineFactory({ system_id: "def456", tags: [] }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <TagForm
+          clearHeaderContent={jest.fn()}
+          machines={machines}
+          processingCount={1}
+          viewingDetails
+          viewingMachineConfig
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.queryByTestId("saving-label")).not.toBeInTheDocument();
+});
+
 it("shows a notification on success", async () => {
   const machines = [machineFactory({ system_id: "abc123", tags: [1] })];
   const store = mockStore(state);

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -16,7 +16,7 @@ import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import { NodeActions } from "app/store/types/node";
 
-type Props = MachineActionFormProps;
+type Props = MachineActionFormProps & { viewingMachineConfig?: boolean };
 
 export enum Label {
   Saved = "Saved all tag changes.",
@@ -33,6 +33,7 @@ export const TagForm = ({
   machines,
   processingCount,
   viewingDetails,
+  viewingMachineConfig = false,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const tagsLoaded = useSelector(tagSelectors.loaded);
@@ -97,11 +98,15 @@ export const TagForm = ({
         );
       }}
       processingCount={processingCount}
+      showProcessingCount={!viewingMachineConfig}
       submitLabel="Save"
       selectedCount={machines.length}
       validationSchema={TagFormSchema}
     >
-      <TagFormFields machines={machines} />
+      <TagFormFields
+        machines={machines}
+        viewingMachineConfig={viewingMachineConfig}
+      />
     </ActionForm>
   );
 };

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -23,6 +23,7 @@ const hasKernelOptions = (tags: Tag[], tag: TagSelectorTag) =>
 
 type Props = {
   machines: Machine[];
+  viewingMachineConfig?: boolean;
 };
 
 export enum Label {
@@ -36,7 +37,10 @@ export enum Label {
 // https://github.com/alex-cory/react-useportal/issues/36
 const NULL_EVENT = { currentTarget: { contains: () => false } };
 
-export const TagFormFields = ({ machines }: Props): JSX.Element => {
+export const TagFormFields = ({
+  machines,
+  viewingMachineConfig = false,
+}: Props): JSX.Element => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const [newTagName, setNewTagName] = useState<string | null>(null);
   const { setFieldValue, values } = useFormikContext<TagFormValues>();
@@ -52,7 +56,7 @@ export const TagFormFields = ({ machines }: Props): JSX.Element => {
   return (
     <>
       <Row>
-        <Col size={6} className="col-start-large-4">
+        <Col emptyLarge={viewingMachineConfig ? undefined : 4} size={6}>
           <TagField
             externalSelectedTags={selectedTags}
             generateDropdownEntry={(

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import TagForm from "./TagForm";
 
+import { Label as TagFormFieldsLabel } from "app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields";
 import machineURLs from "app/machines/urls";
 import { FilterMachines } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
@@ -43,6 +44,7 @@ describe("TagForm", () => {
           tagFactory({ id: 1, name: "tag-1" }),
           tagFactory({ id: 2, name: "tag-2" }),
         ],
+        loaded: true,
       }),
     });
   });
@@ -103,7 +105,9 @@ describe("TagForm", () => {
 
     userEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
 
-    expect(screen.getByLabelText("tag-form")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(TagFormFieldsLabel.TagInput)
+    ).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done

- Surface the tag action form in the machine configuration page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Configuration page of a machine
- Click "Edit" in the Tags section
- Add and remove some tags and submit the form
- Check that the form closes and the tags are updated successfully

## Fixes

Fixes canonical-web-and-design/app-tribe#710
Fixes canonical-web-and-design/app-tribe#743

## Screenshot
