### PR TITLE
feat(legacy): create tags in the controller config form

### DIFF
--- a/legacy/src/app/factories/tags.js
+++ b/legacy/src/app/factories/tags.js
@@ -25,6 +25,11 @@ function TagsManager(RegionConnection, Manager) {
 
   TagsManager.prototype = new Manager();
 
+  // Create a tag.
+  TagsManager.prototype.create = function (tagName) {
+    return RegionConnection.callMethod("tag.create", { name: tagName });
+  };
+
   // Helper for autocomplete that will return a string of tags that
   // contain the query text.
   TagsManager.prototype.autocomplete = function (query) {
@@ -47,7 +52,7 @@ function TagsManager(RegionConnection, Manager) {
 
     angular.forEach(this._items, function (item) {
       if (item.name.indexOf(query) > -1) {
-        matching.push(item);
+        matching.push(item.name);
       }
     });
     return matching;

--- a/legacy/src/app/factories/tests/test_tags.js
+++ b/legacy/src/app/factories/tests/test_tags.js
@@ -10,9 +10,10 @@ describe("TagsManager", function () {
   beforeEach(angular.mock.module("MAAS"));
 
   // Load the TagsManager.
-  var TagsManager;
+  let TagsManager, RegionConnection;
   beforeEach(inject(function ($injector) {
     TagsManager = $injector.get("TagsManager");
+    RegionConnection = $injector.get("RegionConnection");
   }));
 
   it("set requires attributes", function () {
@@ -27,13 +28,22 @@ describe("TagsManager", function () {
         TagsManager._items.push({ name: tag, id: i });
       });
       expect(TagsManager.autocomplete("a")).toStrictEqual([
-        { name: "apple", id: 0 },
-        { name: "banana", id: 1 },
-        { name: "cake", id: 2 },
+        "apple",
+        "banana",
+        "cake",
       ]);
-      expect(TagsManager.autocomplete("do")).toStrictEqual([
-        { name: "donut", id: 3 },
-      ]);
+      expect(TagsManager.autocomplete("do")).toStrictEqual(["donut"]);
+    });
+  });
+
+  describe("create", function () {
+    it("calls the region with expected parameters", function () {
+      var result = {};
+      spyOn(RegionConnection, "callMethod").and.returnValue(result);
+      expect(TagsManager.create("new-tag")).toBe(result);
+      expect(RegionConnection.callMethod).toHaveBeenCalledWith("tag.create", {
+        name: "new-tag",
+      });
     });
   });
 });

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -494,11 +494,10 @@
                   >
                 </span>
                 <tags-input
+                  add-from-autocomplete-only="false"
                   allowed-tags-pattern="[\w-]+"
                   data-ng-model="summary.tags"
                   data-ng-hide="!summary.editing"
-                  display-property="name"
-                  key-property="id"
                 >
                   <auto-complete
                     source="tagsAutocomplete($query)"


### PR DESCRIPTION
## Done

- Create tags and apply them to the controller in the config form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

This can't properly be QAed until controllers have permissions restored: https://bugs.launchpad.net/maas/+bug/1967704.
- Update the `canEdit` function to return true: https://github.com/canonical-web-and-design/maas-ui/blob/master/legacy/src/app/controllers/node_details.js#L775.
- Open the network tab of dev tools and find the legacy websocket and look at the messages.
- Open the details page for a controller and then go to the config tab (this won't be visible until you update `canEdit`).
- Click edit and then enter a new tag name (that doesn't match any existing tags). Submit the form.
- In the websocket messages there should be a "tag.create" message. Find the response and note the tag id.
- Now find the "controller.update" message and check that the new tag id is in the tags array.

## Fixes

Fixes: canonical-web-and-design/app-tribe#637.