### PR TITLE
feat(ui): create common EditableSection component

### DIFF
--- a/ui/src/app/base/components/EditableSection/EditableSection.test.tsx
+++ b/ui/src/app/base/components/EditableSection/EditableSection.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import EditableSection, { Labels } from "./EditableSection";
 
-it("shows an edit button if content can be edited and not currently editing", () => {
+it("can toggle showing content depending on editing state", () => {
   render(
     <EditableSection
       canEdit
-      editing={false}
-      setEditing={jest.fn()}
+      renderContent={(editing) => (editing ? <div>Is editing</div> : null)}
       title="Title"
     />
   );
@@ -15,26 +15,19 @@ it("shows an edit button if content can be edited and not currently editing", ()
   expect(
     screen.getByRole("button", { name: Labels.EditButton })
   ).toBeInTheDocument();
-});
+  expect(screen.queryByText("Is editing")).not.toBeInTheDocument();
 
-it("does not show an edit button if currently editing", () => {
-  render(
-    <EditableSection canEdit editing setEditing={jest.fn()} title="Title" />
-  );
+  userEvent.click(screen.getByRole("button", { name: Labels.EditButton }));
 
   expect(
     screen.queryByRole("button", { name: Labels.EditButton })
   ).not.toBeInTheDocument();
+  expect(screen.getByText("Is editing")).toBeInTheDocument();
 });
 
 it("does not show an edit button if content cannot be edited", () => {
   render(
-    <EditableSection
-      canEdit={false}
-      editing={false}
-      setEditing={jest.fn()}
-      title="Title"
-    />
+    <EditableSection canEdit={false} renderContent={() => null} title="Title" />
   );
 
   expect(

--- a/ui/src/app/base/components/EditableSection/EditableSection.test.tsx
+++ b/ui/src/app/base/components/EditableSection/EditableSection.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+
+import EditableSection, { Labels } from "./EditableSection";
+
+it("shows an edit button if content can be edited and not currently editing", () => {
+  render(
+    <EditableSection
+      canEdit
+      editing={false}
+      setEditing={jest.fn()}
+      title="Title"
+    />
+  );
+
+  expect(
+    screen.getByRole("button", { name: Labels.EditButton })
+  ).toBeInTheDocument();
+});
+
+it("does not show an edit button if currently editing", () => {
+  render(
+    <EditableSection canEdit editing setEditing={jest.fn()} title="Title" />
+  );
+
+  expect(
+    screen.queryByRole("button", { name: Labels.EditButton })
+  ).not.toBeInTheDocument();
+});
+
+it("does not show an edit button if content cannot be edited", () => {
+  render(
+    <EditableSection
+      canEdit={false}
+      editing={false}
+      setEditing={jest.fn()}
+      title="Title"
+    />
+  );
+
+  expect(
+    screen.queryByRole("button", { name: Labels.EditButton })
+  ).not.toBeInTheDocument();
+});

--- a/ui/src/app/base/components/EditableSection/EditableSection.tsx
+++ b/ui/src/app/base/components/EditableSection/EditableSection.tsx
@@ -1,0 +1,45 @@
+import type { PropsWithSpread } from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
+
+import type { Props as TitledSectionProps } from "app/base/components/TitledSection";
+import TitledSection from "app/base/components/TitledSection";
+
+type Props = PropsWithSpread<
+  {
+    canEdit?: boolean;
+    editing: boolean;
+    setEditing: (editing: boolean) => void;
+  },
+  TitledSectionProps
+>;
+
+export enum Labels {
+  EditButton = "Edit",
+}
+
+const EditableSection = ({
+  canEdit = true,
+  editing,
+  setEditing,
+  ...titledSectionProps
+}: Props): JSX.Element => {
+  const showEditButton = canEdit && !editing;
+
+  return (
+    <TitledSection
+      buttons={
+        showEditButton ? (
+          <Button
+            className="u-no-margin--bottom"
+            onClick={() => setEditing(true)}
+          >
+            {Labels.EditButton}
+          </Button>
+        ) : null
+      }
+      {...titledSectionProps}
+    />
+  );
+};
+
+export default EditableSection;

--- a/ui/src/app/base/components/EditableSection/EditableSection.tsx
+++ b/ui/src/app/base/components/EditableSection/EditableSection.tsx
@@ -1,3 +1,6 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
 import type { PropsWithSpread } from "@canonical/react-components";
 import { Button } from "@canonical/react-components";
 
@@ -7,10 +10,12 @@ import TitledSection from "app/base/components/TitledSection";
 type Props = PropsWithSpread<
   {
     canEdit?: boolean;
-    editing: boolean;
-    setEditing: (editing: boolean) => void;
+    renderContent: (
+      editing: boolean,
+      setEditing: (editing: boolean) => void
+    ) => ReactNode;
   },
-  TitledSectionProps
+  Omit<TitledSectionProps, "children">
 >;
 
 export enum Labels {
@@ -19,10 +24,10 @@ export enum Labels {
 
 const EditableSection = ({
   canEdit = true,
-  editing,
-  setEditing,
+  renderContent,
   ...titledSectionProps
 }: Props): JSX.Element => {
+  const [editing, setEditing] = useState(false);
   const showEditButton = canEdit && !editing;
 
   return (
@@ -38,7 +43,9 @@ const EditableSection = ({
         ) : null
       }
       {...titledSectionProps}
-    />
+    >
+      {renderContent(editing, setEditing)}
+    </TitledSection>
   );
 };
 

--- a/ui/src/app/base/components/EditableSection/index.ts
+++ b/ui/src/app/base/components/EditableSection/index.ts
@@ -1,0 +1,1 @@
+export { default, Labels } from "./EditableSection";

--- a/ui/src/app/base/components/TitledSection/TitledSection.test.tsx
+++ b/ui/src/app/base/components/TitledSection/TitledSection.test.tsx
@@ -74,3 +74,17 @@ it("adds a custom heading className", () => {
     "u-no-margin--bottom"
   );
 });
+
+it("can display a full span title", () => {
+  render(<TitledSection hasSidebarTitle={false} title="Title" />);
+
+  expect(screen.getByTestId("has-fullspan-title")).toBeInTheDocument();
+  expect(screen.queryByTestId("has-sidebar-title")).not.toBeInTheDocument();
+});
+
+it("can display the title in a sidebar", () => {
+  render(<TitledSection hasSidebarTitle title="Title" />);
+
+  expect(screen.getByTestId("has-sidebar-title")).toBeInTheDocument();
+  expect(screen.queryByTestId("has-fullspan-title")).not.toBeInTheDocument();
+});

--- a/ui/src/app/base/components/TitledSection/TitledSection.tsx
+++ b/ui/src/app/base/components/TitledSection/TitledSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ReactNode } from "react";
 
-import { Strip } from "@canonical/react-components";
+import { Col, Row, Strip } from "@canonical/react-components";
 import type {
   PropsWithSpread,
   StripProps,
@@ -12,10 +12,11 @@ import VisuallyHidden from "../VisuallyHidden";
 
 import { useId } from "app/base/hooks/base";
 
-type Props = PropsWithSpread<
+export type Props = PropsWithSpread<
   {
     buttons?: ReactNode;
     children?: ReactNode;
+    hasSidebarTitle?: boolean;
     headingElement?: Headings;
     headingClassName?: string;
     headingVisuallyHidden?: boolean;
@@ -44,11 +45,13 @@ const Heading = ({ element, id, className, children }: HeadingProps) =>
 const TitledSection = ({
   buttons,
   children,
-  title,
-  headingElement = "h2",
+  hasSidebarTitle = false,
   headingClassName = "p-heading--4",
+  headingElement = "h2",
   headingVisuallyHidden, // hide the title visually (visibly hidden but still accessible)
-  ...props
+  shallow = true,
+  title,
+  ...stripProps
 }: Props): JSX.Element => {
   const id = useId();
   const heading = (
@@ -64,21 +67,39 @@ const TitledSection = ({
 
   return (
     <Strip
-      shallow
-      element="section"
       aria-labelledby={id}
       data-testid="titled-section"
-      {...props}
+      element="section"
+      shallow={shallow}
+      {...stripProps}
     >
-      {buttons ? (
-        <div className="u-flex--between">
-          {titleElement}
-          <div>{buttons}</div>
-        </div>
+      {hasSidebarTitle ? (
+        <Row data-testid="has-sidebar-title">
+          <Col size={3}>
+            <div className="u-flex--between u-flex--wrap">
+              {titleElement}
+              {buttons && <div className="u-hide--large">{buttons}</div>}
+            </div>
+          </Col>
+          <Col size={buttons ? 6 : 9}>{children}</Col>
+          {buttons && (
+            <Col className="u-align--right" size={3}>
+              <div className="u-hide--small u-hide--medium">{buttons}</div>
+            </Col>
+          )}
+        </Row>
       ) : (
-        titleElement
+        <>
+          <div
+            className="u-flex--between u-flex--wrap"
+            data-testid="has-fullspan-title"
+          >
+            {titleElement}
+            {buttons && <div>{buttons}</div>}
+          </div>
+          {children}
+        </>
       )}
-      {children}
     </Strip>
   );
 };

--- a/ui/src/app/base/components/TitledSection/index.ts
+++ b/ui/src/app/base/components/TitledSection/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TitledSection";
+export type { Props } from "./TitledSection";

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineConfiguration.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineConfiguration.tsx
@@ -1,4 +1,4 @@
-import { Spinner, Strip } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import MachineForm from "./MachineForm";
@@ -25,17 +25,11 @@ const MachineConfiguration = (): JSX.Element => {
 
   return (
     <>
-      <Strip shallow>
-        <MachineForm systemId={machine.system_id} />
-      </Strip>
+      <MachineForm systemId={machine.system_id} />
       <hr />
-      <Strip shallow>
-        <TagForm systemId={machine.system_id} />
-      </Strip>
+      <TagForm systemId={machine.system_id} />
       <hr />
-      <Strip shallow>
-        <PowerForm systemId={machine.system_id} />
-      </Strip>
+      <PowerForm systemId={machine.system_id} />
     </>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import MachineForm from "./MachineForm";
 
+import { Labels } from "app/base/components/EditableSection";
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import {
@@ -53,7 +54,7 @@ describe("MachineForm", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: "Edit" })
+      screen.queryByRole("button", { name: Labels.EditButton })
     ).not.toBeInTheDocument();
   });
 
@@ -66,7 +67,9 @@ describe("MachineForm", () => {
       </Provider>
     );
 
-    expect(screen.getAllByRole("button", { name: "Edit" }).length).not.toBe(0);
+    expect(
+      screen.getAllByRole("button", { name: Labels.EditButton }).length
+    ).not.toBe(0);
   });
 
   it("renders read-only text fields until edit button is pressed", () => {
@@ -79,7 +82,9 @@ describe("MachineForm", () => {
 
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+    userEvent.click(
+      screen.getAllByRole("button", { name: Labels.EditButton })[0]
+    );
 
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
@@ -98,7 +103,9 @@ describe("MachineForm", () => {
       </Provider>
     );
 
-    userEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+    userEvent.click(
+      screen.getAllByRole("button", { name: Labels.EditButton })[0]
+    );
     const noteField = screen.getByRole("textbox", { name: "Note" });
     userEvent.clear(noteField);
     userEvent.type(noteField, "New note");

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -3,8 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import PowerForm, { Labels } from "./PowerForm";
+import PowerForm from "./PowerForm";
 
+import { Labels } from "app/base/components/EditableSection";
 import { PowerTypeNames } from "app/store/general/constants";
 import { PowerFieldScope, PowerFieldType } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
@@ -80,7 +81,7 @@ it("is not editable if machine does not have edit permission", () => {
   );
 
   expect(
-    screen.queryByRole("button", { name: Labels.Edit })
+    screen.queryByRole("button", { name: Labels.EditButton })
   ).not.toBeInTheDocument();
 });
 
@@ -93,9 +94,9 @@ it("is editable if machine has edit permission", () => {
     </Provider>
   );
 
-  expect(screen.getAllByRole("button", { name: Labels.Edit }).length).not.toBe(
-    0
-  );
+  expect(
+    screen.getAllByRole("button", { name: Labels.EditButton }).length
+  ).not.toBe(0);
 });
 
 it("renders read-only text fields until edit button is pressed", () => {
@@ -110,7 +111,9 @@ it("renders read-only text fields until edit button is pressed", () => {
     screen.queryByRole("combobox", { name: "Power type" })
   ).not.toBeInTheDocument();
 
-  userEvent.click(screen.getAllByRole("button", { name: Labels.Edit })[0]);
+  userEvent.click(
+    screen.getAllByRole("button", { name: Labels.EditButton })[0]
+  );
 
   expect(
     screen.getByRole("combobox", { name: "Power type" })
@@ -131,7 +134,9 @@ it("correctly dispatches an action to update a machine's power", async () => {
     </Provider>
   );
 
-  userEvent.click(screen.getAllByRole("button", { name: Labels.Edit })[0]);
+  userEvent.click(
+    screen.getAllByRole("button", { name: Labels.EditButton })[0]
+  );
   fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
     target: { value: PowerTypeNames.APC },
   });

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { Button, Col, Row, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { SchemaOf } from "yup";
 import * as Yup from "yup";
@@ -8,6 +8,7 @@ import * as Yup from "yup";
 import PowerFormFields from "./PowerFormFields";
 import PowerParameters from "./PowerParameters";
 
+import EditableSection from "app/base/components/EditableSection";
 import FormikForm from "app/base/components/FormikForm";
 import { useCanEdit } from "app/base/hooks";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
@@ -32,10 +33,6 @@ export type PowerFormValues = {
   powerType: Machine["power_type"];
   powerParameters: PowerParametersType;
 };
-
-export enum Labels {
-  Edit = "Edit",
-}
 
 type Props = { systemId: Machine["system_id"] };
 
@@ -86,82 +83,63 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
     .defined();
 
   return (
-    <Row>
-      <Col size={3}>
-        <div className="u-flex--between u-flex--wrap">
-          <h4>Power configuration</h4>
-          {canEdit && !editing && (
-            <Button
-              className="u-no-margin--bottom u-hide--large"
-              onClick={() => setEditing(true)}
-            >
-              {Labels.Edit}
-            </Button>
-          )}
-        </div>
-      </Col>
-      <Col size={editing ? 9 : 6}>
-        {editing ? (
-          <FormikForm<PowerFormValues>
-            allowAllEmpty
-            allowUnchanged
-            cleanup={cleanup}
-            editable={editing}
-            errors={errors}
-            initialValues={{
-              powerType: machine.power_type,
-              powerParameters: initialPowerParameters,
-            }}
-            onSaveAnalytics={{
-              action: "Configure power",
-              category: "Machine details",
-              label: "Save changes",
-            }}
-            onCancel={() => setEditing(false)}
-            onSubmit={(values) => {
-              const params = {
-                extra_macs: machine.extra_macs,
-                power_parameters: formatPowerParameters(
-                  selectedPowerType,
-                  values.powerParameters,
-                  fieldScopes
-                ),
-                power_type: values.powerType,
-                pxe_mac: machine.pxe_mac,
-                system_id: machine.system_id,
-              };
-              dispatch(machineActions.update(params));
-            }}
-            onSuccess={() => setEditing(false)}
-            onValuesChanged={(values) => {
-              const powerType = getPowerTypeFromName(
-                powerTypes,
-                values.powerType
-              );
-              setSelectedPowerType(powerType);
-            }}
-            saved={saved}
-            saving={saving}
-            submitLabel="Save changes"
-            validationSchema={PowerFormSchema}
-          >
-            <PowerFormFields machine={machine} />
-          </FormikForm>
-        ) : (
-          <PowerParameters machine={machine} />
-        )}
-      </Col>
-      {canEdit && !editing && (
-        <Col className="u-align--right" size={3}>
-          <Button
-            className="u-no-margin--bottom u-hide--small u-hide--medium"
-            onClick={() => setEditing(true)}
-          >
-            {Labels.Edit}
-          </Button>
-        </Col>
+    <EditableSection
+      canEdit={canEdit}
+      editing={editing}
+      hasSidebarTitle
+      setEditing={setEditing}
+      title="Power configuration"
+    >
+      {editing ? (
+        <FormikForm<PowerFormValues>
+          allowAllEmpty
+          allowUnchanged
+          cleanup={cleanup}
+          editable={editing}
+          errors={errors}
+          initialValues={{
+            powerType: machine.power_type,
+            powerParameters: initialPowerParameters,
+          }}
+          onSaveAnalytics={{
+            action: "Configure power",
+            category: "Machine details",
+            label: "Save changes",
+          }}
+          onCancel={() => setEditing(false)}
+          onSubmit={(values) => {
+            const params = {
+              extra_macs: machine.extra_macs,
+              power_parameters: formatPowerParameters(
+                selectedPowerType,
+                values.powerParameters,
+                fieldScopes
+              ),
+              power_type: values.powerType,
+              pxe_mac: machine.pxe_mac,
+              system_id: machine.system_id,
+            };
+            dispatch(machineActions.update(params));
+          }}
+          onSuccess={() => setEditing(false)}
+          onValuesChanged={(values) => {
+            const powerType = getPowerTypeFromName(
+              powerTypes,
+              values.powerType
+            );
+            setSelectedPowerType(powerType);
+          }}
+          saved={saved}
+          saving={saving}
+          submitLabel="Save changes"
+          validationSchema={PowerFormSchema}
+        >
+          <PowerFormFields machine={machine} />
+        </FormikForm>
+      ) : (
+        <PowerParameters machine={machine} />
       )}
-    </Row>
+    </EditableSection>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import TagForm from "./TagForm";
 
+import { Labels as EditableSectionLabels } from "app/base/components/EditableSection";
 import { Label as TagFormFieldsLabel } from "app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields";
 import machineURLs from "app/machines/urls";
 import { FilterMachines } from "app/store/machine/utils";
@@ -61,7 +62,7 @@ describe("TagForm", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: "Edit" })
+      screen.queryByRole("button", { name: EditableSectionLabels.EditButton })
     ).not.toBeInTheDocument();
   });
 
@@ -76,7 +77,10 @@ describe("TagForm", () => {
       </Provider>
     );
 
-    expect(screen.getAllByRole("button", { name: "Edit" }).length).not.toBe(0);
+    expect(
+      screen.getAllByRole("button", { name: EditableSectionLabels.EditButton })
+        .length
+    ).not.toBe(0);
   });
 
   it("renders list of tag links until edit button is pressed", () => {
@@ -103,7 +107,11 @@ describe("TagForm", () => {
       })}`
     );
 
-    userEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+    userEvent.click(
+      screen.getAllByRole("button", {
+        name: EditableSectionLabels.EditButton,
+      })[0]
+    );
 
     expect(
       screen.getByLabelText(TagFormFieldsLabel.TagInput)

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 
-import { Button, Col, Row, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
+import EditableSection from "app/base/components/EditableSection";
 import TagLinks from "app/base/components/TagLinks";
 import { useCanEdit } from "app/base/hooks";
 import TagActionForm from "app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm";
@@ -45,55 +46,36 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
   }
 
   return (
-    <Row>
-      <Col size={3}>
-        <div className="u-flex--between u-flex--wrap">
-          <h4>Tags</h4>
-          {canEdit && !editing && (
-            <Button
-              className="u-no-margin--bottom u-hide--large"
-              onClick={() => setEditing(true)}
-            >
-              Edit
-            </Button>
-          )}
-        </div>
-      </Col>
-      <Col size={editing ? 9 : 6}>
-        {editing ? (
-          <TagActionForm
-            clearHeaderContent={() => setEditing(false)}
-            errors={errors}
-            machines={[machine]}
-            processingCount={taggingMachines.length}
-            viewingDetails
-            viewingMachineConfig
+    <EditableSection
+      canEdit={canEdit}
+      editing={editing}
+      hasSidebarTitle
+      setEditing={setEditing}
+      title="Tags"
+    >
+      {editing ? (
+        <TagActionForm
+          clearHeaderContent={() => setEditing(false)}
+          errors={errors}
+          machines={[machine]}
+          processingCount={taggingMachines.length}
+          viewingDetails
+          viewingMachineConfig
+        />
+      ) : (
+        <p>
+          <TagLinks
+            getLinkURL={(tag) => {
+              const filter = FilterMachines.filtersToQueryString({
+                tags: [`=${tag.name}`],
+              });
+              return `${machineURLs.machines.index}${filter}`;
+            }}
+            tags={tags}
           />
-        ) : (
-          <p>
-            <TagLinks
-              getLinkURL={(tag) => {
-                const filter = FilterMachines.filtersToQueryString({
-                  tags: [`=${tag.name}`],
-                });
-                return `${machineURLs.machines.index}${filter}`;
-              }}
-              tags={tags}
-            />
-          </p>
-        )}
-      </Col>
-      {canEdit && !editing && (
-        <Col className="u-align--right" size={3}>
-          <Button
-            className="u-no-margin--bottom u-hide--small u-hide--medium"
-            onClick={() => setEditing(true)}
-          >
-            Edit
-          </Button>
-        </Col>
+        </p>
       )}
-    </Row>
+    </EditableSection>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -34,7 +34,6 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
       NodeActions.UNTAG,
     ])
   )[0]?.error;
-  const [editing, setEditing] = useState(false);
   const canEdit = useCanEdit(machine, true);
 
   useEffect(() => {
@@ -48,34 +47,33 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
   return (
     <EditableSection
       canEdit={canEdit}
-      editing={editing}
       hasSidebarTitle
-      setEditing={setEditing}
-      title="Tags"
-    >
-      {editing ? (
-        <TagActionForm
-          clearHeaderContent={() => setEditing(false)}
-          errors={errors}
-          machines={[machine]}
-          processingCount={taggingMachines.length}
-          viewingDetails
-          viewingMachineConfig
-        />
-      ) : (
-        <p>
-          <TagLinks
-            getLinkURL={(tag) => {
-              const filter = FilterMachines.filtersToQueryString({
-                tags: [`=${tag.name}`],
-              });
-              return `${machineURLs.machines.index}${filter}`;
-            }}
-            tags={tags}
+      renderContent={(editing, setEditing) =>
+        editing ? (
+          <TagActionForm
+            clearHeaderContent={() => setEditing(false)}
+            errors={errors}
+            machines={[machine]}
+            processingCount={taggingMachines.length}
+            viewingDetails
+            viewingMachineConfig
           />
-        </p>
-      )}
-    </EditableSection>
+        ) : (
+          <p>
+            <TagLinks
+              getLinkURL={(tag) => {
+                const filter = FilterMachines.filtersToQueryString({
+                  tags: [`=${tag.name}`],
+                });
+                return `${machineURLs.machines.index}${filter}`;
+              }}
+              tags={tags}
+            />
+          </p>
+        )
+      }
+      title="Tags"
+    />
   );
 };
 


### PR DESCRIPTION
## Done

- Updated `TitledSection` component to be able to have the title in a sidebar
- Built `EditableSection` component, that handles showing an edit button in a titled section

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Configuration tab of a machine
- Check that the config sections haven't changed (i.e. title is in sidebar, clicking Edit hides the button)
- Go to a fabric's details page and check that the TitledSections there have not changed either

## Fixes

Fixes #3779 
