### PR TITLE
feat(ui): add tags from the device config form

### DIFF
--- a/ui/src/app/base/components/TagField/TagField.tsx
+++ b/ui/src/app/base/components/TagField/TagField.tsx
@@ -16,6 +16,10 @@ export type Props = {
 } & Omit<Partial<FormikFieldProps>, "name"> &
   Omit<Partial<TagSelectorProps>, "tags">;
 
+export enum Label {
+  Input = "Tags",
+}
+
 const TagField = <V extends AnyObject = AnyObject>({
   storedValue = "name",
   name,
@@ -28,7 +32,7 @@ const TagField = <V extends AnyObject = AnyObject>({
     <FormikField
       allowNewTags
       component={TagSelector}
-      label="Tags"
+      label={Label.Input}
       name={name}
       onTagsUpdate={(tags: TagSelectorTag[]) =>
         setFieldValue(

--- a/ui/src/app/base/components/ZoneSelect/ZoneSelect.tsx
+++ b/ui/src/app/base/components/ZoneSelect/ZoneSelect.tsx
@@ -16,9 +16,13 @@ type Props = {
   valueKey?: keyof Zone;
 } & HTMLProps<HTMLSelectElement>;
 
+export enum Label {
+  Zone = "Zone",
+}
+
 export const DomainSelect = ({
   disabled = false,
-  label = "Zone",
+  label = Label.Zone,
   name,
   valueKey = "name",
   ...props

--- a/ui/src/app/base/constants.ts
+++ b/ui/src/app/base/constants.ts
@@ -18,3 +18,9 @@ export const COLOURS = {
   POSITIVE_MID: "#4DAB4D",
   POSITIVE: "#0E8420",
 } as const;
+
+// usePortal was originally design to work with click events, so to open the
+// portal programmatically we need to fake the event. This workaround can be
+// removed when this issue is resolved:
+// https://github.com/alex-cory/react-useportal/issues/36
+export const NULL_EVENT = { currentTarget: { contains: (): boolean => false } };

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
@@ -1,22 +1,15 @@
 import { useEffect, useState } from "react";
 
-import {
-  Button,
-  Col,
-  Row,
-  Spinner,
-  Strip,
-  Textarea,
-} from "@canonical/react-components";
+import { Button, Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import DeviceConfigurationFields from "./DeviceConfigurationFields";
+import type { DeviceConfigurationValues } from "./types";
+
 import Definition from "app/base/components/Definition";
-import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
-import TagIdField from "app/base/components/TagIdField";
 import TagLinks from "app/base/components/TagLinks";
-import ZoneSelect from "app/base/components/ZoneSelect";
 import { useWindowTitle } from "app/base/hooks";
 import deviceURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
@@ -25,19 +18,17 @@ import type { Device, DeviceMeta } from "app/store/device/types";
 import { FilterDevices, isDeviceDetails } from "app/store/device/utils";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
-import type { Tag, TagMeta } from "app/store/tag/types";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
-
-type DeviceConfigurationValues = {
-  description: string;
-  tags: Tag[TagMeta.PK][];
-  zone: string;
-};
 
 type Props = {
   systemId: Device[DeviceMeta.PK];
 };
+
+export enum Label {
+  Edit = "Edit",
+  Form = "Device configuration",
+}
 
 const DeviceConfigurationSchema = Yup.object().shape({
   description: Yup.string(),
@@ -55,7 +46,6 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
   )[0]?.error;
   const deviceSaved = useSelector(deviceSelectors.saved);
   const deviceSaving = useSelector(deviceSelectors.saving);
-  const allTags = useSelector(tagSelectors.all);
   const deviceTags = useSelector((state: RootState) =>
     tagSelectors.getByIDs(state, device?.tags || null)
   );
@@ -85,12 +75,13 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
             data-testid="edit-device-button"
             onClick={() => setEditing(true)}
           >
-            Edit
+            {Label.Edit}
           </Button>
         )}
       </div>
       {editing ? (
         <FormikForm<DeviceConfigurationValues>
+          aria-label={Label.Form}
           cleanup={deviceActions.cleanup}
           data-testid="device-config-form"
           editable={editing}
@@ -121,21 +112,7 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
           submitLabel="Save changes"
           validationSchema={DeviceConfigurationSchema}
         >
-          <Row>
-            <Col size={6}>
-              <ZoneSelect name="zone" />
-              <FormikField
-                component={Textarea}
-                label="Note"
-                name="description"
-              />
-              <TagIdField
-                name="tags"
-                placeholder="Create or remove tags"
-                tagList={allTags}
-              />
-            </Col>
-          </Row>
+          <DeviceConfigurationFields />
         </FormikForm>
       ) : (
         <div data-testid="device-details">

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfigurationFields/DeviceConfigurationFields.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfigurationFields/DeviceConfigurationFields.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+
+import { Col, Modal, Row, Textarea } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+import usePortal from "react-useportal";
+
+import type { DeviceConfigurationValues } from "../types";
+
+import FormikField from "app/base/components/FormikField";
+import TagIdField from "app/base/components/TagIdField";
+import ZoneSelect from "app/base/components/ZoneSelect";
+import { NULL_EVENT } from "app/base/constants";
+import type { RootState } from "app/store/root/types";
+import tagSelectors from "app/store/tag/selectors";
+import AddTagForm from "app/tags/components/AddTagForm";
+
+export enum Label {
+  AddTag = "Create a new tag",
+  Note = "Note",
+}
+
+const DeviceConfigurationFields = (): JSX.Element => {
+  const { setFieldValue, values } =
+    useFormikContext<DeviceConfigurationValues>();
+  const selectedTags = useSelector((state: RootState) =>
+    tagSelectors.getByIDs(state, values.tags)
+  );
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const [newTagName, setNewTagName] = useState<string | null>(null);
+  const allTags = useSelector(tagSelectors.all);
+
+  return (
+    <>
+      <Row>
+        <Col size={6}>
+          <ZoneSelect name="zone" />
+          <FormikField
+            component={Textarea}
+            label={Label.Note}
+            name="description"
+          />
+          <TagIdField
+            externalSelectedTags={selectedTags}
+            name="tags"
+            placeholder="Create or remove tags"
+            tagList={allTags}
+            onAddNewTag={(name) => {
+              setNewTagName(name);
+              openPortal(NULL_EVENT);
+            }}
+          />
+        </Col>
+      </Row>
+      {isOpen ? (
+        <Portal>
+          <Modal
+            className="tag-form__modal"
+            close={() => closePortal(NULL_EVENT)}
+            title={Label.AddTag}
+          >
+            <AddTagForm
+              name={newTagName}
+              onSaveAnalytics={{
+                action: "Manual tag created",
+                category: "Device configuration create tag form",
+                label: "Save",
+              }}
+              onTagCreated={(tag) => {
+                setFieldValue("tags", values.tags.concat([tag.id]));
+                setNewTagName(null);
+                closePortal(NULL_EVENT);
+              }}
+            />
+          </Modal>
+        </Portal>
+      ) : null}
+    </>
+  );
+};
+
+export default DeviceConfigurationFields;

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfigurationFields/index.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfigurationFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceConfigurationFields";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/types.ts
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/types.ts
@@ -1,0 +1,7 @@
+import type { Tag, TagMeta } from "app/store/tag/types";
+
+export type DeviceConfigurationValues = {
+  description: string;
+  tags: Tag[TagMeta.PK][];
+  zone: string;
+};

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -1,118 +1,47 @@
-import { useEffect, useState } from "react";
-
-import { Col, Row } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
-
-import FormikField from "app/base/components/FormikField";
-import FormikForm from "app/base/components/FormikForm";
 import type { Machine } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
-import { actions as tagActions } from "app/store/tag";
-import tagSelectors from "app/store/tag/selectors";
-import type { CreateParams, Tag } from "app/store/tag/types";
+import type { Tag } from "app/store/tag/types";
 import { NodeStatus } from "app/store/types/node";
-import KernelOptionsField from "app/tags/components/KernelOptionsField";
+import BaseAddTagForm from "app/tags/components/AddTagForm";
 
-type Props = {
+export type Props = {
   machines: Machine[];
   name: string | null;
   onTagCreated: (tag: Tag) => void;
+  viewingDetails?: boolean;
+  viewingMachineConfig?: boolean;
 };
-
-export enum Label {
-  Form = "Create tag",
-  Comment = "Comment",
-  Name = "Tag name",
-}
-
-const AddTagFormSchema = Yup.object().shape({
-  comment: Yup.string(),
-  kernel_opts: Yup.string(),
-  name: Yup.string().required("Name is required."),
-});
 
 export const AddTagForm = ({
   machines,
   name,
   onTagCreated,
+  viewingDetails,
+  viewingMachineConfig,
 }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-  const [savedName, setSavedName] = useState<Tag["name"] | null>(null);
-  const saved = useSelector(tagSelectors.saved);
-  const saving = useSelector(tagSelectors.saving);
-  const errors = useSelector(tagSelectors.errors);
-  const tag = useSelector((state: RootState) =>
-    // Tag names are unique so fetch the newly created tag using the name
-    // provided in this form.
-    tagSelectors.getByName(state, savedName)
-  );
-
-  useEffect(() => {
-    if (tag) {
-      onTagCreated(tag);
-    }
-  }, [onTagCreated, tag]);
-
+  let location = "list";
+  if (viewingMachineConfig) {
+    location = "configuration";
+  } else if (viewingDetails) {
+    location = "details";
+  }
   return (
-    <FormikForm<CreateParams>
-      aria-label={Label.Form}
-      allowUnchanged
-      buttonsAlign="left"
-      buttonsBordered={false}
-      cleanup={tagActions.cleanup}
-      errors={errors}
-      initialValues={{
-        comment: "",
-        kernel_opts: "",
-        name: name ?? "",
-      }}
+    <BaseAddTagForm
+      name={name}
+      onTagCreated={onTagCreated}
       onSaveAnalytics={{
         action: "Manual tag created",
-        category: "Machine list create tag form",
+        category: `Machine ${location} create tag form`,
         label: "Save",
       }}
-      onSubmit={(values) => {
-        dispatch(tagActions.cleanup());
-        dispatch(tagActions.create(values));
-      }}
-      onSuccess={({ name }) => {
-        setSavedName(name);
-      }}
-      saved={saved}
-      saving={saving}
-      submitAppearance="neutral"
-      submitLabel="Create and add to tag changes"
-      validationSchema={AddTagFormSchema}
-    >
-      <Row className="u-no-padding">
-        <Col size={12}>
-          <FormikField
-            label={Label.Name}
-            name="name"
-            placeholder="Enter a name for the tag."
-            type="text"
-            required
-          />
-          <FormikField
-            label={Label.Comment}
-            name="comment"
-            placeholder="Add a comment as an explanation for this tag."
-            type="text"
-          />
-          <KernelOptionsField
-            generateDeployedMessage={(count: number) =>
-              count === 1
-                ? `${count} selected machine is deployed. The new kernel options will not be applied to this machine until it is redeployed.`
-                : `${count} selected machines are deployed. The new kernel options will not be applied to these machines until they are redeployed.`
-            }
-            deployedMachines={machines.filter(
-              ({ status }) => status === NodeStatus.DEPLOYED
-            )}
-          />
-        </Col>
-      </Row>
-    </FormikForm>
+      generateDeployedMessage={(count: number) =>
+        count === 1
+          ? `${count} selected machine is deployed. The new kernel options will not be applied to this machine until it is redeployed.`
+          : `${count} selected machines are deployed. The new kernel options will not be applied to these machines until they are redeployed.`
+      }
+      deployedMachines={machines.filter(
+        ({ status }) => status === NodeStatus.DEPLOYED
+      )}
+    />
   );
 };
 

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -105,6 +105,7 @@ export const TagForm = ({
     >
       <TagFormFields
         machines={machines}
+        viewingDetails={viewingDetails}
         viewingMachineConfig={viewingMachineConfig}
       />
     </ActionForm>

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -12,6 +12,7 @@ import TagChip from "../TagChip";
 import { useSelectedTags, useUnchangedTags } from "../hooks";
 import type { TagFormValues } from "../types";
 
+import { NULL_EVENT } from "app/base/constants";
 import type { Machine } from "app/store/machine/types";
 import type { TagIdCountMap } from "app/store/machine/utils";
 import { getTagCountsForMachines } from "app/store/machine/utils";
@@ -107,11 +108,6 @@ export const TagFormChanges = ({ machines }: Props): JSX.Element | null => {
   const [tagDetails, setTagDetails] = useState<Tag | null>(null);
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const toggleTagDetails = (tag: Tag | null) => {
-    // usePortal was originally design to work with click events, so to open the
-    // portal programmatically we need to fake the event. This workaround can be
-    // removed when this issue is resolved:
-    // https://github.com/alex-cory/react-useportal/issues/36
-    const NULL_EVENT = { currentTarget: { contains: () => false } };
     setTagDetails(tag);
     if (tag) {
       openPortal(NULL_EVENT);

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -13,6 +13,7 @@ import type { TagFormValues } from "../types";
 
 import TagField from "app/base/components/TagField";
 import type { Tag as TagSelectorTag } from "app/base/components/TagSelector/TagSelector";
+import { NULL_EVENT } from "app/base/constants";
 import type { Machine } from "app/store/machine/types";
 import { getTagCountsForMachines } from "app/store/machine/utils";
 import tagSelectors from "app/store/tag/selectors";
@@ -23,6 +24,7 @@ const hasKernelOptions = (tags: Tag[], tag: TagSelectorTag) =>
 
 type Props = {
   machines: Machine[];
+  viewingDetails?: boolean;
   viewingMachineConfig?: boolean;
 };
 
@@ -31,14 +33,9 @@ export enum Label {
   TagInput = "Search existing or add new tags",
 }
 
-// usePortal was originally design to work with click events, so to open the
-// portal programmatically we need to fake the event. This workaround can be
-// removed when this issue is resolved:
-// https://github.com/alex-cory/react-useportal/issues/36
-const NULL_EVENT = { currentTarget: { contains: () => false } };
-
 export const TagFormFields = ({
   machines,
+  viewingDetails = false,
   viewingMachineConfig = false,
 }: Props): JSX.Element => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
@@ -110,6 +107,8 @@ export const TagFormFields = ({
                 setNewTagName(null);
                 closePortal(NULL_EVENT);
               }}
+              viewingDetails={viewingDetails}
+              viewingMachineConfig={viewingMachineConfig}
             />
           </Modal>
         </Portal>

--- a/ui/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddTagForm, { Label } from "./AddTagForm";
+
+import * as baseHooks from "app/base/hooks/base";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import { Label as KernelOptionsLabel } from "app/tags/components/KernelOptionsField";
+import tagsURLs from "app/tags/urls";
+import {
+  tag as tagFactory,
+  rootState as rootStateFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    tag: tagStateFactory(),
+  });
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [false, () => null]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("dispatches an action to create a tag", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <AddTagForm name="new-tag" onTagCreated={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+  userEvent.type(
+    screen.getByRole("textbox", { name: Label.Comment }),
+    "comment1"
+  );
+  userEvent.type(
+    screen.getByRole("textbox", { name: KernelOptionsLabel.KernelOptions }),
+    "options1"
+  );
+  fireEvent.submit(screen.getByRole("form"));
+  const expected = tagActions.create({
+    comment: "comment1",
+    kernel_opts: "options1",
+    name: "new-tag",
+  });
+  await waitFor(() =>
+    expect(
+      store.getActions().find((action) => action.type === expected.type)
+    ).toStrictEqual(expected)
+  );
+});
+
+it("returns the newly created tag on save", async () => {
+  const onTagCreated = jest.fn();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <Route
+          exact
+          path={tagsURLs.tags.index}
+          component={() => (
+            <AddTagForm name="new-tag" onTagCreated={onTagCreated} />
+          )}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  // Simulate the state.tag.saved state going from `save: false` to `saved:
+  // true` which happens when the tag is successfully saved. This in turn will
+  // mean that the form `onSuccess` prop will get called so that the component
+  // knows that the tag was created.
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [true, () => null]);
+  const newTag = tagFactory({ id: 8, name: "new-tag" });
+  state.tag = tagStateFactory({
+    items: [newTag],
+    saved: true,
+  });
+  fireEvent.submit(screen.getByRole("form"));
+  await waitFor(() => expect(onTagCreated).toHaveBeenCalledWith(newTag));
+});

--- a/ui/src/app/tags/components/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/AddTagForm/AddTagForm.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+
+import type { PropsWithSpread } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import type { Props as FormikFormProps } from "app/base/components/FormikForm/FormikForm";
+import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import type { CreateParams, Tag } from "app/store/tag/types";
+import KernelOptionsField from "app/tags/components/KernelOptionsField";
+import type { Props as KernelOptionsFieldProps } from "app/tags/components/KernelOptionsField/KernelOptionsField";
+
+type Props = PropsWithSpread<
+  {
+    deployedMachines?: KernelOptionsFieldProps["deployedMachines"];
+    generateDeployedMessage?: KernelOptionsFieldProps["generateDeployedMessage"];
+    name: string | null;
+    onTagCreated: (tag: Tag) => void;
+  },
+  Partial<FormikFormProps<CreateParams>>
+>;
+
+export enum Label {
+  Form = "Create tag",
+  Comment = "Comment",
+  Name = "Tag name",
+}
+
+const AddTagFormSchema = Yup.object().shape({
+  comment: Yup.string(),
+  kernel_opts: Yup.string(),
+  name: Yup.string().required("Name is required."),
+});
+
+export const AddTagForm = ({
+  deployedMachines,
+  generateDeployedMessage,
+  name,
+  onTagCreated,
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const [savedName, setSavedName] = useState<Tag["name"] | null>(null);
+  const saved = useSelector(tagSelectors.saved);
+  const saving = useSelector(tagSelectors.saving);
+  const errors = useSelector(tagSelectors.errors);
+  const tag = useSelector((state: RootState) =>
+    // Tag names are unique so fetch the newly created tag using the name
+    // provided in this form.
+    tagSelectors.getByName(state, savedName)
+  );
+
+  useEffect(() => {
+    if (tag) {
+      onTagCreated(tag);
+    }
+  }, [onTagCreated, tag]);
+
+  return (
+    <FormikForm<CreateParams>
+      aria-label={Label.Form}
+      allowUnchanged
+      buttonsAlign="left"
+      buttonsBordered={false}
+      cleanup={tagActions.cleanup}
+      errors={errors}
+      initialValues={{
+        comment: "",
+        kernel_opts: "",
+        name: name ?? "",
+      }}
+      onSubmit={(values) => {
+        dispatch(tagActions.cleanup());
+        dispatch(tagActions.create(values));
+      }}
+      onSuccess={({ name }) => {
+        setSavedName(name);
+      }}
+      saved={saved}
+      saving={saving}
+      submitAppearance="neutral"
+      submitLabel="Create and add to tag changes"
+      validationSchema={AddTagFormSchema}
+      {...props}
+    >
+      <Row className="u-no-padding">
+        <Col size={12}>
+          <FormikField
+            label={Label.Name}
+            name="name"
+            placeholder="Enter a name for the tag."
+            type="text"
+            required
+          />
+          <FormikField
+            label={Label.Comment}
+            name="comment"
+            placeholder="Add a comment as an explanation for this tag."
+            type="text"
+          />
+          <KernelOptionsField
+            generateDeployedMessage={generateDeployedMessage}
+            deployedMachines={deployedMachines}
+          />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default AddTagForm;

--- a/ui/src/app/tags/components/AddTagForm/index.ts
+++ b/ui/src/app/tags/components/AddTagForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddTagForm";

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -19,7 +19,7 @@ export enum Label {
   KernelOptions = "Kernel options",
 }
 
-type Props = {
+export type Props = {
   deployedMachines?: Machine[];
   generateDeployedMessage?: (count: number) => string;
   id?: Tag[TagMeta.PK];


### PR DESCRIPTION
## Done

- Made add tag form reusable.
- Add the ability to add new tags from the device config form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page for a device.
- Click on the config tab and click 'Edit'.
- Type in a new tag form and click "Create...".
- The modal should appear.
- Fill out the details and submit.
- The new tag name should appear in the input.
- Submit the form and the new tag should appear in the list of tags.

## Fixes

Fixes: canonical-web-and-design/app-tribe#636.

## Screenshot

<img width="832" alt="Screen Shot 2022-04-07 at 12 03 27 pm" src="https://user-images.githubusercontent.com/361637/162117725-880560a4-02df-4c66-b0a1-97202d69e5b3.png">
