### PR TITLE
[tag management] update docs links

### DIFF
--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
@@ -55,7 +55,7 @@ it("overrides the xpath errors", async () => {
   expect(
     screen.getByRole("textbox", { name: Label.Definition })
   ).toHaveErrorMessage(
-    "The definition is an invalid XPath expression. See our XPath documentation for more examples."
+    "The definition is an invalid XPath expression. See our XPath expressions documentation for more examples."
   );
 });
 

--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
@@ -39,7 +39,7 @@ const getDefinitionError = (
       <span id={definitionErrorId}>
         The definition is an invalid XPath expression. See our{" "}
         <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
-          XPath documentation
+          XPath expressions documentation
         </a>{" "}
         for more examples.
       </span>
@@ -88,10 +88,9 @@ export const DefinitionField = ({ id }: Props): JSX.Element => {
       />
       <p className="p-form-help-text u-sv1">
         Add an XPath expression as a definition. MAAS will auto-assign this tag
-        to all current and future machines that match this definition. More
-        about how to use{" "}
+        to all current and future machines that match this definition.{" "}
         <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
-          XPath Expression
+          Learn how to use XPath expressions
         </a>
         .
       </p>

--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
@@ -35,12 +35,13 @@ const getDefinitionError = (
   definitionErrorId: string
 ) => {
   if (errors.definition?.includes(INVALID_XPATH_ERROR)) {
-    // TODO: Add the link to the docs:
-    // https://github.com/canonical-web-and-design/app-tribe/issues/748
     return (
       <span id={definitionErrorId}>
         The definition is an invalid XPath expression. See our{" "}
-        <a href="#todo">XPath documentation</a> for more examples.
+        <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
+          XPath documentation
+        </a>{" "}
+        for more examples.
       </span>
     );
   }
@@ -85,12 +86,14 @@ export const DefinitionField = ({ id }: Props): JSX.Element => {
 //node[@id="firmware"]/capabilities/capability/@id = "uefi"`}
         rows={3}
       />
-      {/* // TODO: Add the link to the docs:
-          // https://github.com/canonical-web-and-design/app-tribe/issues/748 */}
       <p className="p-form-help-text u-sv1">
         Add an XPath expression as a definition. MAAS will auto-assign this tag
         to all current and future machines that match this definition. More
-        about how to use <a href="#todo">XPath Expression</a>.
+        about how to use{" "}
+        <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
+          XPath Expression
+        </a>
+        .
       </p>
       <p className="p-form-help-text u-sv1">
         This will tag legacy KVM vms running on AMD-based Hosts:

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -63,11 +63,11 @@ export const KernelOptionsField = ({
       help={
         <>
           Kernel options are appended to the kernel command line during booting
-          while machines are commissioning or deploying. Read more about kernel
-          options in{" "}
+          while machines are commissioning or deploying.{" "}
           <a href="https://maas.io/docs/how-to-work-with-tags#heading--kernel-options">
-            tag management.
+            Read more about kernel options in tag management
           </a>
+          .
         </>
       }
       placeholder="e.g. nomodeset console=tty0 console=ttys0,115200n8 amd_iommu=on kvm-amd.nested=1"

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -61,12 +61,13 @@ export const KernelOptionsField = ({
       }
       component={Textarea}
       help={
-        // TODO: Add the link to the docs:
-        // https://github.com/canonical-web-and-design/app-tribe/issues/748
         <>
           Kernel options are appended to the kernel command line during booting
           while machines are commissioning or deploying. Read more about kernel
-          options in <a href="#todo">tag management.</a>
+          options in{" "}
+          <a href="https://maas.io/docs/how-to-work-with-tags#heading--kernel-options">
+            tag management.
+          </a>
         </>
       }
       placeholder="e.g. nomodeset console=tty0 console=ttys0,115200n8 amd_iommu=on kvm-amd.nested=1"

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -213,8 +213,6 @@ const TagTable = ({
               <>
                 {Label.Auto}{" "}
                 <Tooltip
-                  // TODO: add a link to the docs:
-                  // https://github.com/canonical-web-and-design/app-tribe/issues/739
                   message={
                     <>
                       {breakLines(
@@ -224,7 +222,7 @@ const TagTable = ({
                         )
                       )}
                       <br />
-                      <a href="#todo">
+                      <a href="https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags">
                         Check the documentation about automatic tags.
                       </a>
                     </>

--- a/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
@@ -71,7 +71,7 @@ export const TagUpdateFormFields = ({ id }: Props): JSX.Element | null => {
                 This is a manual tag. Definitions cannot be added to manual
                 tags. To learn more about this, check our{" "}
                 <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
-                  XPath documentation
+                  XPath expressions documentation
                 </a>
                 .
               </span>

--- a/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
@@ -65,14 +65,15 @@ export const TagUpdateFormFields = ({ id }: Props): JSX.Element | null => {
           <KernelOptionsField id={id} />
         </Col>
         <Col size={6}>
-          {/* // TODO: Add the link to the docs:
-          // https://github.com/canonical-web-and-design/app-tribe/issues/748 */}
           {!tag.definition ? (
             <Definition label={Label.Definition}>
               <span className="p-form-help-text">
                 This is a manual tag. Definitions cannot be added to manual
                 tags. To learn more about this, check our{" "}
-                <a href="#todo">XPath documentation</a>.
+                <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
+                  XPath documentation
+                </a>
+                .
               </span>
             </Definition>
           ) : (


### PR DESCRIPTION
## Done

- update tag management docs links

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that links work correctly (their placement is described in issues linked to this PR)

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/739
Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/748

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
