### PR TITLE
[periodic hardware sync] remove todo docs links

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -224,8 +224,7 @@ export const DeployFormFields = (): JSX.Element => {
                       <Icon name="information" />
                     </Button>
                   </Tooltip>
-                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}{" "}
-                  <a href="#todo">Hardware sync docs</a>
+                  {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
                 </>
               }
             />

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -169,9 +169,10 @@ describe("StatusCard", () => {
         name: "more about periodic hardware sync",
       })
     );
+    /* TODO: Enable this check after adding docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */
     expect(
-      screen.getByRole("link", { name: "Hardware sync docs" })
-    ).toBeVisible();
+      screen.queryByRole("link", { name: "Hardware sync docs" })
+    ).not.toBeInTheDocument();
   });
 
   it("displays deployed hardware sync interval in a correct format", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -101,19 +101,13 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
             <p className="u-text--muted">
               Periodic hardware sync enabled{" "}
               {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
-              {/* TODO: use actual `sync_interval` value from the back-end https://github.com/canonical-web-and-design/app-tribe/issues/782 */}
               <Tooltip
                 position="right"
                 message={
                   <>
                     This machine hardware info is synced every{" "}
                     {formatSyncInterval(machine.sync_interval)}.{"\n"}
-                    You can check it at the bottom, in the status bar.{"\n"}More
-                    about this in the{" "}
-                    <a href="#todo" className="is-on-dark">
-                      Hardware sync docs
-                    </a>
-                    .
+                    You can check it at the bottom, in the status bar.
                   </>
                 }
               >


### PR DESCRIPTION
## Done

- remove periodic hardware sync todo docs links before release
- remove redundant "use actual `sync_interval`" TODO comment (this has been done)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
