### PR TITLE
fix(ui): use == in NodesTagsLink

### DIFF
--- a/ui/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
+++ b/ui/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
@@ -65,15 +65,15 @@ it("links to nodes", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags==a-tag`
+    `${machineURLs.machines.index}?tags=%3Da-tag`
   );
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags==a-tag`
+    `${controllerURLs.controllers.index}?tags=%3Da-tag`
   );
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags==a-tag`
+    `${deviceURLs.devices.index}?tags=%3Da-tag`
   );
 });
 

--- a/ui/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
+++ b/ui/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
@@ -65,15 +65,15 @@ it("links to nodes", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags=a-tag`
+    `${machineURLs.machines.index}?tags==a-tag`
   );
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags=a-tag`
+    `${controllerURLs.controllers.index}?tags==a-tag`
   );
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags=a-tag`
+    `${deviceURLs.devices.index}?tags==a-tag`
   );
 });
 

--- a/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
+++ b/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
@@ -22,7 +22,7 @@ it("create a link to machines", () => {
   expect(machineLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags=a-tag`
+    `${machineURLs.machines.index}?tags==a-tag`
   );
 });
 
@@ -42,7 +42,7 @@ it("create a link to controllers", () => {
   expect(controllerLink).toBeInTheDocument();
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags=a-tag`
+    `${controllerURLs.controllers.index}?tags==a-tag`
   );
 });
 
@@ -58,6 +58,6 @@ it("create a link to devices", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags=a-tag`
+    `${deviceURLs.devices.index}?tags==a-tag`
   );
 });

--- a/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
+++ b/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
@@ -22,7 +22,7 @@ it("create a link to machines", () => {
   expect(machineLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags==a-tag`
+    `${machineURLs.machines.index}?tags=%3Da-tag`
   );
 });
 
@@ -42,7 +42,7 @@ it("create a link to controllers", () => {
   expect(controllerLink).toBeInTheDocument();
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags==a-tag`
+    `${controllerURLs.controllers.index}?tags=%3Da-tag`
   );
 });
 
@@ -58,6 +58,6 @@ it("create a link to devices", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags==a-tag`
+    `${deviceURLs.devices.index}?tags=%3Da-tag`
   );
 });

--- a/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
+++ b/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
@@ -41,7 +41,7 @@ const NodesTagsLink = ({
     return null;
   }
   return (
-    <Link className="u-block" to={`${url}?tags=${tags.join(",")}`}>
+    <Link className="u-block" to={`${url}?tags==${tags.join(",")}`}>
       {pluralize(nodeName, count, true)}
     </Link>
   );

--- a/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
+++ b/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
@@ -7,6 +7,7 @@ import machineURLs from "app/machines/urls";
 import { ControllerMeta } from "app/store/controller/types";
 import { DeviceMeta } from "app/store/device/types";
 import { MachineMeta } from "app/store/machine/types";
+import { FilterMachines } from "app/store/machine/utils";
 import type { Tag } from "app/store/tag/types";
 import type { NodeModel } from "app/store/types/node";
 
@@ -40,8 +41,11 @@ const NodesTagsLink = ({
   if (!url || !nodeName) {
     return null;
   }
+  const filters = FilterMachines.filtersToQueryString({
+    tags: [`=${tags.join(",")}`],
+  });
   return (
-    <Link className="u-block" to={`${url}?tags==${tags.join(",")}`}>
+    <Link className="u-block" to={`${url}${filters}`}>
       {pluralize(nodeName, count, true)}
     </Link>
   );

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -307,15 +307,15 @@ it("can link to nodes", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags==a-tag`
+    `${machineURLs.machines.index}?tags=%3Da-tag`
   );
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags==a-tag`
+    `${controllerURLs.controllers.index}?tags=%3Da-tag`
   );
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags==a-tag`
+    `${deviceURLs.devices.index}?tags=%3Da-tag`
   );
 });
 

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -307,15 +307,15 @@ it("can link to nodes", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags=a-tag`
+    `${machineURLs.machines.index}?tags==a-tag`
   );
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags=a-tag`
+    `${controllerURLs.controllers.index}?tags==a-tag`
   );
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags=a-tag`
+    `${deviceURLs.devices.index}?tags==a-tag`
   );
 });
 


### PR DESCRIPTION
Use == for machine listing link to get an exact match

## Done

## QA

From Tags list, with a tag that applies to a machine or many machines, click the link to machines (or controllers, or devices).


### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Re: https://github.com/canonical-web-and-design/app-tribe/issues/801

