### PR TITLE
refactor(ui): standardise use of EditableSection component

### DIFF
--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import DeviceConfiguration, { Label } from "./DeviceConfiguration";
 import { Label as DeviceConfigurationFieldsLabel } from "./DeviceConfigurationFields/DeviceConfigurationFields";
 
+import { Labels as EditableSectionLabels } from "app/base/components/EditableSection";
 import { Label as TagFieldLabel } from "app/base/components/TagField/TagField";
 import { Label as ZoneSelectLabel } from "app/base/components/ZoneSelect/ZoneSelect";
 import { actions as deviceActions } from "app/store/device";
@@ -85,7 +86,11 @@ describe("DeviceConfiguration", () => {
       </Provider>
     );
 
-    userEvent.click(screen.getByRole("button", { name: Label.Edit }));
+    userEvent.click(
+      screen.getAllByRole("button", {
+        name: EditableSectionLabels.EditButton,
+      })[0]
+    );
 
     expect(screen.queryByTestId("device-details")).not.toBeInTheDocument();
     expect(screen.getByRole("form", { name: Label.Form })).toBeInTheDocument();
@@ -100,7 +105,11 @@ describe("DeviceConfiguration", () => {
         </MemoryRouter>
       </Provider>
     );
-    userEvent.click(screen.getByRole("button", { name: Label.Edit }));
+    userEvent.click(
+      screen.getAllByRole("button", {
+        name: EditableSectionLabels.EditButton,
+      })[0]
+    );
     const deviceNote = screen.getByRole("textbox", {
       name: DeviceConfigurationFieldsLabel.Note,
     });

--- a/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import DomainSummary from "./DomainSummary";
 
+import { Labels } from "app/base/components/EditableSection";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -69,9 +70,15 @@ describe("DomainSummary", () => {
         <DomainSummary id={1} />
       </Provider>
     );
-    expect(wrapper.find('button[data-testid="edit-domain"]').exists()).toBe(
-      false
-    );
+
+    expect(
+      wrapper
+        .findWhere(
+          (node) =>
+            node.type() === "button" && node.text() === Labels.EditButton
+        )
+        .exists()
+    ).toBe(false);
   });
 
   describe("when user is admin", () => {
@@ -104,9 +111,14 @@ describe("DomainSummary", () => {
         </Provider>
       );
 
-      expect(wrapper.find('button[data-testid="edit-domain"]').exists()).toBe(
-        true
-      );
+      expect(
+        wrapper
+          .findWhere(
+            (node) =>
+              node.type() === "button" && node.text() === Labels.EditButton
+          )
+          .exists()
+      ).toBe(true);
     });
 
     it("renders the form when Edit button is clicked", () => {
@@ -118,7 +130,13 @@ describe("DomainSummary", () => {
         </Provider>
       );
 
-      wrapper.find('button[data-testid="edit-domain"]').simulate("click");
+      wrapper
+        .findWhere(
+          (node) =>
+            node.type() === "button" && node.text() === Labels.EditButton
+        )
+        .at(0)
+        .simulate("click");
 
       expect(wrapper.find('[data-testid="domain-summary"]').exists()).toBe(
         false
@@ -137,7 +155,13 @@ describe("DomainSummary", () => {
         </Provider>
       );
 
-      wrapper.find('button[data-testid="edit-domain"]').simulate("click");
+      wrapper
+        .findWhere(
+          (node) =>
+            node.type() === "button" && node.text() === Labels.EditButton
+        )
+        .at(0)
+        .simulate("click");
       wrapper.find("button[data-testid='cancel-action']").simulate("click");
 
       expect(wrapper.find('[data-testid="domain-summary"]').exists()).toBe(
@@ -157,7 +181,13 @@ describe("DomainSummary", () => {
         </Provider>
       );
 
-      wrapper.find('button[data-testid="edit-domain"]').simulate("click");
+      wrapper
+        .findWhere(
+          (node) =>
+            node.type() === "button" && node.text() === Labels.EditButton
+        )
+        .at(0)
+        .simulate("click");
 
       act(() =>
         submitFormikForm(wrapper, {

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
@@ -53,7 +53,7 @@ const ResourceRecords = ({ id }: Props): JSX.Element | null => {
 
   if (loading) {
     return (
-      <Strip>
+      <Strip shallow>
         <Spinner text="Loading..." />
       </Strip>
     );
@@ -207,7 +207,7 @@ const ResourceRecords = ({ id }: Props): JSX.Element | null => {
   });
 
   return (
-    <Strip>
+    <Strip shallow>
       <Row>
         <Col size={12}>
           <h3 className="p-heading--4">Resource records</h3>

--- a/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.tsx
@@ -81,14 +81,12 @@ const EditFabric = ({ close, id }: Props): JSX.Element | null => {
       <Row>
         <Col size={6}>
           <FormikField label="Name" name="name" type="text" />
-          <FabricController id={fabric.id} />
-        </Col>
-        <Col size={6}>
           <FormikField
             component={Textarea}
             label="Description"
             name="description"
           />
+          <FabricController id={fabric.id} />
         </Col>
       </Row>
     </FormikForm>

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -70,7 +70,9 @@ it("can open and close the Edit fabric summary form", async () => {
     </Provider>
   );
   const fabricSummary = screen.getByRole("region", { name: "Fabric summary" });
-  userEvent.click(within(fabricSummary).getByRole("button", { name: "Edit" }));
+  userEvent.click(
+    within(fabricSummary).getAllByRole("button", { name: "Edit" })[0]
+  );
   await waitFor(() =>
     expect(
       screen.getByRole("form", { name: "Edit fabric summary" })

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.tsx
@@ -1,47 +1,35 @@
-import { useState } from "react";
-
-import { Button, Col, Row } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 
 import EditFabric from "../EditFabric";
 
 import FabricController from "./FabricController";
 
 import Definition from "app/base/components/Definition";
-import TitledSection from "app/base/components/TitledSection";
+import EditableSection from "app/base/components/EditableSection";
 import type { Fabric } from "app/store/fabric/types";
 
 const FabricSummary = ({ fabric }: { fabric: Fabric }): JSX.Element => {
-  const [editing, setEditing] = useState(false);
-
   return (
-    <TitledSection
-      title="Fabric summary"
-      buttons={
-        !editing && (
-          <Button
-            appearance="neutral"
-            className="u-no-margin--bottom"
-            onClick={() => setEditing(true)}
-          >
-            Edit
-          </Button>
+    <EditableSection
+      hasSidebarTitle
+      renderContent={(editing, setEditing) =>
+        editing ? (
+          <EditFabric close={() => setEditing(false)} id={fabric.id} />
+        ) : (
+          <Row>
+            <Col size={6}>
+              <Definition label="Name" description={fabric.name} />
+              <Definition
+                label="Description"
+                description={fabric.description}
+              />
+              <FabricController id={fabric.id} />
+            </Col>
+          </Row>
         )
       }
-    >
-      {editing ? (
-        <EditFabric close={() => setEditing(false)} id={fabric.id} />
-      ) : (
-        <Row>
-          <Col size={6}>
-            <Definition label="Name" description={fabric.name} />
-            <FabricController id={fabric.id} />
-          </Col>
-          <Col size={6}>
-            <Definition label="Description" description={fabric.description} />
-          </Col>
-        </Row>
-      )}
-    </TitledSection>
+      title="Fabric summary"
+    />
   );
 };
 

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -52,7 +52,9 @@ it("can open and close the Edit space summary form", async () => {
     </Provider>
   );
   const spaceSummary = screen.getByRole("region", { name: "Space summary" });
-  userEvent.click(within(spaceSummary).getByRole("button", { name: "Edit" }));
+  userEvent.click(
+    within(spaceSummary).getAllByRole("button", { name: "Edit" })[0]
+  );
   await waitFor(() =>
     expect(
       screen.getByRole("form", { name: "Edit space summary" })

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.tsx
@@ -1,42 +1,32 @@
-import { useState } from "react";
-
-import { Button, Col, Row } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 
 import SpaceSummaryForm from "./SpaceSummaryForm";
 
 import Definition from "app/base/components/Definition";
-import TitledSection from "app/base/components/TitledSection";
+import EditableSection from "app/base/components/EditableSection";
 import type { Space } from "app/store/space/types";
 
 const SpaceSummary = ({ space }: { space: Space }): JSX.Element => {
-  const [isEdit, setIsEdit] = useState(false);
   return (
-    <TitledSection
-      title="Space summary"
-      buttons={
-        <Col size={6} className="u-align--right">
-          <Button disabled={isEdit} onClick={() => setIsEdit(true)}>
-            Edit
-          </Button>
-        </Col>
-      }
-    >
-      <Row>
-        <Col size={6}>
-          {isEdit ? (
-            <SpaceSummaryForm
-              space={space}
-              handleDismiss={() => setIsEdit(false)}
-            />
-          ) : (
-            <>
+    <EditableSection
+      hasSidebarTitle
+      renderContent={(editing, setEditing) =>
+        editing ? (
+          <SpaceSummaryForm
+            handleDismiss={() => setEditing(false)}
+            space={space}
+          />
+        ) : (
+          <Row>
+            <Col size={6}>
               <Definition label="Name">{space.name}</Definition>
               <Definition label="Description">{space.description}</Definition>
-            </>
-          )}
-        </Col>
-      </Row>
-    </TitledSection>
+            </Col>
+          </Row>
+        )
+      }
+      title="Space summary"
+    />
   );
 };
 

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.tsx
@@ -1,3 +1,4 @@
+import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -31,9 +32,10 @@ const SpaceSummaryForm = ({
       cleanup={spaceActions.cleanup}
       errors={spaceErrors}
       initialValues={{
-        name: space?.name || "",
-        description: space?.description || "",
+        name: space.name,
+        description: space.description,
       }}
+      onCancel={handleDismiss}
       onSaveAnalytics={{
         action: "Save",
         category: "Space",
@@ -49,11 +51,14 @@ const SpaceSummaryForm = ({
       saving={saving}
       saved={saved}
       submitLabel="Save"
-      onCancel={handleDismiss}
       validationSchema={spaceSummaryFormSchema}
     >
-      <FormikField label="Name" name="name" type="text" />
-      <FormikField label="Description" name="description" type="text" />
+      <Row>
+        <Col size={6}>
+          <FormikField label="Name" name="name" type="text" />
+          <FormikField label="Description" name="description" type="text" />
+        </Col>
+      </Row>
     </FormikForm>
   );
 };

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-import { Row, Col, Tooltip, Icon, Button } from "@canonical/react-components";
+import { Col, Icon, Row, Tooltip } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
 
 import SubnetSpace from "./SubnetSpace";
 import SubnetSummaryForm from "./SubnetSummaryForm";
 
 import Definition from "app/base/components/Definition";
+import EditableSection from "app/base/components/EditableSection";
 import FabricLink from "app/base/components/FabricLink";
-import TitledSection from "app/base/components/TitledSection";
 import VLANLink from "app/base/components/VLANLink";
 import { actions as fabricActions } from "app/store/fabric";
 import type { RootState } from "app/store/root/types";
@@ -26,7 +26,6 @@ type Props = {
 const formatTooltip = (message: string) => breakLines(unindentString(message));
 
 const SubnetSummary = ({ id }: Props): JSX.Element | null => {
-  const [isEdit, setIsEdit] = useState(false);
   const dispatch = useDispatch();
   const subnet = useSelector((state: RootState) =>
     subnetSelectors.getById(state, id)
@@ -46,124 +45,121 @@ const SubnetSummary = ({ id }: Props): JSX.Element | null => {
   }
 
   return (
-    <TitledSection
-      title="Subnet summary"
-      buttons={
-        <Col size={6} className="u-align--right">
-          <Button disabled={isEdit} onClick={() => setIsEdit(true)}>
-            Edit
-          </Button>
-        </Col>
-      }
-    >
-      {isEdit ? (
-        <SubnetSummaryForm
-          id={subnet.id}
-          handleDismiss={() => setIsEdit(false)}
-        />
-      ) : (
-        <Row>
-          <Col size={6}>
-            <Definition label="Name" description={subnet.name} />
-            <Definition label="CIDR" description={subnet.cidr} />
-            <Definition label="Gateway IP">{subnet.gateway_ip}</Definition>
-            <Definition label="DNS" description={subnet.dns_servers} />
-            <Definition label="Description" description={subnet.description} />
-            <Definition
-              label={
-                <>
-                  Managed allocation{" "}
-                  {subnet.managed ? null : (
-                    <Tooltip
-                      message={formatTooltip(`MAAS allocates IP addresses from
+    <EditableSection
+      renderContent={(editing, setEditing) =>
+        editing ? (
+          <SubnetSummaryForm
+            id={subnet.id}
+            handleDismiss={() => setEditing(false)}
+          />
+        ) : (
+          <Row>
+            <Col size={6}>
+              <Definition label="Name" description={subnet.name} />
+              <Definition label="CIDR" description={subnet.cidr} />
+              <Definition label="Gateway IP">{subnet.gateway_ip}</Definition>
+              <Definition label="DNS" description={subnet.dns_servers} />
+              <Definition
+                label="Description"
+                description={subnet.description}
+              />
+              <Definition
+                label={
+                  <>
+                    Managed allocation{" "}
+                    {subnet.managed ? null : (
+                      <Tooltip
+                        message={formatTooltip(`MAAS allocates IP addresses from
                         this subnet, excluding the reserved and dynamic
                         ranges.`)}
-                      position="btm-right"
-                    >
-                      <Icon name="information" />
-                    </Tooltip>
-                  )}
-                </>
-              }
-            >
-              {subnet.managed ? "Enabled" : "Disabled"}
-            </Definition>
-          </Col>
-          <Col size={6}>
-            <Definition
-              label={
-                <>
-                  Active discovery{" "}
-                  {subnet.managed ? (
-                    <Tooltip
-                      message={formatTooltip(
-                        `When enabled, MAAS will scan this
+                        position="btm-right"
+                      >
+                        <Icon name="information" />
+                      </Tooltip>
+                    )}
+                  </>
+                }
+              >
+                {subnet.managed ? "Enabled" : "Disabled"}
+              </Definition>
+            </Col>
+            <Col size={6}>
+              <Definition
+                label={
+                  <>
+                    Active discovery{" "}
+                    {subnet.managed ? (
+                      <Tooltip
+                        message={formatTooltip(
+                          `When enabled, MAAS will scan this
                         subnet to discover hosts that have not been discovered
                         passively.`
+                        )}
+                        position="btm-right"
+                      >
+                        <Icon name="information" />
+                      </Tooltip>
+                    ) : null}
+                  </>
+                }
+              >
+                {subnet.active_discovery ? "Enabled" : "Disabled"}
+              </Definition>
+              <Definition
+                label={
+                  <>
+                    Proxy access{" "}
+                    <Tooltip
+                      data-testid="proxy-access-tooltip"
+                      message={formatTooltip(
+                        `MAAS will ${
+                          subnet.allow_proxy ? "" : "not"
+                        } allow clients from this subnet to access the MAAS
+                      proxy.`
                       )}
                       position="btm-right"
                     >
                       <Icon name="information" />
                     </Tooltip>
-                  ) : null}
-                </>
-              }
-            >
-              {subnet.active_discovery ? "Enabled" : "Disabled"}
-            </Definition>
-            <Definition
-              label={
-                <>
-                  Proxy access{" "}
-                  <Tooltip
-                    data-testid="proxy-access-tooltip"
-                    message={formatTooltip(
-                      `MAAS will ${
-                        subnet.allow_proxy ? "" : "not"
-                      } allow clients from this subnet to access the MAAS
-                      proxy.`
-                    )}
-                    position="btm-right"
-                  >
-                    <Icon name="information" />
-                  </Tooltip>
-                </>
-              }
-            >
-              {subnet.allow_proxy ? "Allowed" : "Disallowed"}
-            </Definition>
-            <Definition
-              label={
-                <>
-                  Allow DNS resolution{" "}
-                  <Tooltip
-                    data-testid="allow-dns-tooltip"
-                    message={formatTooltip(
-                      `MAAS will ${
-                        subnet.allow_dns ? "" : "not"
-                      } allow clients from this subnet to use MAAS for DNS
+                  </>
+                }
+              >
+                {subnet.allow_proxy ? "Allowed" : "Disallowed"}
+              </Definition>
+              <Definition
+                label={
+                  <>
+                    Allow DNS resolution{" "}
+                    <Tooltip
+                      data-testid="allow-dns-tooltip"
+                      message={formatTooltip(
+                        `MAAS will ${
+                          subnet.allow_dns ? "" : "not"
+                        } allow clients from this subnet to use MAAS for DNS
                       resolution.`
-                    )}
-                    position="btm-right"
-                  >
-                    <Icon name="information" />
-                  </Tooltip>
-                </>
-              }
-            >
-              {subnet.allow_dns ? "Allowed" : "Disallowed"}
-            </Definition>
-            <Definition label="Fabric">
-              <FabricLink id={vlan?.fabric} />
-            </Definition>
-            <Definition label="VLAN">
-              <VLANLink id={subnet.vlan} />
-            </Definition>
-            <SubnetSpace spaceId={subnet.space} />
-          </Col>
-        </Row>
-      )}
-    </TitledSection>
+                      )}
+                      position="btm-right"
+                    >
+                      <Icon name="information" />
+                    </Tooltip>
+                  </>
+                }
+              >
+                {subnet.allow_dns ? "Allowed" : "Disallowed"}
+              </Definition>
+              <Definition label="Fabric">
+                <FabricLink id={vlan?.fabric} />
+              </Definition>
+              <Definition label="VLAN">
+                <VLANLink id={subnet.vlan} />
+              </Definition>
+              <SubnetSpace spaceId={subnet.space} />
+            </Col>
+          </Row>
+        )
+      }
+      title="Subnet summary"
+    />
   );
 };
 

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-
-import { Button, Col, Row } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import EditVLAN from "../EditVLAN";
@@ -8,9 +6,9 @@ import EditVLAN from "../EditVLAN";
 import VLANControllers from "./VLANControllers";
 
 import Definition from "app/base/components/Definition";
+import EditableSection from "app/base/components/EditableSection";
 import FabricLink from "app/base/components/FabricLink";
 import SpaceLink from "app/base/components/SpaceLink";
-import TitledSection from "app/base/components/TitledSection";
 import authSelectors from "app/store/auth/selectors";
 import type { RootState } from "app/store/root/types";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -25,51 +23,39 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
-  const [editing, setEditing] = useState(false);
-  const canEdit = isAdmin;
 
   if (!id || !vlan) {
     return null;
   }
 
   return (
-    <TitledSection
-      title="VLAN summary"
-      buttons={
-        canEdit &&
-        !editing && (
-          <Button
-            appearance="neutral"
-            className="u-no-margin--bottom"
-            onClick={() => setEditing(true)}
-          >
-            Edit
-          </Button>
+    <EditableSection
+      canEdit={isAdmin}
+      renderContent={(editing, setEditing) =>
+        editing ? (
+          <EditVLAN close={() => setEditing(false)} id={id} />
+        ) : (
+          <Row>
+            <Col size={6}>
+              <Definition label="VID" description={`${vlan.vid}`} />
+              <Definition label="Name" description={vlan.name} />
+              <Definition label="MTU" description={`${vlan.mtu}`} />
+              <Definition label="Description" description={vlan.description} />
+            </Col>
+            <Col size={6}>
+              <Definition label="Space">
+                <SpaceLink id={vlan.space} />
+              </Definition>
+              <Definition label="Fabric">
+                <FabricLink id={vlan.fabric} />
+              </Definition>
+              <VLANControllers id={id} />
+            </Col>
+          </Row>
         )
       }
-    >
-      {editing ? (
-        <EditVLAN close={() => setEditing(false)} id={id} />
-      ) : (
-        <Row>
-          <Col size={6}>
-            <Definition label="VID" description={`${vlan.vid}`} />
-            <Definition label="Name" description={vlan.name} />
-            <Definition label="MTU" description={`${vlan.mtu}`} />
-            <Definition label="Description" description={vlan.description} />
-          </Col>
-          <Col size={6}>
-            <Definition label="Space">
-              <SpaceLink id={vlan.space} />
-            </Definition>
-            <Definition label="Fabric">
-              <FabricLink id={vlan.fabric} />
-            </Definition>
-            <VLANControllers id={id} />
-          </Col>
-        </Row>
-      )}
-    </TitledSection>
+      title="VLAN summary"
+    />
   );
 };
 

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import ZoneDetails from "./ZoneDetails";
 
+import { Labels } from "app/base/components/EditableSection";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -55,7 +56,14 @@ describe("ZoneDetails", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find('[data-testid="edit-zone"]').exists()).toBe(true);
+    expect(
+      wrapper
+        .findWhere(
+          (node) =>
+            node.type() === "button" && node.text() === Labels.EditButton
+        )
+        .exists()
+    ).toBe(true);
   });
 
   it("hides Edit button if user is not admin", () => {
@@ -77,6 +85,13 @@ describe("ZoneDetails", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find('[data-testid="edit-zone"]').exists()).toBe(false);
+    expect(
+      wrapper
+        .findWhere(
+          (node) =>
+            node.type() === "button" && node.text() === Labels.EditButton
+        )
+        .exists()
+    ).toBe(false);
   });
 });

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-import { Button, Row, Col } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
 
 import ZoneDetailsContent from "./ZoneDetailsContent";
 import ZoneDetailsForm from "./ZoneDetailsForm";
 import ZoneDetailsHeader from "./ZoneDetailsHeader";
 
+import EditableSection from "app/base/components/EditableSection";
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
@@ -21,7 +21,6 @@ import zoneURLs from "app/zones/urls";
 
 const ZoneDetails = (): JSX.Element => {
   const dispatch = useDispatch();
-  const [showForm, setShowForm] = useState(false);
   const zoneID = useGetURLId(ZoneMeta.PK);
   const isAdmin = useSelector(authSelectors.isAdmin);
   const zonesLoading = useSelector(zoneSelectors.loading);
@@ -42,27 +41,19 @@ const ZoneDetails = (): JSX.Element => {
 
   return (
     <Section header={<ZoneDetailsHeader id={zoneID} />}>
-      {showForm ? (
-        <ZoneDetailsForm
-          id={zoneID}
-          closeForm={() => {
-            setShowForm(false);
-          }}
-        />
-      ) : (
-        <Row>
-          <Col size={6}>
+      <EditableSection
+        canEdit={isAdmin}
+        className="u-no-padding--top"
+        hasSidebarTitle
+        renderContent={(editing, setEditing) =>
+          editing ? (
+            <ZoneDetailsForm id={zoneID} closeForm={() => setEditing(false)} />
+          ) : (
             <ZoneDetailsContent id={zoneID} />
-          </Col>
-          {isAdmin && (
-            <Col size={6} className="u-align--right">
-              <Button data-testid="edit-zone" onClick={() => setShowForm(true)}>
-                Edit
-              </Button>
-            </Col>
-          )}
-        </Row>
-      )}
+          )
+        }
+        title="Zone summary"
+      />
     </Section>
   );
 };

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsContent/ZoneDetailsContent.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsContent/ZoneDetailsContent.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { Row, Col } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
 
+import Definition from "app/base/components/Definition";
 import type { RootState } from "app/store/root/types";
 import { actions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
@@ -12,43 +13,24 @@ type Props = {
 };
 
 const ZoneDetailsContent = ({ id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
   const zone = useSelector((state: RootState) =>
-    zoneSelectors.getById(state, Number(id))
+    zoneSelectors.getById(state, id)
   );
 
-  const dispatch = useDispatch();
   useEffect(() => {
     dispatch(actions.fetch());
   }, [dispatch]);
 
   if (zone) {
     return (
-      <>
-        <Row>
-          <Col size={2}>
-            <p>Name:</p>
-          </Col>
-          <Col size={4}>
-            <p>{zone.name}</p>
-          </Col>
-        </Row>
-        <Row>
-          <Col size={2}>
-            <p>Description:</p>
-          </Col>
-          <Col size={4}>
-            <p>{zone.description}</p>
-          </Col>
-        </Row>
-        <Row>
-          <Col size={2}>
-            <p>Machines:</p>
-          </Col>
-          <Col size={4}>
-            <p>{zone.machines_count}</p>
-          </Col>
-        </Row>
-      </>
+      <Row>
+        <Col size={6}>
+          <Definition label="Name">{zone.name}</Definition>
+          <Definition label="Description">{zone.description}</Definition>
+          <Definition label="Machines">{`${zone.machines_count}`}</Definition>
+        </Col>
+      </Row>
     );
   }
   return null;

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.tsx
@@ -26,7 +26,7 @@ const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
   const saving = useSelector(zoneSelectors.saving);
   const cleanup = useCallback(() => zoneActions.cleanup(), []);
   const zone = useSelector((state: RootState) =>
-    zoneSelectors.getById(state, Number(id))
+    zoneSelectors.getById(state, id)
   );
 
   useEffect(() => {
@@ -36,8 +36,6 @@ const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
   if (zone) {
     return (
       <FormikForm<CreateZoneValues>
-        buttonsAlign="right"
-        buttonsBordered={false}
         cleanup={cleanup}
         errors={errors}
         initialValues={{
@@ -56,7 +54,6 @@ const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
             })
           );
         }}
-        resetOnSave={true}
         saved={saved}
         saving={saving}
         submitLabel="Update AZ"


### PR DESCRIPTION
## Done

- Use `EditableSection` component wherever we use a section with an "Edit" button in the header strip
- Minor tidy up of some styling inconsistencies in these sections (using `Definition` component, including borders above buttons in forms, etc)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the editable sections look consistent and work across the following configuration sections: Machine, Device, Domain, Zone, Fabric, VLAN, Subnet, Space

## Fixes

Fixes #3782 
