### PR TITLE
feat(ui): add validation to tag name in add tag form

### DIFF
--- a/ui/src/app/base/validation.ts
+++ b/ui/src/app/base/validation.ts
@@ -20,3 +20,8 @@ export const MAC_ADDRESS_REGEX = /^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$/;
  * Validate range string e.g 0-2, 4, 6-7
  */
 export const RANGE_REGEX = /^\d{1,3}(-\d{1,3})?(,\s*(\d{1,3}(-\d{1,3})?))*$/;
+
+/**
+ * Validate tag name string (only alphanumeric, dash or underscore)
+ */
+export const TAG_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -217,3 +217,22 @@ it("shows a confirmation when an automatic tag is added", async () => {
     expect(strippedMessage).toBe(`Created name1. ${NewDefinitionMessage}`);
   });
 });
+
+it("shows an error if tag name is invalid", async () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <AddTagForm onClose={jest.fn()} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const nameInput = screen.getByRole("textbox", { name: Label.Name });
+  userEvent.type(nameInput, "invalid name");
+  userEvent.tab();
+
+  await waitFor(() =>
+    expect(nameInput).toHaveErrorMessage(`Error: ${Label.NameValidation}`)
+  );
+});

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -8,6 +8,7 @@ import * as Yup from "yup";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import { useSendAnalytics } from "app/base/hooks";
+import { TAG_NAME_REGEX } from "app/base/validation";
 import { actions as messageActions } from "app/store/message";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -25,13 +26,16 @@ type Props = {
 export enum Label {
   Comment = "Comment",
   Name = "Tag name",
+  NameValidation = "Tag names can only contain letters, numbers, dashes or underscores.",
 }
 
 const AddTagFormSchema = Yup.object().shape({
   comment: Yup.string(),
   definition: Yup.string(),
   kernel_opts: Yup.string(),
-  name: Yup.string().required("Name is required."),
+  name: Yup.string()
+    .matches(TAG_NAME_REGEX, Label.NameValidation)
+    .required("Name is required."),
 });
 
 export const AddTagForm = ({ onClose }: Props): JSX.Element => {


### PR DESCRIPTION
## Done

- Added validation for tag name in add tag form (regex comes from the backend code)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tag list and click "Create new tag"
- Enter an invalid tag name (e.g. with spaces) and blur the field
- Check that an error message shows

### Screenshot

![2022-04-08_15-02](https://user-images.githubusercontent.com/25733845/162368243-08766fea-8a69-4085-92e8-f0fb6183fc84.png)
