### PR TITLE
feat(ui): show "NEW" prefix for newly created tags in machine tag form

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { NotificationSeverity } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -14,6 +14,7 @@ import type { MachineEventErrors } from "app/store/machine/types";
 import { actions as messageActions } from "app/store/message";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
+import type { Tag, TagMeta } from "app/store/tag/types";
 import { NodeActions } from "app/store/types/node";
 
 type Props = MachineActionFormProps & { viewingMachineConfig?: boolean };
@@ -37,6 +38,7 @@ export const TagForm = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const tagsLoaded = useSelector(tagSelectors.loaded);
+  const [newTags, setNewTags] = useState<Tag[TagMeta.PK][]>([]);
 
   let formErrors: Record<string, string | string[]> | null = null;
   if (errors && typeof errors === "object" && "name" in errors) {
@@ -105,6 +107,8 @@ export const TagForm = ({
     >
       <TagFormFields
         machines={machines}
+        newTags={newTags}
+        setNewTags={setNewTags}
         viewingDetails={viewingDetails}
         viewingMachineConfig={viewingMachineConfig}
       />

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -65,7 +65,11 @@ it("displays available tags in the dropdown", async () => {
     <Provider store={store}>
       <MemoryRouter>
         <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormFields machines={state.machine.items} />
+          <TagFormFields
+            machines={state.machine.items}
+            newTags={[]}
+            setNewTags={jest.fn()}
+          />
         </Formik>
       </MemoryRouter>
     </Provider>
@@ -94,7 +98,7 @@ it("displays available tags in the dropdown", async () => {
   );
 });
 
-it("displays the new tags", () => {
+it("displays the tags to be added", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -103,7 +107,11 @@ it("displays the new tags", () => {
           initialValues={{ added: [tags[0].id, tags[2].id], removed: [] }}
           onSubmit={jest.fn()}
         >
-          <TagFormFields machines={state.machine.items} />
+          <TagFormFields
+            machines={state.machine.items}
+            newTags={[]}
+            setNewTags={jest.fn()}
+          />
         </Formik>
       </MemoryRouter>
     </Provider>
@@ -125,7 +133,7 @@ it("can open a create tag form", async () => {
     <Provider store={store}>
       <MemoryRouter>
         <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormFields machines={[]} />
+          <TagFormFields machines={[]} newTags={[]} setNewTags={jest.fn()} />
         </Formik>
       </MemoryRouter>
     </Provider>
@@ -143,6 +151,7 @@ it("can open a create tag form", async () => {
 
 it("updates the new tags after creating a tag", async () => {
   const store = mockStore(state);
+  const setNewTags = jest.fn();
   const Form = ({ tags }: { tags: Tag[TagMeta.PK][] }) => (
     <Provider store={store}>
       <MemoryRouter>
@@ -150,7 +159,11 @@ it("updates the new tags after creating a tag", async () => {
           initialValues={{ added: tags, removed: [] }}
           onSubmit={jest.fn()}
         >
-          <TagFormFields machines={state.machine.items} />
+          <TagFormFields
+            machines={state.machine.items}
+            newTags={[]}
+            setNewTags={setNewTags}
+          />
         </Formik>
       </MemoryRouter>
     </Provider>
@@ -183,4 +196,5 @@ it("updates the new tags after creating a tag", async () => {
       within(changes).getByRole("button", { name: /new-tag/i })
     ).toBeInTheDocument()
   );
+  expect(setNewTags).toHaveBeenCalledWith([newTag.id]);
 });

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -17,13 +17,15 @@ import { NULL_EVENT } from "app/base/constants";
 import type { Machine } from "app/store/machine/types";
 import { getTagCountsForMachines } from "app/store/machine/utils";
 import tagSelectors from "app/store/tag/selectors";
-import type { Tag } from "app/store/tag/types";
+import type { Tag, TagMeta } from "app/store/tag/types";
 
 const hasKernelOptions = (tags: Tag[], tag: TagSelectorTag) =>
   !!tags.find(({ id }) => tag.id === id)?.kernel_opts;
 
 type Props = {
   machines: Machine[];
+  newTags: Tag[TagMeta.PK][];
+  setNewTags: (tags: Tag[TagMeta.PK][]) => void;
   viewingDetails?: boolean;
   viewingMachineConfig?: boolean;
 };
@@ -35,6 +37,8 @@ export enum Label {
 
 export const TagFormFields = ({
   machines,
+  newTags,
+  setNewTags,
   viewingDetails = false,
   viewingMachineConfig = false,
 }: Props): JSX.Element => {
@@ -86,7 +90,7 @@ export const TagFormFields = ({
             storedValue="id"
             tags={availableTags.map(({ id, name }) => ({ id, name }))}
           />
-          <TagFormChanges machines={machines} />
+          <TagFormChanges machines={machines} newTags={newTags} />
         </Col>
       </Row>
       {isOpen ? (
@@ -105,6 +109,7 @@ export const TagFormFields = ({
                   values.added.concat([tag.id.toString()])
                 );
                 setNewTagName(null);
+                setNewTags([...newTags, tag.id]);
                 closePortal(NULL_EVENT);
               }}
               viewingDetails={viewingDetails}


### PR DESCRIPTION
## Done

- Show "NEW" prefix in tag chip for newly created tags

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, select some machines and choose "Tag" from the action menu
- Select some existing tags and check that they don't show "NEW" in the chip
- Enter a new tag name in the input and click "Create tag ${name}"
- Submit the modal form
- Check that the new tag shows up with "NEW" in the chip

## Screenshot

![2022-04-08_14-50](https://user-images.githubusercontent.com/25733845/162367046-b885ca9b-aaa4-48d4-90b1-e866a1e3435c.png)
