### PR TITLE
fix(ui): fix display of mixed selection checkboxes

### DIFF
--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -14,9 +14,7 @@ describe("GroupCheckbox", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  // Skipping until checkbox labels support class names:
-  // https://github.com/canonical-web-and-design/react-components/issues/716
-  it.skip("shows as mixed when some items are checked", () => {
+  it("shows as mixed when some items are checked", () => {
     const wrapper = shallow(
       <GroupCheckbox
         items={[1, 2, 3]}
@@ -25,7 +23,7 @@ describe("GroupCheckbox", () => {
       />
     );
     expect(wrapper.prop("checked")).toBe(true);
-    expect(wrapper.hasClass("p-checkbox--mixed")).toBe(true);
+    expect(wrapper.prop("aria-checked")).toBe("mixed");
   });
 
   it("can show a label", () => {
@@ -75,6 +73,6 @@ describe("GroupCheckbox", () => {
       />
     );
     expect(wrapper.prop("checked")).toBe(true);
-    expect(wrapper.hasClass("p-checkbox--mixed")).toBe(true);
+    expect(wrapper.prop("aria-checked")).toBe("mixed");
   });
 });

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -6,7 +6,6 @@ import { Input } from "@canonical/react-components";
 import { nanoid } from "@reduxjs/toolkit";
 import classNames from "classnames";
 
-import { someInArray, someNotAll } from "app/utils";
 import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
 type Props<S> = PropsWithSpread<
@@ -37,19 +36,18 @@ const GroupCheckbox = <S,>({
   ...props
 }: Props<S>): JSX.Element => {
   const id = useRef(nanoid());
-  const notAllSelected = checkAllSelected
-    ? !checkAllSelected(items, selectedItems)
-    : someNotAll(items, selectedItems);
+  const allSelected = checkAllSelected
+    ? checkAllSelected(items, selectedItems)
+    : selectedItems.length > 0 && selectedItems.length === items.length;
+  const someSelected =
+    !allSelected && checkSelected
+      ? checkSelected(items, selectedItems)
+      : selectedItems.length > 0 && !allSelected;
+
   return (
     <Input
-      checked={
-        checkSelected
-          ? checkSelected(items, selectedItems)
-          : someInArray(items, selectedItems)
-      }
-      className={classNames({
-        "p-checkbox--mixed": selectedItems.length > 0 && notAllSelected,
-      })}
+      aria-checked={allSelected ? "true" : someSelected ? "mixed" : "false"}
+      checked={someSelected || allSelected}
       disabled={items.length === 0 || disabled}
       id={id.current}
       label={inputLabel ? inputLabel : " "}

--- a/ui/src/app/base/components/GroupCheckbox/__snapshots__/GroupCheckbox.test.tsx.snap
+++ b/ui/src/app/base/components/GroupCheckbox/__snapshots__/GroupCheckbox.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`GroupCheckbox renders 1`] = `
 <Input
+  aria-checked="false"
   checked={false}
-  className=""
   disabled={true}
   id="mock-redux-js-nanoid-1"
   label=" "

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -460,8 +460,8 @@ describe("MachineListTable", () => {
         wrapper
           .find("[data-testid='group-cell'] input")
           .at(0)
-          .hasClass("p-checkbox--mixed")
-      ).toBe(false);
+          .prop("aria-checked")
+      ).not.toBe("mixed");
     });
 
     it("shows a checked checkbox in header row if all machines are selected", () => {
@@ -492,8 +492,8 @@ describe("MachineListTable", () => {
       expect(
         wrapper
           .find("[data-testid='all-machines-checkbox'] input")
-          .hasClass("p-checkbox--mixed")
-      ).toBe(false);
+          .prop("aria-checked")
+      ).not.toBe("mixed");
     });
 
     it("correctly dispatches action when unchecked machine checkbox clicked", () => {
@@ -639,9 +639,7 @@ describe("MachineListTable", () => {
       });
     });
 
-    // Skipping until checkbox labels support class names:
-    // https://github.com/canonical-web-and-design/react-components/issues/716
-    it.skip("shows group checkbox in mixed selection state if some machines selected", () => {
+    it("shows group checkbox in mixed selection state if some machines selected", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
@@ -664,8 +662,8 @@ describe("MachineListTable", () => {
         wrapper
           .find("[data-testid='group-cell'] input")
           .at(0)
-          .hasClass("p-checkbox--mixed")
-      ).toBe(true);
+          .prop("aria-checked")
+      ).toBe("mixed");
     });
 
     it("correctly dispatches action when unchecked header checkbox clicked", () => {
@@ -771,9 +769,7 @@ describe("MachineListTable", () => {
     });
   });
 
-  // Skipping until checkbox labels support class names:
-  // https://github.com/canonical-web-and-design/react-components/issues/716
-  it.skip("shows header checkbox in mixed selection state if some machines selected", () => {
+  it("shows header checkbox in mixed selection state if some machines selected", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -796,8 +792,8 @@ describe("MachineListTable", () => {
       wrapper
         .find("[data-testid='all-machines-checkbox'] input")
         .at(0)
-        .hasClass("p-checkbox--mixed")
-    ).toBe(true);
+        .prop("aria-checked")
+    ).toBe("mixed");
   });
 
   it("remove selected filter when unchecking the only checked machine", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -43,6 +43,7 @@ import {
   groupAsMap,
   isComparable,
   simpleSortByKey,
+  someInArray,
 } from "app/utils";
 import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
@@ -463,6 +464,12 @@ const generateGroupRows = ({
                   primary={
                     showActions ? (
                       <GroupCheckbox
+                        checkAllSelected={(_, selectedIDs) =>
+                          machineIDs.every((id) => selectedIDs.includes(id))
+                        }
+                        checkSelected={(_, selectedIDs) =>
+                          someInArray(selectedIDs, machineIDs)
+                        }
                         inRow
                         items={machineIDs}
                         selectedItems={selectedIDs}
@@ -618,10 +625,10 @@ export const MachineListTable = ({
         <div className="u-flex">
           {showActions && (
             <GroupCheckbox
+              data-testid="all-machines-checkbox"
+              handleGroupCheckbox={handleGroupCheckbox}
               items={machineIDs}
               selectedItems={selectedIDs}
-              handleGroupCheckbox={handleGroupCheckbox}
-              data-testid="all-machines-checkbox"
             />
           )}
           <div>

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -33,14 +33,6 @@
     min-width: auto;
   }
 
-  .p-checkbox--mixed:checked {
-    + label::after {
-      border-left: 0;
-      top: 0.3125rem;
-      transform: none;
-    }
-  }
-
   // Custom styling for form fields inside a table.
   .p-form--table {
     input,


### PR DESCRIPTION
## Done

- Use Vanilla `aria-checked` handling and remove local overrides
- Fixed logic for display mixed checkboxes in the grouped machine list

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and select some, but not all, machines in a group
- Check that the group checkboxes show up as mixed
- Select all machines in a group
- The checkbox should show up as checked

## Fixes

Fixes canonical-web-and-design/app-tribe#796

## Screenshot

![2022-04-08_17-05](https://user-images.githubusercontent.com/25733845/162382867-34741e2e-85f3-4170-845c-85ce2c6d6d9e.png)

