### PR TITLE
fix(ui): unset IP mode when removing subnet

### DIFF
--- a/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
+++ b/ui/src/app/base/components/FabricSelect/FabricSelect.tsx
@@ -12,6 +12,10 @@ type Props = {
   defaultOption?: { label: string; value: string; disabled?: boolean } | null;
 } & FormikFieldProps;
 
+export enum Label {
+  Select = "Fabric",
+}
+
 export const FabricSelect = ({
   defaultOption = { label: "Select fabric", value: "", disabled: true },
   name,

--- a/ui/src/app/base/components/LinkModeSelect/LinkModeSelect.tsx
+++ b/ui/src/app/base/components/LinkModeSelect/LinkModeSelect.tsx
@@ -10,6 +10,10 @@ type Props = {
   subnet?: Subnet["id"] | null;
 } & FormikFieldProps;
 
+export enum Label {
+  Select = "IP mode",
+}
+
 const getAvailableLinkModes = (
   interfaceType: NetworkInterfaceTypes | null,
   subnet?: Subnet["id"] | null

--- a/ui/src/app/base/components/SubnetSelect/SubnetSelect.tsx
+++ b/ui/src/app/base/components/SubnetSelect/SubnetSelect.tsx
@@ -20,6 +20,10 @@ type Props = {
   vlan?: Subnet["vlan"];
 } & FormikFieldProps;
 
+export enum Label {
+  Select = "Subnet",
+}
+
 export const SubnetSelect = ({
   defaultOption = { label: "Select subnet", value: "" },
   filterFunction,

--- a/ui/src/app/base/components/VLANSelect/VLANSelect.tsx
+++ b/ui/src/app/base/components/VLANSelect/VLANSelect.tsx
@@ -28,6 +28,10 @@ type Props = {
   vlans?: VLAN[] | null;
 } & FormikFieldProps;
 
+export enum Label {
+  Select = "VLAN",
+}
+
 export const VLANSelect = ({
   defaultOption = { disabled: true, label: "Select VLAN", value: "" },
   fabric,

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -57,6 +57,10 @@ type Props = {
   vlans?: VLAN[] | null;
 };
 
+export enum Label {
+  IPAddress = "IP address",
+}
+
 const NetworkFields = ({
   editing,
   fabricDisabled,
@@ -70,13 +74,17 @@ const NetworkFields = ({
   const subnets: Subnet[] = useSelector(subnetSelectors.all);
   const { handleChange, setFieldValue, values } =
     useFormikContext<NetworkValues>();
-  const resetFollowingFields = (name: keyof NetworkValues) => {
+  const resetFollowingFields = (
+    name: keyof NetworkValues,
+    hasSubnet?: boolean
+  ) => {
     // Reset all fields after this one.
     const position = fieldOrder.indexOf(name);
     for (let i = position + 1; i < fieldOrder.length; i++) {
       let value = "";
       if (fieldOrder[i] === "mode") {
-        value = editing ? NetworkLinkMode.AUTO : NetworkLinkMode.LINK_UP;
+        value =
+          editing && hasSubnet ? NetworkLinkMode.AUTO : NetworkLinkMode.LINK_UP;
       }
       setFieldValue(fieldOrder[i], value);
     }
@@ -128,7 +136,7 @@ const NetworkFields = ({
         name="subnet"
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
           handleChange(evt);
-          resetFollowingFields("subnet");
+          resetFollowingFields("subnet", !!evt.target.value);
         }}
         vlan={toFormikNumber(values.vlan)}
       />
@@ -156,7 +164,7 @@ const NetworkFields = ({
         />
       ) : null}
       {values.mode === NetworkLinkMode.STATIC ? (
-        <FormikField label="IP address" type="text" name="ip_address" />
+        <FormikField label={Label.IPAddress} type="text" name="ip_address" />
       ) : null}
     </>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -83,6 +83,9 @@ const NetworkFields = ({
     for (let i = position + 1; i < fieldOrder.length; i++) {
       let value = "";
       if (fieldOrder[i] === "mode") {
+        // When editing and the subnet has been changed to another subnet then
+        // set the mode to auto, otherwise if the subnet is set to unconfigured
+        // then the link mode also needs to be set to unconfigured (LINK_UP).
         value =
           editing && hasSubnet ? NetworkLinkMode.AUTO : NetworkLinkMode.LINK_UP;
       }


### PR DESCRIPTION
## Done

- Fix unsetting an interface's IP mode when the subnet is set to unconfigured.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab for a machine where the network is editable and has a subnet and a physical interface that is set to "Auto assign" (or update an interface to this state).
- Open the edit form for the interface.
- Open the Subnet select and change it to "Unconfigured".
- Save the form and the IP column should change to "Unconfigured".

## Fixes

Fixes: #3687.