### PR TITLE
fix(ui): open links in new tab

### DIFF
--- a/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -184,7 +184,7 @@ const DHCPTable = ({
               </Link>,
               <a
                 href="https://maas.io/docs/dhcp"
-                rel="noreferrer"
+                rel="noreferrer noopener"
                 target="_blank"
               >
                 About DHCP snippets

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
@@ -78,7 +78,7 @@ export const SSHKeyFormFields = ({
       </Row>
       <Link
         href="https://maas.io/docs/user-accounts#heading--ssh-keys"
-        rel="noreferrer"
+        rel="noreferrer noopener"
         target="_blank"
       >
         About SSH keys

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
@@ -76,7 +76,11 @@ export const SSHKeyFormFields = ({
           </p>
         </Col>
       </Row>
-      <Link href="https://maas.io/docs/user-accounts#heading--ssh-keys">
+      <Link
+        href="https://maas.io/docs/user-accounts#heading--ssh-keys"
+        rel="noreferrer"
+        target="_blank"
+      >
         About SSH keys
       </Link>
     </>

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -57,7 +57,11 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
       />
       <Row>
         <Col size={6}>
-          <a href="https://maas.io/docs/rack-controller">
+          <a
+            href="https://maas.io/docs/rack-controller"
+            rel="noreferrer"
+            target="_blank"
+          >
             Help with adding a rack controller
           </a>
         </Col>

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -59,7 +59,7 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
         <Col size={6}>
           <a
             href="https://maas.io/docs/rack-controller"
-            rel="noreferrer"
+            rel="noreferrer noopener"
             target="_blank"
           >
             Help with adding a rack controller

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
@@ -35,7 +35,13 @@ export const StatusColumn = ({ systemId }: Props): JSX.Element | null => {
           <>
             {issue}
             <br />
-            <a href="https://discourse.maas.io/t/4555">More info</a>
+            <a
+              href="https://discourse.maas.io/t/4555"
+              rel="noreferrer"
+              target="_blank"
+            >
+              More info
+            </a>
           </>
         }
         position="top-center"

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
@@ -37,7 +37,7 @@ export const StatusColumn = ({ systemId }: Props): JSX.Element | null => {
             <br />
             <a
               href="https://discourse.maas.io/t/4555"
-              rel="noreferrer"
+              rel="noreferrer noopener"
               target="_blank"
             >
               More info

--- a/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.tsx
@@ -41,7 +41,11 @@ const ClearAllForm = ({ closeForm }: Props): JSX.Element => {
         </p>
         <p>
           Learn more about{" "}
-          <Link href="https://maas.io/docs/network-discovery">
+          <Link
+            href="https://maas.io/docs/network-discovery"
+            rel="noreferrer"
+            target="_blank"
+          >
             network discovery
           </Link>
           .

--- a/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.tsx
@@ -43,7 +43,7 @@ const ClearAllForm = ({ closeForm }: Props): JSX.Element => {
           Learn more about{" "}
           <Link
             href="https://maas.io/docs/network-discovery"
-            rel="noreferrer"
+            rel="noreferrer noopener"
             target="_blank"
           >
             network discovery

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -143,7 +143,7 @@ export const DeployFormFields = (): JSX.Element => {
                   Register as MAAS KVM host.{" "}
                   <a
                     href="https://maas.io/docs/kvm-introduction"
-                    rel="noreferrer"
+                    rel="noreferrer noopener"
                     target="_blank"
                   >
                     KVM docs
@@ -193,7 +193,7 @@ export const DeployFormFields = (): JSX.Element => {
                   Cloud-init user-data&hellip;{" "}
                   <a
                     href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
-                    rel="noreferrer"
+                    rel="noreferrer noopener"
                     target="_blank"
                   >
                     Cloud-init docs

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -141,7 +141,13 @@ export const DeployFormFields = (): JSX.Element => {
               label={
                 <>
                   Register as MAAS KVM host.{" "}
-                  <a href="https://maas.io/docs/kvm-introduction">KVM docs</a>
+                  <a
+                    href="https://maas.io/docs/kvm-introduction"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    KVM docs
+                  </a>
                 </>
               }
               onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -185,7 +191,11 @@ export const DeployFormFields = (): JSX.Element => {
               label={
                 <>
                   Cloud-init user-data&hellip;{" "}
-                  <a href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init">
+                  <a
+                    href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
                     Cloud-init docs
                   </a>
                 </>

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.tsx
@@ -11,7 +11,11 @@ const SSHKeyList = (): JSX.Element => {
       <BaseSSHKeyList
         buttons={[{ label: "Import SSH key", url: prefsURLs.sshKeys.add }]}
       />
-      <Link href="https://maas.io/docs/user-accounts#heading--ssh-keys">
+      <Link
+        href="https://maas.io/docs/user-accounts#heading--ssh-keys"
+        rel="noreferrer"
+        target="_blank"
+      >
         About SSH keys
       </Link>
     </>

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.tsx
@@ -13,7 +13,7 @@ const SSHKeyList = (): JSX.Element => {
       />
       <Link
         href="https://maas.io/docs/user-accounts#heading--ssh-keys"
-        rel="noreferrer"
+        rel="noreferrer noopener"
         target="_blank"
       >
         About SSH keys

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -74,7 +74,11 @@ const CommissioningFormFields = (): JSX.Element => {
           <>
             Specify this key to encrypt all communication between IPMI clients
             and the BMC. Leave this blank for no encryption.&nbsp;
-            <Link href="https://maas.io/docs/snap/2.9/ui/power-management#heading--ipmi">
+            <Link
+              href="https://maas.io/docs/snap/2.9/ui/power-management#heading--ipmi"
+              rel="noreferrer"
+              target="_blank"
+            >
               IPMI and BMC key
             </Link>
           </>

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -76,7 +76,7 @@ const CommissioningFormFields = (): JSX.Element => {
             and the BMC. Leave this blank for no encryption.&nbsp;
             <Link
               href="https://maas.io/docs/snap/2.9/ui/power-management#heading--ipmi"
-              rel="noreferrer"
+              rel="noreferrer noopener"
               target="_blank"
             >
               IPMI and BMC key

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -113,7 +113,7 @@ const GeneralForm = (): JSX.Element => {
             Error Tracking.{" "}
             <Link
               href="https://ubuntu.com/legal/data-privacy"
-              rel="noreferrer"
+              rel="noreferrer noopener"
               target="_blank"
             >
               Data privacy

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -111,7 +111,11 @@ const GeneralForm = (): JSX.Element => {
           <>
             The analytics used in MAAS are Google Analytics, Usabilla and Sentry
             Error Tracking.{" "}
-            <Link href="https://ubuntu.com/legal/data-privacy">
+            <Link
+              href="https://ubuntu.com/legal/data-privacy"
+              rel="noreferrer"
+              target="_blank"
+            >
               Data privacy
             </Link>
           </>

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -333,7 +333,11 @@ const ReservedRanges = ({
           />
         </FormCard>
       ) : null}
-      <a href="https://maas.io/docs/ip-ranges" rel="noreferrer" target="_blank">
+      <a
+        href="https://maas.io/docs/ip-ranges"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
         About IP ranges
       </a>
     </TitledSection>

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -143,7 +143,15 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
             allowUnchanged
             cleanup={cleanup}
             errors={configureDHCPError}
-            buttonsHelp={<a href="https://maas.io/docs/dhcp">About DHCP</a>}
+            buttonsHelp={
+              <a
+                href="https://maas.io/docs/dhcp"
+                rel="noreferrer"
+                target="_blank"
+              >
+                About DHCP
+              </a>
+            }
             initialValues={{
               dhcpType: isId(vlan.relay_vlan)
                 ? DHCPType.RELAY

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -146,7 +146,7 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
             buttonsHelp={
               <a
                 href="https://maas.io/docs/dhcp"
-                rel="noreferrer"
+                rel="noreferrer noopener"
                 target="_blank"
               >
                 About DHCP

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -141,7 +141,9 @@ const DHCPStatus = ({ id, openForm }: Props): JSX.Element | null => {
         </Col>
       </Row>
       <p>
-        <a href="https://maas.io/docs/dhcp">About DHCP</a>
+        <a href="https://maas.io/docs/dhcp" rel="noreferrer" target="_blank">
+          About DHCP
+        </a>
       </p>
     </TitledSection>
   );

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -141,7 +141,11 @@ const DHCPStatus = ({ id, openForm }: Props): JSX.Element | null => {
         </Col>
       </Row>
       <p>
-        <a href="https://maas.io/docs/dhcp" rel="noreferrer" target="_blank">
+        <a
+          href="https://maas.io/docs/dhcp"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
           About DHCP
         </a>
       </p>

--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
@@ -38,7 +38,11 @@ const getDefinitionError = (
     return (
       <span id={definitionErrorId}>
         The definition is an invalid XPath expression. See our{" "}
-        <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
+        <a
+          href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
+          rel="noreferrer"
+          target="_blank"
+        >
           XPath expressions documentation
         </a>{" "}
         for more examples.
@@ -89,7 +93,11 @@ export const DefinitionField = ({ id }: Props): JSX.Element => {
       <p className="p-form-help-text u-sv1">
         Add an XPath expression as a definition. MAAS will auto-assign this tag
         to all current and future machines that match this definition.{" "}
-        <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
+        <a
+          href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
+          rel="noreferrer"
+          target="_blank"
+        >
           Learn how to use XPath expressions
         </a>
         .

--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
@@ -40,7 +40,7 @@ const getDefinitionError = (
         The definition is an invalid XPath expression. See our{" "}
         <a
           href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
-          rel="noreferrer"
+          rel="noreferrer noopener"
           target="_blank"
         >
           XPath expressions documentation
@@ -95,7 +95,7 @@ export const DefinitionField = ({ id }: Props): JSX.Element => {
         to all current and future machines that match this definition.{" "}
         <a
           href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
-          rel="noreferrer"
+          rel="noreferrer noopener"
           target="_blank"
         >
           Learn how to use XPath expressions

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -66,7 +66,7 @@ export const KernelOptionsField = ({
           while machines are commissioning or deploying.{" "}
           <a
             href="https://maas.io/docs/how-to-work-with-tags#heading--kernel-options"
-            rel="noreferrer"
+            rel="noreferrer noopener"
             target="_blank"
           >
             Read more about kernel options in tag management

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -64,7 +64,11 @@ export const KernelOptionsField = ({
         <>
           Kernel options are appended to the kernel command line during booting
           while machines are commissioning or deploying.{" "}
-          <a href="https://maas.io/docs/how-to-work-with-tags#heading--kernel-options">
+          <a
+            href="https://maas.io/docs/how-to-work-with-tags#heading--kernel-options"
+            rel="noreferrer"
+            target="_blank"
+          >
             Read more about kernel options in tag management
           </a>
           .

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -224,7 +224,7 @@ const TagTable = ({
                       <br />
                       <a
                         href="https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags"
-                        rel="noreferrer"
+                        rel="noreferrer noopener"
                         target="_blank"
                       >
                         Check the documentation about automatic tags.

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -222,7 +222,11 @@ const TagTable = ({
                         )
                       )}
                       <br />
-                      <a href="https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags">
+                      <a
+                        href="https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags"
+                        rel="noreferrer"
+                        target="_blank"
+                      >
                         Check the documentation about automatic tags.
                       </a>
                     </>

--- a/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
@@ -72,7 +72,7 @@ export const TagUpdateFormFields = ({ id }: Props): JSX.Element | null => {
                 tags. To learn more about this, check our{" "}
                 <a
                   href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
-                  rel="noreferrer"
+                  rel="noreferrer noopener"
                   target="_blank"
                 >
                   XPath expressions documentation

--- a/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
@@ -70,7 +70,11 @@ export const TagUpdateFormFields = ({ id }: Props): JSX.Element | null => {
               <span className="p-form-help-text">
                 This is a manual tag. Definitions cannot be added to manual
                 tags. To learn more about this, check our{" "}
-                <a href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions">
+                <a
+                  href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
+                  rel="noreferrer"
+                  target="_blank"
+                >
                   XPath expressions documentation
                 </a>
                 .


### PR DESCRIPTION
## Done

- Open all external links in a new tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the tag list and open the create tag form.
- Click on the links in the help text open in new tabs.
- Go to the machine list, tick some machines and open the tag form.
- Type in a new tag name and open the create tag modal.
- Check that the help links open in a new tab.

## Fixes

Fixes: canonical-web-and-design/app-tribe#811.