### PR TITLE
feat(ui): display a message in tag form if no machines have tags

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -240,3 +240,30 @@ it("discards removed tags", async () => {
     );
   });
 });
+
+it("shows a message if no tags are assigned to the selected machines", () => {
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machineFactory({ tags: [] }), machineFactory({ tags: [] })],
+      loaded: true,
+      loading: false,
+    }),
+    tag: tagStateFactory({
+      items: [tagFactory(), tagFactory()],
+      loaded: true,
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
+          <TagFormChanges machines={state.machine.items} newTags={[]} />
+        </Formik>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(screen.getByText(Label.NoTags)).toBeInTheDocument();
+});

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -36,6 +36,7 @@ export enum Label {
   Remove = "Remove",
   Removed = "To be removed",
   Table = "Tag changes",
+  NoTags = "No tags are currently assigned to the selected machines.",
 }
 
 export enum RowType {
@@ -170,7 +171,7 @@ export const TagFormChanges = ({
     []
   );
   if (!hasAutomaticTags && !hasManualTags && !hasAddedTags && !hasRemovedTags) {
-    return null;
+    return <p className="u-text--muted">{Label.NoTags}</p>;
   }
   addedTags.forEach((tag) => {
     // Added tags will be applied to all machines.


### PR DESCRIPTION
## Done

- Display a message in tag form if no machines have tags

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and select one or more machines that do not have any tags
- Open the tag form and check there is a message

## Screenshot

![2022-04-12_10-32](https://user-images.githubusercontent.com/25733845/162854915-924f80e7-c94b-4af2-91a6-c00c375f0f81.png)

