### PR TITLE
fix(ui): make sure OS info is loaded before initialising deploy form

### DIFF
--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -129,6 +129,36 @@ describe("DeployForm", () => {
     });
   });
 
+  it("shows a spinner if data has not loaded yet", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        osInfo: osInfoStateFactory({
+          loaded: false,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm
+            clearHeaderContent={jest.fn()}
+            machines={[]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-testid='loading-deploy-data']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("form").exists()).toBe(false);
+  });
+
   it("correctly dispatches actions to deploy given machines", () => {
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -62,6 +63,14 @@ export const DeployForm = ({
     dispatch(machineActions.fetch());
   }, [dispatch]);
 
+  if (!defaultMinHweKernelLoaded || !osInfoLoaded) {
+    return (
+      <Strip data-testid="loading-deploy-data">
+        <Spinner text="Loading..." />
+      </Strip>
+    );
+  }
+
   // Default OS+release is set in the backend even if the image has not yet been
   // downloaded. The following conditionals check whether the OS+release actually
   // exist in state before setting initial values in the form.
@@ -94,7 +103,6 @@ export const DeployForm = ({
         vmHostType: "",
         enableHwSync: false,
       }}
-      loaded={defaultMinHweKernelLoaded && osInfoLoaded}
       modelName="machine"
       onCancel={clearHeaderContent}
       onSaveAnalytics={{


### PR DESCRIPTION
## Done

- Make sure OS info is loaded before initialising deploy form. I'm not fully convinced this will fix the original issue (that I could not reproduce), but the problem was that the form was not initialising values properly so I'm hoping this addresses it.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes #3558 

