### PR TITLE
fix(ui): remove local p-button--link styles

### DIFF
--- a/ui/src/app/base/components/TableHeader/TableHeader.tsx
+++ b/ui/src/app/base/components/TableHeader/TableHeader.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import type { ButtonProps } from "@canonical/react-components";
 import { Button, Icon } from "@canonical/react-components";
+import classNames from "classnames";
 
 import type { Sort } from "app/base/types";
 
@@ -25,7 +26,11 @@ const TableHeader = ({
   }
 
   return (
-    <Button appearance="link" className={className} onClick={onClick}>
+    <Button
+      appearance="link"
+      className={classNames("p-button--table-header", className)}
+      onClick={onClick}
+    >
       <span>{children}</span>
       {currentSort && currentSort.key === sortKey && (
         <Icon

--- a/ui/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/ui/src/app/kvm/components/VmResources/VmResources.tsx
@@ -18,8 +18,8 @@ const VmResources = ({ loading = false, vms }: Props): JSX.Element => {
           <ContextualMenu
             data-testid="vms-dropdown"
             dropdownClassName="vm-resources__dropdown"
-            toggleAppearance="base"
-            toggleClassName="vm-resources__toggle is-dense p-button--link"
+            toggleAppearance="link"
+            toggleClassName="vm-resources__toggle is-dense"
             toggleDisabled={vms.length === 0}
             toggleLabel={`Total VMs: ${vms.length}`}
           >

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -141,7 +141,7 @@ const TestResults = ({
               position={"top-left"}
             >
               <Button
-                className="p-button--link"
+                appearance="link"
                 disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
                   setHeaderContent({

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -7,68 +7,26 @@
     }
   }
 
-  // Button styles that make it look like a link
-  .p-button--link {
-    @extend %vf-button-base;
-    background-color: inherit;
-    border: 0 !important;
-    color: $color-link;
-    font-size: inherit;
-    line-height: 1rem;
-    margin-bottom: 0;
+  // Custom class for sort buttons in table headers. We don't use the default
+  // Vanilla th[aria-sort] pattern due to the use of double rows in MAAS, so we
+  // approximate it with these styles.
+  .p-button--table-header {
+    @extend %table-header-label;
+    color: $color-dark;
+    margin: 0;
     padding: 0;
-    pointer-events: all;
-    text-align: left;
-    text-transform: inherit;
-
-    &:visited {
-      color: $color-link;
-    }
 
     &:hover {
-      background-color: inherit;
       color: $color-link;
-      text-decoration: underline;
     }
 
-    &:active {
-      background-color: inherit !important;
-    }
-
-    &:focus {
-      color: $color-link;
-      outline: 0;
-      text-decoration: underline;
-    }
-
-    &.is-inline {
-      margin: 0;
-    }
-
-    // Table header sort buttons
-    th & {
-      color: $color-dark;
-      font-weight: 400;
-
-      .p-icon--chevron-down,
-      .p-icon--chevron-up {
-        @include vf-icon-size(0.875rem);
-        margin-left: $sp-x-small;
-      }
+    [class*="p-icon"] {
+      @include vf-icon-size(0.875rem);
+      margin-left: $sp-x-small;
     }
   }
 
   [class*="p-button"].no-background {
     background-color: transparent;
-  }
-
-  table .p-button--link {
-    margin: 0;
-    padding-bottom: 0;
-    padding-top: 0;
-  }
-
-  .p-button--link:not(:last-of-type):not(:only-of-type) {
-    margin-right: 0;
   }
 }


### PR DESCRIPTION
## Done

- Refactored a small portion of our local `p-button--link` styles for use in table headers, and removed the rest in favour of Vanilla's implementation.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the styling for sortable tables with double rows has not changed

## Fixes

Fixes #2707 

