### PR TITLE
fix(ui): hide tag buttons when showing forms

### DIFF
--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -66,9 +66,10 @@ const SectionHeader = <P,>({
   tabLinks,
   title,
   titleClassName,
+  ...props
 }: Props<P>): JSX.Element | null => {
   return (
-    <div className={classNames("section-header", className)}>
+    <div className={classNames("section-header", className)} {...props}>
       <div className="section-header__main-row u-flex--between u-flex--wrap">
         <div className="section-header__titles u-flex--align-baseline u-flex--grow u-flex--wrap">
           {loading || !title ? (

--- a/ui/src/app/base/views/NotFound/NotFound.tsx
+++ b/ui/src/app/base/views/NotFound/NotFound.tsx
@@ -5,22 +5,25 @@ type Props = {
   includeSection?: boolean;
 };
 
+export enum Label {
+  Title = "Error: Page not found.",
+}
+
 const NotFound = ({ includeSection = false }: Props): JSX.Element => {
-  const title = "Error: Page not found.";
-  useWindowTitle(title);
+  useWindowTitle(Label.Title);
   const message = `The requested URL ${window.location.pathname} was not found on this server.`;
   if (includeSection) {
     return (
-      <Section header={title}>
+      <Section header={Label.Title} aria-label={Label.Title}>
         <h2 className="p-heading--4">{message}</h2>
       </Section>
     );
   }
   return (
-    <>
-      <h2 className="p-heading--4">{title}</h2>
+    <div aria-label={Label.Title}>
+      <h2 className="p-heading--4">{Label.Title}</h2>
       <p>{message}</p>
-    </>
+    </div>
   );
 };
 

--- a/ui/src/app/tags/components/TagsHeader/TagsHeader.tsx
+++ b/ui/src/app/tags/components/TagsHeader/TagsHeader.tsx
@@ -4,11 +4,18 @@ import MachinesHeader from "app/base/components/node/MachinesHeader";
 import TagHeaderForms from "app/tags/components/TagsHeader/TagHeaderForms";
 import { TagHeaderViews } from "app/tags/constants";
 import type { TagHeaderContent, TagSetHeaderContent } from "app/tags/types";
+import { TagViewState } from "app/tags/types";
 
-type Props = {
+export type Props = {
   headerContent: TagHeaderContent | null;
   setHeaderContent: TagSetHeaderContent;
+  tagViewState?: TagViewState | null;
 };
+
+export enum Label {
+  CreateButton = "Create new tag",
+  Header = "Tags header",
+}
 
 export const getHeaderTitle = (
   headerContent: TagHeaderContent | null
@@ -28,17 +35,25 @@ export const getHeaderTitle = (
 export const TagsHeader = ({
   headerContent,
   setHeaderContent,
+  tagViewState,
 }: Props): JSX.Element => {
   return (
     <MachinesHeader
-      buttons={[
-        <Button
-          appearance="positive"
-          onClick={() => setHeaderContent({ view: TagHeaderViews.AddTag })}
-        >
-          Create new tag
-        </Button>,
-      ]}
+      aria-label={Label.Header}
+      buttons={
+        tagViewState === TagViewState.Updating
+          ? null
+          : [
+              <Button
+                appearance="positive"
+                onClick={() =>
+                  setHeaderContent({ view: TagHeaderViews.AddTag })
+                }
+              >
+                {Label.CreateButton}
+              </Button>,
+            ]
+      }
       headerContent={
         headerContent && (
           <TagHeaderForms

--- a/ui/src/app/tags/types.ts
+++ b/ui/src/app/tags/types.ts
@@ -13,3 +13,9 @@ export type TagHeaderContent =
     >;
 
 export type TagSetHeaderContent = SetHeaderContent<TagHeaderContent>;
+
+export enum TagViewState {
+  Creating = "creating",
+  Deleting = "deleting",
+  Updating = "updating",
+}

--- a/ui/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -11,6 +11,7 @@ import TagDetails from "./TagDetails";
 
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
+import { TagViewState } from "app/tags/types";
 import tagURLs from "app/tags/urls";
 import {
   rootState as rootStateFactory,
@@ -125,7 +126,12 @@ it("can display the edit form", () => {
         <Route
           exact
           path={tagURLs.tag.update(null, true)}
-          component={() => <TagDetails isEditing onDelete={jest.fn()} />}
+          component={() => (
+            <TagDetails
+              tagViewState={TagViewState.Updating}
+              onDelete={jest.fn()}
+            />
+          )}
         />
       </MemoryRouter>
     </Provider>

--- a/ui/src/app/tags/views/TagList/TagList.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.tsx
@@ -15,6 +15,10 @@ type Props = {
   onDelete: (id: Tag[TagMeta.PK], fromDetails?: boolean) => void;
 };
 
+export enum Label {
+  Title = "Tag list",
+}
+
 const TagList = ({ onDelete }: Props): JSX.Element => {
   const [currentPage, setCurrentPage] = useState(1);
   const [filter, setFilter] = useState(TagSearchFilter.All);
@@ -27,7 +31,7 @@ const TagList = ({ onDelete }: Props): JSX.Element => {
   useWindowTitle("Tags");
 
   return (
-    <>
+    <div aria-label={Label.Title}>
       <TagListControls
         aria-label="tag list controls"
         aria-controls={tableId}
@@ -49,7 +53,7 @@ const TagList = ({ onDelete }: Props): JSX.Element => {
         setCurrentPage={setCurrentPage}
         tags={tags}
       />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Done

- Update the tags pages to hide add/edit/delete buttons when displaying forms.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tag details page and you should see the "Create new tag", "Edit" and "Delete" buttons.
- Click "Edit" and all three buttons should get hidden.
- Click "Delete" and the "Edit" and "Delete" buttons should get hidden.
- Click "Create new tag" and the "Edit" and "Delete" buttons should get hidden.

## Fixes

Fixes: canonical-web-and-design/app-tribe#812.