### PR TITLE
fix(ui): select correct fabric/VLAN when adding an alias or VLAN to nic

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
@@ -56,6 +56,9 @@ const AddAliasOrVlan = ({
   const unusedVLANs = useSelector((state: RootState) =>
     vlanSelectors.getUnusedForInterface(state, machine, nic)
   );
+  const nicVLAN = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, nic?.vlan_id)
+  );
   const cleanup = useCallback(() => machineActions.cleanup(), []);
   const isAlias = interfaceType === NetworkInterfaceTypes.ALIAS;
   const { errors, saved, saving } = useMachineDetailsForm(
@@ -85,6 +88,8 @@ const AddAliasOrVlan = ({
         initialValues={{
           ...networkFieldsInitialValues,
           ...(isAlias ? {} : { tags: [] }),
+          fabric: nicVLAN?.fabric || "",
+          vlan: nic.vlan_id,
         }}
         onSaveAnalytics={{
           action: `Add ${interfaceType}`,


### PR DESCRIPTION
## Done

- Initialise `AddAliasOrVlan` form with the parent interface's fabric and VLAN

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Network tab of a Ready or Allocated machine
- Add an interface with a configured IP mode (i.e. select a subnet and IP mode in the form)
- Click the action dropdown and select "Add alias"
- Check that the fabric and VLAN selects are disabled, and they are automatically picked to be the interface's fabric and VLAN
- Check the same thing when adding a VLAN, except only the fabric select is disabled

## Fixes

Fixes #3683 
