### PR TITLE
fix(ui): fix edit VLAN form inadvertently creating an alias

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -181,6 +181,8 @@ describe("EditAliasOrVlanForm", () => {
   });
 
   it("dispatches an action to update a VLAN", async () => {
+    const link = networkLinkFactory({ id: 101 });
+    nic.links = [networkLinkFactory(), link];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -190,6 +192,7 @@ describe("EditAliasOrVlanForm", () => {
           <EditAliasOrVlanForm
             close={jest.fn()}
             interfaceType={NetworkInterfaceTypes.VLAN}
+            link={link}
             nic={nic}
             systemId="abc123"
           />
@@ -221,6 +224,7 @@ describe("EditAliasOrVlanForm", () => {
           fabric: 1,
           interface_id: nic.id,
           ip_address: "1.2.3.4",
+          link_id: link.id,
           mode: NetworkLinkMode.STATIC,
           subnet: 1,
           system_id: "abc123",

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
@@ -129,8 +129,8 @@ const EditAliasOrVlanForm = ({
         const payload = preparePayload({
           ...values,
           interface_id: nic.id,
+          link_id: link?.id,
           system_id: systemId,
-          ...(isAlias ? { link_id: link?.id } : {}),
         }) as UpdateInterfaceParams;
         dispatch(machineActions.updateInterface(payload));
       }}


### PR DESCRIPTION
## Done

- Fixed the "Edit VLAN" form inadvertently creating an alias

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Network tab for a machine
- Add a physical interface that's connected to a fabric with at least one unused VLAN and at least one subnet
- For the new interface, open the action menu and click "Add VLAN"
- Choose a VLAN and subnet and give it an Auto IP mode then submit the form
- For the newly added VLAN, open the action menu and click "Edit VLAN"
- Change the IP mode to something else (like static) and submit the form
- Check that the VLAN is successfully edited and an alias is not created

## Fixes

Fixes #3767 
