### PR TITLE
fix(deps): update dependency @canonical/react-components to v0.34.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/canonical-web-and-design/maas-ui/issues",
   "dependencies": {
     "@canonical/macaroon-bakery": "1.0.0",
-    "@canonical/react-components": "0.34.0",
+    "@canonical/react-components": "0.34.1",
     "@maas-ui/maas-ui-shared": "3.2.0",
     "@reduxjs/toolkit": "1.8.1",
     "@sentry/browser": "6.19.3",

--- a/ui/src/app/base/components/FormikField/__snapshots__/FormikField.test.tsx.snap
+++ b/ui/src/app/base/components/FormikField/__snapshots__/FormikField.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`FormikField can render 1`] = `
       forId="username"
       help="Required."
       helpId="mock-nanoid-2"
+      isTickElement={false}
       label="Username"
       required={true}
       validationId="mock-nanoid-1"

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -60,9 +60,12 @@ it("can display a tooltip for the secondary submit action", async () => {
       />
     </Formik>
   );
-  expect(screen.queryByText("Will add another")).not.toBeInTheDocument();
-  userEvent.hover(screen.getByRole("button", { name: "Save and add another" }));
-  expect(screen.getByText("Will add another")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Save and add another" })
+  ).toHaveAccessibleDescription("Will add another");
+  expect(
+    screen.getByRole("tooltip", { name: "Will add another" })
+  ).toBeInTheDocument();
 });
 
 it("displays a border if bordered is true", () => {

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`NodeNameFields displays the fields 1`] = `
         error={null}
         forId="mock-redux-js-nanoid-1"
         helpId="mock-nanoid-2"
+        isTickElement={false}
         required={true}
         validationId="mock-nanoid-1"
       >

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -301,6 +301,7 @@ exports[`NodeName can display the form 1`] = `
                   error={null}
                   forId="mock-redux-js-nanoid-1"
                   helpId="mock-nanoid-2"
+                  isTickElement={false}
                   required={true}
                   validationId="mock-nanoid-1"
                 >

--- a/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
+++ b/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
             <Field
               forId="mock-nanoid-1"
               helpId="mock-nanoid-3"
+              isTickElement={false}
               required={false}
               validationId="mock-nanoid-2"
             >
@@ -199,6 +200,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
             <Field
               forId="mock-nanoid-1"
               helpId="mock-nanoid-3"
+              isTickElement={false}
               required={false}
               validationId="mock-nanoid-2"
             >

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -451,18 +451,11 @@ describe("DeployFormFields", () => {
       </Provider>
     );
 
-    const tooltipText =
-      /Enable this to make MAAS periodically check the hardware/;
     expect(
-      screen.getByText(/Hardware sync interval: 15min/)
-    ).toBeInTheDocument();
-    expect(screen.queryByText(tooltipText)).not.toBeInTheDocument();
-    userEvent.hover(
-      screen.getByRole("button", {
-        name: /more about periodically sync hardware/,
+      screen.getByRole("tooltip", {
+        name: /Enable this to make MAAS periodically check the hardware/,
       })
-    );
-    expect(screen.getByText(tooltipText)).toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 
   it("'Periodically sync hardware' is unchecked by default", async () => {

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -10,7 +10,6 @@ import {
   Row,
   Select,
   Tooltip,
-  useId,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
@@ -35,8 +34,6 @@ export const DeployFormFields = (): JSX.Element => {
   const [userDataVisible, setUserDataVisible] = useState(false);
   const formikProps = useFormikContext<DeployFormValues>();
   const { handleChange, setFieldValue, values } = formikProps;
-  const deployVmHostHelpText = useId();
-  const enableHwSyncHelpText = useId();
 
   const user = useSelector(authSelectors.get);
   const osOptions = useSelector(configSelectors.defaultOSystemOptions);
@@ -132,9 +129,6 @@ export const DeployFormFields = (): JSX.Element => {
           </Col>
           <Col size={9}>
             <Input
-              // TODO: use an Input help text prop instead once the bug below is resolved
-              // https://github.com/canonical-web-and-design/react-components/issues/748
-              aria-describedby={deployVmHostHelpText}
               checked={deployVmHost}
               disabled={!canBeKVMHost || noImages}
               id="deployVmHost"
@@ -150,6 +144,7 @@ export const DeployFormFields = (): JSX.Element => {
                   </a>
                 </>
               }
+              help="Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported."
               onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
                 const { checked } = evt.target;
                 if (checked) {
@@ -161,13 +156,6 @@ export const DeployFormFields = (): JSX.Element => {
               }}
               type="checkbox"
             />
-            <p
-              id={deployVmHostHelpText}
-              className="p-form-help-text is-tick-element"
-            >
-              Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially
-              supported.
-            </p>
             {deployVmHost && (
               <>
                 <FormikField
@@ -213,9 +201,6 @@ export const DeployFormFields = (): JSX.Element => {
             <FormikField
               type="checkbox"
               name="enableHwSync"
-              // TODO: use an Input help text prop instead once the bug below is resolved
-              // https://github.com/canonical-web-and-design/react-components/issues/748
-              aria-describedby={enableHwSyncHelpText}
               label={
                 <>
                   Periodically sync hardware{" "}
@@ -237,14 +222,10 @@ export const DeployFormFields = (): JSX.Element => {
                   {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
                 </>
               }
+              help={`Hardware sync interval: ${timeSpanToMinutes(
+                hardwareSyncInterval
+              )}min - Admins can change this in the global settings.`}
             />
-            <p
-              id={enableHwSyncHelpText}
-              className="p-form-help-text is-tick-element"
-            >
-              Hardware sync interval: {timeSpanToMinutes(hardwareSyncInterval)}
-              min - Admins can change this in the global settings.
-            </p>
             {userDataVisible && (
               <UploadTextArea
                 label="Upload script"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/CoresColumn/__snapshots__/CoresColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/CoresColumn/__snapshots__/CoresColumn.test.tsx.snap
@@ -89,11 +89,54 @@ exports[`CoresColumn renders 1`] = `
                 }
               >
                 <span
+                  aria-describedby="mock-nanoid-1"
                   data-testid="arch"
+                  key=".0"
                 >
                   amd64
                 </span>
               </span>
+              <Component>
+                <Portal
+                  containerInfo={
+                    <div>
+                      <span
+                        class="p-tooltip--btm-left is-detached u-off-screen"
+                        data-testid="tooltip-portal"
+                        style="position: absolute; left: -99999999999999px; top: -99999999999999px;"
+                      >
+                        <span
+                          class="p-tooltip__message"
+                          id="mock-nanoid-1"
+                          role="tooltip"
+                        >
+                          amd64/generic
+                        </span>
+                      </span>
+                    </div>
+                  }
+                >
+                  <span
+                    className="p-tooltip--btm-left is-detached u-off-screen"
+                    data-testid="tooltip-portal"
+                    style={
+                      Object {
+                        "left": -99999999999999,
+                        "position": "absolute",
+                        "top": -99999999999999,
+                      }
+                    }
+                  >
+                    <span
+                      className="p-tooltip__message"
+                      id="mock-nanoid-1"
+                      role="tooltip"
+                    >
+                      amd64/generic
+                    </span>
+                  </span>
+                </Portal>
+              </Component>
             </span>
           </Tooltip>
         </div>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`NameColumn renders 1`] = `
                   className="u-no-margin--bottom u-nudge--checkbox"
                   forId="mock-redux-js-nanoid-1"
                   helpId="mock-nanoid-2"
+                  isTickElement={true}
                   label=""
                   labelClassName="u-no-margin--bottom u-no-padding--top"
                   validationId="mock-nanoid-1"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`PowerColumn renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  aria-controls="mock-nanoid-1"
+                  aria-controls="mock-nanoid-2"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-pressed="false"
@@ -161,7 +161,7 @@ exports[`PowerColumn renders 1`] = `
                   type="button"
                 >
                   <button
-                    aria-controls="mock-nanoid-1"
+                    aria-controls="mock-nanoid-2"
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-pressed="false"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,18 +2301,18 @@
   dependencies:
     macaroon "3.0.4"
 
-"@canonical/react-components@0.34.0":
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.34.0.tgz#2258b7aea9ee92e57762dec84ba362647152680a"
-  integrity sha512-1C0LmLSA9xlwpEA98D8aeOKGnvcufqmOpRC3US1u94gLeanHFjeIP87vHLi7K+DEFlrdhgp+st+iUJR+K9pW+A==
+"@canonical/react-components@0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.34.1.tgz#3e23f6c934874a7ee01e2dc9b23d39fd9648fcac"
+  integrity sha512-38aBDYnj0lREdVWhm51d6/rE8wzfV0Qc263ut0FTcHaaIL3EHA8pyEpVlxh0szhcoQ8rvB8R9WCyyYzgnlEXlg==
   dependencies:
     "@types/jest" "27.4.1"
     "@types/node" "16.11.26"
-    "@types/react" "17.0.39"
-    "@types/react-dom" "17.0.13"
-    "@types/react-table" "7.7.9"
+    "@types/react" "17.0.43"
+    "@types/react-dom" "17.0.14"
+    "@types/react-table" "7.7.10"
     classnames "2.3.1"
-    nanoid "3.3.1"
+    nanoid "3.3.2"
     prop-types "15.8.1"
     react-table "7.7.0"
     react-useportal "1.0.16"
@@ -3800,13 +3800,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@17.0.13":
-  version "17.0.13"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
-  integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@17.0.14":
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.14.tgz#c8f917156b652ddf807711f5becbd2ab018dea9f"
@@ -3866,10 +3859,10 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react-table@7.7.9":
-  version "7.7.9"
-  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.9.tgz#ea82875775fc6ee71a28408dcc039396ae067c92"
-  integrity sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==
+"@types/react-table@7.7.10":
+  version "7.7.10"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.10.tgz#ca8bb5420bfeae964ff61682f31f1cadfcfee726"
+  integrity sha512-yt7FHv/2cFsucStSWLBOB3OmsRZF08DvVHzz8Zg41B4tzRL6pQ+5VYvmhaR1dKS//tDG4UOJ1RQJPEINHYoRtg==
   dependencies:
     "@types/react" "*"
 
@@ -3884,15 +3877,6 @@
   version "17.0.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.19.tgz#8f2a85e8180a43b57966b237d26a29481dacc991"
   integrity sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@17.0.39":
-  version "17.0.39"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
-  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -12575,11 +12559,6 @@ nanoclone@^0.2.1:
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
   integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
-nanoid@3.3.1, nanoid@^3.2.0, nanoid@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
-
 nanoid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
@@ -12594,6 +12573,11 @@ nanoid@^3.1.30:
   version "3.1.30"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+
+nanoid@^3.2.0, nanoid@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
## Done

- update @canonical/react-components to v0.34.1
  - this release includes the tooltip fix https://github.com/canonical-web-and-design/react-components/releases/tag/v0.34.1
  - use help text prop in DeployFormFields

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- select a machine that can be deployed (e.g. `/r/machine/c7mn8b/summary` on bolla) from the machines list and go to actions > deploy
- verify that the machine deploy form inputs look the same as before (help text indentation is aligned with the input correctly)
- verify that tooltips activate correctly on hover/focus

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/816

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
