### PR TITLE
fix(ui): fix machine name validation

### DIFF
--- a/ui/src/app/base/components/FormikField/FormikField.test.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.test.tsx
@@ -29,4 +29,32 @@ describe("FormikField", () => {
     );
     expect(wrapper.find("Textarea").exists()).toBe(true);
   });
+
+  it("can pass errors", () => {
+    const wrapper = mount(
+      <Formik
+        initialErrors={{ username: "Uh oh!" }}
+        initialValues={{ username: "" }}
+        initialTouched={{ username: true }}
+        onSubmit={jest.fn()}
+      >
+        <FormikField name="username" />
+      </Formik>
+    );
+    expect(wrapper.find("Input").prop("error")).toBe("Uh oh!");
+  });
+
+  it("can hide the errors", () => {
+    const wrapper = mount(
+      <Formik
+        initialErrors={{ username: "Uh oh!" }}
+        initialValues={{ username: "" }}
+        initialTouched={{ username: true }}
+        onSubmit={jest.fn()}
+      >
+        <FormikField displayError={false} name="username" />
+      </Formik>
+    );
+    expect(wrapper.find("Input").prop("error")).toBe(null);
+  });
 });

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -12,12 +12,14 @@ import { useId } from "app/base/hooks/base";
 
 export type Props<C extends ElementType | ComponentType = typeof Input> = {
   component?: C;
+  displayError?: boolean;
   name: string;
   value?: HTMLProps<HTMLElement>["value"];
 } & ComponentProps<C>;
 
 const FormikField = <C extends ElementType | ComponentType = typeof Input>({
   component: Component = Input,
+  displayError = true,
   name,
   value,
   label,
@@ -27,7 +29,7 @@ const FormikField = <C extends ElementType | ComponentType = typeof Input>({
   const [field, meta] = useField({ name, type: props.type, value });
   return (
     <Component
-      error={meta.touched ? meta.error : null}
+      error={meta.touched && displayError ? meta.error : null}
       id={id}
       aria-label={label}
       label={label}

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -19,6 +19,7 @@ const FormikForm = <V, E = null>({
   cleanup,
   editable,
   errors,
+  footer,
   inline,
   loading,
   onCancel,
@@ -55,6 +56,7 @@ const FormikForm = <V, E = null>({
         cleanup={cleanup}
         editable={editable}
         errors={errors}
+        footer={footer}
         inline={inline}
         loading={loading}
         onCancel={onCancel}

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -476,4 +476,23 @@ describe("FormikFormContent", () => {
     await waitForComponentToPaint(wrapper);
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
+
+  it("can display a footer", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <FormikFormContent
+              onCancel={jest.fn()}
+              footer={<div data-testid="footer"></div>}
+            >
+              Content
+            </FormikFormContent>
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-testid='footer']").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -26,6 +26,7 @@ export type Props<V, E> = {
   "data-testid"?: string;
   editable?: boolean;
   errors?: APIError<E>;
+  footer?: ReactNode;
   inline?: boolean;
   loading?: boolean;
   onSaveAnalytics?: {
@@ -78,6 +79,7 @@ const FormikFormContent = <V, E = null>({
   cleanup,
   editable = true,
   errors,
+  footer,
   inline,
   loading,
   onSaveAnalytics = {},
@@ -183,6 +185,7 @@ const FormikFormContent = <V, E = null>({
           submitDisabled={loading || saving || formDisabled || submitDisabled}
         />
       )}
+      {footer}
     </Form>
   );
 };

--- a/ui/src/app/base/components/NodeName/NodeName.test.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.test.tsx
@@ -1,10 +1,12 @@
 import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import NodeName from "./NodeName";
 import type { Props as NodeNameProps } from "./NodeName";
+import NodeNameFields from "./NodeNameFields";
 
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -176,5 +178,30 @@ describe("NodeName", () => {
       saving: false,
     });
     expect(setEditingName).toHaveBeenCalledWith(false);
+  });
+
+  it("can display a hostname error", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NodeName
+            editingName={true}
+            node={machine}
+            onSubmit={jest.fn()}
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => {
+      wrapper.find(NodeNameFields).props().setHostnameError("Uh oh!");
+    });
+    wrapper.update();
+    const error = wrapper.find(".node-name__error");
+    expect(error.exists()).toBe(true);
+    expect(error.text()).toBe("Error: Uh oh!");
   });
 });

--- a/ui/src/app/base/components/NodeName/NodeName.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Button, Spinner } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
+import type { FormikErrors } from "formik";
 import * as Yup from "yup";
 
 import NodeNameFields from "./NodeNameFields";
@@ -33,13 +34,14 @@ export type FormValues = {
 
 const hostnamePattern = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
 
+export enum Label {
+  HostnamePatternError = "Hostname must only contain letters, numbers and hyphens.",
+}
+
 const Schema = Yup.object().shape({
   hostname: Yup.string()
     .max(63, "Hostname must be 63 characters or less.")
-    .matches(
-      hostnamePattern,
-      "Hostname must only contain letters, numbers and hyphens."
-    )
+    .matches(hostnamePattern, Label.HostnamePatternError)
     .required(),
   domain: Yup.string(),
 });
@@ -52,6 +54,9 @@ const NodeName = ({
   saved,
   saving,
 }: Props): JSX.Element => {
+  const [hostnameError, setHostnameError] = useState<
+    FormikErrors<FormValues>["hostname"] | null
+  >(null);
   const canEdit = useCanEdit(node);
   const previousSaving = usePrevious(saving);
 
@@ -84,6 +89,15 @@ const NodeName = ({
       buttonsAlign="right"
       buttonsBordered={false}
       className="node-name"
+      footer={
+        hostnameError ? (
+          <div className="node-name__error is-error">
+            <p className="p-form-validation__message u-no-margin--bottom">
+              <strong>Error:</strong> {hostnameError}
+            </p>
+          </div>
+        ) : null
+      }
       initialValues={{
         domain: String(node.domain.id),
         hostname: node.hostname,
@@ -102,7 +116,7 @@ const NodeName = ({
       saved={saved}
       validationSchema={Schema}
     >
-      <NodeNameFields saving={saving} />
+      <NodeNameFields saving={saving} setHostnameError={setHostnameError} />
     </FormikForm>
   );
 };

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.test.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.test.tsx
@@ -51,7 +51,7 @@ describe("NodeNameFields", () => {
             }}
             onSubmit={jest.fn()}
           >
-            <NodeNameFields />
+            <NodeNameFields setHostnameError={jest.fn()} />
           </FormikForm>
         </MemoryRouter>
       </Provider>
@@ -73,7 +73,7 @@ describe("NodeNameFields", () => {
             }}
             onSubmit={jest.fn()}
           >
-            <NodeNameFields />
+            <NodeNameFields setHostnameError={jest.fn()} />
           </FormikForm>
         </MemoryRouter>
       </Provider>
@@ -95,7 +95,7 @@ describe("NodeNameFields", () => {
             }}
             onSubmit={jest.fn()}
           >
-            <NodeNameFields saving />
+            <NodeNameFields saving setHostnameError={jest.fn()} />
           </FormikForm>
         </MemoryRouter>
       </Provider>
@@ -103,5 +103,29 @@ describe("NodeNameFields", () => {
     expect(
       wrapper.find("FormikField").everyWhere((n) => Boolean(n.prop("disabled")))
     ).toBe(true);
+  });
+
+  it("updates the hostname errors if they exist", () => {
+    const setHostnameError = jest.fn();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <FormikForm
+            initialErrors={{ hostname: "Uh oh!" }}
+            initialValues={{
+              domain: "",
+              hostname: "",
+            }}
+            onSubmit={jest.fn()}
+          >
+            <NodeNameFields saving setHostnameError={setHostnameError} />
+          </FormikForm>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(setHostnameError).toHaveBeenCalledWith("Uh oh!");
   });
 });

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -1,4 +1,7 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
+import type { FormikErrors } from "formik";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
@@ -11,11 +14,22 @@ import { DomainMeta } from "app/store/domain/types";
 
 type Props = {
   saving?: boolean;
+  setHostnameError: (
+    error: FormikErrors<FormValues>["hostname"] | null
+  ) => void;
 };
 
-export const NodeNameFields = ({ saving }: Props): JSX.Element => {
+export const NodeNameFields = ({
+  saving,
+  setHostnameError,
+}: Props): JSX.Element => {
   const domainsLoaded = useSelector(domainSelectors.loaded);
-  const { values } = useFormikContext<FormValues>();
+  const { errors, values } = useFormikContext<FormValues>();
+  const hostnameError = errors.hostname;
+
+  useEffect(() => {
+    setHostnameError(hostnameError ?? null);
+  }, [hostnameError, setHostnameError]);
 
   return (
     <>
@@ -23,22 +37,24 @@ export const NodeNameFields = ({ saving }: Props): JSX.Element => {
         type="text"
         className="node-name__hostname"
         disabled={saving}
+        displayError={false}
+        label="Hostname"
         name="hostname"
-        required={true}
         style={{ width: `${values.hostname.length}ch` }}
         takeFocus
-        wrapperClassName="u-nudge-left--small u-no-margin--right"
+        wrapperClassName="u-no-margin--right"
       />
-      <span className="u-nudge-left--small u-no-margin--right">.</span>
+      <span className="node-name__dot u-nudge-left--small u-no-margin--right">
+        .
+      </span>
       {domainsLoaded ? (
         <DomainSelect
           className="u-no-margin--bottom"
           disabled={saving}
-          label={null}
+          label="Domain"
           name="domain"
-          required
           valueKey={DomainMeta.PK}
-          wrapperClassName="u-nudge-left u-no-margin--right"
+          wrapperClassName="node-name__domain"
         />
       ) : (
         <Spinner className="u-width--auto" />

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -1,11 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NodeNameFields displays the fields 1`] = `
-<NodeNameFields>
+<NodeNameFields
+  setHostnameError={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          null,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+>
   <FormikField
     className="node-name__hostname"
+    displayError={false}
+    label="Hostname"
     name="hostname"
-    required={true}
     style={
       Object {
         "width": "0ch",
@@ -13,16 +30,17 @@ exports[`NodeNameFields displays the fields 1`] = `
     }
     takeFocus={true}
     type="text"
-    wrapperClassName="u-nudge-left--small u-no-margin--right"
+    wrapperClassName="u-no-margin--right"
   >
     <Input
+      aria-label="Hostname"
       className="node-name__hostname"
       error={null}
       id="mock-redux-js-nanoid-1"
+      label="Hostname"
       name="hostname"
       onBlur={[Function]}
       onChange={[Function]}
-      required={true}
       style={
         Object {
           "width": "0ch",
@@ -31,19 +49,29 @@ exports[`NodeNameFields displays the fields 1`] = `
       takeFocus={true}
       type="text"
       value=""
-      wrapperClassName="u-nudge-left--small u-no-margin--right"
+      wrapperClassName="u-no-margin--right"
     >
       <Field
-        className="u-nudge-left--small u-no-margin--right"
+        className="u-no-margin--right"
         error={null}
         forId="mock-redux-js-nanoid-1"
         helpId="mock-nanoid-2"
-        required={true}
+        label="Hostname"
         validationId="mock-nanoid-1"
       >
         <div
-          className="p-form__group p-form-validation u-nudge-left--small u-no-margin--right"
+          className="p-form__group p-form-validation u-no-margin--right"
         >
+          <Label
+            forId="mock-redux-js-nanoid-1"
+          >
+            <label
+              className="p-form__label"
+              htmlFor="mock-redux-js-nanoid-1"
+            >
+              Hostname
+            </label>
+          </Label>
           <div
             className="p-form__control u-clearfix"
           >
@@ -51,12 +79,13 @@ exports[`NodeNameFields displays the fields 1`] = `
               aria-describedby={null}
               aria-errormessage={null}
               aria-invalid={false}
+              aria-label="Hostname"
               className="p-form-validation__input node-name__hostname"
               id="mock-redux-js-nanoid-1"
+              label="Hostname"
               name="hostname"
               onBlur={[Function]}
               onChange={[Function]}
-              required={true}
               style={
                 Object {
                   "width": "0ch",
@@ -71,23 +100,22 @@ exports[`NodeNameFields displays the fields 1`] = `
     </Input>
   </FormikField>
   <span
-    className="u-nudge-left--small u-no-margin--right"
+    className="node-name__dot u-nudge-left--small u-no-margin--right"
   >
     .
   </span>
   <DomainSelect
     className="u-no-margin--bottom"
-    label={null}
+    label="Domain"
     name="domain"
-    required={true}
     valueKey="id"
-    wrapperClassName="u-nudge-left u-no-margin--right"
+    wrapperClassName="node-name__domain"
   >
     <FormikField
       className="u-no-margin--bottom"
       component={[Function]}
       disabled={false}
-      label={null}
+      label="Domain"
       name="domain"
       options={
         Array [
@@ -98,16 +126,15 @@ exports[`NodeNameFields displays the fields 1`] = `
           },
         ]
       }
-      required={true}
-      wrapperClassName="u-nudge-left u-no-margin--right"
+      wrapperClassName="node-name__domain"
     >
       <Select
-        aria-label={null}
+        aria-label="Domain"
         className="u-no-margin--bottom"
         disabled={false}
         error={null}
         id="mock-redux-js-nanoid-2"
-        label={null}
+        label="Domain"
         name="domain"
         onBlur={[Function]}
         onChange={[Function]}
@@ -120,23 +147,31 @@ exports[`NodeNameFields displays the fields 1`] = `
             },
           ]
         }
-        required={true}
         value=""
-        wrapperClassName="u-nudge-left u-no-margin--right"
+        wrapperClassName="node-name__domain"
       >
         <Field
-          className="u-nudge-left u-no-margin--right"
+          className="node-name__domain"
           error={null}
           forId="mock-redux-js-nanoid-2"
           helpId="mock-nanoid-4"
           isSelect={true}
-          label={null}
-          required={true}
+          label="Domain"
           validationId="mock-nanoid-3"
         >
           <div
-            className="p-form__group p-form-validation u-nudge-left u-no-margin--right"
+            className="p-form__group p-form-validation node-name__domain"
           >
+            <Label
+              forId="mock-redux-js-nanoid-2"
+            >
+              <label
+                className="p-form__label"
+                htmlFor="mock-redux-js-nanoid-2"
+              >
+                Domain
+              </label>
+            </Label>
             <div
               className="p-form__control u-clearfix"
             >
@@ -147,7 +182,7 @@ exports[`NodeNameFields displays the fields 1`] = `
                   aria-describedby={null}
                   aria-errormessage={null}
                   aria-invalid={false}
-                  aria-label={null}
+                  aria-label="Domain"
                   className="p-form-validation__input u-no-margin--bottom"
                   disabled={false}
                   id="mock-redux-js-nanoid-2"

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`NodeName can display the form 1`] = `
   buttonsAlign="right"
   buttonsBordered={false}
   className="node-name"
+  footer={null}
   initialValues={
     Object {
       "domain": "99",
@@ -245,6 +246,7 @@ exports[`NodeName can display the form 1`] = `
       buttonsAlign="right"
       buttonsBordered={false}
       className="node-name"
+      footer={null}
       inline={true}
       onCancel={[Function]}
       onSaveAnalytics={
@@ -264,11 +266,14 @@ exports[`NodeName can display the form 1`] = `
           className="node-name p-form p-form--inline"
           onSubmit={[Function]}
         >
-          <NodeNameFields>
+          <NodeNameFields
+            setHostnameError={[Function]}
+          >
             <FormikField
               className="node-name__hostname"
+              displayError={false}
+              label="Hostname"
               name="hostname"
-              required={true}
               style={
                 Object {
                   "width": "14ch",
@@ -276,16 +281,17 @@ exports[`NodeName can display the form 1`] = `
               }
               takeFocus={true}
               type="text"
-              wrapperClassName="u-nudge-left--small u-no-margin--right"
+              wrapperClassName="u-no-margin--right"
             >
               <Input
+                aria-label="Hostname"
                 className="node-name__hostname"
                 error={null}
                 id="mock-redux-js-nanoid-1"
+                label="Hostname"
                 name="hostname"
                 onBlur={[Function]}
                 onChange={[Function]}
-                required={true}
                 style={
                   Object {
                     "width": "14ch",
@@ -294,19 +300,29 @@ exports[`NodeName can display the form 1`] = `
                 takeFocus={true}
                 type="text"
                 value="test-machine-5"
-                wrapperClassName="u-nudge-left--small u-no-margin--right"
+                wrapperClassName="u-no-margin--right"
               >
                 <Field
-                  className="u-nudge-left--small u-no-margin--right"
+                  className="u-no-margin--right"
                   error={null}
                   forId="mock-redux-js-nanoid-1"
                   helpId="mock-nanoid-2"
-                  required={true}
+                  label="Hostname"
                   validationId="mock-nanoid-1"
                 >
                   <div
-                    className="p-form__group p-form-validation u-nudge-left--small u-no-margin--right"
+                    className="p-form__group p-form-validation u-no-margin--right"
                   >
+                    <Label
+                      forId="mock-redux-js-nanoid-1"
+                    >
+                      <label
+                        className="p-form__label"
+                        htmlFor="mock-redux-js-nanoid-1"
+                      >
+                        Hostname
+                      </label>
+                    </Label>
                     <div
                       className="p-form__control u-clearfix"
                     >
@@ -314,12 +330,13 @@ exports[`NodeName can display the form 1`] = `
                         aria-describedby={null}
                         aria-errormessage={null}
                         aria-invalid={false}
+                        aria-label="Hostname"
                         className="p-form-validation__input node-name__hostname"
                         id="mock-redux-js-nanoid-1"
+                        label="Hostname"
                         name="hostname"
                         onBlur={[Function]}
                         onChange={[Function]}
-                        required={true}
                         style={
                           Object {
                             "width": "14ch",
@@ -334,7 +351,7 @@ exports[`NodeName can display the form 1`] = `
               </Input>
             </FormikField>
             <span
-              className="u-nudge-left--small u-no-margin--right"
+              className="node-name__dot u-nudge-left--small u-no-margin--right"
             >
               .
             </span>

--- a/ui/src/app/base/components/NodeName/_index.scss
+++ b/ui/src/app/base/components/NodeName/_index.scss
@@ -13,12 +13,55 @@
     }
   }
 
+  .node-name__error {
+    // Force the errors to wrap onto a new line rather than appear on the same
+    // row as the inline fields.
+    flex-basis: 100%;
+  }
+
+  .node-name__error .p-form-validation__message {
+    margin-top: $spv--small;
+  }
+
   [type="text"].node-name__hostname {
     @extend %vf-heading-4;
-    box-sizing: content-box;
-    margin-bottom: -1px;
-    min-width: 3rem;
-    // Remove 2px to account for the top and bottom borders.
-    padding: calc(#{$sp-xx-small} - 2px) $spv--large calc(#{$sp-xx-small} + 1px);
+
+    @media only screen and (min-width: $breakpoint-large) {
+      box-sizing: content-box;
+      margin-bottom: -1px;
+      min-width: 3rem;
+      // Remove 2px to account for the top and bottom borders.
+      padding: calc(#{$sp-xx-small} - 2px) $spv--large
+        calc(#{$sp-xx-small} + 1px);
+    }
+  }
+
+  @media only screen and (max-width: $breakpoint-large) {
+    .node-name__dot {
+      // Hide the dot on small screens.
+      display: none;
+    }
+
+    .node-name__hostname {
+      // Don't auto size the name input to match the content.
+      width: 100% !important;
+    }
+
+    .node-name__domain {
+      // Add space before the buttons.
+      margin-bottom: $spv--small;
+    }
+  }
+
+  @media only screen and (min-width: $breakpoint-large) {
+    .node-name__hostname {
+      // Add space before the dot.
+      margin-right: $sph--small;
+    }
+
+    .node-name label {
+      // Hide the labels on large screens.
+      display: none;
+    }
   }
 }

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -22,6 +22,20 @@ describe("SectionHeader", () => {
     );
   });
 
+  it("displays the title as a h1 by default", () => {
+    const wrapper = shallow(<SectionHeader title="Title" />);
+    const title = wrapper.find("h1[data-testid='section-header-title']");
+    expect(title.exists()).toBe(true);
+    expect(title.hasClass("p-heading--4")).toBe(true);
+  });
+
+  it("can change the title element", () => {
+    const wrapper = shallow(<SectionHeader title="Title" titleElement="div" />);
+    const title = wrapper.find("div[data-testid='section-header-title']");
+    expect(title.exists()).toBe(true);
+    expect(title.hasClass("p-heading--4")).toBe(false);
+  });
+
   it("shows a spinner instead of title if loading", () => {
     const wrapper = shallow(
       <SectionHeader title="Title" subtitle="Subtitle" loading />

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -18,6 +18,7 @@ export type Props<P = LinkProps> = {
   tabLinks?: DataTestElement<TabsProps<P>["links"]>;
   title?: ReactNode;
   titleClassName?: string;
+  titleElement?: keyof JSX.IntrinsicElements;
 };
 
 const generateSubtitle = (
@@ -66,6 +67,7 @@ const SectionHeader = <P,>({
   tabLinks,
   title,
   titleClassName,
+  titleElement: TitleElement = "h1",
   ...props
 }: Props<P>): JSX.Element | null => {
   return (
@@ -81,15 +83,18 @@ const SectionHeader = <P,>({
               <Spinner text="Loading..." aria-hidden="true" />
             </h4>
           ) : (
-            <h1
+            <TitleElement
               className={classNames(
-                "section-header__title p-heading--4 u-flex--no-shrink",
-                titleClassName
+                "section-header__title u-flex--no-shrink",
+                titleClassName,
+                {
+                  "p-heading--4": TitleElement === "h1",
+                }
               )}
               data-testid="section-header-title"
             >
               {title}
-            </h1>
+            </TitleElement>
           )}
           {generateSubtitle(
             subtitle,

--- a/ui/src/app/base/components/SectionHeader/__snapshots__/SectionHeader.test.tsx.snap
+++ b/ui/src/app/base/components/SectionHeader/__snapshots__/SectionHeader.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SectionHeader can render 1`] = `
       className="section-header__titles u-flex--align-baseline u-flex--grow u-flex--wrap"
     >
       <h1
-        className="section-header__title p-heading--4 u-flex--no-shrink"
+        className="section-header__title u-flex--no-shrink p-heading--4"
         data-testid="section-header-title"
       >
         Title

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -234,6 +234,7 @@ const MachineHeader = ({
           />
         )
       }
+      titleElement={editingName ? "div" : "h1"}
     />
   );
 };


### PR DESCRIPTION
## Done

- Fix broken machine name validation appearance.
- Improved responsive display.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine details page.
- Click on the machine's name in the header to open the form.
- Add an invalid character e.g. !@#$%^&*(). The validation error should appear below the form.

## Fixes

Fixes: #3337.

## Screenshots
<img width="966" alt="Screen Shot 2022-04-12 at 4 40 55 pm" src="https://user-images.githubusercontent.com/361637/163074025-305fbe51-9d2e-41d3-bc52-03114f745c44.png">
<img width="748" alt="Screen Shot 2022-04-12 at 4 57 41 pm" src="https://user-images.githubusercontent.com/361637/163074033-1959e756-308f-45d4-88e5-f6cc3aa72052.png">
<img width="337" alt="Screen Shot 2022-04-12 at 5 42 45 pm" src="https://user-images.githubusercontent.com/361637/163074036-dcea7706-c6be-49b6-9649-b79fae3a76e4.png">
