### PR TITLE
fix(ui): fix machine name after removing all content

### DIFF
--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -33,18 +33,22 @@ export const NodeNameFields = ({
 
   return (
     <>
-      <FormikField
-        type="text"
-        className="node-name__hostname"
-        disabled={saving}
-        displayError={false}
-        label="Hostname"
-        name="hostname"
-        style={{ width: `${values.hostname.length}ch` }}
-        takeFocus
-        wrapperClassName="u-no-margin--right"
-      />
-      <span className="node-name__dot u-nudge-left--small u-no-margin--right">
+      <div className="node-name__hostname-wrapper u-no-margin--right">
+        <div aria-hidden="true" className="node-name__hostname-spacer">
+          {values.hostname}
+        </div>
+        <FormikField
+          type="text"
+          className="node-name__hostname"
+          disabled={saving}
+          displayError={false}
+          label="Hostname"
+          name="hostname"
+          takeFocus
+          wrapperClassName="u-no-margin--right"
+        />
+      </div>
+      <span className="node-name__dot u-nudge-right--small u-nudge-left--small u-no-margin--right">
         .
       </span>
       {domainsLoaded ? (

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -53,7 +53,6 @@ exports[`NodeNameFields displays the fields 1`] = `
           error={null}
           forId="mock-redux-js-nanoid-1"
           helpId="mock-nanoid-2"
-          isTickElement={false}
           label="Hostname"
           validationId="mock-nanoid-1"
         >

--- a/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/__snapshots__/NodeNameFields.test.tsx.snap
@@ -18,89 +18,83 @@ exports[`NodeNameFields displays the fields 1`] = `
     }
   }
 >
-  <FormikField
-    className="node-name__hostname"
-    displayError={false}
-    label="Hostname"
-    name="hostname"
-    style={
-      Object {
-        "width": "0ch",
-      }
-    }
-    takeFocus={true}
-    type="text"
-    wrapperClassName="u-no-margin--right"
+  <div
+    className="node-name__hostname-wrapper u-no-margin--right"
   >
-    <Input
-      aria-label="Hostname"
+    <div
+      aria-hidden="true"
+      className="node-name__hostname-spacer"
+    />
+    <FormikField
       className="node-name__hostname"
-      error={null}
-      id="mock-redux-js-nanoid-1"
+      displayError={false}
       label="Hostname"
       name="hostname"
-      onBlur={[Function]}
-      onChange={[Function]}
-      style={
-        Object {
-          "width": "0ch",
-        }
-      }
       takeFocus={true}
       type="text"
-      value=""
       wrapperClassName="u-no-margin--right"
     >
-      <Field
-        className="u-no-margin--right"
+      <Input
+        aria-label="Hostname"
+        className="node-name__hostname"
         error={null}
-        forId="mock-redux-js-nanoid-1"
-        helpId="mock-nanoid-2"
+        id="mock-redux-js-nanoid-1"
         label="Hostname"
-        validationId="mock-nanoid-1"
+        name="hostname"
+        onBlur={[Function]}
+        onChange={[Function]}
+        takeFocus={true}
+        type="text"
+        value=""
+        wrapperClassName="u-no-margin--right"
       >
-        <div
-          className="p-form__group p-form-validation u-no-margin--right"
+        <Field
+          className="u-no-margin--right"
+          error={null}
+          forId="mock-redux-js-nanoid-1"
+          helpId="mock-nanoid-2"
+          isTickElement={false}
+          label="Hostname"
+          validationId="mock-nanoid-1"
         >
-          <Label
-            forId="mock-redux-js-nanoid-1"
-          >
-            <label
-              className="p-form__label"
-              htmlFor="mock-redux-js-nanoid-1"
-            >
-              Hostname
-            </label>
-          </Label>
           <div
-            className="p-form__control u-clearfix"
+            className="p-form__group p-form-validation u-no-margin--right"
           >
-            <input
-              aria-describedby={null}
-              aria-errormessage={null}
-              aria-invalid={false}
-              aria-label="Hostname"
-              className="p-form-validation__input node-name__hostname"
-              id="mock-redux-js-nanoid-1"
-              label="Hostname"
-              name="hostname"
-              onBlur={[Function]}
-              onChange={[Function]}
-              style={
-                Object {
-                  "width": "0ch",
-                }
-              }
-              type="text"
-              value=""
-            />
+            <Label
+              forId="mock-redux-js-nanoid-1"
+            >
+              <label
+                className="p-form__label"
+                htmlFor="mock-redux-js-nanoid-1"
+              >
+                Hostname
+              </label>
+            </Label>
+            <div
+              className="p-form__control u-clearfix"
+            >
+              <input
+                aria-describedby={null}
+                aria-errormessage={null}
+                aria-invalid={false}
+                aria-label="Hostname"
+                className="p-form-validation__input node-name__hostname"
+                id="mock-redux-js-nanoid-1"
+                label="Hostname"
+                name="hostname"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="text"
+                value=""
+              />
+            </div>
           </div>
-        </div>
-      </Field>
-    </Input>
-  </FormikField>
+        </Field>
+      </Input>
+    </FormikField>
+  </div>
   <span
-    className="node-name__dot u-nudge-left--small u-no-margin--right"
+    className="node-name__dot u-nudge-right--small u-nudge-left--small u-no-margin--right"
   >
     .
   </span>

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -306,7 +306,6 @@ exports[`NodeName can display the form 1`] = `
                     error={null}
                     forId="mock-redux-js-nanoid-1"
                     helpId="mock-nanoid-2"
-                    isTickElement={false}
                     label="Hostname"
                     validationId="mock-nanoid-1"
                   >

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -269,89 +269,85 @@ exports[`NodeName can display the form 1`] = `
           <NodeNameFields
             setHostnameError={[Function]}
           >
-            <FormikField
-              className="node-name__hostname"
-              displayError={false}
-              label="Hostname"
-              name="hostname"
-              style={
-                Object {
-                  "width": "14ch",
-                }
-              }
-              takeFocus={true}
-              type="text"
-              wrapperClassName="u-no-margin--right"
+            <div
+              className="node-name__hostname-wrapper u-no-margin--right"
             >
-              <Input
-                aria-label="Hostname"
+              <div
+                aria-hidden="true"
+                className="node-name__hostname-spacer"
+              >
+                test-machine-5
+              </div>
+              <FormikField
                 className="node-name__hostname"
-                error={null}
-                id="mock-redux-js-nanoid-1"
+                displayError={false}
                 label="Hostname"
                 name="hostname"
-                onBlur={[Function]}
-                onChange={[Function]}
-                style={
-                  Object {
-                    "width": "14ch",
-                  }
-                }
                 takeFocus={true}
                 type="text"
-                value="test-machine-5"
                 wrapperClassName="u-no-margin--right"
               >
-                <Field
-                  className="u-no-margin--right"
+                <Input
+                  aria-label="Hostname"
+                  className="node-name__hostname"
                   error={null}
-                  forId="mock-redux-js-nanoid-1"
-                  helpId="mock-nanoid-2"
+                  id="mock-redux-js-nanoid-1"
                   label="Hostname"
-                  validationId="mock-nanoid-1"
+                  name="hostname"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  takeFocus={true}
+                  type="text"
+                  value="test-machine-5"
+                  wrapperClassName="u-no-margin--right"
                 >
-                  <div
-                    className="p-form__group p-form-validation u-no-margin--right"
+                  <Field
+                    className="u-no-margin--right"
+                    error={null}
+                    forId="mock-redux-js-nanoid-1"
+                    helpId="mock-nanoid-2"
+                    isTickElement={false}
+                    label="Hostname"
+                    validationId="mock-nanoid-1"
                   >
-                    <Label
-                      forId="mock-redux-js-nanoid-1"
-                    >
-                      <label
-                        className="p-form__label"
-                        htmlFor="mock-redux-js-nanoid-1"
-                      >
-                        Hostname
-                      </label>
-                    </Label>
                     <div
-                      className="p-form__control u-clearfix"
+                      className="p-form__group p-form-validation u-no-margin--right"
                     >
-                      <input
-                        aria-describedby={null}
-                        aria-errormessage={null}
-                        aria-invalid={false}
-                        aria-label="Hostname"
-                        className="p-form-validation__input node-name__hostname"
-                        id="mock-redux-js-nanoid-1"
-                        label="Hostname"
-                        name="hostname"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        style={
-                          Object {
-                            "width": "14ch",
-                          }
-                        }
-                        type="text"
-                        value="test-machine-5"
-                      />
+                      <Label
+                        forId="mock-redux-js-nanoid-1"
+                      >
+                        <label
+                          className="p-form__label"
+                          htmlFor="mock-redux-js-nanoid-1"
+                        >
+                          Hostname
+                        </label>
+                      </Label>
+                      <div
+                        className="p-form__control u-clearfix"
+                      >
+                        <input
+                          aria-describedby={null}
+                          aria-errormessage={null}
+                          aria-invalid={false}
+                          aria-label="Hostname"
+                          className="p-form-validation__input node-name__hostname"
+                          id="mock-redux-js-nanoid-1"
+                          label="Hostname"
+                          name="hostname"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          type="text"
+                          value="test-machine-5"
+                        />
+                      </div>
                     </div>
-                  </div>
-                </Field>
-              </Input>
-            </FormikField>
+                  </Field>
+                </Input>
+              </FormikField>
+            </div>
             <span
-              className="node-name__dot u-nudge-left--small u-no-margin--right"
+              className="node-name__dot u-nudge-right--small u-nudge-left--small u-no-margin--right"
             >
               .
             </span>

--- a/ui/src/app/base/components/NodeName/_index.scss
+++ b/ui/src/app/base/components/NodeName/_index.scss
@@ -23,11 +23,32 @@
     margin-top: $spv--small;
   }
 
+  .node-name__hostname-wrapper {
+    // Make the wrapping element take the space of the spacer.
+    flex-basis: min-content;
+
+    .p-form__control {
+      // Make the input's wrapper take up the space that's determined by the spacer.
+      width: 100%;
+    }
+  }
+
+  .node-name__hostname-spacer {
+    @extend %vf-heading-4;
+    // Collapse the spacer so it's taking up horizontal space but not vertical space.
+    height: 0;
+    margin: 0;
+    // Include space for the left and right borders on the input.
+    padding: 0 calc(#{$sph--large} + 1px);
+    visibility: hidden;
+    // Need to use pre so that the width includes any trailing whitespace.
+    white-space: pre;
+  }
+
   [type="text"].node-name__hostname {
     @extend %vf-heading-4;
 
     @media only screen and (min-width: $breakpoint-large) {
-      box-sizing: content-box;
       margin-bottom: -1px;
       min-width: 3rem;
       // Remove 2px to account for the top and bottom borders.


### PR DESCRIPTION
## Done

- Improve the display of the auto-sizing machine name field so that the content doesn't get cut off
after clearing the field.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine details page.
- Click on the name to open the form.
- Clear the name and start typing.
- The input should nicely adjust to the size of the text as you type (and it shouldn't get cut off a the edges).

## Fixes

Fixes: #3341.

## Screenshots

![rename](https://user-images.githubusercontent.com/361637/163086069-4bd12317-e713-4ca7-bb01-e9ce88af0922.gif)

