### PR TITLE
[periodic hardware sync] verify back-end integration

### DIFF
--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -73,6 +73,7 @@ it("can show if a machine has not been commissioned yet", () => {
 it("can show the last time a machine was commissioned", () => {
   state.machine.items = [
     machineDetailsFactory({
+      enable_hw_sync: false,
       commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
       fqdn: "test.maas",
       status: NodeStatus.DEPLOYED,
@@ -90,6 +91,7 @@ it("can show the last time a machine was commissioned", () => {
 it("can handle an incorrectly formatted commissioning timestamp", () => {
   state.machine.items = [
     machineDetailsFactory({
+      enable_hw_sync: false,
       commissioning_start_time: "2020-03-01 09:12:43",
       fqdn: "test.maas",
       status: NodeStatus.DEPLOYED,

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -452,10 +452,35 @@ describe("DeployFormFields", () => {
     );
 
     expect(
+      screen.getByRole("checkbox", { name: /Periodically sync hardware/ })
+    ).toHaveAccessibleDescription(/Hardware sync interval: 15 minutes/);
+    expect(
       screen.getByRole("tooltip", {
         name: /Enable this to make MAAS periodically check the hardware/,
       })
     ).toBeInTheDocument();
+  });
+
+  it("displays a correct description text for an invalid sync interval", () => {
+    state.config.items.push({ name: "hardware_sync_interval", value: "" });
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <DeployForm
+            clearHeaderContent={jest.fn()}
+            machines={[]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      screen.getByRole("checkbox", { name: /Periodically sync hardware/ })
+    ).toHaveAccessibleDescription(/Hardware sync interval: Invalid/i);
   });
 
   it("'Periodically sync hardware' is unchecked by default", async () => {

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -222,9 +222,15 @@ export const DeployFormFields = (): JSX.Element => {
                   {/* TODO: Update docs links https://github.com/canonical-web-and-design/app-tribe/issues/787 */}
                 </>
               }
-              help={`Hardware sync interval: ${timeSpanToMinutes(
-                hardwareSyncInterval
-              )}min - Admins can change this in the global settings.`}
+              help={
+                <>
+                  Hardware sync interval:{" "}
+                  {!hardwareSyncInterval
+                    ? "Invalid"
+                    : `${timeSpanToMinutes(hardwareSyncInterval)} minutes`}{" "}
+                  - Admins can change this in the global settings.
+                </>
+              }
             />
             {userDataVisible && (
               <UploadTextArea

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -148,6 +148,7 @@ describe("StatusCard", () => {
     const machine = machineDetailsFactory({
       enable_hw_sync: true,
       status: NodeStatus.DEPLOYED,
+      sync_interval: 900,
     });
     const store = mockStore(state);
 

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -67,7 +67,8 @@ export type BaseMachine = BaseNode & {
 // used in the machine details pages. This type contains all possible properties
 // of a machine model.
 export type MachineDetails = BaseMachine &
-  TimestampFields & {
+  TimestampFields &
+  HardwareSyncFields & {
     bios_boot_method: string;
     bmc: number;
     boot_disk: Disk | null;
@@ -82,7 +83,6 @@ export type MachineDetails = BaseMachine &
     devices: NodeDeviceRef[];
     dhcp_on: boolean;
     disks: Disk[];
-    enable_hw_sync: boolean;
     error: string;
     events: NodeEvent[];
     grouped_storages: GroupedStorage[];
@@ -92,14 +92,11 @@ export type MachineDetails = BaseMachine &
     installation_status: number;
     interface_test_status: TestStatus;
     interfaces: NetworkInterface[];
-    is_sync_healthy?: boolean;
-    last_sync: string;
     license_key: string;
     memory_test_status: TestStatus;
     metadata: NodeMetadata;
     min_hwe_kernel: string;
     network_test_status: TestStatus;
-    next_sync: string;
     node_type: number;
     numa_nodes: NodeNumaNode[];
     on_network: boolean;
@@ -111,10 +108,21 @@ export type MachineDetails = BaseMachine &
     storage_layout_issues: string[];
     storage_test_status: TestStatus;
     supported_filesystems: SupportedFilesystem[];
-    sync_interval: Seconds;
     swap_size: number | null;
     testing_start_time: string;
   };
+
+type HardwareSyncFields =
+  | {
+      enable_hw_sync: false;
+    }
+  | {
+      enable_hw_sync: true;
+      last_sync: string;
+      next_sync: string;
+      is_sync_healthy: boolean;
+      sync_interval: Seconds;
+    };
 
 // Depending on where the user has navigated in the app, machines in state can
 // either be of type BaseMachine or MachineDetails.

--- a/ui/src/app/store/machine/utils/common.ts
+++ b/ui/src/app/store/machine/utils/common.ts
@@ -49,7 +49,7 @@ export const getMachineFieldScopes = (machine: Machine): PowerFieldScope[] => {
  * @returns Whether this machine failed to sync when it was scheduled.
  */
 export const getHasSyncFailed = (machine?: Machine | null): boolean => {
-  if (!machine || !isMachineDetails(machine)) {
+  if (!isMachineDetails(machine) || !machine.enable_hw_sync) {
     return false;
   }
   return machine.is_sync_healthy === false;

--- a/ui/src/app/utils/timeSpan.test.ts
+++ b/ui/src/app/utils/timeSpan.test.ts
@@ -1,6 +1,6 @@
 import { timeSpanToMinutes, timeSpanToSeconds } from "./timeSpan";
 
-describe("formatTimeSpanStringToSeconds", () => {
+describe("timeSpanToSeconds", () => {
   it("converts a partial timespan string to a number of seconds", () => {
     expect(timeSpanToSeconds("60s")).toEqual(60);
     expect(timeSpanToSeconds("1m")).toEqual(60);
@@ -14,9 +14,9 @@ describe("formatTimeSpanStringToSeconds", () => {
     expect(timeSpanToSeconds("1h1m1s")).toEqual(3661);
   });
 
-  it("returns null for a timespan string in an invalid format", () => {
-    expect(timeSpanToSeconds("1")).toEqual(null);
-    expect(timeSpanToSeconds("s")).toEqual(null);
+  it("returns 0 for a timespan string in an invalid format", () => {
+    expect(timeSpanToSeconds("1")).toEqual(0);
+    expect(timeSpanToSeconds("s")).toEqual(0);
   });
 });
 

--- a/ui/src/app/utils/timeSpan.ts
+++ b/ui/src/app/utils/timeSpan.ts
@@ -1,5 +1,5 @@
 import type { Duration } from "date-fns";
-import { secondsToMinutes } from "date-fns";
+import { add, differenceInSeconds, secondsToMinutes } from "date-fns";
 
 import type { Minutes, Seconds, TimeSpan } from "app/base/types";
 
@@ -8,36 +8,25 @@ export const timeSpanToDuration = (timeSpan: TimeSpan | null): Duration => {
     return {};
   }
   return {
-    hours: Number(timeSpan.match(/([\d]+)\s*(?:hs?|hours?)\s*/)?.[1]),
-    minutes: Number(timeSpan.match(/([\d]+)\s*(?:ms?|mins?|minutes?)\s*/)?.[1]),
-    seconds: Number(timeSpan.match(/([\d]+)\s*(?:s|secs?|seconds?)\s*/)?.[1]),
+    hours:
+      Number(timeSpan.match(/([\d]+)\s*(?:hs?|hours?)\s*/)?.[1]) || undefined,
+    minutes:
+      Number(timeSpan.match(/([\d]+)\s*(?:ms?|mins?|minutes?)\s*/)?.[1]) ||
+      undefined,
+    seconds:
+      Number(timeSpan.match(/([\d]+)\s*(?:s|secs?|seconds?)\s*/)?.[1]) ||
+      undefined,
   };
 };
 
-const durationToSeconds = (duration: Duration): Seconds | null => {
-  const multiplier = {
-    hours: 3600,
-    minutes: 60,
-    seconds: 1,
-  };
-  const total = Object.entries(duration).reduce((total, [key, value]) => {
-    if (!value) {
-      return total;
-    }
-    return (total += value * multiplier[key as keyof typeof multiplier]);
-  }, 0);
-  return total > 0 ? total : null;
-};
+const durationToSeconds = (duration: Duration): Seconds =>
+  differenceInSeconds(add(new Date(), duration), new Date());
 
-export const timeSpanToSeconds = (timeSpan: TimeSpan | null): Seconds | null =>
+const durationToMinutes = (duration: Duration): Minutes =>
+  secondsToMinutes(differenceInSeconds(add(new Date(), duration), new Date()));
+
+export const timeSpanToSeconds = (timeSpan: TimeSpan | null): Seconds =>
   durationToSeconds(timeSpanToDuration(timeSpan));
 
-export const timeSpanToMinutes = (
-  timeSpan: TimeSpan | null
-): Minutes | null => {
-  const seconds = timeSpanToSeconds(timeSpan);
-  if (!seconds) {
-    return null;
-  }
-  return secondsToMinutes(seconds);
-};
+export const timeSpanToMinutes = (timeSpan: TimeSpan | null): Minutes =>
+  durationToMinutes(timeSpanToDuration(timeSpan));

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -313,7 +313,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   devices: () => [],
   dhcp_on: false,
   disks: () => [],
-  enable_hw_sync: false,
+  enable_hw_sync: true,
   error_description: "",
   error: "",
   events: () => [],
@@ -323,8 +323,6 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   installation_start_time: "Thu, 15 Oct. 2020 07:25:10",
   installation_status: 3,
   interfaces: () => [],
-  is_sync_healthy: true,
-  last_sync: "",
   license_key: "",
   metadata: () => ({
     cpu_model: "Intel(R) Xeon(R) CPU E5620",
@@ -342,7 +340,6 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
     chassis_version: "pc-q35-5.1",
   }),
   min_hwe_kernel: "",
-  next_sync: "",
   node_type: 0,
   numa_nodes: () => [],
   on_network: false,
@@ -357,7 +354,6 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   storage_layout_issues: () => [],
   supported_filesystems: () => [],
   swap_size: null,
-  sync_interval: 900,
   testing_start_time: "Thu, 15 Oct. 2020 07:25:10",
   updated: "Fri, 23 Oct. 2020 05:24:41",
 });


### PR DESCRIPTION
## Done

- verify hardware sync back-end integration
- refactor timeSpan with date-fns
- add HardwareSyncFields type for better type safety, more info below.

#### HardwareSyncFields type
```tsx
type HardwareSyncFields =
  | {
      enable_hw_sync: false;
    }
  | {
      enable_hw_sync: true;
      last_sync: string;
      next_sync: string;
      is_sync_healthy: boolean;
      sync_interval: Seconds;
    };
```

Now the code below will throw an error (and rightly so, as `is_sync_healthy` won't be added to the machine details object if the hardware sync is not enabled.
```javascript
export const getHasSyncFailed = (machine?: Machine | null): boolean => {
  if (!isMachineDetails(machine)) {
    return false;
  }
  return machine.is_sync_healthy === false;
};
```

This can be fixed by checking whether `machine.enable_hw_sync` is true and the rest of keys will exist on the machine details object.
```javascript
export const getHasSyncFailed = (machine?: Machine | null): boolean => {
  if (!isMachineDetails(machine) || !machine.enable_hw_sync) {
    return false;
  }
  return machine.is_sync_healthy === false;
};
```

Note: this isn't as strict in tests due to how `cooky-cutter` type merging works; e.g. code below does not report type errors.
```javascript
machineDetailsFactory({
  enable_hw_sync: false,
  is_sync_healthy: true,
}
```

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- go to a machine that can be deployed (e.g. `MAAS/r/machine/c7mn8b/summary`) and to deploy form via "take action" -> "deploy"
- verify that the checkbox looks like before - and displays the interval in `minutes`

## Fixes
Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/788

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
