### PR TITLE
refactor: add aria-label directly to Spinner component

### DIFF
--- a/ui/src/app/base/components/ControllerLink/ControllerLink.tsx
+++ b/ui/src/app/base/components/ControllerLink/ControllerLink.tsx
@@ -26,13 +26,7 @@ const ControllerLink = ({ systemId }: Props): JSX.Element | null => {
   }, [dispatch]);
 
   if (controllersLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading controllers">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading controllers" />;
   }
   if (!controller) {
     return null;

--- a/ui/src/app/base/components/DeviceLink/DeviceLink.tsx
+++ b/ui/src/app/base/components/DeviceLink/DeviceLink.tsx
@@ -26,13 +26,7 @@ const DeviceLink = ({ systemId }: Props): JSX.Element | null => {
   }, [dispatch]);
 
   if (devicesLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading devices">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading devices" />;
   }
   if (!device) {
     return null;

--- a/ui/src/app/base/components/FabricLink/FabricLink.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.tsx
@@ -28,13 +28,7 @@ const FabricLink = ({ id }: Props): JSX.Element => {
   }, [dispatch]);
 
   if (fabricsLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading fabrics">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading fabrics" />;
   }
   if (!fabric) {
     return <>{fabricDisplay}</>;

--- a/ui/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/ui/src/app/base/components/MachineLink/MachineLink.tsx
@@ -26,13 +26,7 @@ const MachineLink = ({ systemId }: Props): JSX.Element | null => {
   }, [dispatch]);
 
   if (machinesLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading machines">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading machines" />;
   }
   if (!machine) {
     return null;

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -34,11 +34,11 @@ const generateSubtitle = (
   let content = subtitle;
   if (subtitleLoading) {
     content = (
-      // TODO: pass the `data-testid` directly to Spinner once once issue below is resolved:
-      // https://github.com/canonical-web-and-design/react-components/issues/651
-      <span data-testid="section-header-subtitle-spinner">
-        <Spinner className="u-text--muted" text="Loading..." />
-      </span>
+      <Spinner
+        className="u-text--muted"
+        text="Loading..."
+        data-testid="section-header-subtitle-spinner"
+      />
     );
   } else if (typeof subtitle === "string") {
     content = <span className="u-text--muted">{subtitle}</span>;

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
@@ -28,13 +28,7 @@ const SpaceLink = ({ id }: Props): JSX.Element => {
   }, [dispatch]);
 
   if (spacesLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading spaces">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading spaces" />;
   }
   if (!space) {
     return <>{spaceDisplay}</>;

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
@@ -28,13 +28,7 @@ const SubnetLink = ({ id }: Props): JSX.Element => {
   }, [dispatch]);
 
   if (subnetsLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading subnets">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading subnets" />;
   }
   if (!subnet) {
     return <>{subnetDisplay}</>;

--- a/ui/src/app/base/components/VLANLink/VLANLink.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.tsx
@@ -28,13 +28,7 @@ const VLANLink = ({ id }: Props): JSX.Element => {
   }, [dispatch]);
 
   if (vlansLoading) {
-    // TODO: Put aria-label directly on Spinner component when issue is fixed.
-    // https://github.com/canonical-web-and-design/react-components/issues/651
-    return (
-      <span aria-label="Loading VLANs">
-        <Spinner />
-      </span>
-    );
+    return <Spinner aria-label="Loading VLANs" />;
   }
   if (!vlan) {
     return <>{vlanDisplay}</>;


### PR DESCRIPTION
## Done

- add `aria-label` and `data-testid` directly to Spinner component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/817

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
