### PR TITLE
[periodic hardware sync] - QA fixes

### DIFF
--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -8,7 +8,7 @@ import configSelectors from "app/store/config/selectors";
 import { version as versionSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
-import { shouldShowHardwareSyncStatus } from "app/store/machine/utils/common";
+import { isDeployedWithHardwareSync } from "app/store/machine/utils/common";
 import { NodeStatus } from "app/store/types/node";
 
 const getTimeDistanceString = (utcTimeString: string) =>
@@ -61,7 +61,7 @@ export const StatusBar = (): JSX.Element | null => {
   }
 
   let status: ReactNode = "";
-  if (shouldShowHardwareSyncStatus(activeMachine)) {
+  if (isDeployedWithHardwareSync(activeMachine)) {
     status = (
       <ul className="p-inline-list u-no-margin--bottom">
         <li className="p-inline-list__item">

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -8,7 +8,7 @@ import configSelectors from "app/store/config/selectors";
 import { version as versionSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
-import { isMachineDetails } from "app/store/machine/utils";
+import { shouldShowHardwareSyncStatus } from "app/store/machine/utils/common";
 import { NodeStatus } from "app/store/types/node";
 
 const getTimeDistanceString = (utcTimeString: string) =>
@@ -61,11 +61,7 @@ export const StatusBar = (): JSX.Element | null => {
   }
 
   let status: ReactNode = "";
-  if (
-    isMachineDetails(activeMachine) &&
-    activeMachine?.status === NodeStatus.DEPLOYED &&
-    activeMachine.enable_hw_sync === true
-  ) {
+  if (shouldShowHardwareSyncStatus(activeMachine)) {
     status = (
       <ul className="p-inline-list u-no-margin--bottom">
         <li className="p-inline-list__item">

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -7,6 +7,7 @@ import SummaryNotifications from "./SummaryNotifications";
 
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
+import { NodeStatus } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
   generalState as generalStateFactory,
@@ -169,6 +170,7 @@ describe("SummaryNotifications", () => {
       machineDetailsFactory({
         architecture: "amd64",
         system_id: "abc123",
+        status: NodeStatus.DEPLOYED,
         is_sync_healthy: false,
       }),
     ];

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -15,7 +15,10 @@ import {
   isMachineDetails,
   useHasInvalidArchitecture,
 } from "app/store/machine/utils";
-import { getHasSyncFailed } from "app/store/machine/utils/common";
+import {
+  getHasSyncFailed,
+  shouldShowHardwareSyncStatus,
+} from "app/store/machine/utils/common";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
 import type { NodeEvent } from "app/store/types/node";
@@ -49,7 +52,8 @@ const SummaryNotifications = ({ id }: Props): JSX.Element | null => {
   const canEdit = useCanEdit(machine, true);
   const isRackControllerConnected = useIsRackControllerConnected();
   const hasInvalidArchitecture = useHasInvalidArchitecture(machine);
-  const hasSyncFailed = getHasSyncFailed(machine);
+  const hasSyncFailed =
+    shouldShowHardwareSyncStatus(machine) && getHasSyncFailed(machine);
 
   useEffect(() => {
     dispatch(generalActions.fetchArchitectures());

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -17,7 +17,7 @@ import {
 } from "app/store/machine/utils";
 import {
   getHasSyncFailed,
-  shouldShowHardwareSyncStatus,
+  isDeployedWithHardwareSync,
 } from "app/store/machine/utils/common";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
@@ -53,7 +53,7 @@ const SummaryNotifications = ({ id }: Props): JSX.Element | null => {
   const isRackControllerConnected = useIsRackControllerConnected();
   const hasInvalidArchitecture = useHasInvalidArchitecture(machine);
   const hasSyncFailed =
-    shouldShowHardwareSyncStatus(machine) && getHasSyncFailed(machine);
+    isDeployedWithHardwareSync(machine) && getHasSyncFailed(machine);
 
   useEffect(() => {
     dispatch(generalActions.fetchArchitectures());

--- a/ui/src/app/store/machine/utils/common.test.ts
+++ b/ui/src/app/store/machine/utils/common.test.ts
@@ -3,9 +3,11 @@ import {
   getMachineFieldScopes,
   getTagCountsForMachines,
   isMachineDetails,
+  shouldShowHardwareSyncStatus,
 } from "./common";
 
 import { PowerFieldScope } from "app/store/general/types";
+import { NodeStatus } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
@@ -80,6 +82,41 @@ describe("common machine utils", () => {
       expect(
         getHasSyncFailed(machineDetailsFactory({ is_sync_healthy: false }))
       ).toBe(true);
+    });
+  });
+
+  describe("shouldShowHardwareSyncStatus", () => {
+    it("returns false for deploying machines", () => {
+      expect(
+        shouldShowHardwareSyncStatus(
+          machineDetailsFactory({
+            status: NodeStatus.DEPLOYING,
+            enable_hw_sync: true,
+          })
+        )
+      ).toBe(false);
+    });
+
+    it("returns true for deployed machines with hardware sync enabled", () => {
+      expect(
+        shouldShowHardwareSyncStatus(
+          machineDetailsFactory({
+            status: NodeStatus.DEPLOYED,
+            enable_hw_sync: true,
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("returns false for deployed machines with hardware sync disabled", () => {
+      expect(
+        shouldShowHardwareSyncStatus(
+          machineDetailsFactory({
+            status: NodeStatus.DEPLOYED,
+            enable_hw_sync: false,
+          })
+        )
+      ).toBe(false);
     });
   });
 });

--- a/ui/src/app/store/machine/utils/common.test.ts
+++ b/ui/src/app/store/machine/utils/common.test.ts
@@ -3,7 +3,7 @@ import {
   getMachineFieldScopes,
   getTagCountsForMachines,
   isMachineDetails,
-  shouldShowHardwareSyncStatus,
+  isDeployedWithHardwareSync,
 } from "./common";
 
 import { PowerFieldScope } from "app/store/general/types";
@@ -85,10 +85,10 @@ describe("common machine utils", () => {
     });
   });
 
-  describe("shouldShowHardwareSyncStatus", () => {
+  describe("isDeployedWithHardwareSync", () => {
     it("returns false for deploying machines", () => {
       expect(
-        shouldShowHardwareSyncStatus(
+        isDeployedWithHardwareSync(
           machineDetailsFactory({
             status: NodeStatus.DEPLOYING,
             enable_hw_sync: true,
@@ -99,7 +99,7 @@ describe("common machine utils", () => {
 
     it("returns true for deployed machines with hardware sync enabled", () => {
       expect(
-        shouldShowHardwareSyncStatus(
+        isDeployedWithHardwareSync(
           machineDetailsFactory({
             status: NodeStatus.DEPLOYED,
             enable_hw_sync: true,
@@ -110,7 +110,7 @@ describe("common machine utils", () => {
 
     it("returns false for deployed machines with hardware sync disabled", () => {
       expect(
-        shouldShowHardwareSyncStatus(
+        isDeployedWithHardwareSync(
           machineDetailsFactory({
             status: NodeStatus.DEPLOYED,
             enable_hw_sync: false,

--- a/ui/src/app/store/machine/utils/common.ts
+++ b/ui/src/app/store/machine/utils/common.ts
@@ -1,6 +1,7 @@
 import { PowerFieldScope } from "app/store/general/types";
 import type { Machine, MachineDetails } from "app/store/machine/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
+import { NodeStatus } from "app/store/types/node";
 
 /**
  * Whether a machine has a Machine or MachineDetails type.
@@ -44,6 +45,22 @@ export const getMachineFieldScopes = (machine: Machine): PowerFieldScope[] => {
   }
   return [PowerFieldScope.BMC, PowerFieldScope.NODE];
 };
+
+/**
+ * @returns Whether this machine hardware sync status should be shown.
+ */
+export function shouldShowHardwareSyncStatus(
+  machine?: Machine | null
+): machine is MachineDetails & {
+  enable_hw_sync: true;
+  status: NodeStatus.DEPLOYED;
+} {
+  return (
+    isMachineDetails(machine) &&
+    machine.status === NodeStatus.DEPLOYED &&
+    machine.enable_hw_sync === true
+  );
+}
 
 /**
  * @returns Whether this machine failed to sync when it was scheduled.

--- a/ui/src/app/store/machine/utils/common.ts
+++ b/ui/src/app/store/machine/utils/common.ts
@@ -47,9 +47,9 @@ export const getMachineFieldScopes = (machine: Machine): PowerFieldScope[] => {
 };
 
 /**
- * @returns Whether this machine hardware sync status should be shown.
+ * @returns Whether this machine is deployed and has hardware sync enabled.
  */
-export function shouldShowHardwareSyncStatus(
+export function isDeployedWithHardwareSync(
   machine?: Machine | null
 ): machine is MachineDetails & {
   enable_hw_sync: true;

--- a/ui/src/app/utils/timeSpan.test.ts
+++ b/ui/src/app/utils/timeSpan.test.ts
@@ -1,4 +1,14 @@
+import MockDate from "mockdate";
+
 import { timeSpanToMinutes, timeSpanToSeconds } from "./timeSpan";
+
+beforeAll(() => {
+  MockDate.set("2020-01-01");
+});
+
+afterAll(() => {
+  MockDate.reset();
+});
 
 describe("timeSpanToSeconds", () => {
   it("converts a partial timespan string to a number of seconds", () => {


### PR DESCRIPTION
## Done

- hide sync failure for deploying machines
  - add shouldShowHardwareSyncStatus util

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- deploy a machine with "periodic hardware sync" checkbox enabled
- Make sure "hardware sync failed" notification is not displayed for a machine that is in "deploying" state

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/814

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
