### PR TITLE
feat(ui): add Security tab to Settings page

### DIFF
--- a/ui/src/app/settings/components/Nav/Nav.tsx
+++ b/ui/src/app/settings/components/Nav/Nav.tsx
@@ -9,6 +9,10 @@ export const Nav = (): JSX.Element => (
         subNav: [
           { path: settingsURLs.configuration.general, label: "General" },
           {
+            path: settingsURLs.configuration.security,
+            label: "Security",
+          },
+          {
             path: settingsURLs.configuration.commissioning,
             label: "Commissioning",
           },

--- a/ui/src/app/settings/components/Routes/Routes.tsx
+++ b/ui/src/app/settings/components/Routes/Routes.tsx
@@ -6,6 +6,7 @@ import Commissioning from "app/settings/views/Configuration/Commissioning";
 import Deploy from "app/settings/views/Configuration/Deploy";
 import General from "app/settings/views/Configuration/General";
 import KernelParameters from "app/settings/views/Configuration/KernelParameters";
+import Security from "app/settings/views/Configuration/Security";
 import DhcpAdd from "app/settings/views/Dhcp/DhcpAdd";
 import DhcpEdit from "app/settings/views/Dhcp/DhcpEdit";
 import DhcpList from "app/settings/views/Dhcp/DhcpList";
@@ -37,6 +38,11 @@ const Routes = (): JSX.Element => {
         exact
         path={settingsURLs.configuration.general}
         render={() => <General />}
+      />
+      <Route
+        exact
+        path={settingsURLs.configuration.security}
+        render={() => <Security />}
       />
       <Route
         exact

--- a/ui/src/app/settings/urls.ts
+++ b/ui/src/app/settings/urls.ts
@@ -12,6 +12,7 @@ const urls = {
     general: "/settings/configuration/general",
     index: "/settings/configuration",
     kernelParameters: "/settings/configuration/kernel-parameters",
+    security: "/settings/configuration/security",
   },
   dhcp: {
     add: "/settings/dhcp/add",

--- a/ui/src/app/settings/views/Configuration/Security/Security.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/Security.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from "@testing-library/react";
+
+import Security from "./Security";
+
+import {
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+  tlsCertificate as tlsCertificateFactory,
+  tlsCertificateState as tlsCertificateStateFactory,
+} from "testing/factories";
+import { renderWithMockStore } from "testing/utils";
+
+it("displays loading text if TLS certificate has not loaded", () => {
+  const state = rootStateFactory({
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        data: null,
+        loaded: false,
+      }),
+    }),
+  });
+  renderWithMockStore(<Security />, { state });
+
+  expect(screen.getByText(/Loading.../)).toBeInTheDocument();
+});
+
+it("renders TLS disabled section if no TLS certificate is present", () => {
+  const state = rootStateFactory({
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        data: {},
+        loaded: true,
+      }),
+    }),
+  });
+  renderWithMockStore(<Security />, { state });
+
+  expect(screen.getByText(/TLS disabled/)).toBeInTheDocument();
+  expect(screen.queryByText(/TLS enabled/)).not.toBeInTheDocument();
+});
+
+it("renders TLS enabled section if TLS certificate is present", () => {
+  const state = rootStateFactory({
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        data: tlsCertificateFactory(),
+        loaded: true,
+      }),
+    }),
+  });
+  renderWithMockStore(<Security />, { state });
+
+  expect(screen.getByText(/TLS enabled/)).toBeInTheDocument();
+  expect(screen.queryByText(/TLS disabled/)).not.toBeInTheDocument();
+});

--- a/ui/src/app/settings/views/Configuration/Security/Security.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/Security.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+import { Col, Row, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import TLSDisabled from "./TLSDisabled";
+import TLSEnabled from "./TLSEnabled";
+
+import { useWindowTitle } from "app/base/hooks";
+import { actions as generalActions } from "app/store/general";
+import { tlsCertificate as tlsCertificateSelectors } from "app/store/general/selectors";
+import { isTlsCertificate } from "app/store/general/utils";
+
+const Security = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const tlsCertificate = useSelector(tlsCertificateSelectors.get);
+  const tlsCertificateLoaded = useSelector(tlsCertificateSelectors.loaded);
+  useWindowTitle("Security");
+
+  useEffect(() => {
+    dispatch(generalActions.fetchTlsCertificate());
+  }, [dispatch]);
+
+  if (!tlsCertificateLoaded) {
+    return <Spinner text="Loading..." />;
+  }
+
+  const isTlsEnabled = isTlsCertificate(tlsCertificate);
+  return (
+    <Row>
+      <Col size={6}>{isTlsEnabled ? <TLSEnabled /> : <TLSDisabled />}</Col>
+    </Row>
+  );
+};
+
+export default Security;

--- a/ui/src/app/settings/views/Configuration/Security/TLSDisabled/TLSDisabled.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSDisabled/TLSDisabled.tsx
@@ -1,0 +1,37 @@
+import {
+  CodeSnippet,
+  CodeSnippetBlockAppearance,
+  Icon,
+} from "@canonical/react-components";
+
+const TLSDisabled = (): JSX.Element => {
+  return (
+    <>
+      <p>
+        <Icon name="warning" />
+        <span className="u-nudge-right--small">TLS disabled</span>
+      </p>
+      <p>
+        You can enable TLS with a certificate and a private key in the CLI with
+        the following command:
+      </p>
+      <CodeSnippet
+        blocks={[
+          {
+            appearance: CodeSnippetBlockAppearance.LINUX_PROMPT,
+            code: "maas config-tls enable $key $cert --port YYYY",
+          },
+        ]}
+      />
+      <p>
+        {/*
+          TODO: Add docs links
+          https://github.com/canonical-web-and-design/app-tribe/issues/829
+        */}
+        <a href="#todo">More about MAAS native TLS</a>
+      </p>
+    </>
+  );
+};
+
+export default TLSDisabled;

--- a/ui/src/app/settings/views/Configuration/Security/TLSDisabled/index.ts
+++ b/ui/src/app/settings/views/Configuration/Security/TLSDisabled/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TLSDisabled";

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
@@ -1,0 +1,12 @@
+import { Icon } from "@canonical/react-components";
+
+// TODO: Build "TLS enabled" version of security settings
+// https://github.com/canonical-web-and-design/app-tribe/issues/821
+const TLSEnabled = (): JSX.Element => (
+  <p>
+    <Icon name="lock-locked-active" />
+    <span className="u-nudge-right--small">TLS enabled</span>
+  </p>
+);
+
+export default TLSEnabled;

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/index.ts
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TLSEnabled";

--- a/ui/src/app/settings/views/Configuration/Security/index.ts
+++ b/ui/src/app/settings/views/Configuration/Security/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Security";

--- a/ui/src/app/store/general/utils/index.ts
+++ b/ui/src/app/store/general/utils/index.ts
@@ -1,4 +1,4 @@
-export { splitCertificateName } from "./certificates";
+export { isTlsCertificate, splitCertificateName } from "./certificates";
 
 export { useInitialPowerParameters } from "./hooks";
 

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -16,6 +16,7 @@
 @include vf-p-icon-begin-downloading;
 @include vf-p-icon-change-version;
 @include vf-p-icon-inspector-debug;
+@include vf-p-icon-lock-locked-active;
 @include vf-p-icon-restart;
 @include vf-p-icon-settings;
 @include vf-p-icon-success-grey;


### PR DESCRIPTION
## Done

- Added Security tab to Settings page
- Built "TLS disabled" version of the page (though it's missing the correct docs link, will address in a follow up when it's ready)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Settings page and check that there is a Security tab under Configuration
- Click on the Security tab and check that it looks like [the design for TLS disabled](https://docs.google.com/document/d/1noqxCF1hPwzToO6i0gxqSMfNFB4HdZeDsEFGjVF1LRM/edit#)

## Fixes

Fixes canonical-web-and-design/app-tribe#820

## Screenshot

![Screenshot 2022-04-19 at 10-12-43 Security bolla MAAS](https://user-images.githubusercontent.com/25733845/163896079-b5900499-269c-4871-b394-a430e71adbf5.png)
