### PR TITLE
feat(ui): add selectors for TLS expiration notification config

### DIFF
--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -4,6 +4,7 @@ export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit
 
 export type Seconds = number;
 export type Minutes = number;
+export type Days = number;
 /**
  * hours / minutes / seconds in systemd.time timespan format, e.g. "1h 15m 20seconds"
  * https://www.freedesktop.org/software/systemd/man/systemd.time.html

--- a/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.test.tsx
+++ b/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.test.tsx
@@ -36,7 +36,7 @@ it("displays a message if TLS is disabled", () => {
   const state = rootStateFactory({
     general: generalStateFactory({
       tlsCertificate: tlsCertificateStateFactory({
-        data: {},
+        data: null,
         loaded: true,
       }),
     }),

--- a/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.tsx
+++ b/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.tsx
@@ -6,7 +6,6 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { actions as generalActions } from "app/store/general";
 import { tlsCertificate as tlsCertificateSelectors } from "app/store/general/selectors";
-import { isTlsCertificate } from "app/store/general/utils";
 import { breakLines, unindentString } from "app/utils";
 
 export enum Labels {
@@ -20,13 +19,12 @@ const TLSCertificate = (): JSX.Element | null => {
   const dispatch = useDispatch();
   const tlsCertificate = useSelector(tlsCertificateSelectors.get);
   const loaded = useSelector(tlsCertificateSelectors.loaded);
-  const isTlsEnabled = isTlsCertificate(tlsCertificate);
 
   useEffect(() => {
     dispatch(generalActions.fetchTlsCertificate());
   }, [dispatch]);
 
-  if (!isTlsEnabled) {
+  if (!tlsCertificate) {
     return (
       <>
         <h2 className="p-heading--5 u-sv-1">{Labels.Title}</h2>

--- a/ui/src/app/settings/views/Configuration/Security/Security.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/Security.test.tsx
@@ -28,7 +28,7 @@ it("renders TLS disabled section if no TLS certificate is present", () => {
   const state = rootStateFactory({
     general: generalStateFactory({
       tlsCertificate: tlsCertificateStateFactory({
-        data: {},
+        data: null,
         loaded: true,
       }),
     }),

--- a/ui/src/app/settings/views/Configuration/Security/Security.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/Security.tsx
@@ -9,7 +9,6 @@ import TLSEnabled from "./TLSEnabled";
 import { useWindowTitle } from "app/base/hooks";
 import { actions as generalActions } from "app/store/general";
 import { tlsCertificate as tlsCertificateSelectors } from "app/store/general/selectors";
-import { isTlsCertificate } from "app/store/general/utils";
 
 const Security = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -25,10 +24,9 @@ const Security = (): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
-  const isTlsEnabled = isTlsCertificate(tlsCertificate);
   return (
     <Row>
-      <Col size={6}>{isTlsEnabled ? <TLSEnabled /> : <TLSDisabled />}</Col>
+      <Col size={6}>{tlsCertificate ? <TLSEnabled /> : <TLSDisabled />}</Col>
     </Row>
   );
 };

--- a/ui/src/app/store/config/selectors.test.ts
+++ b/ui/src/app/store/config/selectors.test.ts
@@ -514,4 +514,36 @@ describe("config selectors", () => {
       expect(config.rpcSharedSecret(state)).toBe("veryverysecret");
     });
   });
+
+  describe("tlsCertExpirationNotificationEnabled", () => {
+    it("returns MAAS config for TLS cert expiration notification enabled", () => {
+      const state = rootStateFactory({
+        config: configStateFactory({
+          items: [
+            configFactory({
+              name: "tls_cert_expiration_notification_enabled",
+              value: true,
+            }),
+          ],
+        }),
+      });
+      expect(config.tlsCertExpirationNotificationEnabled(state)).toBe(true);
+    });
+  });
+
+  describe("tlsCertExpirationNotificationInterval", () => {
+    it("returns MAAS config for TLS cert expiration notification interval", () => {
+      const state = rootStateFactory({
+        config: configStateFactory({
+          items: [
+            configFactory({
+              name: "tls_cert_expiration_notification_interval",
+              value: 45,
+            }),
+          ],
+        }),
+      });
+      expect(config.tlsCertExpirationNotificationInterval(state)).toBe(45);
+    });
+  });
 });

--- a/ui/src/app/store/config/selectors.ts
+++ b/ui/src/app/store/config/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import type { TimeSpan } from "app/base/types";
+import type { Days, TimeSpan } from "app/base/types";
 import type {
   AutoIpmiPrivilegeLevel,
   Config,
@@ -518,6 +518,24 @@ const hardwareSyncInterval = createSelector([all], (configs) =>
   getValueFromName<TimeSpan>(configs, "hardware_sync_interval")
 );
 
+/**
+ * Returns MAAS config for whether the TLS expiration notification is enabled.
+ * @param state - The redux state.
+ * @returns Whether the TLS expiration notification is enabled.
+ */
+const tlsCertExpirationNotificationEnabled = createSelector([all], (configs) =>
+  getValueFromName<boolean>(configs, "tls_cert_expiration_notification_enabled")
+);
+
+/**
+ * Returns MAAS config for the interval in which to show TLS expiration notification.
+ * @param state - The redux state.
+ * @returns The interval in which to show TLS expiration notification.
+ */
+const tlsCertExpirationNotificationInterval = createSelector([all], (configs) =>
+  getValueFromName<Days>(configs, "tls_cert_expiration_notification_interval")
+);
+
 const config = {
   activeDiscoveryInterval,
   all,
@@ -562,6 +580,8 @@ const config = {
   saving,
   storageLayoutOptions,
   thirdPartyDriversEnabled,
+  tlsCertExpirationNotificationEnabled,
+  tlsCertExpirationNotificationInterval,
   upstreamDns,
   usePeerProxy,
   uuid,

--- a/ui/src/app/store/general/types/base.ts
+++ b/ui/src/app/store/general/types/base.ts
@@ -12,7 +12,7 @@ import type {
   PowerFieldType,
 } from "./enum";
 
-import type { APIError, EmptyObject } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { MachineActions } from "app/store/machine/types";
 
 export type Architecture = string;
@@ -229,7 +229,7 @@ export type TLSCertificate =
 
 export type TLSCertificateState = {
   errors: APIError;
-  data: TLSCertificate | EmptyObject | null;
+  data: TLSCertificate | null;
   loaded: boolean;
   loading: boolean;
 };

--- a/ui/src/app/store/general/utils/certificates.test.ts
+++ b/ui/src/app/store/general/utils/certificates.test.ts
@@ -1,6 +1,4 @@
-import { isTlsCertificate, splitCertificateName } from "./certificates";
-
-import { tlsCertificate as tlsCertificateFactory } from "testing/factories";
+import { splitCertificateName } from "./certificates";
 
 describe("splitCertificateName", () => {
   it("handles null case", () => {
@@ -23,14 +21,5 @@ describe("splitCertificateName", () => {
       host: "host",
       name: "machine@address",
     });
-  });
-});
-
-describe("isTlsCertificate", () => {
-  it("can determine whether a certificate is a TLS certificate", () => {
-    expect(isTlsCertificate(tlsCertificateFactory())).toBe(true);
-    expect(isTlsCertificate({})).toBe(false);
-    expect(isTlsCertificate(null)).toBe(false);
-    expect(isTlsCertificate()).toBe(false);
   });
 });

--- a/ui/src/app/store/general/utils/certificates.ts
+++ b/ui/src/app/store/general/utils/certificates.ts
@@ -1,8 +1,4 @@
-import type { EmptyObject } from "app/base/types";
-import type {
-  CertificateMetadata,
-  TLSCertificate,
-} from "app/store/general/types";
+import type { CertificateMetadata } from "app/store/general/types";
 
 /**
  * Split a certificate name in to object and host names, where certificate names
@@ -28,12 +24,3 @@ export const splitCertificateName = (
   const name = split.slice(0, split.length - 1).join("@");
   return { name, host };
 };
-
-/**
- * Determine whether a certificate is a TLS certificate
- * @param cert - the certificate to check.
- * @returns whether the certificate is of type TLSCertificate.
- */
-export const isTlsCertificate = (
-  cert?: TLSCertificate | EmptyObject | null
-): cert is TLSCertificate => (cert && "certificate" in cert) || false;

--- a/ui/src/app/store/general/utils/index.ts
+++ b/ui/src/app/store/general/utils/index.ts
@@ -1,4 +1,4 @@
-export { isTlsCertificate, splitCertificateName } from "./certificates";
+export { splitCertificateName } from "./certificates";
 
 export { useInitialPowerParameters } from "./hooks";
 

--- a/ui/src/app/utils/timeSpan.ts
+++ b/ui/src/app/utils/timeSpan.ts
@@ -19,11 +19,15 @@ export const timeSpanToDuration = (timeSpan: TimeSpan | null): Duration => {
   };
 };
 
-const durationToSeconds = (duration: Duration): Seconds =>
-  differenceInSeconds(add(new Date(), duration), new Date());
+const durationToSeconds = (duration: Duration): Seconds => {
+  const now = new Date();
+  return differenceInSeconds(add(now, duration), now);
+};
 
-const durationToMinutes = (duration: Duration): Minutes =>
-  secondsToMinutes(differenceInSeconds(add(new Date(), duration), new Date()));
+const durationToMinutes = (duration: Duration): Minutes => {
+  const now = new Date();
+  return secondsToMinutes(differenceInSeconds(add(now, duration), now));
+};
 
 export const timeSpanToSeconds = (timeSpan: TimeSpan | null): Seconds =>
   durationToSeconds(timeSpanToDuration(timeSpan));


### PR DESCRIPTION
## Done

- Added selectors for TLS expiration notification config
- Updated API shape for `general.tls_certificate` to remove the empty object case and removed the util that handled that case

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes canonical-web-and-design/app-tribe#819

