### PR TITLE
feat(ui): build "TLS enabled" version of security settings

### DIFF
--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as fileDownload from "js-file-download";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import TLSEnabled, { Labels } from "./TLSEnabled";
+
+import { actions as configActions } from "app/store/config";
+import {
+  config as configFactory,
+  configState as configStateFactory,
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+  tlsCertificate as tlsCertificateFactory,
+  tlsCertificateState as tlsCertificateStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+jest.mock("js-file-download", () => jest.fn());
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("can generate a download based on the TLS certificate details", async () => {
+  const downloadSpy = jest.spyOn(fileDownload, "default");
+  const tlsCertificate = tlsCertificateFactory();
+  const state = rootStateFactory({
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        data: tlsCertificate,
+        loaded: true,
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <TLSEnabled />
+    </Provider>
+  );
+
+  userEvent.click(screen.getByRole("button", { name: /Download certificate/ }));
+
+  await waitFor(() => {
+    expect(downloadSpy).toHaveBeenCalledWith(
+      tlsCertificate.certificate,
+      "TLS certificate"
+    );
+  });
+});
+
+it("disables the interval field if notification is not enabled", async () => {
+  const tlsCertificate = tlsCertificateFactory();
+  const state = rootStateFactory({
+    config: configStateFactory({
+      items: [
+        configFactory({
+          name: "tls_cert_expiration_notification_enabled",
+          value: false,
+        }),
+        configFactory({
+          name: "tls_cert_expiration_notification_interval",
+          value: 45,
+        }),
+      ],
+    }),
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        data: tlsCertificate,
+        loaded: true,
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <TLSEnabled />
+    </Provider>
+  );
+  const slider = screen.getByRole("slider", { name: Labels.Interval });
+  expect(slider).toBeDisabled();
+
+  userEvent.click(
+    screen.getByRole("checkbox", { name: Labels.NotificationCheckbox })
+  );
+
+  await waitFor(() => {
+    expect(slider).not.toBeDisabled();
+  });
+});
+
+it("dispatches an action to update TLS notification config", async () => {
+  const tlsCertificate = tlsCertificateFactory();
+  const state = rootStateFactory({
+    config: configStateFactory({
+      items: [
+        configFactory({
+          name: "tls_cert_expiration_notification_enabled",
+          value: false,
+        }),
+        configFactory({
+          name: "tls_cert_expiration_notification_interval",
+          value: 60,
+        }),
+      ],
+    }),
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        data: tlsCertificate,
+        loaded: true,
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <TLSEnabled />
+    </Provider>
+  );
+
+  userEvent.click(
+    screen.getByRole("checkbox", { name: Labels.NotificationCheckbox })
+  );
+  fireEvent.change(screen.getByRole("slider", { name: Labels.Interval }), {
+    target: { value: 45 },
+  });
+  userEvent.click(screen.getByRole("button", { name: /Save/ }));
+
+  await waitFor(() => {
+    const actualActions = store.getActions();
+    const expectedAction = configActions.update({
+      tls_cert_expiration_notification_enabled: true,
+      tls_cert_expiration_notification_interval: 45,
+    });
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
@@ -1,12 +1,102 @@
 import { Icon } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
 
-// TODO: Build "TLS enabled" version of security settings
-// https://github.com/canonical-web-and-design/app-tribe/issues/821
-const TLSEnabled = (): JSX.Element => (
-  <p>
-    <Icon name="lock-locked-active" />
-    <span className="u-nudge-right--small">TLS enabled</span>
-  </p>
-);
+import TLSEnabledFields from "./TLSEnabledFields";
+
+import CertificateDownload from "app/base/components/CertificateDownload";
+import CertificateMetadata from "app/base/components/CertificateMetadata";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as configActions } from "app/store/config";
+import configSelectors from "app/store/config/selectors";
+import { TLSExpiryNotificationInterval } from "app/store/config/types";
+import { tlsCertificate as tlsCertificateSelectors } from "app/store/general/selectors";
+
+export type TLSEnabledValues = {
+  notificationEnabled: boolean;
+  notificationInterval: number;
+};
+
+export enum Labels {
+  NotificationCheckbox = "Notify the certificate is due to expire in...",
+  Interval = "Days",
+  IntervalRangeError = "Notification interval must be between 0 and 90 days.",
+}
+
+const TLSEnabledSchema = Yup.object()
+  .shape({
+    notificationEnabled: Yup.boolean(),
+    notificationInterval: Yup.number()
+      .min(TLSExpiryNotificationInterval.MIN, Labels.IntervalRangeError)
+      .max(TLSExpiryNotificationInterval.MAX, Labels.IntervalRangeError),
+  })
+  .defined();
+
+const TLSEnabled = (): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const notificationEnabled = useSelector(
+    configSelectors.tlsCertExpirationNotificationEnabled
+  );
+  const notificationInterval = useSelector(
+    configSelectors.tlsCertExpirationNotificationInterval
+  );
+  const tlsCertificate = useSelector(tlsCertificateSelectors.get);
+  const saved = useSelector(configSelectors.saved);
+  const saving = useSelector(configSelectors.saving);
+
+  if (!tlsCertificate) {
+    return null;
+  }
+
+  return (
+    <>
+      <p>
+        <Icon name="lock-locked-active" />
+        <span className="u-nudge-right--small">TLS enabled</span>
+      </p>
+      <CertificateMetadata
+        metadata={{
+          CN: tlsCertificate.CN,
+          expiration: tlsCertificate.expiration,
+          fingerprint: tlsCertificate.fingerprint,
+        }}
+      />
+      <CertificateDownload
+        certificate={tlsCertificate.certificate}
+        filename="TLS certificate"
+      />
+      <FormikForm<TLSEnabledValues>
+        buttonsAlign="left"
+        buttonsBordered={false}
+        cleanup={configActions.cleanup}
+        initialValues={{
+          notificationEnabled: notificationEnabled || false,
+          notificationInterval: notificationInterval || 30,
+        }}
+        onSaveAnalytics={{
+          action: "Saved",
+          category: "Storage settings",
+          label: "Storage form",
+        }}
+        onSubmit={(values, { resetForm }) => {
+          const { notificationEnabled, notificationInterval } = values;
+          dispatch(configActions.cleanup());
+          dispatch(
+            configActions.update({
+              tls_cert_expiration_notification_enabled: notificationEnabled,
+              tls_cert_expiration_notification_interval: notificationInterval,
+            })
+          );
+          resetForm({ values });
+        }}
+        saving={saving}
+        saved={saved}
+        validationSchema={TLSEnabledSchema}
+      >
+        <TLSEnabledFields />
+      </FormikForm>
+    </>
+  );
+};
 
 export default TLSEnabled;

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/TLSEnabledFields.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/TLSEnabledFields.tsx
@@ -1,0 +1,53 @@
+import { Slider } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { TLSEnabledValues } from "../TLSEnabled";
+import { Labels } from "../TLSEnabled";
+
+import FormikField from "app/base/components/FormikField";
+import { TLSExpiryNotificationInterval } from "app/store/config/types";
+
+const TLSEnabledFields = (): JSX.Element => {
+  const { setFieldValue, values } = useFormikContext<TLSEnabledValues>();
+
+  return (
+    <>
+      <FormikField
+        label={Labels.NotificationCheckbox}
+        name="notificationEnabled"
+        type="checkbox"
+      />
+      <div className="p-slider--inline">
+        <FormikField<typeof Slider>
+          component={Slider}
+          disabled={values.notificationEnabled === false}
+          help={
+            <>
+              <span>{TLSExpiryNotificationInterval.MIN}</span>
+              <span>{TLSExpiryNotificationInterval.MAX}</span>
+            </>
+          }
+          label={Labels.Interval}
+          max={TLSExpiryNotificationInterval.MAX}
+          min={TLSExpiryNotificationInterval.MIN}
+          name="notificationInterval"
+          onChange={(e) =>
+            setFieldValue("notificationInterval", Number(e.currentTarget.value))
+          }
+          showInput
+          step={1}
+          value={values.notificationInterval}
+        />
+      </div>
+      <p>
+        {/*
+          TODO: Add docs links
+          https://github.com/canonical-web-and-design/app-tribe/issues/829
+        */}
+        <a href="#todo">How to set up auto-renew for certificates</a>
+      </p>
+    </>
+  );
+};
+
+export default TLSEnabledFields;

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/_index.scss
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/_index.scss
@@ -1,0 +1,36 @@
+@mixin TLSEnabledFields {
+  // TODO: Rewrite using Slider classNames instead of targeting Vanilla classes.
+  // https://github.com/canonical-web-and-design/react-components/issues/765
+  .p-slider--inline {
+    .p-form__group {
+      display: inline-flex;
+      gap: $sph--large;
+      width: 100%;
+    }
+
+    .p-form__control {
+      width: 100%;
+    }
+
+    .p-slider__wrapper {
+      margin-bottom: 0;
+    }
+
+    .p-form-help-text {
+      display: inline-flex;
+      justify-content: space-between;
+      max-width: none;
+      width: calc(100% - 4rem);
+    }
+
+    .p-slider__input {
+      flex: 0 1 3rem;
+      min-width: unset;
+    }
+
+    input[type="range"] {
+      background-color: transparent;
+      flex: 1;
+    }
+  }
+}

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/index.ts
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TLSEnabledFields";

--- a/ui/src/app/store/config/types/enum.ts
+++ b/ui/src/app/store/config/types/enum.ts
@@ -12,3 +12,8 @@ export enum NetworkDiscovery {
 export enum ConfigMeta {
   MODEL = "config",
 }
+
+export enum TLSExpiryNotificationInterval {
+  MIN = 0,
+  MAX = 90,
+}

--- a/ui/src/app/store/config/types/index.ts
+++ b/ui/src/app/store/config/types/index.ts
@@ -1,3 +1,8 @@
 export type { Config, ConfigChoice, ConfigState, ConfigValues } from "./base";
 
-export { NetworkDiscovery, AutoIpmiPrivilegeLevel, ConfigMeta } from "./enum";
+export {
+  AutoIpmiPrivilegeLevel,
+  ConfigMeta,
+  NetworkDiscovery,
+  TLSExpiryNotificationInterval,
+} from "./enum";

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -246,6 +246,7 @@
 
 // settings
 @import "~app/settings/components/SettingsTable";
+@import "~app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields";
 @import "~app/settings/views/Dhcp/DhcpList";
 @import "~app/settings/views/LicenseKeys/LicenseKeyList";
 @import "~app/settings/views/Repositories/RepositoriesList";
@@ -260,6 +261,7 @@
 @include RepositoryFormFields;
 @include ScriptsList;
 @include ScriptsUpload;
+@include TLSEnabledFields;
 @include UsersList;
 
 // subnets


### PR DESCRIPTION
## Done

- Built "TLS enabled" version of security settings

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- To test the "TLS enabled" security settings you will need to either:
  - Enable TLS for real using `sudo maas config-tls enable $path-to-key $path-to-cert` (if you use the snap the cert files will need to be located in `/var/snap/maas`), or;
  - Fake a TLS certificate.
    - Open `ui/src/app/settings/views/Configuration/Security/Security.tsx`
    - Replace `const tlsCertificate` on line 15 with a `tlsCertificate` factory
    - Open `ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx`
    - Replace `const tlsCertificate` on line 43 with a `tlsCertificate` factory
- Check that you can download the certificate details
- Check that you can successfully update the TLS notification enabled and TLS notification interval config options

## Fixes

Fixes canonical-web-and-design/app-tribe#821

## Screenshot

![Screenshot 2022-04-20 at 14-26-11 Security bolla MAAS](https://user-images.githubusercontent.com/25733845/164161546-7ce21b9f-62fb-476d-a744-575dedfe79dd.png)

