### PR TITLE
fix(ui): fix instances of link buttons having incorrect spacing

### DIFF
--- a/ui/src/app/base/components/ModelListSubtitle/ModelListSubtitle.tsx
+++ b/ui/src/app/base/components/ModelListSubtitle/ModelListSubtitle.tsx
@@ -41,6 +41,7 @@ export const ModelListSubtitle = ({
     return (
       <Button
         appearance="link"
+        className="u-no-margin--bottom"
         data-testid="filter-selected"
         onClick={filterSelected}
       >

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
@@ -52,6 +52,7 @@ const NotificationGroup = ({ notifications, severity }: Props): JSX.Element => {
             <Button
               appearance="link"
               aria-label={`${notifications.length} ${severity}, click to open messages.`}
+              className="u-no-margin--bottom"
               onClick={(evt: React.MouseEvent) => {
                 evt.preventDefault();
                 setGroupOpen(!groupOpen);
@@ -68,7 +69,8 @@ const NotificationGroup = ({ notifications, severity }: Props): JSX.Element => {
             {dismissable && (
               <Button
                 appearance="link"
-                className="u-nudge-right"
+                className="u-no-margin--bottom"
+                inline
                 onClick={() => dismissAll(notifications, dispatch)}
               >
                 Dismiss all

--- a/ui/src/app/base/components/NotificationGroup/__snapshots__/NotificationGroup.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationGroup/__snapshots__/NotificationGroup.test.tsx.snap
@@ -71,6 +71,7 @@ exports[`NotificationGroup renders 1`] = `
           <Button
             appearance="link"
             aria-label="2 negative, click to open messages."
+            className="u-no-margin--bottom"
             onClick={[Function]}
           >
             <span
@@ -85,7 +86,8 @@ exports[`NotificationGroup renders 1`] = `
           </Button>
           <Button
             appearance="link"
-            className="u-nudge-right"
+            className="u-no-margin--bottom"
+            inline={true}
             onClick={[Function]}
           >
             Dismiss all
@@ -106,11 +108,12 @@ exports[`NotificationGroup renders 1`] = `
             <Button
               appearance="link"
               aria-label="2 negative, click to open messages."
+              className="u-no-margin--bottom"
               onClick={[Function]}
             >
               <button
                 aria-label="2 negative, click to open messages."
-                className="p-button--link"
+                className="p-button--link u-no-margin--bottom"
                 onClick={[Function]}
               >
                 <span
@@ -130,11 +133,12 @@ exports[`NotificationGroup renders 1`] = `
             </Button>
             <Button
               appearance="link"
-              className="u-nudge-right"
+              className="u-no-margin--bottom"
+              inline={true}
               onClick={[Function]}
             >
               <button
-                className="p-button--link u-nudge-right"
+                className="p-button--link is-inline u-no-margin--bottom"
                 onClick={[Function]}
               >
                 Dismiss all

--- a/ui/src/app/base/components/UserForm/UserForm.tsx
+++ b/ui/src/app/base/components/UserForm/UserForm.tsx
@@ -169,6 +169,7 @@ export const UserForm = ({
         <div className="u-sv2">
           <Button
             appearance="link"
+            className="u-no-margin--bottom"
             data-testid="toggle-passwords"
             onClick={() => setPasswordVisible(!passwordVisible)}
           >

--- a/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
+++ b/ui/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
@@ -121,8 +121,8 @@ export const NodeActionFormWrapper = ({
             . To proceed,{" "}
             <Button
               appearance="link"
+              className="u-no-margin--bottom"
               data-testid="on-update-selected"
-              inline
               onClick={() => onUpdateSelected(actionableNodeIDs)}
             >
               update your selection

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.tsx
@@ -73,7 +73,6 @@ const FetchImagesFormFields = (): JSX.Element => {
                 />
                 <Button
                   appearance="link"
-                  className="u-sv2"
                   data-testid="hide-advanced"
                   onClick={() => {
                     setShowAdvanced(false);
@@ -87,7 +86,6 @@ const FetchImagesFormFields = (): JSX.Element => {
             ) : (
               <Button
                 appearance="link"
-                className="u-sv2"
                 data-testid="show-advanced"
                 onClick={() => setShowAdvanced(true)}
               >

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -142,6 +142,7 @@ const TestResults = ({
             >
               <Button
                 appearance="link"
+                className="u-no-margin--bottom"
                 disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
                   setHeaderContent({


### PR DESCRIPTION
## Done

- Previously I removed the custom `p-button--link` class we used in favour of Vanilla's, assuming it was basically identical. It wasn't! The Vanilla version includes margin like a normal button, so I've removed the margin in places where we don't want it.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check there is no margin in link buttons:
  - Machine list > Select some machines > Subtitle
  - Machine list > Select some machines > Open action form that not all machines can do > Message
  - Machine details for machine that has not run tests > Test storage...
  - User preferences > Details > Change password...

## Fixes

Fixes #3830 

