### PR TITLE
fix(proxy): fix proxy server crashing when proxying to TLS-enabled MAAS

### DIFF
--- a/proxy/index.js
+++ b/proxy/index.js
@@ -20,6 +20,7 @@ app.get(`${BASENAME}/`, (req, res) =>
 // Proxy API endpoints to the MAAS.
 app.use(
   createProxyMiddleware([`${BASENAME}/api`, `${BASENAME}/accounts`], {
+    secure: false,
     target: process.env.MAAS_URL,
   })
 );
@@ -27,6 +28,7 @@ app.use(
 // Proxy the WebSocket API endpoint to the MAAS.
 app.use(
   createProxyMiddleware(`${BASENAME}/ws`, {
+    secure: false,
     target: process.env.MAAS_URL,
     ws: true,
   })

--- a/proxy/ui.js
+++ b/proxy/ui.js
@@ -18,6 +18,7 @@ app.get(`${BASENAME}/`, (req, res) =>
 // Proxy API endpoints to the MAAS.
 app.use(
   createProxyMiddleware([`${BASENAME}/api`, `${BASENAME}/accounts`], {
+    secure: false,
     target: process.env.MAAS_URL,
   })
 );
@@ -25,6 +26,7 @@ app.use(
 // Proxy the WebSocket API endpoint to the MAAS.
 app.use(
   createProxyMiddleware(`${BASENAME}/ws`, {
+    secure: false,
     target: process.env.MAAS_URL,
     ws: true,
   })


### PR DESCRIPTION
## Done

- Fixed proxy server crashing when using a TLS-enabled MAAS (by stopping it from verifying certificates - shouldn't matter just for local development)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that a MAAS without TLS still works (e.g. bolla) for both `yarn start` and `yarn ui` development servers. The Settings > Configuration > Security page should say "TLS disabled".
- Enable TLS on a MAAS
  - Create a certificate and key (or use [these](https://github.com/canonical-web-and-design/maas-ui/files/8526835/certs.zip)) in a location that your MAAS instance can access (e.g. for a snap they will need to be located in `/var/snap/maas`)
  - Run `sudo maas config-tls enable $path-to-key $path-to-cert`
- Check that the built version of your MAAS still works. Navigating to the old http URL should redirect to the new https one (and with a different port if you didn't specify it earlier)
- Update `proxy/.env.local` with your new MAAS URL
- Check that both `yarn start` and `yarn ui` still work. The Settings > Configuration > Security page should now say "TLS enabled"


## Fixes

Fixes canonical-web-and-design/app-tribe#838

