### PR TITLE
fix(ui): update TLS sections based on latest changes

### DIFF
--- a/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.test.tsx
+++ b/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.test.tsx
@@ -18,21 +18,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it("displays loading text if TLS certificate has not loaded", () => {
-  const state = rootStateFactory({
-    general: generalStateFactory({
-      tlsCertificate: tlsCertificateStateFactory({
-        data: null,
-        loaded: false,
-      }),
-    }),
-  });
-  renderWithMockStore(<TLSCertificate />, { state });
-
-  expect(screen.getByText(/Loading.../)).toBeInTheDocument();
-});
-
-it("displays a message if TLS is disabled", () => {
+it("does not render if there is no TLS certificate", () => {
   const state = rootStateFactory({
     general: generalStateFactory({
       tlsCertificate: tlsCertificateStateFactory({
@@ -41,9 +27,9 @@ it("displays a message if TLS is disabled", () => {
       }),
     }),
   });
-  renderWithMockStore(<TLSCertificate />, { state });
+  const { container } = renderWithMockStore(<TLSCertificate />, { state });
 
-  expect(screen.getByText(Labels.NotEnabled)).toBeInTheDocument();
+  expect(container).toBeEmptyDOMElement();
 });
 
 it("renders TLS certificate data if it exists", () => {

--- a/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.tsx
+++ b/ui/src/app/preferences/views/APIAuthentication/TLSCertificate/TLSCertificate.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { Button, Icon, Spinner, Tooltip } from "@canonical/react-components";
+import { Button, Icon, Tooltip } from "@canonical/react-components";
 import fileDownload from "js-file-download";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -11,27 +11,19 @@ import { breakLines, unindentString } from "app/utils";
 export enum Labels {
   Download = "Download TLS certificate",
   Filename = "TLS certificate",
-  NotEnabled = "TLS has not been enabled on this MAAS.",
   Title = "TLS certificate",
 }
 
 const TLSCertificate = (): JSX.Element | null => {
   const dispatch = useDispatch();
   const tlsCertificate = useSelector(tlsCertificateSelectors.get);
-  const loaded = useSelector(tlsCertificateSelectors.loaded);
 
   useEffect(() => {
     dispatch(generalActions.fetchTlsCertificate());
   }, [dispatch]);
 
   if (!tlsCertificate) {
-    return (
-      <>
-        <h2 className="p-heading--5 u-sv-1">{Labels.Title}</h2>
-        <p>{loaded ? Labels.NotEnabled : <Spinner text="Loading..." />}</p>
-        <hr />
-      </>
-    );
+    return null;
   }
 
   return (

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import * as fileDownload from "js-file-download";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -18,14 +17,7 @@ import {
 
 const mockStore = configureStore();
 
-jest.mock("js-file-download", () => jest.fn());
-
-afterEach(() => {
-  jest.restoreAllMocks();
-});
-
-it("can generate a download based on the TLS certificate details", async () => {
-  const downloadSpy = jest.spyOn(fileDownload, "default");
+it("renders certificate content", () => {
   const tlsCertificate = tlsCertificateFactory();
   const state = rootStateFactory({
     general: generalStateFactory({
@@ -42,14 +34,9 @@ it("can generate a download based on the TLS certificate details", async () => {
     </Provider>
   );
 
-  userEvent.click(screen.getByRole("button", { name: /Download certificate/ }));
-
-  await waitFor(() => {
-    expect(downloadSpy).toHaveBeenCalledWith(
-      tlsCertificate.certificate,
-      "TLS certificate"
-    );
-  });
+  expect(screen.getByRole("textbox", { name: Labels.Textarea })).toHaveValue(
+    tlsCertificate.certificate
+  );
 });
 
 it("disables the interval field if notification is not enabled", async () => {

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
@@ -1,10 +1,9 @@
-import { Icon } from "@canonical/react-components";
+import { Icon, Textarea } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import TLSEnabledFields from "./TLSEnabledFields";
 
-import CertificateDownload from "app/base/components/CertificateDownload";
 import CertificateMetadata from "app/base/components/CertificateMetadata";
 import FormikForm from "app/base/components/FormikForm";
 import { actions as configActions } from "app/store/config";
@@ -20,15 +19,17 @@ export type TLSEnabledValues = {
 export enum Labels {
   NotificationCheckbox = "Notify the certificate is due to expire in...",
   Interval = "Days",
-  IntervalRangeError = "Notification interval must be between 0 and 90 days.",
+  Textarea = "TLS certificate",
 }
+
+const INTERVAL_RANGE_ERROR = `Notification interval must be between ${TLSExpiryNotificationInterval.MIN} and ${TLSExpiryNotificationInterval.MAX} days.`;
 
 const TLSEnabledSchema = Yup.object()
   .shape({
     notificationEnabled: Yup.boolean(),
     notificationInterval: Yup.number()
-      .min(TLSExpiryNotificationInterval.MIN, Labels.IntervalRangeError)
-      .max(TLSExpiryNotificationInterval.MAX, Labels.IntervalRangeError),
+      .min(TLSExpiryNotificationInterval.MIN, INTERVAL_RANGE_ERROR)
+      .max(TLSExpiryNotificationInterval.MAX, INTERVAL_RANGE_ERROR),
   })
   .defined();
 
@@ -61,9 +62,12 @@ const TLSEnabled = (): JSX.Element | null => {
           fingerprint: tlsCertificate.fingerprint,
         }}
       />
-      <CertificateDownload
-        certificate={tlsCertificate.certificate}
-        filename="TLS certificate"
+      <Textarea
+        aria-label={Labels.Textarea}
+        className="p-textarea--readonly"
+        readOnly
+        rows={5}
+        value={tlsCertificate.certificate}
       />
       <FormikForm<TLSEnabledValues>
         buttonsAlign="left"

--- a/ui/src/app/store/config/types/enum.ts
+++ b/ui/src/app/store/config/types/enum.ts
@@ -14,6 +14,6 @@ export enum ConfigMeta {
 }
 
 export enum TLSExpiryNotificationInterval {
-  MIN = 0,
+  MIN = 1,
   MAX = 90,
 }


### PR DESCRIPTION
## Done

- Removed download button from TLS enabled page.
- Hide TLS section in user preferences if TLS is not enabled.
- Change lower limit for TLS expiry notification from 0 days to 1 day.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- For a MAAS with TLS disabled:
  - Check that there is no "TLS fingerprint" section in User preferences > API authentication
- For a MAAS with TLS enabled:
  - Check that there is no certificate download button in Settings > Configuration > Security
  - Check that the minimum notification interval is 1 day instead of 0 days

## Fixes

Fixes canonical-web-and-design/app-tribe#839
