### PR TITLE
fix(ui) fix minor styling bugs in KVM pages

### DIFF
--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -108,7 +108,7 @@ export const ComposeFormFields = ({
             type="checkbox"
           />
         </Tooltip>
-        <p>Cores</p>
+        <p className="u-no-margin--bottom">Cores</p>
         <Input
           checked={!pinningCores}
           id="not-pinning-cores"

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
@@ -134,8 +134,9 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
                   </TableCell>
                   <TableCell aria-label="Boot" className="u-align-non-field">
                     <FormikField
+                      aria-label="Boot"
                       checked={bootDisk === disk.id}
-                      label=" "
+                      labelClassName="p-radio--inline u-nudge-right--small"
                       name="bootDisk"
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         handleChange(e);

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -61,6 +61,7 @@ const VMsActionBar = ({
               className="u-rotate-right"
               appearance="base"
               data-testid="refresh-kvm"
+              dense
               hasIcon
               onClick={onRefreshClick}
               small
@@ -79,6 +80,7 @@ const VMsActionBar = ({
             <Button
               appearance="base"
               data-testid="delete-vm"
+              dense
               disabled={vmActionsDisabled}
               hasIcon
               onClick={() =>

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.tsx
@@ -1,4 +1,4 @@
-import { Col, Icon, MainTable, Row } from "@canonical/react-components";
+import { Icon, MainTable } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 
@@ -163,124 +163,118 @@ const LxdKVMHostTable = ({ rows }: Props): JSX.Element => {
   });
   const sortedRows = sortRows(rows, zones);
   return (
-    <Row>
-      <Col size={12}>
-        <MainTable
-          className="lxd-table"
-          headers={[
-            {
-              className: "name-col",
-              content: (
-                <>
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-testid="name-header"
-                    onClick={() => updateSort("name")}
-                    sortKey="name"
-                  >
-                    Name
-                  </TableHeader>
-                  <TableHeader>Project</TableHeader>
-                </>
-              ),
-            },
-            {
-              className: "host-type-col",
-              content: (
-                <TableHeader
-                  className="p-double-row__header-spacer"
-                  currentSort={currentSort}
-                  data-testid="host-type-header"
-                  onClick={() => updateSort("hostType")}
-                  sortKey="hostType"
-                >
-                  KVM host type
-                </TableHeader>
-              ),
-            },
-            {
-              className: "vms-col u-align--right",
-              content: (
-                <>
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-testid="vms-header"
-                    onClick={() => updateSort("vms")}
-                    sortKey="vms"
-                  >
-                    VM<span className="u-no-text-transform">s</span>
-                  </TableHeader>
-                  <TableHeader>LXD version</TableHeader>
-                </>
-              ),
-            },
-            {
-              className: "tags-col",
-              content: (
-                <TableHeader data-testid="tags-header">Tags</TableHeader>
-              ),
-            },
-            {
-              className: "zone-col",
-              content: (
-                <>
-                  <TableHeader
-                    data-testid="zone-header"
-                    currentSort={currentSort}
-                    onClick={() => updateSort("zone")}
-                    sortKey="zone"
-                  >
-                    AZ
-                  </TableHeader>
-                  <TableHeader>Resource pool</TableHeader>
-                </>
-              ),
-            },
-            {
-              className: "cpu-col",
-              content: (
-                <TableHeader
-                  data-testid="cpu-header"
-                  currentSort={currentSort}
-                  onClick={() => updateSort("cpu")}
-                  sortKey="cpu"
-                >
-                  CPU cores
-                </TableHeader>
-              ),
-            },
-            {
-              className: "ram-col",
-              content: (
-                <TableHeader
-                  data-testid="ram-header"
-                  currentSort={currentSort}
-                  onClick={() => updateSort("ram")}
-                  sortKey="ram"
-                >
-                  RAM
-                </TableHeader>
-              ),
-            },
-            {
-              className: "storage-col",
-              content: (
-                <TableHeader
-                  data-testid="storage-header"
-                  currentSort={currentSort}
-                  onClick={() => updateSort("storage")}
-                  sortKey="storage"
-                >
-                  Storage
-                </TableHeader>
-              ),
-            },
-          ]}
-          paginate={50}
-          rows={generateRows(sortedRows)}
-        />
-      </Col>
-    </Row>
+    <MainTable
+      className="lxd-table"
+      headers={[
+        {
+          className: "name-col",
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                data-testid="name-header"
+                onClick={() => updateSort("name")}
+                sortKey="name"
+              >
+                Name
+              </TableHeader>
+              <TableHeader>Project</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "host-type-col",
+          content: (
+            <TableHeader
+              className="p-double-row__header-spacer"
+              currentSort={currentSort}
+              data-testid="host-type-header"
+              onClick={() => updateSort("hostType")}
+              sortKey="hostType"
+            >
+              KVM host type
+            </TableHeader>
+          ),
+        },
+        {
+          className: "vms-col u-align--right",
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                data-testid="vms-header"
+                onClick={() => updateSort("vms")}
+                sortKey="vms"
+              >
+                VM<span className="u-no-text-transform">s</span>
+              </TableHeader>
+              <TableHeader>LXD version</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "tags-col",
+          content: <TableHeader data-testid="tags-header">Tags</TableHeader>,
+        },
+        {
+          className: "zone-col",
+          content: (
+            <>
+              <TableHeader
+                data-testid="zone-header"
+                currentSort={currentSort}
+                onClick={() => updateSort("zone")}
+                sortKey="zone"
+              >
+                AZ
+              </TableHeader>
+              <TableHeader>Resource pool</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "cpu-col",
+          content: (
+            <TableHeader
+              data-testid="cpu-header"
+              currentSort={currentSort}
+              onClick={() => updateSort("cpu")}
+              sortKey="cpu"
+            >
+              CPU cores
+            </TableHeader>
+          ),
+        },
+        {
+          className: "ram-col",
+          content: (
+            <TableHeader
+              data-testid="ram-header"
+              currentSort={currentSort}
+              onClick={() => updateSort("ram")}
+              sortKey="ram"
+            >
+              RAM
+            </TableHeader>
+          ),
+        },
+        {
+          className: "storage-col",
+          content: (
+            <TableHeader
+              data-testid="storage-header"
+              currentSort={currentSort}
+              onClick={() => updateSort("storage")}
+              sortKey="storage"
+            >
+              Storage
+            </TableHeader>
+          ),
+        },
+      ]}
+      paginate={50}
+      rows={generateRows(sortedRows)}
+    />
   );
 };
 

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
@@ -1,4 +1,4 @@
-import { Col, Row, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import LxdKVMHostTable from "./LxdKVMHostTable";
@@ -87,13 +87,7 @@ const LxdTable = (): JSX.Element | null => {
     // https://github.com/canonical-web-and-design/app-squad/issues/340.
     return null;
   }
-  return (
-    <Row>
-      <Col size={12}>
-        <LxdKVMHostTable rows={rows} />
-      </Col>
-    </Row>
-  );
+  return <LxdKVMHostTable rows={rows} />;
 };
 
 export default LxdTable;

--- a/ui/src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx
@@ -1,4 +1,4 @@
-import { Col, MainTable, Row } from "@canonical/react-components";
+import { MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import TableHeader from "app/base/components/TableHeader";
@@ -115,109 +115,105 @@ const VirshTable = (): JSX.Element => {
   const sortedKVMs = sortRows(virshKvms, pools);
 
   return (
-    <Row>
-      <Col size={12}>
-        <MainTable
-          className="virsh-table"
-          headers={[
-            {
-              className: "name-col",
-              content: (
-                <>
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-testid="name-header"
-                    onClick={() => updateSort("name")}
-                    sortKey="name"
-                  >
-                    Name
-                  </TableHeader>
-                  <TableHeader>Address</TableHeader>
-                </>
-              ),
-            },
-            {
-              className: "vms-col u-align--right",
-              content: (
-                <TableHeader
-                  currentSort={currentSort}
-                  data-testid="vms-header"
-                  onClick={() => updateSort("vms")}
-                  sortKey="vms"
-                >
-                  VM<span className="u-no-text-transform">s</span>
-                </TableHeader>
-              ),
-            },
-            {
-              className: "tags-col",
-              content: (
-                <TableHeader data-testid="tags-header" sortKey="tags">
-                  Tags
-                </TableHeader>
-              ),
-            },
-            {
-              className: "pool-col",
-              content: (
-                <>
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-testid="pool-header"
-                    onClick={() => updateSort("pool")}
-                    sortKey="pool"
-                  >
-                    Resource pool
-                  </TableHeader>
-                  <TableHeader>Az</TableHeader>
-                </>
-              ),
-            },
-            {
-              className: "cpu-col",
-              content: (
-                <TableHeader
-                  currentSort={currentSort}
-                  data-testid="cpu-header"
-                  onClick={() => updateSort("cpu")}
-                  sortKey="cpu"
-                >
-                  CPU cores
-                </TableHeader>
-              ),
-            },
-            {
-              className: "ram-col",
-              content: (
-                <TableHeader
-                  currentSort={currentSort}
-                  data-testid="ram-header"
-                  onClick={() => updateSort("ram")}
-                  sortKey="ram"
-                >
-                  RAM
-                </TableHeader>
-              ),
-            },
-            {
-              className: "storage-col",
-              content: (
-                <TableHeader
-                  currentSort={currentSort}
-                  data-testid="storage-header"
-                  onClick={() => updateSort("storage")}
-                  sortKey="storage"
-                >
-                  Storage
-                </TableHeader>
-              ),
-            },
-          ]}
-          paginate={50}
-          rows={generateRows(sortedKVMs)}
-        />
-      </Col>
-    </Row>
+    <MainTable
+      className="virsh-table"
+      headers={[
+        {
+          className: "name-col",
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                data-testid="name-header"
+                onClick={() => updateSort("name")}
+                sortKey="name"
+              >
+                Name
+              </TableHeader>
+              <TableHeader>Address</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "vms-col u-align--right",
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              data-testid="vms-header"
+              onClick={() => updateSort("vms")}
+              sortKey="vms"
+            >
+              VM<span className="u-no-text-transform">s</span>
+            </TableHeader>
+          ),
+        },
+        {
+          className: "tags-col",
+          content: (
+            <TableHeader data-testid="tags-header" sortKey="tags">
+              Tags
+            </TableHeader>
+          ),
+        },
+        {
+          className: "pool-col",
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                data-testid="pool-header"
+                onClick={() => updateSort("pool")}
+                sortKey="pool"
+              >
+                Resource pool
+              </TableHeader>
+              <TableHeader>Az</TableHeader>
+            </>
+          ),
+        },
+        {
+          className: "cpu-col",
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              data-testid="cpu-header"
+              onClick={() => updateSort("cpu")}
+              sortKey="cpu"
+            >
+              CPU cores
+            </TableHeader>
+          ),
+        },
+        {
+          className: "ram-col",
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              data-testid="ram-header"
+              onClick={() => updateSort("ram")}
+              sortKey="ram"
+            >
+              RAM
+            </TableHeader>
+          ),
+        },
+        {
+          className: "storage-col",
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              data-testid="storage-header"
+              onClick={() => updateSort("storage")}
+              sortKey="storage"
+            >
+              Storage
+            </TableHeader>
+          ),
+        },
+      ]}
+      paginate={50}
+      rows={generateRows(sortedKVMs)}
+    />
   );
 };
 

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsActionBar/LXDClusterHostsActionBar.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsActionBar/LXDClusterHostsActionBar.tsx
@@ -50,6 +50,7 @@ const LXDClusterHostsActionBar = ({
           className="u-rotate-right"
           appearance="base"
           data-testid="refresh-hosts"
+          dense
           hasIcon
           onClick={() => {
             if (cluster.hosts.length) {


### PR DESCRIPTION
## Done

- Removed infinitely nested rows in KVM list tables
- Minor styling fixes in KVM details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the LXD and Virsh KVM lists are unchanged visually
- Go to a LXD single host details page and check that the table action bar buttons are aligned properly
- Click "Add virtual machine"
- Check that there isn't a huge gap between the "Cores" label and radio button
- Check that the "Boot" radio button in the storage table is aligned properly
- Go to a LXD cluster details page and check that the table action bar buttons are aligned properly

## Fixes

Fixes #3828 
