### PR TITLE
fix(ui): fix subnets icon breaking layout

### DIFF
--- a/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
@@ -31,9 +31,8 @@ const SubnetsControls = ({
         />
       </Col>
       <Col size={3}>
-        <Row className="subnets-controls-group-by">
+        <div className="u-flex--align-baseline">
           <Select
-            stacked
             aria-label="Group by"
             name="groupBy"
             value={groupBy}
@@ -50,38 +49,38 @@ const SubnetsControls = ({
                 value: SubnetsColumns.SPACE,
               },
             ]}
+            wrapperClassName="u-flex--grow"
           />
-          <Button
-            aria-label="more about group by"
-            appearance="base"
-            dense
-            hasIcon
-            onClick={() => setIsInfoOpen(!isInfoOpen)}
-          >
-            <Icon name="help" />
-          </Button>
-        </Row>
-        <Row>
-          {isInfoOpen ? (
-            <div
-              className="u-nudge-down--x-small"
-              data-testId="subnets-groupby-help-text"
+          <div className="u-nudge-right">
+            <Button
+              aria-label="more about group by"
+              appearance="base"
+              dense
+              hasIcon
+              onClick={() => setIsInfoOpen(!isInfoOpen)}
             >
-              <p className="p-form-help-text">
-                <strong>Fabric</strong> is a set of consistent interconnected
-                VLANs that are capable of mutual communication.
-              </p>
-              <p className="p-form-help-text">
-                <strong>Space</strong> is a grouping of networks (VLANs and
-                their subnets) that are able to mutually communicate with each
-                other.
-              </p>
-              <p className="p-form-help-text">
-                Subnets within a space do not need to belong to the same fabric.
-              </p>
-            </div>
-          ) : null}
-        </Row>
+              <Icon name="help" />
+            </Button>
+          </div>
+        </div>
+        {isInfoOpen ? (
+          <div
+            className="u-nudge-down--x-small"
+            data-testid="subnets-groupby-help-text"
+          >
+            <p className="p-form-help-text">
+              <strong>Fabric</strong> is a set of consistent interconnected
+              VLANs that are capable of mutual communication.
+            </p>
+            <p className="p-form-help-text">
+              <strong>Space</strong> is a grouping of networks (VLANs and their
+              subnets) that are able to mutually communicate with each other.
+            </p>
+            <p className="p-form-help-text">
+              Subnets within a space do not need to belong to the same fabric.
+            </p>
+          </div>
+        ) : null}
       </Col>
     </Row>
   );

--- a/ui/src/app/subnets/views/SubnetsList/_index.scss
+++ b/ui/src/app/subnets/views/SubnetsList/_index.scss
@@ -55,9 +55,4 @@
       width: 1px;
     }
   }
-
-  .subnets-controls-group-by {
-    display: flex;
-    align-items: baseline;
-  }
 }


### PR DESCRIPTION
## Done

- Fix the subnets page that was breaking the page layout at certain sizes.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click Subnets in the header.
- Resize your window and check that at about 1050 pixels wide the help icon next to the grouping select box does not disappear or break out of the frame (See the issue for reference: https://github.com/canonical-web-and-design/maas-ui/issues/3822).

## Fixes

Fixes: #3822.