### PR TITLE
feat(ui): add hostname validation for all node forms

### DIFF
--- a/ui/src/app/base/components/NodeName/NodeName.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.tsx
@@ -9,6 +9,7 @@ import NodeNameFields from "./NodeNameFields";
 
 import FormikForm from "app/base/components/FormikForm";
 import { useCanEdit } from "app/base/hooks";
+import { hostnameValidation } from "app/base/validation";
 import type { Device } from "app/store/device/types";
 import type { Domain, DomainMeta } from "app/store/domain/types";
 import type { Machine } from "app/store/machine/types";
@@ -32,17 +33,8 @@ export type FormValues = {
   domain: string;
 };
 
-const hostnamePattern = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
-
-export enum Label {
-  HostnamePatternError = "Hostname must only contain letters, numbers and hyphens.",
-}
-
 const Schema = Yup.object().shape({
-  hostname: Yup.string()
-    .max(63, "Hostname must be 63 characters or less.")
-    .matches(hostnamePattern, Label.HostnamePatternError)
-    .required(),
+  hostname: hostnameValidation.required(),
   domain: Yup.string(),
 });
 

--- a/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
+++ b/ui/src/app/base/components/NodeName/__snapshots__/NodeName.test.tsx.snap
@@ -105,6 +105,8 @@ exports[`NodeName can display the form 1`] = `
             [Function],
             [Function],
             [Function],
+            [Function],
+            [Function],
           ],
           "transforms": Array [
             [Function],
@@ -216,6 +218,8 @@ exports[`NodeName can display the form 1`] = `
               "strip": false,
             },
             "tests": Array [
+              [Function],
+              [Function],
               [Function],
               [Function],
               [Function],

--- a/ui/src/app/base/validation.test.ts
+++ b/ui/src/app/base/validation.test.ts
@@ -1,0 +1,21 @@
+import { hostnamePattern } from "./validation";
+
+describe("hostname validation", () => {
+  const regex = new RegExp(hostnamePattern);
+
+  it("handles valid strings", () => {
+    expect(regex.test("valid-name")).toBe(true);
+  });
+
+  it("handles invalid characters", () => {
+    expect(regex.test("valid_name")).toBe(false);
+  });
+
+  it("is invalid if it starts with a dash", () => {
+    expect(regex.test("-invalidname")).toBe(false);
+  });
+
+  it("is invalid if it ends with a dash", () => {
+    expect(regex.test("invalidname-")).toBe(false);
+  });
+});

--- a/ui/src/app/base/validation.test.ts
+++ b/ui/src/app/base/validation.test.ts
@@ -1,21 +1,45 @@
-import { hostnamePattern } from "./validation";
+import { ValidationError } from "yup";
 
-describe("hostname validation", () => {
-  const regex = new RegExp(hostnamePattern);
+import { hostnameValidation, HostnameValidationLabel } from "./validation";
 
-  it("handles valid strings", () => {
-    expect(regex.test("valid-name")).toBe(true);
+describe("hostname regex", () => {
+  it("handles valid characters", async () => {
+    await expect(hostnameValidation.validate("valid-name")).resolves.toBe(
+      "valid-name"
+    );
   });
 
-  it("handles invalid characters", () => {
-    expect(regex.test("valid_name")).toBe(false);
+  it("handles invalid characters", async () => {
+    await expect(
+      hostnameValidation.validate("valid_name")
+    ).rejects.toStrictEqual(
+      new ValidationError(HostnameValidationLabel.CharactersError)
+    );
   });
 
-  it("is invalid if it starts with a dash", () => {
-    expect(regex.test("-invalidname")).toBe(false);
+  it("is invalid if it starts with a dash", async () => {
+    await expect(
+      hostnameValidation.validate("-invalidname")
+    ).rejects.toStrictEqual(
+      new ValidationError(HostnameValidationLabel.DashStartError)
+    );
   });
 
-  it("is invalid if it ends with a dash", () => {
-    expect(regex.test("invalidname-")).toBe(false);
+  it("is invalid if it ends with a dash", async () => {
+    await expect(
+      hostnameValidation.validate("invalidname-")
+    ).rejects.toStrictEqual(
+      new ValidationError(HostnameValidationLabel.DashEndError)
+    );
+  });
+
+  it("is invalid if it is longer than 63 characters", async () => {
+    await expect(
+      hostnameValidation.validate(
+        "invalidnamethatiswaytoolongimeanthisislongbyanystandardormeasure"
+      )
+    ).rejects.toStrictEqual(
+      new ValidationError(HostnameValidationLabel.LengthError)
+    );
   });
 });

--- a/ui/src/app/base/validation.ts
+++ b/ui/src/app/base/validation.ts
@@ -1,3 +1,5 @@
+import * as Yup from "yup";
+
 /**
  * Validate domain name e.g. "www.example.com"
  * XXX This should be updated as it currently allows e.g. "www.example.com."
@@ -25,3 +27,19 @@ export const RANGE_REGEX = /^\d{1,3}(-\d{1,3})?(,\s*(\d{1,3}(-\d{1,3})?))*$/;
  * Validate tag name string (only alphanumeric, dash or underscore)
  */
 export const TAG_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Validate host name string (only alphanumeric or dash and does not start or
+ * end with a dash)
+ */
+export const hostnamePattern =
+  /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
+
+export enum HostnameValidationLabel {
+  LengthError = "Hostname must be 63 characters or less.",
+  PatternError = "Hostname must only contain letters, numbers and hyphens.",
+}
+
+export const hostnameValidation = Yup.string()
+  .max(63, HostnameValidationLabel.LengthError)
+  .matches(hostnamePattern, HostnameValidationLabel.PatternError);

--- a/ui/src/app/base/validation.ts
+++ b/ui/src/app/base/validation.ts
@@ -28,18 +28,18 @@ export const RANGE_REGEX = /^\d{1,3}(-\d{1,3})?(,\s*(\d{1,3}(-\d{1,3})?))*$/;
  */
 export const TAG_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 
-/**
- * Validate host name string (only alphanumeric or dash and does not start or
- * end with a dash)
- */
-export const hostnamePattern =
-  /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
-
 export enum HostnameValidationLabel {
   LengthError = "Hostname must be 63 characters or less.",
-  PatternError = "Hostname must only contain letters, numbers and hyphens.",
+  CharactersError = "Hostname must only contain letters, numbers and hyphens.",
+  DashStartError = "Hostname must not start wth a hyphen.",
+  DashEndError = "Hostname must not end wth a hyphen.",
 }
 
 export const hostnameValidation = Yup.string()
   .max(63, HostnameValidationLabel.LengthError)
-  .matches(hostnamePattern, HostnameValidationLabel.PatternError);
+  // Validate host name only contains alphanumeric or dash.
+  .matches(/^[a-zA-Z0-9-]*$/, HostnameValidationLabel.CharactersError)
+  // Validate host name does not start with a dash.
+  .matches(/^[a-zA-Z0-9]/, HostnameValidationLabel.DashStartError)
+  // Validate host name does not end with a dash.
+  .matches(/[a-zA-Z0-9]$/, HostnameValidationLabel.DashEndError);

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
@@ -11,6 +11,7 @@ import type { DiscoveryAddValues } from "./types";
 
 import FormikForm from "app/base/components/FormikForm";
 import { useCycled } from "app/base/hooks";
+import { hostnameValidation } from "app/base/validation";
 import deviceURLs from "app/devices/urls";
 import machineURLs from "app/machines/urls";
 import { actions as deviceActions } from "app/store/device";
@@ -105,7 +106,7 @@ const DiscoveryAddSchema = Yup.object().shape({
     ),
   }),
   domain: Yup.string(),
-  hostname: Yup.string(),
+  hostname: hostnameValidation,
   ip_assignment: Yup.string(),
   parent: Yup.string(),
   type: Yup.string(),

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
@@ -13,7 +13,7 @@ import FormikForm from "app/base/components/FormikForm";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import { useAddMessage } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
-import { MAC_ADDRESS_REGEX } from "app/base/validation";
+import { hostnameValidation, MAC_ADDRESS_REGEX } from "app/base/validation";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import { DeviceIpAssignment } from "app/store/device/types";
@@ -30,7 +30,7 @@ type Props = {
 
 const AddDeviceSchema = Yup.object().shape({
   domain: Yup.string().required("Domain required"),
-  hostname: Yup.string(),
+  hostname: hostnameValidation,
   interfaces: Yup.array()
     .of(
       Yup.object().shape({

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
@@ -15,7 +15,7 @@ import StorageTable from "./StorageTable";
 
 import ActionForm from "app/base/components/ActionForm";
 import type { ClearHeaderContent } from "app/base/types";
-import { RANGE_REGEX } from "app/base/validation";
+import { hostnameValidation, RANGE_REGEX } from "app/base/validation";
 import { useActivePod } from "app/kvm/hooks";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
@@ -326,7 +326,7 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
         )
         .min(1, "At least one disk is required"),
       domain: Yup.string(),
-      hostname: Yup.string(),
+      hostname: hostnameValidation,
       hugepagesBacked: Yup.boolean(),
       interfaces: Yup.array().of(
         Yup.object()

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -10,7 +10,7 @@ import type { AddMachineValues } from "../types";
 import FormikForm from "app/base/components/FormikForm";
 import { useAddMessage } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
-import { MAC_ADDRESS_REGEX } from "app/base/validation";
+import { hostnameValidation, MAC_ADDRESS_REGEX } from "app/base/validation";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import { actions as generalActions } from "app/store/general";
@@ -88,7 +88,7 @@ export const AddMachineForm = ({ clearHeaderContent }: Props): JSX.Element => {
     extra_macs: Yup.array().of(
       Yup.string().matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
     ),
-    hostname: Yup.string(),
+    hostname: hostnameValidation,
     min_hwe_kernel: Yup.string(),
     pool: Yup.string().required("Resource pool required"),
     power_parameters: Yup.object().shape(


### PR DESCRIPTION
## Done

- Update all node forms to use the same hostname validation.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the add machine, add device etc. forms validate the hostname length and characters.

## Fixes

Fixes: #3806.