### PR TITLE
fix(ui): select correct fabric/VLAN when adding an alias or VLAN to nic (#3796)

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -14,6 +14,7 @@ import type { NetworkInterface } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
   fabric as fabricFactory,
+  fabricState as fabricStateFactory,
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
@@ -21,6 +22,7 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
   vlan as vlanFactory,
+  vlanState as vlanStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -149,6 +151,70 @@ describe("AddAliasOrVlan", () => {
     expect(wrapper.find("FormikForm").prop("secondarySubmitTooltip")).toBe(
       "There are no more unused VLANS for this interface."
     );
+  });
+
+  it("correctly initialises fabric and VLAN when adding an alias", () => {
+    const fabric = fabricFactory({ id: 1 });
+    const vlan = vlanFactory({ fabric: fabric.id, id: 5001 });
+    const nic = machineInterfaceFactory({ vlan_id: vlan.id });
+    const machine = machineDetailsFactory({
+      system_id: "abc123",
+      interfaces: [nic],
+    });
+    const state = rootStateFactory({
+      fabric: fabricStateFactory({
+        items: [fabric],
+        loaded: true,
+        loading: false,
+      }),
+      machine: machineStateFactory({
+        items: [machine],
+        statuses: machineStatusesFactory({
+          [machine.system_id]: machineStatusFactory(),
+        }),
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
+        loaded: true,
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            interfaceType={NetworkInterfaceTypes.ALIAS}
+            nic={nic}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .findWhere(
+          (node) =>
+            node.name() === "select" &&
+            node.prop("name") === "fabric" &&
+            node.prop("value") === fabric.id
+        )
+        .exists()
+    ).toBe(true);
+    expect(
+      wrapper
+        .findWhere(
+          (node) =>
+            node.name() === "select" &&
+            node.prop("name") === "vlan" &&
+            node.prop("value") === vlan.id
+        )
+        .exists()
+    ).toBe(true);
   });
 
   it("correctly dispatches actions to add a VLAN", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
@@ -54,6 +54,9 @@ const AddAliasOrVlan = ({
   const unusedVLANs = useSelector((state: RootState) =>
     vlanSelectors.getUnusedForInterface(state, machine, nic)
   );
+  const nicVLAN = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, nic?.vlan_id)
+  );
   const cleanup = useCallback(() => machineActions.cleanup(), []);
   const isAlias = interfaceType === NetworkInterfaceTypes.ALIAS;
   const { errors, saved, saving } = useMachineDetailsForm(
@@ -84,6 +87,8 @@ const AddAliasOrVlan = ({
         initialValues={{
           ...networkFieldsInitialValues,
           ...(isAlias ? {} : { tags: [] }),
+          fabric: nicVLAN?.fabric || "",
+          vlan: nic.vlan_id,
         }}
         onSaveAnalytics={{
           action: `Add ${interfaceType}`,


### PR DESCRIPTION
## Done

- Cherry-pick commit from https://github.com/canonical-web-and-design/maas-ui/pull/3796

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Network tab of a Ready or Allocated machine
- Add an interface with a configured IP mode (i.e. select a subnet and IP mode in the form)
- Click the action dropdown and select "Add alias"
- Check that the fabric and VLAN selects are disabled, and they are automatically picked to be the interface's fabric and VLAN
- Check the same thing when adding a VLAN, except only the fabric select is disabled
