### PR TITLE
fix: cypress non admin header test

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,6 +35,11 @@ jobs:
           working-directory: integration
       - name: Create MAAS admin
         run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
+      - name: Create MAAS non-admin user
+        run: |
+          export API_KEY=`sudo maas apikey --username=admin`
+          maas login admin http://localhost:5240/MAAS $API_KEY
+          maas admin users create username=user password=test email=fake-user@example.org is_superuser=0
       - name: Run Cypress tests with a user
         uses: cypress-io/github-action@master
         with:

--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -4,6 +4,8 @@
   "env": {
     "username": "admin",
     "password": "test",
+    "nonAdminUsername": "user",
+    "nonAdminPassword": "test",
     "skipA11yFailures": true
   },
   "projectId": "gp2cox",

--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -3,13 +3,10 @@ import { generateNewURL } from "@maas-ui/maas-ui-shared";
 context("Header - non-admin", () => {
   beforeEach(() => {
     cy.loginNonAdmin();
-    // Need the window to be wide enough so that menu items aren't hidden under
-    // the hardware menu.
-    cy.viewport("macbook-13");
     cy.visit(generateNewURL("/"));
   });
 
-  it("navigates to the machine list when clicking on the logo as a non admin", () => {
+  it("navigates to the machine list when clicking on the logo", () => {
     cy.get(".p-navigation__logo a").click();
     cy.location("pathname").should("eq", generateNewURL("/machines"));
     cy.get(".p-navigation__item.is-selected a").contains("Machines");

--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -1,8 +1,8 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
-context("Header", () => {
+context("Header - non-admin", () => {
   beforeEach(() => {
-    cy.login();
+    cy.loginNonAdmin();
     // Need the window to be wide enough so that menu items aren't hidden under
     // the hardware menu.
     cy.viewport("macbook-13");
@@ -13,6 +13,16 @@ context("Header", () => {
     cy.get(".p-navigation__logo a").click();
     cy.location("pathname").should("eq", generateNewURL("/machines"));
     cy.get(".p-navigation__item.is-selected a").contains("Machines");
+  });
+});
+
+context("Header - admin", () => {
+  beforeEach(() => {
+    cy.login();
+    // Need the window to be wide enough so that menu items aren't hidden under
+    // the hardware menu.
+    cy.viewport("macbook-13");
+    cy.visit(generateNewURL("/"));
   });
 
   it("navigates to machines", () => {

--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -6,8 +6,8 @@ context("Header - non-admin", () => {
     cy.visit(generateNewURL("/"));
   });
 
-  it("navigates to the machine list when clicking on the logo", () => {
-    cy.get(".p-navigation__logo a").click();
+  it("navigates to machines when clicking on the logo", () => {
+    cy.findByRole("link", { name: "Homepage" }).click();
     cy.location("pathname").should("eq", generateNewURL("/machines"));
     cy.get(".p-navigation__item.is-selected a").contains("Machines");
   });
@@ -20,6 +20,15 @@ context("Header - admin", () => {
     // the hardware menu.
     cy.viewport("macbook-13");
     cy.visit(generateNewURL("/"));
+  });
+
+  it("navigates to dashboard when clicking on the logo", () => {
+    cy.waitForPageToLoad();
+    cy.findByRole("link", { name: "Homepage" }).click();
+    cy.location("pathname").should("eq", generateNewURL("/dashboard"));
+    cy.findByRole("link", { current: "page", name: "Homepage" }).should(
+      "exist"
+    );
   });
 
   it("navigates to machines", () => {

--- a/integration/cypress/support/commands.ts
+++ b/integration/cypress/support/commands.ts
@@ -29,6 +29,13 @@ Cypress.Commands.add("login", (options) => {
   });
 });
 
+Cypress.Commands.add("loginNonAdmin", () => {
+  cy.login({
+    username: Cypress.env("nonAdminUsername"),
+    password: Cypress.env("nonAdminPassword"),
+  });
+});
+
 function logViolations(violations: Result[], pageContext: A11yPageContext) {
   const divider =
     "\n====================================================================================================\n";

--- a/integration/cypress/support/index.ts
+++ b/integration/cypress/support/index.ts
@@ -15,6 +15,7 @@ declare global {
         shouldSkipIntro?: boolean;
         shouldSkipSetupIntro?: boolean;
       }): void;
+      loginNonAdmin(): void;
       testA11y(pageContext: A11yPageContext): void;
       waitForPageToLoad(): void;
     }


### PR DESCRIPTION
## Done

- fix: cypress non admin header test for non-admin user (this only worked accidentally as we were logging in as an admin user)
- add test case for clicking on the logo as an admin
- add an ability to run tests when logged in as a non-admin user via `cy.loginNonAdmin()`

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/165448920-4be39787-a84f-46f2-8133-ffdb71109cc6.png) https://github.com/canonical-web-and-design/maas-ui/runs/6184977680?check_suite_focus=true


 Note: Includes fixes from https://github.com/canonical-web-and-design/maas-ui/pull/3849, you may want to review it first 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3764

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
