### PR TITLE
fix: display alternative text for empty string

### DIFF
--- a/ui/src/app/base/components/Definition/Definition.test.tsx
+++ b/ui/src/app/base/components/Definition/Definition.test.tsx
@@ -36,3 +36,10 @@ it("displays alternative text with no description provided", () => {
   expect(screen.getByText("Term")).toBeInTheDocument();
   expect(screen.getByText("—")).toBeInTheDocument();
 });
+
+it("displays alternative text for empty string as description", () => {
+  // eslint-disable-next-line prettier/prettier
+  render(<Definition label="Term">{""}</Definition>);
+  expect(screen.getByText("Term")).toBeInTheDocument();
+  expect(screen.getByText("—")).toBeInTheDocument();
+});

--- a/ui/src/app/base/components/Definition/Definition.tsx
+++ b/ui/src/app/base/components/Definition/Definition.tsx
@@ -27,8 +27,10 @@ const Definition = ({ label, children, description }: Props): JSX.Element => {
       </p>
       {description ? (
         <p aria-labelledby={id}>{description}</p>
-      ) : React.Children.toArray(children).length > 0 ? (
-        React.Children.toArray(children).map(
+      ) : React.Children.toArray(children).filter((child) => child !== "")
+          .length > 0 ? (
+        React.Children.map(
+          children,
           (child, i) =>
             child && (
               <p key={i} aria-labelledby={id}>


### PR DESCRIPTION
## Done

- display alternative text for empty string as description

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a space summary page with an empty description and verify that "-" is displayed.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/868

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
