### PR TITLE
e2e tests for maas.io docs #876

### DIFF
--- a/integration/cypress/integration/docs/docs.spec.ts
+++ b/integration/cypress/integration/docs/docs.spec.ts
@@ -1,7 +1,11 @@
-import maasDocsUrls from "@maas-ui/maas-ui/src/app/base/maasDocsUrls";
+import docsUrls from "@maas-ui/maas-ui/src/app/base/docsUrls";
 
-context("maas.io docs contain specified resources", () => {
-  Object.values(maasDocsUrls).forEach((url) => {
+context("docs resources exists", () => {
+  beforeEach(() => {
+    cy.setCookie("_cookies_accepted", "all");
+  });
+
+  Object.values(docsUrls).forEach((url) => {
     it(url, () => {
       cy.visit(url);
       const { hash } = new URL(url);

--- a/integration/cypress/integration/docs/docs.spec.ts
+++ b/integration/cypress/integration/docs/docs.spec.ts
@@ -1,0 +1,13 @@
+import maasDocsUrls from "@maas-ui/maas-ui/src/app/base/maasDocsUrls";
+
+context("maas.io docs contain specified resources", () => {
+  Object.values(maasDocsUrls).forEach((url) => {
+    it(url, () => {
+      cy.visit(url);
+      const { hash } = new URL(url);
+      if (hash) {
+        cy.get(hash).should("exist");
+      }
+    });
+  });
+});

--- a/integration/cypress/tsconfig.json
+++ b/integration/cypress/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "baseUrl": "../node_modules",
     "target": "es6",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "types": ["cypress", "cypress-axe", "@testing-library/cypress", "@percy/cypress"],
     "moduleResolution": "Node"
   },

--- a/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -9,6 +9,7 @@ import TitledSection from "../TitledSection";
 import EditDHCP from "./EditDHCP";
 
 import TableActions from "app/base/components/TableActions";
+import docsUrls from "app/base/docsUrls";
 import settingsURLs from "app/settings/urls";
 import { actions as dhcpsnippetActions } from "app/store/dhcpsnippet";
 import dhcpsnippetSelectors from "app/store/dhcpsnippet/selectors";
@@ -182,11 +183,7 @@ const DHCPTable = ({
               <Link to={settingsURLs.dhcp.index}>
                 All snippets: Settings &gt; DHCP snippets
               </Link>,
-              <a
-                href="https://maas.io/docs/dhcp"
-                rel="noreferrer noopener"
-                target="_blank"
-              >
+              <a href={docsUrls.dhcp} rel="noreferrer noopener" target="_blank">
                 About DHCP snippets
               </a>,
             ]}

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
@@ -13,6 +13,7 @@ import type { SSHKeyFormValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 import { COL_SIZES } from "app/base/constants";
+import docsUrls from "app/base/docsUrls";
 
 type Props = {
   cols?: number;
@@ -76,11 +77,7 @@ export const SSHKeyFormFields = ({
           </p>
         </Col>
       </Row>
-      <Link
-        href="https://maas.io/docs/user-accounts#heading--ssh-keys"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
+      <Link href={docsUrls.sshKeys} rel="noreferrer noopener" target="_blank">
         About SSH keys
       </Link>
     </>

--- a/ui/src/app/base/docsUrls.ts
+++ b/ui/src/app/base/docsUrls.ts
@@ -1,0 +1,26 @@
+const docsUrls = {
+  customisingDeployedMachines:
+    "https://maas.io/docs/how-to-customise-machines#heading--about-customising-deployed-machines",
+  dhcp: "https://maas.io/docs/dhcp",
+  sshKeys: "https://maas.io/docs/user-accounts#heading--ssh-keys",
+  rackController: "https://maas.io/docs/rack-controller",
+  networkDiscovery: "https://maas.io/docs/network-discovery",
+  configurationJourney: "https://maas.io/docs/configuration-journey",
+  cloudInit:
+    "https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init",
+  kvmIntroduction: "https://maas.io/docs/kvm-introduction",
+  addNodesViaChassis:
+    "https://maas.io/docs/add-machines#heading--add-nodes-via-a-chassis",
+  addMachines: "https://maas.io/docs/add-machines",
+  images: "https://maas.io/docs/images",
+  ipmi: "https://maas.io/docs/snap/2.9/ui/power-management#heading--ipmi",
+  ipRanges: "https://maas.io/docs/ip-ranges",
+  tagsXpathExpressions:
+    "https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions",
+  tagsKernelOptions:
+    "https://maas.io/docs/how-to-work-with-tags#heading--kernel-options",
+  tagsAutomatic:
+    "https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags",
+};
+
+export default docsUrls;

--- a/ui/src/app/base/maasDocsUrls.ts
+++ b/ui/src/app/base/maasDocsUrls.ts
@@ -1,6 +1,0 @@
-const maasDocsUrls = {
-  customisingDeployedMachines:
-    "https://maas.io/docs/how-to-customise-machines#heading--about-customising-deployed-machines",
-};
-
-export default maasDocsUrls;

--- a/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/ui/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -1,6 +1,7 @@
 import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import docsUrls from "app/base/docsUrls";
 import type { ClearHeaderContent } from "app/base/types";
 import configSelectors from "app/store/config/selectors";
 
@@ -58,7 +59,7 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
       <Row>
         <Col size={6}>
           <a
-            href="https://maas.io/docs/rack-controller"
+            href={docsUrls.rackController}
             rel="noreferrer noopener"
             target="_blank"
           >

--- a/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.tsx
@@ -8,6 +8,7 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikForm from "app/base/components/FormikForm";
+import docsUrls from "app/base/docsUrls";
 import type { EmptyObject } from "app/base/types";
 import configSelectors from "app/store/config/selectors";
 import { NetworkDiscovery } from "app/store/config/types";
@@ -42,7 +43,7 @@ const ClearAllForm = ({ closeForm }: Props): JSX.Element => {
         <p>
           Learn more about{" "}
           <Link
-            href="https://maas.io/docs/network-discovery"
+            href={docsUrls.networkDiscovery}
             rel="noreferrer noopener"
             target="_blank"
           >

--- a/ui/src/app/intro/views/IncompleteCard/IncompleteCard.tsx
+++ b/ui/src/app/intro/views/IncompleteCard/IncompleteCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@canonical/react-components";
 
+import docsUrls from "app/base/docsUrls";
 import IntroCard from "app/intro/components/IntroCard";
 import IntroSection from "app/intro/components/IntroSection";
 
@@ -11,10 +12,7 @@ const IncompleteCard = (): JSX.Element => {
         data-testid="maas-name-form"
         title="Welcome to MAAS"
         titleLink={
-          <Link
-            href="https://maas.io/docs/configuration-journey"
-            target="_blank"
-          >
+          <Link href={docsUrls.configurationJourney} target="_blank">
             Help with configuring MAAS
           </Link>
         }

--- a/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
@@ -4,6 +4,7 @@ import { useFormikContext } from "formik";
 import type { MaasIntroValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import docsUrls from "app/base/docsUrls";
 import IntroCard from "app/intro/components/IntroCard";
 
 const NameCard = (): JSX.Element => {
@@ -16,7 +17,7 @@ const NameCard = (): JSX.Element => {
       hasErrors={!!errors.name}
       title="Welcome to MAAS"
       titleLink={
-        <Link href="https://maas.io/docs/configuration-journey" target="_blank">
+        <Link href={docsUrls.configurationJourney} target="_blank">
           Help with configuring MAAS
         </Link>
       }

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -20,7 +20,7 @@ import type { DeployFormValues } from "../DeployForm";
 
 import FormikField from "app/base/components/FormikField";
 import UploadTextArea from "app/base/components/UploadTextArea";
-import maasDocsUrls from "app/base/maasDocsUrls";
+import docsUrls from "app/base/docsUrls";
 import imagesURLs from "app/images/urls";
 import prefsURLs from "app/preferences/urls";
 import authSelectors from "app/store/auth/selectors";
@@ -137,7 +137,7 @@ export const DeployFormFields = (): JSX.Element => {
                 <>
                   Register as MAAS KVM host.{" "}
                   <a
-                    href="https://maas.io/docs/kvm-introduction"
+                    href={docsUrls.kvmIntroduction}
                     rel="noreferrer noopener"
                     target="_blank"
                   >
@@ -181,7 +181,7 @@ export const DeployFormFields = (): JSX.Element => {
                 <>
                   Cloud-init user-data&hellip;{" "}
                   <a
-                    href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+                    href={docsUrls.cloudInit}
                     rel="noreferrer noopener"
                     target="_blank"
                   >
@@ -229,7 +229,7 @@ export const DeployFormFields = (): JSX.Element => {
                     </Button>
                   </Tooltip>{" "}
                   <a
-                    href={maasDocsUrls.customisingDeployedMachines}
+                    href={docsUrls.customisingDeployedMachines}
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/ui/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.tsx
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 import AddChassisFormFields from "../AddChassisFormFields";
 
 import FormikForm from "app/base/components/FormikForm";
+import docsUrls from "app/base/docsUrls";
 import { useAddMessage } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
 import { actions as domainActions } from "app/store/domain";
@@ -74,7 +75,7 @@ export const AddChassisForm = ({ clearHeaderContent }: Props): JSX.Element => {
           buttonsHelp={
             <p>
               <Link
-                href="https://maas.io/docs/add-machines#heading--add-nodes-via-a-chassis"
+                href={docsUrls.addNodesViaChassis}
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -8,6 +8,7 @@ import AddMachineFormFields from "../AddMachineFormFields";
 import type { AddMachineValues } from "../types";
 
 import FormikForm from "app/base/components/FormikForm";
+import docsUrls from "app/base/docsUrls";
 import { useAddMessage } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
 import { hostnameValidation, MAC_ADDRESS_REGEX } from "app/base/validation";
@@ -124,7 +125,7 @@ export const AddMachineForm = ({ clearHeaderContent }: Props): JSX.Element => {
           buttonsHelp={
             <p>
               <Link
-                href="https://maas.io/docs/add-machines"
+                href={docsUrls.addMachines}
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -9,6 +9,7 @@ import DatastoresTable from "./DatastoresTable";
 import FilesystemsTable from "./FilesystemsTable";
 import UsedStorageTable from "./UsedStorageTable";
 
+import docsUrls from "app/base/docsUrls";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import settingsURLs from "app/settings/urls";
@@ -79,7 +80,7 @@ const MachineStorage = (): JSX.Element => {
             Learn more about deploying{" "}
             <a
               data-testid="docs-footer-link"
-              href="https://maas.io/docs/images"
+              href={docsUrls.images}
               onClick={() =>
                 sendAnalytics(
                   "Machine storage",

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 
 import StatusCard from "./StatusCard";
 
-import maasDocsUrls from "app/base/maasDocsUrls";
+import docsUrls from "app/base/docsUrls";
 import type { RootState } from "app/store/root/types";
 import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
@@ -177,7 +177,7 @@ describe("StatusCard", () => {
     expect(hardwareSyncDocs).toBeInTheDocument();
     expect(hardwareSyncDocs).toHaveAttribute(
       "href",
-      maasDocsUrls.customisingDeployedMachines
+      docsUrls.customisingDeployedMachines
     );
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -2,7 +2,7 @@ import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { formatDuration, intervalToDuration } from "date-fns";
 import { useSelector } from "react-redux";
 
-import maasDocsUrls from "app/base/maasDocsUrls";
+import docsUrls from "app/base/docsUrls";
 import type { Seconds } from "app/base/types";
 import { PowerTypeNames } from "app/store/general/constants";
 import type { MachineDetails } from "app/store/machine/types";
@@ -110,7 +110,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
                     You can check it at the bottom, in the status bar.{"\n"}
                     More about this in the{" "}
                     <a
-                      href={maasDocsUrls.customisingDeployedMachines}
+                      href={docsUrls.customisingDeployedMachines}
                       rel="noopener noreferrer"
                       target="_blank"
                       className="is-on-dark"

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@canonical/react-components";
 
 import BaseSSHKeyList from "app/base/components/SSHKeyList";
+import docsUrls from "app/base/docsUrls";
 import { useWindowTitle } from "app/base/hooks";
 import prefsURLs from "app/preferences/urls";
 
@@ -11,11 +12,7 @@ const SSHKeyList = (): JSX.Element => {
       <BaseSSHKeyList
         buttons={[{ label: "Import SSH key", url: prefsURLs.sshKeys.add }]}
       />
-      <Link
-        href="https://maas.io/docs/user-accounts#heading--ssh-keys"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
+      <Link href={docsUrls.sshKeys} rel="noreferrer noopener" target="_blank">
         About SSH keys
       </Link>
     </>

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -7,6 +7,7 @@ import { useSelector } from "react-redux";
 import type { CommissioningFormValues } from "../CommissioningForm";
 
 import FormikField from "app/base/components/FormikField";
+import docsUrls from "app/base/docsUrls";
 import configSelectors from "app/store/config/selectors";
 import { osInfo as osInfoSelectors } from "app/store/general/selectors";
 import type { RootState } from "app/store/root/types";
@@ -75,7 +76,7 @@ const CommissioningFormFields = (): JSX.Element => {
             Specify this key to encrypt all communication between IPMI clients
             and the BMC. Leave this blank for no encryption.&nbsp;
             <Link
-              href="https://maas.io/docs/snap/2.9/ui/power-management#heading--ipmi"
+              href={docsUrls.ipmi}
               rel="noreferrer noopener"
               target="_blank"
             >

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
@@ -8,6 +8,7 @@ import type { Dispatch } from "redux";
 import ColumnToggle from "app/base/components/ColumnToggle";
 import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import docsUrls from "app/base/docsUrls";
 import { useWindowTitle, useAddMessage } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
 import settingsURLs from "app/settings/urls";
@@ -256,7 +257,7 @@ const DhcpList = (): JSX.Element => {
         },
       ]}
       helpLabel="About DHCP"
-      helpLink="https://maas.io/docs/dhcp"
+      helpLink={docsUrls.dhcp}
       loaded={dhcpsnippetLoaded}
       loading={dhcpsnippetLoading}
       rows={generateRows(

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -19,6 +19,7 @@ import SubnetLink from "app/base/components/SubnetLink";
 import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import TitledSection from "app/base/components/TitledSection";
+import docsUrls from "app/base/docsUrls";
 import { actions as ipRangeActions } from "app/store/iprange";
 import ipRangeSelectors from "app/store/iprange/selectors";
 import type { IPRange, IPRangeMeta } from "app/store/iprange/types";
@@ -333,11 +334,7 @@ const ReservedRanges = ({
           />
         </FormCard>
       ) : null}
-      <a
-        href="https://maas.io/docs/ip-ranges"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
+      <a href={docsUrls.ipRanges} rel="noreferrer noopener" target="_blank">
         About IP ranges
       </a>
     </TitledSection>

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -9,6 +9,7 @@ import DHCPReservedRanges from "./DHCPReservedRanges";
 
 import FormikForm from "app/base/components/FormikForm";
 import TitledSection from "app/base/components/TitledSection";
+import docsUrls from "app/base/docsUrls";
 import { useCycled } from "app/base/hooks";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
@@ -144,11 +145,7 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
             cleanup={cleanup}
             errors={configureDHCPError}
             buttonsHelp={
-              <a
-                href="https://maas.io/docs/dhcp"
-                rel="noreferrer noopener"
-                target="_blank"
-              >
+              <a href={docsUrls.dhcp} rel="noreferrer noopener" target="_blank">
                 About DHCP
               </a>
             }

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -13,6 +13,7 @@ import { Link } from "react-router-dom";
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";
 import TitledSection from "app/base/components/TitledSection";
+import docsUrls from "app/base/docsUrls";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import type { Fabric } from "app/store/fabric/types";
@@ -141,11 +142,7 @@ const DHCPStatus = ({ id, openForm }: Props): JSX.Element | null => {
         </Col>
       </Row>
       <p>
-        <a
-          href="https://maas.io/docs/dhcp"
-          rel="noreferrer noopener"
-          target="_blank"
-        >
+        <a href={docsUrls.dhcp} rel="noreferrer noopener" target="_blank">
           About DHCP
         </a>
       </p>

--- a/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
+++ b/ui/src/app/tags/components/DefinitionField/DefinitionField.tsx
@@ -6,6 +6,7 @@ import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
+import docsUrls from "app/base/docsUrls";
 import { useSendAnalytics } from "app/base/hooks";
 import { useId } from "app/base/hooks/base";
 import type { RootState } from "app/store/root/types";
@@ -39,7 +40,7 @@ const getDefinitionError = (
       <span id={definitionErrorId}>
         The definition is an invalid XPath expression. See our{" "}
         <a
-          href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
+          href={docsUrls.tagsXpathExpressions}
           rel="noreferrer noopener"
           target="_blank"
         >
@@ -94,7 +95,7 @@ export const DefinitionField = ({ id }: Props): JSX.Element => {
         Add an XPath expression as a definition. MAAS will auto-assign this tag
         to all current and future machines that match this definition.{" "}
         <a
-          href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
+          href={docsUrls.tagsXpathExpressions}
           rel="noreferrer noopener"
           target="_blank"
         >

--- a/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/ui/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -3,6 +3,7 @@ import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
+import docsUrls from "app/base/docsUrls";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -65,7 +66,7 @@ export const KernelOptionsField = ({
           Kernel options are appended to the kernel command line during booting
           while machines are commissioning or deploying.{" "}
           <a
-            href="https://maas.io/docs/how-to-work-with-tags#heading--kernel-options"
+            href={docsUrls.tagsKernelOptions}
             rel="noreferrer noopener"
             target="_blank"
           >

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -14,6 +14,7 @@ import { TAGS_PER_PAGE } from "../constants";
 
 import TableActions from "app/base/components/TableActions";
 import TableHeader from "app/base/components/TableHeader";
+import docsUrls from "app/base/docsUrls";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import { actions as tagActions } from "app/store/tag";
@@ -223,7 +224,7 @@ const TagTable = ({
                       )}
                       <br />
                       <a
-                        href="https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags"
+                        href={docsUrls.tagsAutomatic}
                         rel="noreferrer noopener"
                         target="_blank"
                       >

--- a/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 
 import Definition from "app/base/components/Definition";
 import FormikField from "app/base/components/FormikField";
+import docsUrls from "app/base/docsUrls";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
@@ -71,7 +72,7 @@ export const TagUpdateFormFields = ({ id }: Props): JSX.Element | null => {
                 This is a manual tag. Definitions cannot be added to manual
                 tags. To learn more about this, check our{" "}
                 <a
-                  href="https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions"
+                  href={docsUrls.tagsXpathExpressions}
                   rel="noreferrer noopener"
                   target="_blank"
                 >


### PR DESCRIPTION
## Done

- add e2e tests for maas.io docs #876

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
