### PR TITLE
fix: invalid links to tags on controllers page

### DIFF
--- a/legacy/src/app/partials/cards/tags.html
+++ b/legacy/src/app/partials/cards/tags.html
@@ -5,7 +5,7 @@
   <p>
     <span data-ng-if="!node.tags.length"><i>No tags</i></span>
     <span data-ng-repeat="tag in node.tags">
-      <a href="{$ newURLBase $}/controllers?q=tags:({$ tag $})"
+      <a href="{$ newURLBase $}/controllers?q=tags:({$ getTagName(tag) $})"
         >{$ getTagName(tag) $}</a
       >
     </span>


### PR DESCRIPTION
## Done

- fix: invalid links to tags on controllers page (tag id was being used instead of a tag name)

## Screenshots
### Before

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/7452681/165784371-78fa0d16-058f-4c11-a5a9-1f01f2ab0d35.png">

### After
<img width="797" alt="image" src="https://user-images.githubusercontent.com/7452681/165784649-6598a03b-f7a4-4544-b37f-b60a3a44f564.png">


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to controller details page (e.g. http://bolla.internal:5240/MAAS/l/controller/knpge8) and click on a link to controller
- Controllers list should be displayed with a correct tag in the search input field and controllers 

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/881

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
