### PR TITLE
add e2e tests for controllers tag management 

### DIFF
--- a/integration/cypress/integration/controllers/list.spec.ts
+++ b/integration/cypress/integration/controllers/list.spec.ts
@@ -17,4 +17,42 @@ context("Controller listing", () => {
       generateNewURL("/controllers")
     );
   });
+
+  it("can add a tag to the controller", () => {
+    // displays the controller details page on click of the controller name
+    cy.findByRole("gridcell", { name: "Name" }).within(() => {
+      cy.findByRole("link").click();
+    });
+
+    cy.findByText(/Controller summary/).should("exist");
+
+    // can add a tag to the controller
+    cy.findByRole("tab", {
+      name: /Configuration/,
+    }).click();
+    cy.findAllByRole("button", {
+      name: /Edit/,
+    })
+      .first()
+      .click();
+    cy.get("input[placeholder='Add a tag']").type("test-tag");
+    cy.findByRole("button", { name: /Save changes/ }).click();
+
+    cy.findByRole("tab", { name: /Controller summary/ }).click();
+    cy.findByRole("link", { name: "new-tag" }).should("exist");
+
+    // displays the controller listing page filtered by tag on click of the tag name
+    cy.findByRole("link", { name: "new-tag" }).click();
+
+    // displays the correct tag in the searchbox
+    cy.findByRole("searchbox", { name: /Search/ }).should(
+      "have.value",
+      "tag:(new-tag)"
+    );
+
+    // displays the correct number of controllers
+    cy.findByRole("grid", { name: "controllers list" }).within(() => {
+      cy.get("tbody tr").should("have.length", 1);
+    });
+  });
 });

--- a/legacy/src/app/partials/cards/tags.html
+++ b/legacy/src/app/partials/cards/tags.html
@@ -11,6 +11,6 @@
     </span>
   </p>
   <p data-ng-if="canEdit()">
-    <a data-ng-click="section.area = 'configuration'">Edit &rsaquo;</a>
+    <a href="#" aria-label="Edit tags" data-ng-click="section.area = 'configuration'">Edit &rsaquo;</a>
   </p>
 </div>

--- a/legacy/src/app/partials/cards/tags.html
+++ b/legacy/src/app/partials/cards/tags.html
@@ -5,7 +5,7 @@
   <p>
     <span data-ng-if="!node.tags.length"><i>No tags</i></span>
     <span data-ng-repeat="tag in node.tags">
-      <a href="{$ newURLBase $}/controllers?q=tags:({$ tag $})"
+      <a href="{$ newURLBase $}/controllers?q=tags:({$ getTagName(tag) $})"
         >{$ getTagName(tag) $}</a
       >
     </span>

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -450,6 +450,7 @@
             class="p-button u-float--right u-no-margin--bottom"
             data-ng-if="canEdit()"
             data-ng-click="editSummary()"
+            aria-label="Edit summary"
           >
             Edit
           </button>

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -133,6 +133,7 @@ const ControllerListTable = ({
 
   return (
     <MainTable
+      aria-label="controllers list"
       className="controller-list-table"
       emptyStateMsg={
         loading ? (


### PR DESCRIPTION
## Done

- add e2e test for controllers tag management
  - this currently fails as the configuration tab is broken but will work once that's fixed https://github.com/canonical-web-and-design/maas-ui/issues/3728

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/882

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
