### PR TITLE
fix(ui): fix table headings on small screens for non-MainTables

### DIFF
--- a/ui/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/ui/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -24,9 +24,7 @@ const NetworkCardInterface = ({ interfaces }: Props): JSX.Element => {
     <Table className="network-card-table" responsive>
       <thead>
         <TableRow>
-          <TableHeader aria-label="Name" className="name">
-            Name
-          </TableHeader>
+          <TableHeader className="name">Name</TableHeader>
           <TableHeader className="mac">MAC</TableHeader>
           <TableHeader className="speed">Link speed</TableHeader>
           <TableHeader className="fabric">
@@ -51,19 +49,19 @@ const NetworkCardInterface = ({ interfaces }: Props): JSX.Element => {
 
           return (
             <TableRow key={iface.id}>
-              <TableCell aria-label="Name" className="name">
+              <TableCell data-heading="Name" className="name">
                 {iface.name}
               </TableCell>
-              <TableCell aria-label="MAC" className="mac">
+              <TableCell data-heading="MAC" className="mac">
                 {iface.mac_address}
               </TableCell>
-              <TableCell aria-label="Link speed" className="speed">
+              <TableCell data-heading="Link speed" className="speed">
                 {formatSpeedUnits(iface.link_speed)}
               </TableCell>
-              <TableCell aria-label="Fabric" className="fabric">
+              <TableCell data-heading="Fabric" className="fabric">
                 {getFabricDisplay(fabric) || "Unknown"}
               </TableCell>
-              <TableCell aria-label="DHCP" className="dhcp">
+              <TableCell data-heading="DHCP" className="dhcp">
                 {dhcpStatus}
                 {dhcpStatus === "Relayed" && (
                   <Tooltip
@@ -76,7 +74,7 @@ const NetworkCardInterface = ({ interfaces }: Props): JSX.Element => {
                   </Tooltip>
                 )}
               </TableCell>
-              <TableCell aria-label="SR-IOV" className="sriov">
+              <TableCell data-heading="SR-IOV" className="sriov">
                 {iface.sriov_max_vf > 0 ? "Yes" : "No"}
               </TableCell>
             </TableRow>

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -231,12 +231,14 @@ describe("InterfacesTable", () => {
         .simulate("click");
     });
     wrapper.update();
-    expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe(
+    expect(wrapper.find("TableCell[data-heading='Fabric']").text()).toBe(
       fabric.name
     );
-    expect(wrapper.find("TableCell[aria-label='VLAN']").text()).toBe(vlan.name);
+    expect(wrapper.find("TableCell[data-heading='VLAN']").text()).toBe(
+      vlan.name
+    );
     expect(
-      wrapper.find("TableCell[aria-label='PXE'] i").prop("className")
+      wrapper.find("TableCell[data-heading='PXE'] i").prop("className")
     ).toBe("p-icon--success");
   });
 
@@ -264,14 +266,14 @@ describe("InterfacesTable", () => {
     wrapper.find("[data-testid='define-interfaces'] button").simulate("click");
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find("SubnetSelect").text()).toBe("pxe-subnet");
-    expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe(
+    expect(wrapper.find("TableCell[data-heading='Fabric']").text()).toBe(
       "pxe-fabric"
     );
-    expect(wrapper.find("TableCell[aria-label='VLAN']").text()).toBe(
+    expect(wrapper.find("TableCell[data-heading='VLAN']").text()).toBe(
       "pxe-vlan"
     );
     expect(
-      wrapper.find("TableCell[aria-label='PXE'] i").prop("className")
+      wrapper.find("TableCell[data-heading='PXE'] i").prop("className")
     ).toBe("p-icon--success");
   });
 });

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -168,17 +168,17 @@ export const InterfacesTable = ({ hostId }: Props): JSX.Element => {
 
               return (
                 <TableRow key={iface.id}>
-                  <TableCell aria-label="Name">
+                  <TableCell data-heading="Name">
                     <FormikField name={`interfaces[${i}].name`} type="text" />
                   </TableCell>
-                  <TableCell aria-label="IP address">
+                  <TableCell data-heading="IP address">
                     <FormikField
                       name={`interfaces[${i}].ipAddress`}
                       placeholder="Leave empty to auto-assign"
                       type="text"
                     />
                   </TableCell>
-                  <TableCell aria-label="Space">
+                  <TableCell data-heading="Space">
                     <FormikField
                       component={Select}
                       name={`interfaces[${i}].space`}
@@ -199,7 +199,7 @@ export const InterfacesTable = ({ hostId }: Props): JSX.Element => {
                       ]}
                     />
                   </TableCell>
-                  <TableCell aria-label="Subnet">
+                  <TableCell data-heading="Subnet">
                     <SubnetSelect
                       hostId={hostId}
                       iface={iface}
@@ -209,17 +209,20 @@ export const InterfacesTable = ({ hostId }: Props): JSX.Element => {
                       }}
                     />
                   </TableCell>
-                  <TableCell aria-label="Fabric" className="u-align-non-field">
+                  <TableCell
+                    data-heading="Fabric"
+                    className="u-align-non-field"
+                  >
                     {fabric?.name || ""}
                   </TableCell>
-                  <TableCell aria-label="VLAN" className="u-align-non-field">
+                  <TableCell data-heading="VLAN" className="u-align-non-field">
                     {vlan?.name || ""}
                   </TableCell>
-                  <TableCell aria-label="PXE" className="u-align-non-field">
+                  <TableCell data-heading="PXE" className="u-align-non-field">
                     <i className={getPxeIconClass(pod, vlan)}></i>
                   </TableCell>
                   <TableCell
-                    aria-label="Actions"
+                    data-heading="Actions"
                     className="u-align--right u-no-padding--right u-align-non-field"
                   >
                     <TableActions
@@ -234,10 +237,10 @@ export const InterfacesTable = ({ hostId }: Props): JSX.Element => {
         ) : (
           <tbody>
             <TableRow data-testid="undefined-interface">
-              <TableCell aria-label="Name">
+              <TableCell data-heading="Name">
                 <em>default</em>
               </TableCell>
-              <TableCell aria-label="IP address" colSpan={7}>
+              <TableCell data-heading="IP address" colSpan={7}>
                 Created by hypervisor at compose time
               </TableCell>
             </TableRow>

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.tsx
@@ -95,7 +95,7 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
               const isBootDisk = disk.id === bootDisk;
               return (
                 <TableRow key={disk.id}>
-                  <TableCell aria-label="Size">
+                  <TableCell data-heading="Size">
                     <FormikField
                       caution={
                         isBootDisk && disk.size < 8
@@ -116,7 +116,7 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
                       type="number"
                     />
                   </TableCell>
-                  <TableCell aria-label="Location">
+                  <TableCell data-heading="Location">
                     <PoolSelect
                       disk={disk}
                       hostId={hostId}
@@ -125,14 +125,14 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
                       }}
                     />
                   </TableCell>
-                  <TableCell aria-label="Tags">
+                  <TableCell data-heading="Tags">
                     <TagNameField
                       label={null}
                       name={`disks[${i}].tags`}
                       placeholder="Add tags"
                     />
                   </TableCell>
-                  <TableCell aria-label="Boot" className="u-align-non-field">
+                  <TableCell data-heading="Boot" className="u-align-non-field">
                     <FormikField
                       aria-label="Boot"
                       checked={bootDisk === disk.id}
@@ -146,7 +146,7 @@ export const StorageTable = ({ defaultDisk, hostId }: Props): JSX.Element => {
                     />
                   </TableCell>
                   <TableCell
-                    aria-label="Actions"
+                    data-heading="Actions"
                     className="u-align--right u-no-padding--right u-align-non-field"
                   >
                     <TableActions


### PR DESCRIPTION
## Done

- Fixed mobile tables in node summary network card and KVM compose form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Resize the screen to mobile size
- Go to a machine's details page and check that the network card shows the table headers
- Go to a KVM's details page and click "Add machine"
- Check that the interfaces and storage tables show the table headers

## Fixes

Fixes canonical-web-and-design/app-tribe#872
Fixes canonical-web-and-design/app-tribe#875

