### PR TITLE
fix(ui): fix security form not showing saved values

### DIFF
--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
@@ -17,6 +17,40 @@ import {
 
 const mockStore = configureStore();
 
+it("displays a spinner while loading config", () => {
+  const state = rootStateFactory({
+    config: configStateFactory({
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <TLSEnabled />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.Loading)).toBeInTheDocument();
+});
+
+it("displays a spinner while loading the certificate", () => {
+  const state = rootStateFactory({
+    general: generalStateFactory({
+      tlsCertificate: tlsCertificateStateFactory({
+        loading: true,
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <TLSEnabled />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.Loading)).toBeInTheDocument();
+});
+
 it("renders certificate content", () => {
   const tlsCertificate = tlsCertificateFactory();
   const state = rootStateFactory({

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.tsx
@@ -1,4 +1,4 @@
-import { Icon, Textarea } from "@canonical/react-components";
+import { Icon, Spinner, Textarea } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -17,6 +17,7 @@ export type TLSEnabledValues = {
 };
 
 export enum Labels {
+  Loading = "Loading security settings",
   NotificationCheckbox = "Notify the certificate is due to expire in...",
   Interval = "Days",
   Textarea = "TLS certificate",
@@ -41,9 +42,15 @@ const TLSEnabled = (): JSX.Element | null => {
   const notificationInterval = useSelector(
     configSelectors.tlsCertExpirationNotificationInterval
   );
+  const configLoading = useSelector(configSelectors.loading);
+  const tlsCertificateLoading = useSelector(tlsCertificateSelectors.loading);
   const tlsCertificate = useSelector(tlsCertificateSelectors.get);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+
+  if (configLoading || tlsCertificateLoading) {
+    return <Spinner aria-label={Labels.Loading} />;
+  }
 
   if (!tlsCertificate) {
     return null;
@@ -79,8 +86,8 @@ const TLSEnabled = (): JSX.Element | null => {
         }}
         onSaveAnalytics={{
           action: "Saved",
-          category: "Storage settings",
-          label: "Storage form",
+          category: "Security settings",
+          label: "Security form",
         }}
         onSubmit={(values, { resetForm }) => {
           const { notificationEnabled, notificationInterval } = values;


### PR DESCRIPTION
## Done

- Update the security settings form to wait for the data to be loaded before initialising the form. This fixes a race condition where the form could be initialising before the config values were loaded.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Enable TLS for your MAAS (the first few steps in this issue: https://github.com/canonical-web-and-design/app-tribe/issues/847).
- Go to Settings -> Security (/MAAS/r/settings/configuration/security).
- Tick the notification checkbox and change the number of days.
- The form should save and the values in the form shouldn't change.
- Refresh the window and note that the checkbox is ticked and the number of days matches what you set previously.

## Fixes

Fixes: canonical-web-and-design/app-tribe#885.