### PR TITLE
fix(ui): add cleanup actions to add network model forms

### DIFF
--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -35,7 +35,7 @@ test("renders the form correctly", async () => {
   expect(screen.getByRole("button", { name: /Add Fabric/ })).toBeEnabled();
 });
 
-test("correctly dispatches fabric create action on submit with name provided", async () => {
+test("correctly dispatches fabric cleanup and create actions on submit with name provided", async () => {
   const { store } = renderTestCase();
 
   expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
@@ -43,12 +43,13 @@ test("correctly dispatches fabric create action on submit with name provided", a
 
   await waitFor(() =>
     expect(store.getActions()).toStrictEqual([
+      fabricActions.cleanup(),
       fabricActions.create({ name: "", description: "" }),
     ])
   );
 });
 
-test("correctly dispatches fabric create action on submit with name provided", async () => {
+test("correctly dispatches fabric cleanup and create actions on submit with name provided", async () => {
   const { store } = renderTestCase();
 
   const name = "Fabric name";
@@ -57,12 +58,13 @@ test("correctly dispatches fabric create action on submit with name provided", a
 
   await waitFor(() =>
     expect(store.getActions()).toStrictEqual([
+      fabricActions.cleanup(),
       fabricActions.create({ name, description: "" }),
     ])
   );
 });
 
-test("correctly dispatches fabric create action on submit with all details provided", async () => {
+test("correctly dispatches fabric cleanup and create actions on submit with all details provided", async () => {
   const { store } = renderTestCase();
 
   expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
@@ -79,6 +81,7 @@ test("correctly dispatches fabric create action on submit with all details provi
 
   await waitFor(() =>
     expect(store.getActions()).toStrictEqual([
+      fabricActions.cleanup(),
       fabricActions.create({ name, description }),
     ])
   );

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.tsx
@@ -24,9 +24,9 @@ const AddFabric = ({
 
   return (
     <FormikForm<AddFabricValues>
+      allowAllEmpty
       aria-label="Add fabric"
       buttonsBordered={false}
-      allowAllEmpty
       cleanup={fabricActions.cleanup}
       initialValues={{ name: "", description: "" }}
       onSaveAnalytics={{
@@ -36,6 +36,7 @@ const AddFabric = ({
       }}
       submitLabel={`Add ${activeForm}`}
       onSubmit={({ name, description }) => {
+        dispatch(fabricActions.cleanup());
         dispatch(fabricActions.create({ name, description }));
       }}
       onCancel={() => setActiveForm(null)}

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -9,7 +9,7 @@ import AddSpace from "./AddSpace";
 import { actions as spaceActions } from "app/store/space";
 import { rootState as rootStateFactory } from "testing/factories";
 
-test("correctly dispatches space create action on form submit", async () => {
+test("correctly dispatches space cleanup and create actions on form submit", async () => {
   const store = configureStore()(rootStateFactory());
 
   render(
@@ -30,6 +30,9 @@ test("correctly dispatches space create action on form submit", async () => {
   userEvent.click(screen.getByRole("button", { name: /Add Space/ }));
 
   await waitFor(() =>
-    expect(store.getActions()).toStrictEqual([spaceActions.create({ name })])
+    expect(store.getActions()).toStrictEqual([
+      spaceActions.cleanup(),
+      spaceActions.create({ name }),
+    ])
   );
 });

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.tsx
@@ -23,9 +23,10 @@ const AddSpace = ({
 
   return (
     <FormikForm<AddSpaceValues>
+      allowAllEmpty
       aria-label="Add space"
       buttonsBordered={false}
-      allowAllEmpty
+      cleanup={spaceActions.cleanup}
       initialValues={{ name: "" }}
       onSaveAnalytics={{
         action: "Add space",
@@ -34,6 +35,7 @@ const AddSpace = ({
       }}
       submitLabel={`Add ${activeForm}`}
       onSubmit={({ name }) => {
+        dispatch(spaceActions.cleanup());
         dispatch(spaceActions.create({ name }));
       }}
       onCancel={() => setActiveForm(null)}

--- a/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -15,7 +15,7 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 
-it("correctly dispatches space create action on form submit", async () => {
+it("correctly dispatches subnet cleanup and create actions on form submit", async () => {
   const vlan1 = vlanFactory({ id: 111, fabric: 5 });
   const vlan2 = vlanFactory({
     id: 222,
@@ -74,6 +74,7 @@ it("correctly dispatches space create action on form submit", async () => {
 
   await waitFor(() =>
     expect(store.getActions()).toStrictEqual([
+      subnetActions.cleanup(),
       subnetActions.create({
         cidr,
         fabric: fabric.id,

--- a/ui/src/app/subnets/views/FormActions/components/AddSubnet.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSubnet.tsx
@@ -122,7 +122,6 @@ const AddSubnet = ({
       aria-label="Add subnet"
       validationSchema={addSubnetSchema}
       buttonsBordered={false}
-      allowAllEmpty
       initialValues={{
         vlan: "",
         name: "",
@@ -139,6 +138,7 @@ const AddSubnet = ({
       cleanup={subnetActions.cleanup}
       submitLabel={`Add ${activeForm}`}
       onSubmit={({ cidr, name, fabric, vlan, dns_servers, gateway_ip }) => {
+        dispatch(subnetActions.cleanup());
         dispatch(
           subnetActions.create({
             cidr,

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -52,7 +52,7 @@ it("displays validation messages for VID", async () => {
   );
 });
 
-it("correctly dispatches VLAN create action on form submit", async () => {
+it("correctly dispatches VLAN cleanup and create actions on form submit", async () => {
   const vid = 123;
   const name = "VLAN name";
   const space = { id: 1, name: "space1" };
@@ -91,15 +91,21 @@ it("correctly dispatches VLAN create action on form submit", async () => {
 
   userEvent.click(screen.getByRole("button", { name: "Add VLAN" }));
 
-  const expectedAction = vlanActions.create({
-    vid,
-    name,
-    fabric: fabric.id,
-    space: space.id,
+  const expectedActions = [
+    vlanActions.cleanup(),
+    vlanActions.create({
+      vid,
+      name,
+      fabric: fabric.id,
+      space: space.id,
+    }),
+  ];
+  await waitFor(() => {
+    const actualActions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        actualActions.find(({ type }) => type === expectedAction.type)
+      ).toStrictEqual(expectedAction);
+    });
   });
-  await waitFor(() =>
-    expect(
-      store.getActions().find((action) => action.type === expectedAction.type)
-    ).toStrictEqual(expectedAction)
-  );
 });

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.tsx
@@ -62,6 +62,7 @@ const AddVlan = ({
       aria-label="Add VLAN"
       validationSchema={vlanSchema}
       buttonsBordered={false}
+      cleanup={vlanActions.cleanup}
       initialValues={{
         vid: "",
         name: "",
@@ -75,6 +76,7 @@ const AddVlan = ({
       }}
       submitLabel={`Add ${activeForm}`}
       onSubmit={({ name, fabric, vid, space }) => {
+        dispatch(vlanActions.cleanup());
         dispatch(
           vlanActions.create({
             name,


### PR DESCRIPTION
## Done

- Include store cleanup actions for fabric, VLAN, subnet and space add forms.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the subnets list and click "Add" > "Space"
- Enter the name of a space that already exists and submit. You should see an error.
- Close the form and open it again. The error should no longer be showing.
- Submit the form with the same name as before. The error should show again.

## Fixes

Fixes canonical-web-and-design/app-tribe#883

