### PR TITLE
fix(ui): fix mobile styling of "VLANs on this fabric" table

### DIFF
--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.tsx
@@ -47,7 +47,7 @@ const generateRows = (vlans: VLAN[], subnets: Subnet[]) => {
             {
               "aria-label": headers[0],
               content: (
-                <span className={i > 0 ? "u-hide--medium u-hide--large" : ""}>
+                <span className={i > 0 ? "u-hide--large" : ""}>
                   <VLANLink id={vlan.id} />
                 </span>
               ),
@@ -55,7 +55,7 @@ const generateRows = (vlans: VLAN[], subnets: Subnet[]) => {
             {
               "aria-label": headers[1],
               content: (
-                <span className={i > 0 ? "u-hide--medium u-hide--large" : ""}>
+                <span className={i > 0 ? "u-hide--large" : ""}>
                   <SpaceLink id={vlan.space} />
                 </span>
               ),

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/_index.scss
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/_index.scss
@@ -5,7 +5,7 @@
     $subnets-width: 40%;
     $available-width: 10%;
 
-    @media only screen and (min-width: $breakpoint-small) {
+    @media only screen and (min-width: $breakpoint-large) {
       .truncated-border {
         overflow: visible;
         position: relative;


### PR DESCRIPTION
## Done

- Fixed the mobile card styling of the "VLANs on this fabric" table. Vanilla 3 changed the mobile card breakpoint from medium to large which was no accounted for here.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a fabric that has a VLAN with at least 2 subnets (e.g. `/MAAS/r/fabric/249` on bolla).
- Resize the screen to <1035px to change the table to mobile cards and check that the styling and content look correct.

## Fixes

Fixes canonical-web-and-design/app-tribe#870
