### PR TITLE
refactor(ui): use the same structure for each network model delete form

### DIFF
--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.tsx
@@ -41,21 +41,21 @@ const FabricDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
   let warning: ReactNode;
   if (fabricIsDefault) {
     warning = (
-      <Notification borderless inline severity="negative">
+      <Notification borderless severity="negative">
         This fabric cannot be deleted because it is the default fabric for this
         MAAS.
       </Notification>
     );
   } else if (hasSubnets) {
     warning = (
-      <Notification borderless inline severity="negative">
+      <Notification borderless severity="negative">
         This fabric cannot be deleted because it has subnets attached. Remove
         all subnets from the VLANs on this fabric to allow deletion.
       </Notification>
     );
   } else {
     warning = (
-      <Notification borderless inline severity="caution">
+      <Notification borderless severity="caution">
         Are you sure you want to delete this fabric?
       </Notification>
     );

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDelete/SpaceDelete.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDelete/SpaceDelete.tsx
@@ -1,88 +1,58 @@
-import {
-  Button,
-  Strip,
-  Notification,
-  Row,
-  Col,
-  ActionButton,
-} from "@canonical/react-components";
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router";
 
-import { useCycled } from "app/base/hooks";
+import FormikForm from "app/base/components/FormikForm";
+import type { EmptyObject } from "app/base/types";
 import { actions as spaceActions } from "app/store/space";
 import spaceSelectors from "app/store/space/selectors";
 import type { Space } from "app/store/space/types";
 import { getCanBeDeleted } from "app/store/space/utils";
 import urls from "app/subnets/urls";
-import { formatErrors } from "app/utils";
 
 type SpaceDeleteProps = {
-  space: Space;
   handleClose?: () => void;
+  space: Space;
 };
 
 export const SpaceDelete = ({
-  space,
   handleClose,
+  space,
 }: SpaceDeleteProps): JSX.Element => {
   const canBeDeleted = getCanBeDeleted(space);
   const dispatch = useDispatch();
-  const history = useHistory();
   const errors = useSelector(spaceSelectors.errors);
   const saving = useSelector(spaceSelectors.saving);
   const saved = useSelector(spaceSelectors.saved);
-  const errorMessage = formatErrors(errors);
-
-  const handleDelete = () => {
-    dispatch(spaceActions.delete(space.id));
-  };
-  useCycled(saved, () => {
-    if (saved) {
-      history.replace(urls.indexWithParams({ by: "space" }));
-    }
-  });
 
   return (
-    <Strip shallow element="section">
-      <Row>
-        {errors ? (
-          <Notification inline severity="negative" title="Error:">
-            {errorMessage}
-          </Notification>
-        ) : null}
-        {!canBeDeleted ? (
-          <Notification
-            inline
-            severity="negative"
-            title="Error:"
-            onDismiss={handleClose}
-          >
-            Space cannot be deleted because it has subnets attached. Remove all
-            subnets from the space to allow deletion.
-          </Notification>
-        ) : null}
-        {canBeDeleted ? (
-          <>
-            <Col size={8}>
-              <p>Are you sure you want to delete {space.name} space?</p>
-            </Col>
-            <Col size={4} className="u-align--right">
-              <ActionButton
-                appearance="negative"
-                onClick={handleDelete}
-                disabled={saving}
-              >
-                Yes, delete space
-              </ActionButton>
-              <Button onClick={handleClose} disabled={saving}>
-                No, cancel
-              </Button>
-            </Col>
-          </>
-        ) : null}
-      </Row>
-    </Strip>
+    <FormikForm<EmptyObject>
+      buttonsBordered={false}
+      cleanup={spaceActions.cleanup}
+      errors={errors}
+      initialValues={{}}
+      onCancel={handleClose}
+      onSubmit={() => {
+        dispatch(spaceActions.cleanup());
+        dispatch(spaceActions.delete(space.id));
+      }}
+      savedRedirect={urls.indexWithParams({ by: "fabric" })}
+      saved={saved}
+      saving={saving}
+      submitAppearance="negative"
+      submitDisabled={!canBeDeleted}
+      submitLabel="Delete space"
+    >
+      {canBeDeleted ? (
+        <Notification borderless severity="caution">
+          Are you sure you want to delete this space?
+        </Notification>
+      ) : (
+        <Notification borderless severity="negative">
+          Space cannot be deleted because it has subnets attached. Remove all
+          subnets from the space to allow deletion.
+        </Notification>
+      )}
+    </FormikForm>
   );
 };
 

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -57,7 +57,7 @@ it("shows the space name as the section title", () => {
   );
 });
 
-it("displays a delete confirmation before delete", () => {
+it("displays a delete confirmation before delete", async () => {
   const { store } = renderTestCase(
     spaceFactory({
       id: 1,
@@ -65,21 +65,24 @@ it("displays a delete confirmation before delete", () => {
       description: "space 1 description",
     })
   );
-  userEvent.click(screen.getByRole("button", { name: "Delete" }));
+  userEvent.click(screen.getByRole("button", { name: "Delete space" }));
   expect(
-    screen.getByText("Are you sure you want to delete space1 space?")
+    screen.getByText("Are you sure you want to delete this space?")
   ).toBeInTheDocument();
 
-  userEvent.click(screen.getByRole("button", { name: "Yes, delete space" }));
+  userEvent.click(screen.getByRole("button", { name: "Delete space" }));
 
-  const expectedActions = [spaceActions.delete(1)];
-  const actualActions = store.getActions();
-  expectedActions.forEach((expectedAction) => {
-    expect(
-      actualActions.find(
-        (actualAction) => actualAction.type === expectedAction.type
-      )
-    ).toStrictEqual(expectedAction);
+  const expectedActions = [spaceActions.cleanup(), spaceActions.delete(1)];
+
+  await waitFor(() => {
+    const actualActions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        actualActions.find(
+          (actualAction) => actualAction.type === expectedAction.type
+        )
+      ).toStrictEqual(expectedAction);
+    });
   });
 });
 
@@ -92,9 +95,9 @@ it("displays an error if there are any subnets on the space.", () => {
       subnet_ids: [1],
     })
   );
-  userEvent.click(screen.getByRole("button", { name: "Delete" }));
+  userEvent.click(screen.getByRole("button", { name: "Delete space" }));
   expect(screen.getByText(/Space cannot be deleted/)).toBeInTheDocument();
-  userEvent.click(screen.getByRole("button", { name: "Close notification" }));
+  userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
   expect(screen.queryByText(/Space cannot be deleted/)).not.toBeInTheDocument();
 });

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.tsx
@@ -17,12 +17,8 @@ const SpaceDetailsHeader = ({ space }: Props): JSX.Element => {
     <SectionHeader
       title={space.name}
       buttons={[
-        <Button
-          appearance="negative"
-          disabled={isDeleteOpen}
-          onClick={() => setIsDeleteOpen(true)}
-        >
-          Delete
+        <Button disabled={isDeleteOpen} onClick={() => setIsDeleteOpen(true)}>
+          Delete space
         </Button>,
       ]}
       headerContent={

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.tsx
@@ -1,7 +1,6 @@
-import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Col, Notification, Row } from "@canonical/react-components";
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikForm from "app/base/components/FormikForm";
@@ -29,34 +28,12 @@ export const DeleteSubnet = ({
     dispatch(subnetActions.fetch());
   }, [dispatch]);
 
-  let message: ReactNode;
-
-  if (canBeDeleted) {
-    message = (
-      <>
-        <p>Are you sure you want to delete this subnet?</p>
-        {dhcpEnabled ? null : (
-          <p>
-            Beware IP addresses on devices on this subnet might not be retained.
-          </p>
-        )}
-      </>
-    );
-  } else {
-    message = (
-      <Notification inline severity="negative" title="Error:">
-        This subnet cannot be deleted as there are nodes that have an IP address
-        obtained through DHCP services on this subnet. Release these nodes in
-        order to proceed.
-      </Notification>
-    );
-  }
-
   return (
-    <TitledSection title="Delete subnet?" headingVisuallyHidden>
-      <Row>
-        <Col size={8}>{message}</Col>
-      </Row>
+    <TitledSection
+      className="u-no-padding"
+      headingVisuallyHidden
+      title="Delete subnet?"
+    >
       <FormikForm<EmptyObject>
         aria-label="Delete subnet"
         buttonsBordered={false}
@@ -73,7 +50,26 @@ export const DeleteSubnet = ({
         submitAppearance="negative"
         submitDisabled={!canBeDeleted}
         submitLabel="Delete"
-      />
+      >
+        {canBeDeleted ? (
+          <Notification borderless severity="caution">
+            Are you sure you want to delete this subnet?
+            {dhcpEnabled ? null : (
+              <>
+                <br />
+                Beware IP addresses on devices on this subnet might not be
+                retained.
+              </>
+            )}
+          </Notification>
+        ) : (
+          <Notification borderless severity="negative">
+            This subnet cannot be deleted as there are nodes that have an IP
+            address obtained through DHCP services on this subnet. Release these
+            nodes in order to proceed.
+          </Notification>
+        )}
+      </FormikForm>
     </TitledSection>
   );
 };

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.tsx
@@ -56,12 +56,12 @@ const VLANDeleteForm = ({ closeForm, id }: Props): JSX.Element | null => {
       submitLabel="Delete VLAN"
     >
       {isDefaultVLAN ? (
-        <Notification borderless inline severity="negative">
+        <Notification borderless severity="negative">
           This VLAN cannot be deleted because it is the default VLAN for{" "}
           <FabricLink id={fabric.id} />.
         </Notification>
       ) : (
-        <Notification borderless inline severity="caution">
+        <Notification borderless severity="caution">
           Are you sure you want to delete this VLAN?
         </Notification>
       )}


### PR DESCRIPTION
## Done

- Standardise how each of the network delete forms work, i.e. notifications, cleanup, styling.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the subnets list and delete one of each of a fabric, VLAN, subnet and space
- Check that they all function the same way

## Fixes

Fixes canonical-web-and-design/app-tribe#884
