### PR TITLE
fix(ui): fix mobile logout button width

### DIFF
--- a/legacy/src/scss/_vanilla-overrides.scss
+++ b/legacy/src/scss/_vanilla-overrides.scss
@@ -1,0 +1,9 @@
+@media screen and (max-width: $breakpoint-small) {
+  // 29-04-2022 Huw: Fix for navigation buttons not being full width inside the
+  // mobile menu.
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/4444
+  button.p-navigation__link {
+    text-align: left;
+    width: 100%;
+  }
+}

--- a/legacy/src/scss/_vanilla-overrides.scss
+++ b/legacy/src/scss/_vanilla-overrides.scss
@@ -1,4 +1,4 @@
-@media screen and (max-width: $breakpoint-small) {
+@media screen and (max-width: $breakpoint-navigation-threshold) {
   // 29-04-2022 Huw: Fix for navigation buttons not being full width inside the
   // mobile menu.
   // https://github.com/canonical-web-and-design/vanilla-framework/issues/4444

--- a/legacy/src/scss/build.scss
+++ b/legacy/src/scss/build.scss
@@ -18,6 +18,7 @@
 @import "2.0-migration";
 
 @import "utils";
+@import "vanilla-overrides";
 // Import local patterns
 @import "maas";
 @import "base_typography";

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -63,4 +63,12 @@ input[type="radio"] {
       margin-bottom: $sph--x-small;
     }
   }
+
+  // 29-04-2022 Huw: Fix for navigation buttons not being full width inside the
+  // mobile menu.
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/4444
+  button.p-navigation__link {
+    text-align: left;
+    width: 100%;
+  }
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -63,7 +63,9 @@ input[type="radio"] {
       margin-bottom: $sph--x-small;
     }
   }
+  }
 
+  @media screen and (max-width: $breakpoint-navigation-threshold) {
   // 29-04-2022 Huw: Fix for navigation buttons not being full width inside the
   // mobile menu.
   // https://github.com/canonical-web-and-design/vanilla-framework/issues/4444


### PR DESCRIPTION
## Done

- Fix the width of the logout button in the mobile menu.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the full client (`yarn start`).
- Go to a react page and resize down to mobile width.
- Open the mobile navigation menu.
- Check that the logout button is full width.
- Go to a controller details page and resize down to mobile width.
- Open the mobile navigation menu.
- Check that the logout button is full width.

## Fixes

Fixes: canonical-web-and-design/app-tribe#866.

## Screenshot

<img width="549" alt="Screen Shot 2022-04-29 at 3 22 36 pm" src="https://user-images.githubusercontent.com/361637/165889751-3cdbb8e4-470e-4bcc-a47e-28525d69fc34.png">
