### PR TITLE
fix: delete machine is missing machine name

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -5,7 +5,7 @@ import { Spinner, Strip } from "@canonical/react-components";
 import type { FormikFormProps } from "app/base/components/FormikForm";
 import FormikForm from "app/base/components/FormikForm";
 import { useProcessing } from "app/base/hooks";
-import { NodeActions } from "app/store/types/node";
+import { getNodeActionLabel } from "app/store/utils";
 
 const getLabel = (
   modelName: string,
@@ -27,72 +27,7 @@ const getLabel = (
     // e.g. "2 machines"
     modelString = `${selectedCount} ${modelName}s`;
   }
-
-  switch (actionName) {
-    case NodeActions.ABORT:
-      return `${processing ? "Aborting" : "Abort"} actions for ${modelString}`;
-    case NodeActions.ACQUIRE:
-      return `${processing ? "Allocating" : "Allocate"} ${modelString}`;
-    case NodeActions.CLONE:
-      return processing ? "Cloning in progress" : `Clone to ${modelString}`;
-    case NodeActions.COMMISSION:
-      return `${
-        processing ? "Starting" : "Start"
-      } commissioning for ${modelString}`;
-    case "compose":
-      return `${processing ? "Composing" : "Compose"} ${modelString}`;
-    case NodeActions.DELETE:
-      return `${processing ? "Deleting" : "Delete"} ${modelString}`;
-    case NodeActions.DEPLOY:
-      return `${
-        processing ? "Starting" : "Start"
-      } deployment for ${modelString}`;
-    case NodeActions.EXIT_RESCUE_MODE:
-      return `${
-        processing ? "Exiting" : "Exit"
-      } rescue mode for ${modelString}`;
-    case NodeActions.IMPORT_IMAGES:
-      return `${
-        processing ? "Importing images" : "Import images"
-      } for ${modelString}`;
-    case NodeActions.LOCK:
-      return `${processing ? "Locking" : "Lock"} ${modelString}`;
-    case NodeActions.ON:
-      return `${processing ? "Powering" : "Power"} on ${modelString}`;
-    case NodeActions.OFF:
-      return `${processing ? "Powering" : "Power"} off ${modelString}`;
-    case NodeActions.MARK_BROKEN:
-      return `${processing ? "Marking" : "Mark"} ${modelString} broken`;
-    case NodeActions.MARK_FIXED:
-      return `${processing ? "Marking" : "Mark"} ${modelString} fixed`;
-    case NodeActions.OVERRIDE_FAILED_TESTING:
-      return `${
-        processing ? "Overriding" : "Override"
-      } failed tests for ${modelString}`;
-    case NodeActions.RELEASE:
-      return `${processing ? "Releasing" : "Release"} ${modelString}`;
-    case "refresh":
-      return `${processing ? "Refreshing" : "Refresh"} ${modelString}`;
-    case "remove":
-      return `${processing ? "Removing" : "Remove"} ${modelString}`;
-    case NodeActions.RESCUE_MODE:
-      return `${
-        processing ? "Entering" : "Enter"
-      } rescue mode for ${modelString}`;
-    case NodeActions.SET_POOL:
-      return `${processing ? "Setting" : "Set"} pool for ${modelString}`;
-    case NodeActions.SET_ZONE:
-      return `${processing ? "Setting" : "Set"} zone for ${modelString}`;
-    case NodeActions.TAG:
-    case NodeActions.UNTAG:
-      return `${processing ? "Updating" : "Update"} tags for ${modelString}`;
-    case NodeActions.TEST:
-      return `${processing ? "Starting" : "Start"} tests for ${modelString}`;
-    case NodeActions.UNLOCK:
-      return `${processing ? "Unlocking" : "Unlock"} ${modelString}`;
-    default:
-      return `${processing ? "Processing" : "Process"} ${modelString}`;
-  }
+  return getNodeActionLabel(modelString, actionName, processing);
 };
 
 export type Props<V, E = null> = Omit<

--- a/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
+++ b/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+
+import NodeActionConfirmationText from "./NodeActionConfirmationText";
+
+import { NodeActions } from "app/store/types/node";
+import { machine as machineFactory } from "testing/factories";
+
+it("displays correct confirmation text for deleting a single node", () => {
+  render(
+    <NodeActionConfirmationText
+      nodes={[machineFactory({ fqdn: "test" })]}
+      action={NodeActions.DELETE}
+    />
+  );
+  expect(
+    screen.getByText("Are you sure you want to delete test?")
+  ).toBeInTheDocument();
+});
+
+it("displays correct confirmation text for deleting multiple nodes", () => {
+  render(
+    <NodeActionConfirmationText
+      nodes={[
+        machineFactory({ fqdn: "test" }),
+        machineFactory({ fqdn: "test2" }),
+      ]}
+      action={NodeActions.DELETE}
+    />
+  );
+  expect(
+    screen.getByText(/Are you sure you want to delete the following?/)
+  ).toBeInTheDocument();
+  expect(screen.getByText(/test, test2/)).toBeInTheDocument();
+});

--- a/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
+++ b/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
@@ -8,6 +8,7 @@ import { machine as machineFactory } from "testing/factories";
 it("displays correct confirmation text for deleting a single node", () => {
   render(
     <NodeActionConfirmationText
+      modelName="machine"
       nodes={[machineFactory({ fqdn: "test" })]}
       action={NodeActions.DELETE}
     />
@@ -20,6 +21,7 @@ it("displays correct confirmation text for deleting a single node", () => {
 it("displays correct confirmation text for deleting multiple nodes", () => {
   render(
     <NodeActionConfirmationText
+      modelName="machine"
       nodes={[
         machineFactory({ fqdn: "test" }),
         machineFactory({ fqdn: "test2" }),
@@ -28,7 +30,6 @@ it("displays correct confirmation text for deleting multiple nodes", () => {
     />
   );
   expect(
-    screen.getByText(/Are you sure you want to delete the following?/)
+    screen.getByText(/Are you sure you want to delete 2 machines?/)
   ).toBeInTheDocument();
-  expect(screen.getByText(/test, test2/)).toBeInTheDocument();
 });

--- a/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.tsx
+++ b/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.tsx
@@ -1,21 +1,25 @@
 import type { Node, NodeActions } from "app/store/types/node";
-import { getNodeActionTitle } from "app/store/utils";
+import { getNodeActionLabel } from "app/store/utils";
 
 const NodeActionConfirmationText = ({
   nodes,
   action,
+  modelName,
 }: {
   nodes: Node[];
   action: NodeActions;
+  modelName: string;
 }): JSX.Element => (
   <>
     <p>
-      Are you sure you want to {getNodeActionTitle(action)}{" "}
-      {nodes.length > 1 ? " the following?" : nodes[0].fqdn}?
+      Are you sure you want to{" "}
+      {getNodeActionLabel(
+        nodes.length > 1 ? `${nodes.length} ${modelName}s` : nodes[0].fqdn,
+        action,
+        false
+      ).toLowerCase()}
+      ?
     </p>
-    {nodes.length > 1 ? (
-      <p>{nodes.map((node) => `${node.fqdn}`).join(", ")}</p>
-    ) : null}
   </>
 );
 

--- a/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.tsx
+++ b/ui/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.tsx
@@ -1,0 +1,22 @@
+import type { Node, NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils";
+
+const NodeActionConfirmationText = ({
+  nodes,
+  action,
+}: {
+  nodes: Node[];
+  action: NodeActions;
+}): JSX.Element => (
+  <>
+    <p>
+      Are you sure you want to {getNodeActionTitle(action)}{" "}
+      {nodes.length > 1 ? " the following?" : nodes[0].fqdn}?
+    </p>
+    {nodes.length > 1 ? (
+      <p>{nodes.map((node) => `${node.fqdn}`).join(", ")}</p>
+    ) : null}
+  </>
+);
+
+export default NodeActionConfirmationText;

--- a/ui/src/app/base/components/NodeActionConfirmationText/index.ts
+++ b/ui/src/app/base/components/NodeActionConfirmationText/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeActionConfirmationText";

--- a/ui/src/app/base/components/node/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/base/components/node/DeleteForm/DeleteForm.tsx
@@ -1,6 +1,6 @@
 import { Redirect } from "react-router-dom";
 
-import MachineActionConfirmationText from "../../NodeActionConfirmationText";
+import NodeActionConfirmationText from "../../NodeActionConfirmationText";
 import type { NodeActionFormProps } from "../types";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -55,9 +55,10 @@ export const DeleteForm = <E,>({
       selectedCount={nodes.length}
       submitAppearance="negative"
     >
-      <MachineActionConfirmationText
+      <NodeActionConfirmationText
         nodes={nodes}
         action={NodeActions.DELETE}
+        modelName={modelName}
       />
     </ActionForm>
   );

--- a/ui/src/app/base/components/node/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/base/components/node/DeleteForm/DeleteForm.tsx
@@ -1,5 +1,6 @@
 import { Redirect } from "react-router-dom";
 
+import MachineActionConfirmationText from "../../NodeActionConfirmationText";
 import type { NodeActionFormProps } from "../types";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -53,7 +54,12 @@ export const DeleteForm = <E,>({
       processingCount={processingCount}
       selectedCount={nodes.length}
       submitAppearance="negative"
-    />
+    >
+      <MachineActionConfirmationText
+        nodes={nodes}
+        action={NodeActions.DELETE}
+      />
+    </ActionForm>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -67,6 +67,18 @@ const MachineHeader = ({
 
   return (
     <SectionHeader
+      title={
+        headerContent ? (
+          getHeaderTitle(machine.hostname, headerContent)
+        ) : (
+          <MachineName
+            editingName={editingName}
+            id={systemId}
+            setEditingName={setEditingName}
+          />
+        )
+      }
+      titleElement={editingName ? "div" : "h1"}
       buttons={[
         <NodeActionMenu
           alwaysShowLifecycle
@@ -223,18 +235,6 @@ const MachineHeader = ({
           to: `${urlBase}/configuration`,
         },
       ]}
-      title={
-        headerContent ? (
-          getHeaderTitle(machine.hostname, headerContent)
-        ) : (
-          <MachineName
-            editingName={editingName}
-            id={systemId}
-            setEditingName={setEditingName}
-          />
-        )
-      }
-      titleElement={editingName ? "div" : "h1"}
     />
   );
 };

--- a/ui/src/app/store/utils/index.ts
+++ b/ui/src/app/store/utils/index.ts
@@ -1,6 +1,7 @@
 export {
   canOpenActionForm,
   getNodeActionTitle,
+  getNodeActionLabel,
   getNodeTypeDisplay,
   nodeIsController,
   nodeIsDevice,

--- a/ui/src/app/store/utils/node/base.ts
+++ b/ui/src/app/store/utils/node/base.ts
@@ -91,6 +91,80 @@ export const getNodeActionTitle = (actionName: NodeActions): string => {
   }
 };
 
+export const getNodeActionLabel = (
+  modelString: string,
+  actionName: string,
+  isProcessing: boolean
+): string => {
+  switch (actionName) {
+    case NodeActions.ABORT:
+      return `${
+        isProcessing ? "Aborting" : "Abort"
+      } actions for ${modelString}`;
+    case NodeActions.ACQUIRE:
+      return `${isProcessing ? "Allocating" : "Allocate"} ${modelString}`;
+    case NodeActions.CLONE:
+      return isProcessing ? "Cloning in progress" : `Clone to ${modelString}`;
+    case NodeActions.COMMISSION:
+      return `${
+        isProcessing ? "Starting" : "Start"
+      } commissioning for ${modelString}`;
+    case "compose":
+      return `${isProcessing ? "Composing" : "Compose"} ${modelString}`;
+    case NodeActions.DELETE:
+      return `${isProcessing ? "Deleting" : "Delete"} ${modelString}`;
+    case NodeActions.DEPLOY:
+      return `${
+        isProcessing ? "Starting" : "Start"
+      } deployment for ${modelString}`;
+    case NodeActions.EXIT_RESCUE_MODE:
+      return `${
+        isProcessing ? "Exiting" : "Exit"
+      } rescue mode for ${modelString}`;
+    case NodeActions.IMPORT_IMAGES:
+      return `${
+        isProcessing ? "Importing images" : "Import images"
+      } for ${modelString}`;
+    case NodeActions.LOCK:
+      return `${isProcessing ? "Locking" : "Lock"} ${modelString}`;
+    case NodeActions.ON:
+      return `${isProcessing ? "Powering" : "Power"} on ${modelString}`;
+    case NodeActions.OFF:
+      return `${isProcessing ? "Powering" : "Power"} off ${modelString}`;
+    case NodeActions.MARK_BROKEN:
+      return `${isProcessing ? "Marking" : "Mark"} ${modelString} broken`;
+    case NodeActions.MARK_FIXED:
+      return `${isProcessing ? "Marking" : "Mark"} ${modelString} fixed`;
+    case NodeActions.OVERRIDE_FAILED_TESTING:
+      return `${
+        isProcessing ? "Overriding" : "Override"
+      } failed tests for ${modelString}`;
+    case NodeActions.RELEASE:
+      return `${isProcessing ? "Releasing" : "Release"} ${modelString}`;
+    case "refresh":
+      return `${isProcessing ? "Refreshing" : "Refresh"} ${modelString}`;
+    case "remove":
+      return `${isProcessing ? "Removing" : "Remove"} ${modelString}`;
+    case NodeActions.RESCUE_MODE:
+      return `${
+        isProcessing ? "Entering" : "Enter"
+      } rescue mode for ${modelString}`;
+    case NodeActions.SET_POOL:
+      return `${isProcessing ? "Setting" : "Set"} pool for ${modelString}`;
+    case NodeActions.SET_ZONE:
+      return `${isProcessing ? "Setting" : "Set"} zone for ${modelString}`;
+    case NodeActions.TAG:
+    case NodeActions.UNTAG:
+      return `${isProcessing ? "Updating" : "Update"} tags for ${modelString}`;
+    case NodeActions.TEST:
+      return `${isProcessing ? "Starting" : "Start"} tests for ${modelString}`;
+    case NodeActions.UNLOCK:
+      return `${isProcessing ? "Unlocking" : "Unlock"} ${modelString}`;
+    default:
+      return `${isProcessing ? "Processing" : "Process"} ${modelString}`;
+  }
+};
+
 // TODO: Replace NodeLinkType with NodeType when it is made available on all
 // node list types.
 // https://bugs.launchpad.net/maas/+bug/1951893


### PR DESCRIPTION
## Done

- fix: delete machine is missing machine name
- add NodeActionConfirmationText component

## Screenshots
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/7452681/166704578-09325a3e-c2ec-4513-96c2-bce28a85b2b7.png">
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/7452681/166704644-49681556-2395-4a24-9d74-877e039a431e.png">
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/7452681/166704703-6cfdfbd3-61e2-4416-ab02-8a8cbf8d4344.png">


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Try to delete a machine/multiple machines and verify that their names are displayed in the confirmation dialog.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/887

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
