### PR TITLE
fix(ui): fix styling of machine logs download button

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
@@ -112,9 +112,8 @@ export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
     return null;
   }
   return (
-    <div>
+    <div className="download-menu">
       <ContextualMenu
-        className="download-menu"
         hasToggleIcon
         links={[
           ...generateItem(

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/_index.scss
@@ -1,5 +1,11 @@
 @mixin DownloadMenu {
   .download-menu {
-    @extend %vf-pseudo-border--bottom;
+    text-align: right;
+
+    @media only screen and (min-width: $breakpoint-small) {
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
   }
 }

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -31,9 +31,8 @@ const MachineLogs = ({ systemId }: Props): JSX.Element => {
   );
   return (
     <>
-      <div className="u-flex">
+      <div className="u-position--relative">
         <Tabs
-          className="u-flex--grow"
           links={[
             {
               active:

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -169,6 +169,10 @@
     color: $color-mid-dark !important;
   }
 
+  .u-position--relative {
+    position: relative !important;
+  }
+
   .u-upper-case--first:first-letter {
     text-transform: capitalize;
   }


### PR DESCRIPTION
## Done

- Fixed styling of machine logs download button

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the "Logs" tab for a machine
- Check that the "Download" button looks normal on all screen sizes

## Fixes

Fixes canonical-web-and-design/app-tribe#874

