### PR TITLE
feat(ui): add docs links to native TLS pages

### DIFF
--- a/ui/src/app/base/docsUrls.ts
+++ b/ui/src/app/base/docsUrls.ts
@@ -1,29 +1,33 @@
 const docsUrls = {
+  aboutNativeTLS:
+    "https://maas.io/docs/how-to-enable-tls-encryption#heading--about-maas-native-tls",
+  addMachines:
+    "https://maas.io/docs/how-to-manage-machines#heading--how-to-create-delete-and-configure-machines",
+  addNodesViaChassis:
+    "https://maas.io/docs/how-to-manage-machines#heading--how-to-add-machines-via-a-chassis",
+  autoRenewTLSCert:
+    "https://maas.io/docs/how-to-enable-tls-encryption#heading--about-auto-renewal-for-certificates",
+  cloudInit:
+    "https://maas.io/docs/how-to-customise-machines#heading--cloud-init",
+  configurationJourney:
+    "https://maas.io/docs/how-to-install-maas#heading--configure-maas",
   customisingDeployedMachines:
     "https://maas.io/docs/about-customising-machines#heading--about-customising-deployed-machines",
   dhcp: "https://maas.io/docs/how-to-manage-dhcp",
-  sshKeys: "https://maas.io/docs/how-to-manage-user-accounts#heading--ssh-keys",
-  rackController: "https://maas.io/docs/how-to-manage-racks",
-  networkDiscovery:
-    "https://maas.io/docs/about-networking#heading--about-network-discovery",
-  configurationJourney:
-    "https://maas.io/docs/how-to-install-maas#heading--configure-maas",
-  cloudInit:
-    "https://maas.io/docs/how-to-customise-machines#heading--cloud-init",
-  kvmIntroduction: "https://maas.io/docs/about-vm-hosting",
-  addNodesViaChassis:
-    "https://maas.io/docs/how-to-manage-machines#heading--how-to-add-machines-via-a-chassis",
-  addMachines:
-    "https://maas.io/docs/how-to-manage-machines#heading--how-to-create-delete-and-configure-machines",
   images: "https://maas.io/docs/about-images",
   ipmi: "https://maas.io/docs/power-management-reference#heading--ipmi",
   ipRanges: "https://maas.io/docs/how-to-manage-ip-ranges",
-  tagsXpathExpressions:
-    "https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions",
-  tagsKernelOptions:
-    "https://maas.io/docs/how-to-work-with-tags#heading--kernel-options",
+  kvmIntroduction: "https://maas.io/docs/about-vm-hosting",
+  networkDiscovery:
+    "https://maas.io/docs/about-networking#heading--about-network-discovery",
+  rackController: "https://maas.io/docs/how-to-manage-racks",
+  sshKeys: "https://maas.io/docs/how-to-manage-user-accounts#heading--ssh-keys",
   tagsAutomatic:
     "https://maas.io/docs/how-to-work-with-tags#heading--automatic-tags",
-};
+  tagsKernelOptions:
+    "https://maas.io/docs/how-to-work-with-tags#heading--kernel-options",
+  tagsXpathExpressions:
+    "https://maas.io/docs/how-to-work-with-tags#heading--xpath-expressions",
+} as const;
 
 export default docsUrls;

--- a/ui/src/app/settings/views/Configuration/Security/TLSDisabled/TLSDisabled.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSDisabled/TLSDisabled.tsx
@@ -4,6 +4,8 @@ import {
   Icon,
 } from "@canonical/react-components";
 
+import docsUrls from "app/base/docsUrls";
+
 const TLSDisabled = (): JSX.Element => {
   return (
     <>
@@ -24,11 +26,13 @@ const TLSDisabled = (): JSX.Element => {
         ]}
       />
       <p>
-        {/*
-          TODO: Add docs links
-          https://github.com/canonical-web-and-design/app-tribe/issues/829
-        */}
-        <a href="#todo">More about MAAS native TLS</a>
+        <a
+          href={docsUrls.aboutNativeTLS}
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          More about MAAS native TLS
+        </a>
       </p>
     </>
   );

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/TLSEnabledFields.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/TLSEnabledFields.tsx
@@ -5,6 +5,7 @@ import type { TLSEnabledValues } from "../TLSEnabled";
 import { Labels } from "../TLSEnabled";
 
 import FormikField from "app/base/components/FormikField";
+import docsUrls from "app/base/docsUrls";
 import { TLSExpiryNotificationInterval } from "app/store/config/types";
 
 const TLSEnabledFields = (): JSX.Element => {
@@ -40,11 +41,13 @@ const TLSEnabledFields = (): JSX.Element => {
         />
       </div>
       <p>
-        {/*
-          TODO: Add docs links
-          https://github.com/canonical-web-and-design/app-tribe/issues/829
-        */}
-        <a href="#todo">How to set up auto-renew for certificates</a>
+        <a
+          href={docsUrls.autoRenewTLSCert}
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          How to set up auto-renew for certificates
+        </a>
       </p>
     </>
   );


### PR DESCRIPTION
## Done

- Added docs links to native TLS pages

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Settings > Security page of a MAAS with TLS disabled
- Check that the docs link takes you [here](https://maas.io/docs/how-to-enable-tls-encryption#heading--about-maas-native-tls)
- Go to the Settings > Security page of a MAAS with TLS enabled
- Check that the docs link takes you [here](https://maas.io/docs/how-to-enable-tls-encryption#heading--about-auto-renewal-for-certificates)

## Fixes

Fixes canonical-web-and-design/app-tribe#829
