### PR TITLE
fix(ui): fix instances of tooltip icons not using buttons

### DIFF
--- a/ui/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/ui/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -3,10 +3,10 @@ import {
   TableCell,
   TableHeader,
   TableRow,
-  Tooltip,
 } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import TooltipButton from "app/base/components/TooltipButton";
 import fabricSelectors from "app/store/fabric/selectors";
 import { getFabricDisplay } from "app/store/fabric/utils";
 import type { NetworkInterface } from "app/store/types/node";
@@ -29,11 +29,11 @@ const NetworkCardInterface = ({ interfaces }: Props): JSX.Element => {
           <TableHeader className="speed">Link speed</TableHeader>
           <TableHeader className="fabric">
             Fabric
-            <Tooltip message="Untagged traffic only" position="top-right">
-              <div className="u-nudge-right--small">
-                <i className="p-icon--information"></i>
-              </div>
-            </Tooltip>
+            <TooltipButton
+              className="u-nudge-right--small"
+              message="Untagged traffic only"
+              position="top-right"
+            />
           </TableHeader>
           <TableHeader className="dhcp">DHCP</TableHeader>
           <TableHeader className="sriov">SR-IOV</TableHeader>
@@ -64,14 +64,11 @@ const NetworkCardInterface = ({ interfaces }: Props): JSX.Element => {
               <TableCell data-heading="DHCP" className="dhcp">
                 {dhcpStatus}
                 {dhcpStatus === "Relayed" && (
-                  <Tooltip
+                  <TooltipButton
+                    className="u-nudge-right--small"
                     message={getDHCPStatus(vlan, vlans, fabrics, true)}
                     position="btm-right"
-                  >
-                    <div className="u-nudge-right--small">
-                      <i className="p-icon--information"></i>
-                    </div>
-                  </Tooltip>
+                  />
                 )}
               </TableCell>
               <TableCell data-heading="SR-IOV" className="sriov">

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
@@ -1,17 +1,11 @@
-import {
-  Col,
-  Link,
-  Row,
-  Select,
-  Textarea,
-  Tooltip,
-} from "@canonical/react-components";
+import { Col, Link, Row, Select, Textarea } from "@canonical/react-components";
 import type { ColSize } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { SSHKeyFormValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import TooltipButton from "app/base/components/TooltipButton";
 import { COL_SIZES } from "app/base/constants";
 import docsUrls from "app/base/docsUrls";
 
@@ -58,12 +52,13 @@ export const SSHKeyFormFields = ({
               label={
                 <>
                   Public key{" "}
-                  <Tooltip
+                  <TooltipButton
+                    iconName="help"
                     position="btm-left"
-                    message={`Begins with 'ssh-rsa', 'ssh-dss', 'ssh-ed25519',\n 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', or\n 'ecdsa-sha2-nistp521`}
-                  >
-                    <i className="p-icon--help"></i>
-                  </Tooltip>
+                    message={`Begins with 'ssh-rsa', 'ssh-dss', 'ssh-ed25519',
+                    'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', or
+                    'ecdsa-sha2-nistp521`}
+                  />
                 </>
               }
               style={{ minHeight: "10rem" }}

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.tsx
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.tsx
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import ScriptStatus from "./ScriptStatus";
 
@@ -59,5 +59,20 @@ describe("ScriptStatus", () => {
       <ScriptStatus status={ScriptResultStatus.PASSED} />
     );
     expect(wrapper.find("Icon").prop("className")).toBe("");
+  });
+
+  it("can have its icon wrapped in a tooltip", () => {
+    const wrapper = mount(
+      <ScriptStatus
+        status={ScriptResultStatus.PASSED}
+        tooltipMessage="Tooltip!"
+        tooltipPosition="top-right"
+      />
+    );
+
+    expect(wrapper.find("[role='tooltip']").text()).toBe("Tooltip!");
+    expect(wrapper.find("[className*='p-tooltip--top-right']").exists()).toBe(
+      true
+    );
   });
 });

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.tsx
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.tsx
@@ -1,12 +1,16 @@
 import { Icon } from "@canonical/react-components";
+import type { Position } from "@canonical/react-components/dist/components/Tooltip/Tooltip";
 import classNames from "classnames";
 
+import TooltipButton from "app/base/components/TooltipButton";
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import { TestStatusStatus } from "app/store/types/node";
 
 type Props = {
   children?: React.ReactNode;
   status: ScriptResultStatus | TestStatusStatus;
+  tooltipMessage?: React.ReactNode;
+  tooltipPosition?: Position;
 };
 
 const getIconName = (status: ScriptResultStatus | TestStatusStatus): string => {
@@ -41,8 +45,30 @@ const getIconName = (status: ScriptResultStatus | TestStatusStatus): string => {
   }
 };
 
-const ScriptStatus = ({ children, status }: Props): JSX.Element => {
+const ScriptStatus = ({
+  children,
+  status,
+  tooltipMessage,
+  tooltipPosition,
+}: Props): JSX.Element => {
   const iconName = getIconName(status);
+
+  if (tooltipMessage) {
+    return (
+      <>
+        <TooltipButton
+          className={classNames({
+            "u-nudge-left--x-small":
+              children !== null && children !== undefined,
+          })}
+          iconName={iconName}
+          message={tooltipMessage}
+          position={tooltipPosition}
+        />
+        {children}
+      </>
+    );
+  }
 
   return (
     <span>

--- a/ui/src/app/base/components/TooltipButton/TooltipButton.test.tsx
+++ b/ui/src/app/base/components/TooltipButton/TooltipButton.test.tsx
@@ -20,7 +20,8 @@ it("can override default props", () => {
     <TooltipButton
       buttonProps={{ appearance: "negative", className: "button-class" }}
       data-testid="tooltip-portal"
-      iconProps={{ className: "icon-class", name: "warning" }}
+      iconName="warning"
+      iconProps={{ className: "icon-class" }}
       message="Tooltip"
       tooltipClassName="tooltip-class"
     />

--- a/ui/src/app/base/components/TooltipButton/TooltipButton.tsx
+++ b/ui/src/app/base/components/TooltipButton/TooltipButton.tsx
@@ -13,12 +13,14 @@ import { breakLines, unindentString } from "app/utils";
 type Props = Omit<TooltipProps, "children"> & {
   buttonProps?: SubComponentProps<ButtonProps>;
   children?: ReactNode;
-  iconProps?: SubComponentProps<IconProps>;
+  iconName?: IconProps["name"];
+  iconProps?: SubComponentProps<Omit<IconProps, "name">>;
 };
 
 const TooltipButton = ({
   buttonProps,
   children,
+  iconName = "information",
   iconProps,
   message,
   ...tooltipProps
@@ -34,13 +36,13 @@ const TooltipButton = ({
     >
       <Button
         appearance="base"
-        className="u-display--block u-no-border u-no-margin"
+        className="u-no-border u-no-margin u-text--default-size"
         hasIcon
         small
         type="button"
         {...buttonProps}
       >
-        {children || <Icon name="information" {...iconProps} />}
+        {children || <Icon name={iconName} {...iconProps} />}
       </Button>
     </Tooltip>
   );

--- a/ui/src/app/base/components/TooltipButton/TooltipButton.tsx
+++ b/ui/src/app/base/components/TooltipButton/TooltipButton.tsx
@@ -10,14 +10,16 @@ import { Button, Icon, Tooltip } from "@canonical/react-components";
 
 import { breakLines, unindentString } from "app/utils";
 
-type Props = Omit<TooltipProps, "children"> & {
-  buttonProps?: SubComponentProps<ButtonProps>;
+type Props = Omit<TooltipProps, "aria-label" | "children"> & {
+  "aria-label"?: ButtonProps["aria-label"];
+  buttonProps?: SubComponentProps<Omit<ButtonProps, "aria-label">>;
   children?: ReactNode;
   iconName?: IconProps["name"];
   iconProps?: SubComponentProps<Omit<IconProps, "name">>;
 };
 
 const TooltipButton = ({
+  "aria-label": ariaLabel,
   buttonProps,
   children,
   iconName = "information",
@@ -36,13 +38,15 @@ const TooltipButton = ({
     >
       <Button
         appearance="base"
-        className="u-no-border u-no-margin u-text--default-size"
+        aria-label={ariaLabel}
+        className="u-no-border u-no-line-height u-no-margin"
         hasIcon
         small
         type="button"
         {...buttonProps}
       >
-        {children || <Icon name={iconName} {...iconProps} />}
+        {children}
+        {iconName ? <Icon name={iconName} {...iconProps} /> : null}
       </Button>
     </Tooltip>
   );

--- a/ui/src/app/base/components/TooltipButton/__snapshots__/TooltipButton.test.tsx.snap
+++ b/ui/src/app/base/components/TooltipButton/__snapshots__/TooltipButton.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`renders with default options correctly 1`] = `
 exports[`renders with default options correctly 2`] = `
 <button
   aria-describedby="mock-nanoid-1"
-  class="p-button--base has-icon is-small u-no-border u-no-margin u-text--default-size"
+  class="p-button--base has-icon is-small u-no-border u-no-line-height u-no-margin"
   type="button"
 >
   <i

--- a/ui/src/app/base/components/TooltipButton/__snapshots__/TooltipButton.test.tsx.snap
+++ b/ui/src/app/base/components/TooltipButton/__snapshots__/TooltipButton.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`renders with default options correctly 1`] = `
 exports[`renders with default options correctly 2`] = `
 <button
   aria-describedby="mock-nanoid-1"
-  class="p-button--base has-icon is-small u-display--block u-no-border u-no-margin"
+  class="p-button--base has-icon is-small u-no-border u-no-margin u-text--default-size"
   type="button"
 >
   <i

--- a/ui/src/app/base/components/node/networking/DHCPColumn/DHCPColumn.tsx
+++ b/ui/src/app/base/components/node/networking/DHCPColumn/DHCPColumn.tsx
@@ -1,7 +1,8 @@
-import { Icon, Spinner, Tooltip } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import TooltipButton from "app/base/components/TooltipButton";
 import fabricSelectors from "app/store/fabric/selectors";
 import type { RootState } from "app/store/root/types";
 import type { NetworkInterface } from "app/store/types/node";
@@ -29,12 +30,10 @@ const DHCPColumn = ({ nic }: Props): JSX.Element | null => {
       data-testid="dhcp"
       icon={
         vlan && vlan.relay_vlan ? (
-          <Tooltip
+          <TooltipButton
             position="btm-right"
             message={getDHCPStatus(vlan, vlans, fabrics, true)}
-          >
-            <Icon name="information" />
-          </Tooltip>
+          />
         ) : null
       }
       iconSpace={true}

--- a/ui/src/app/base/components/node/networking/TypeColumn/TypeColumn.tsx
+++ b/ui/src/app/base/components/node/networking/TypeColumn/TypeColumn.tsx
@@ -1,6 +1,5 @@
-import { Icon, Tooltip } from "@canonical/react-components";
-
 import DoubleRow from "app/base/components/DoubleRow";
+import TooltipButton from "app/base/components/TooltipButton";
 import type { NetworkInterface, NetworkLink, Node } from "app/store/types/node";
 import { getInterfaceNumaNodes, getInterfaceTypeText } from "app/store/utils";
 
@@ -19,12 +18,11 @@ const TypeColumn = ({ link, nic, node }: Props): JSX.Element | null => {
       data-testid="type"
       icon={
         numaNodes && numaNodes.length > 1 ? (
-          <Tooltip
+          <TooltipButton
+            iconName="warning"
             position="top-left"
             message="This bond is spread over multiple NUMA nodes. This may lead to suboptimal performance."
-          >
-            <Icon name="warning" />
-          </Tooltip>
+          />
         ) : null
       }
       iconSpace={true}

--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
@@ -164,6 +164,6 @@ describe("ControllerStatus", () => {
       </Provider>
     );
     expect(wrapper.find("Icon").prop("name")).toEqual("power-unknown");
-    expect(wrapper.find("Tooltip").prop("message")).toBe(null);
+    expect(wrapper.find("Tooltip").exists()).toBe(false);
   });
 });

--- a/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
+++ b/ui/src/app/controllers/components/ControllerStatus/ControllerStatus.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
 
-import { Icon, Tooltip } from "@canonical/react-components";
+import { Icon } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
+import TooltipButton from "app/base/components/TooltipButton";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
@@ -54,11 +55,11 @@ export const ControllerStatus = ({ systemId }: Props): JSX.Element | null => {
   } else {
     icon = "power-unknown";
   }
-  return (
-    <Tooltip message={message}>
-      <Icon name={icon} />
-    </Tooltip>
-  );
+
+  if (message) {
+    return <TooltipButton iconName={icon} message={message} />;
+  }
+  return <Icon name={icon} />;
 };
 
 export default ControllerStatus;

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.tsx
@@ -1,6 +1,7 @@
-import { Icon, Tooltip } from "@canonical/react-components";
+import { Icon } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import TooltipButton from "app/base/components/TooltipButton";
 import ControllerStatus from "app/controllers/components/ControllerStatus";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
@@ -29,13 +30,13 @@ export const StatusColumn = ({ systemId }: Props): JSX.Element | null => {
   return issue ? (
     <span data-testid="version-error">
       <Icon name="error" />{" "}
-      <Tooltip
-        className="status-icon--negative-space"
+      <TooltipButton
         message={
           <>
             {issue}
             <br />
             <a
+              className="is-on-dark"
               href="https://discourse.maas.io/t/4555"
               rel="noreferrer noopener"
               target="_blank"
@@ -45,9 +46,7 @@ export const StatusColumn = ({ systemId }: Props): JSX.Element | null => {
           </>
         }
         position="top-center"
-      >
-        <Icon name="information" />
-      </Tooltip>
+      />
     </span>
   ) : (
     <ControllerStatus systemId={systemId} />

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/VersionColumn/VersionColumn.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/VersionColumn/VersionColumn.test.tsx
@@ -99,9 +99,7 @@ describe("VersionColumn", () => {
       </Provider>
     );
     expect(wrapper.find('[data-testid="origin"]').text()).toBe("Deb ");
-    expect(wrapper.find('[data-testid="origin-tooltip"]').prop("message")).toBe(
-      "stable"
-    );
+    expect(wrapper.find('[role="tooltip"]').text()).toBe("stable");
   });
 
   it("can display a cohort tooltip", () => {
@@ -119,7 +117,7 @@ describe("VersionColumn", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find('[data-testid="origin-tooltip"]').prop("message")).toBe(
+    expect(wrapper.find('[role="tooltip"]').text()).toBe(
       "Cohort key: \nMSBzaFkyMllUWjNSaEpKRE9qME1mbVNoVE5aVEViM \nUppcSAxNjE3MTgyOTcxIGJhM2VlYzQ2NDc5ZDdmNT \nI3NzIzNTUyMmRlOTc1MGIzZmNhYTI0MDE1MTQ3ZjV \nhM2ViNzQwZGZmYzk5OWFiYWU="
     );
   });

--- a/ui/src/app/controllers/views/ControllerList/ControllerListTable/VersionColumn/VersionColumn.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerListTable/VersionColumn/VersionColumn.tsx
@@ -1,7 +1,7 @@
-import { Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import TooltipButton from "app/base/components/TooltipButton";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
@@ -34,10 +34,7 @@ export const VersionColumn = ({ systemId }: Props): JSX.Element | null => {
         <span data-testid="version">
           {versions.current.version ?? (
             <>
-              Unknown{" "}
-              <Tooltip message="Less than 2.3.0">
-                <Icon name="information" />
-              </Tooltip>
+              Unknown <TooltipButton message="Less than 2.3.0" />
             </>
           )}
         </span>
@@ -50,12 +47,7 @@ export const VersionColumn = ({ systemId }: Props): JSX.Element | null => {
             {!!origin && <>{isDeb ? "Deb" : origin} </>}
           </span>
           {!!(cohortTooltip || isDeb) && (
-            <Tooltip
-              data-testid="origin-tooltip"
-              message={isDeb ? origin : cohortTooltip}
-            >
-              <Icon name="information" />
-            </Tooltip>
+            <TooltipButton message={isDeb ? origin : cohortTooltip} />
           )}
         </>
       }

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -5,8 +5,6 @@ import {
   Col,
   ContextualMenu,
   MainTable,
-  Tooltip,
-  Icon,
   Row,
   SearchBox,
   Spinner,
@@ -21,6 +19,7 @@ import DiscoveriesFilterAccordion from "./DiscoveriesFilterAccordion";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import TooltipButton from "app/base/components/TooltipButton";
 import { useWindowTitle } from "app/base/hooks";
 import { actions as discoveryActions } from "app/store/discovery";
 import discoverySelectors from "app/store/discovery/selectors";
@@ -94,13 +93,11 @@ const generateRows = (
             <>
               {name}
               {discovery.is_external_dhcp ? (
-                <Tooltip
+                <TooltipButton
+                  className="u-nudge-right--x-small"
                   message="This device is providing DHCP"
-                  className="u-nudge-right"
                   position="top-center"
-                >
-                  <Icon name="information" />
-                </Tooltip>
+                />
               ) : null}
             </>
           ),

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -1,4 +1,4 @@
-import { Col, Icon, Row, Select, Tooltip } from "@canonical/react-components";
+import { Col, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
@@ -8,6 +8,7 @@ import { DeviceType } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
+import TooltipButton from "app/base/components/TooltipButton";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import { DeviceMeta } from "app/store/device/types";
@@ -99,9 +100,7 @@ const DiscoveryAddFormFields = ({
               label={
                 <>
                   Device name{" "}
-                  <Tooltip message="Create as an interface on the selected device.">
-                    <Icon name="information" />
-                  </Tooltip>
+                  <TooltipButton message="Create as an interface on the selected device." />
                 </>
               }
               name={DeviceMeta.PK}
@@ -124,9 +123,7 @@ const DiscoveryAddFormFields = ({
               label={
                 <>
                   Parent{" "}
-                  <Tooltip message="Assign this device as a child of the parent machine.">
-                    <Icon name="information" />
-                  </Tooltip>
+                  <TooltipButton message="Assign this device as a child of the parent machine." />
                 </>
               }
               name="parent"

--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
@@ -111,9 +111,9 @@ describe("ArchSelect", () => {
         .findWhere((n) => n.name() === "Input" && n.prop("id") === "arch-i386")
         .prop("disabled")
     ).toBe(true);
-    expect(
-      wrapper.find("[data-testid='disabled-arch-tooltip']").prop("message")
-    ).toBe("i386 is not available on 20.04 LTS.");
+    expect(wrapper.find("[role='tooltip']").text()).toBe(
+      "i386 is not available on 20.04 LTS."
+    );
   });
 
   it(`disables a checkbox if it's the last checked arch for the default
@@ -149,9 +149,10 @@ describe("ArchSelect", () => {
     expect(archCheckbox.prop("checked")).toBe(true);
     expect(archCheckbox.prop("disabled")).toBe(true);
     expect(
-      archCheckbox.find("[data-testid='disabled-arch-tooltip']").prop("message")
-    ).toBe(
-      "At least one architecture must be selected for the default commissioning release."
-    );
+      archCheckbox
+        .find("[role='tooltip']")
+        .text()
+        .match(/At least one architecture must be selected/)
+    ).toBeTruthy();
   });
 });

--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
@@ -1,7 +1,8 @@
-import { Col, Icon, Input, Tooltip } from "@canonical/react-components";
+import { Col, Input } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
+import TooltipButton from "app/base/components/TooltipButton";
 import type { ImageValue } from "app/images/types";
 import type {
   BaseImageFields,
@@ -113,18 +114,15 @@ const ArchSelect = ({ arches, release, resources }: Props): JSX.Element => {
                 <span>
                   {arch.name}
                   {isDisabled(arch) && (
-                    <Tooltip
+                    <TooltipButton
                       className="u-nudge-right--small"
-                      data-testid="disabled-arch-tooltip"
                       message={
                         isLastCommissioningArch(arch)
                           ? "At least one architecture must be selected for the default commissioning release."
                           : `${arch.name} is not available on ${release.title}.`
                       }
                       positionElementClassName="u-display--inline"
-                    >
-                      <Icon name="help" />
-                    </Tooltip>
+                    />
                   )}
                 </span>
               }

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from "react";
 
-import { Icon, Spinner, Tooltip } from "@canonical/react-components";
+import { Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import SwitchField from "app/base/components/SwitchField";
+import TooltipButton from "app/base/components/TooltipButton";
 import { useCycled } from "app/base/hooks";
 import bootResourceSelectors from "app/store/bootresource/selectors";
 import type { BootResourceState } from "app/store/bootresource/types";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
-import { breakLines, unindentString } from "app/utils";
 
 const generateImportStatus = (
   rackImportRunning: BootResourceState["rackImportRunning"],
@@ -71,20 +71,15 @@ const ImageListHeader = (): JSX.Element => {
                   label={
                     <span>
                       <span>Automatically sync images</span>
-                      <Tooltip
+                      <TooltipButton
                         className="u-nudge-right--small"
-                        message={breakLines(
-                          unindentString(
-                            `Enables automatic image updates (sync). The region
-                      controller will check for new images every hour and
-                      automatically sync them, if available, from the stream
-                      configured below. Syncing at the rack controller level
-                      occurs every 5 minutes and cannot be disabled.`
-                          )
-                        )}
-                      >
-                        <Icon name="help"></Icon>
-                      </Tooltip>
+                        iconName="help"
+                        message={`Enables automatic image updates (sync). The
+                        region controller will check for new images every hour
+                        and automatically sync them, if available, from the
+                        stream configured below. Syncing at the rack controller
+                        level occurs every 5 minutes and cannot be disabled.`}
+                      />
                     </span>
                   }
                   onChange={() => {

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -2,14 +2,11 @@ import { useState } from "react";
 import * as React from "react";
 
 import {
-  Button,
   Col,
-  Icon,
   Input,
   Notification,
   Row,
   Select,
-  Tooltip,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
@@ -19,6 +16,7 @@ import { Link } from "react-router-dom";
 import type { DeployFormValues } from "../DeployForm";
 
 import FormikField from "app/base/components/FormikField";
+import TooltipButton from "app/base/components/TooltipButton";
 import UploadTextArea from "app/base/components/UploadTextArea";
 import docsUrls from "app/base/docsUrls";
 import imagesURLs from "app/images/urls";
@@ -28,7 +26,7 @@ import configSelectors from "app/store/config/selectors";
 import { osInfo as osInfoSelectors } from "app/store/general/selectors";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
-import { timeSpanToMinutes, breakLines } from "app/utils";
+import { timeSpanToMinutes } from "app/utils";
 
 export const DeployFormFields = (): JSX.Element => {
   const [deployVmHost, setDeployVmHost] = useState(false);
@@ -213,21 +211,12 @@ export const DeployFormFields = (): JSX.Element => {
               label={
                 <>
                   Periodically sync hardware{" "}
-                  <Tooltip
-                    positionElementClassName="u-display--inline"
-                    message={breakLines(
-                      "Enable this to make MAAS periodically check the hardware configuration of this machine and reflect any possible change after the deployment."
-                    )}
-                  >
-                    <Button
-                      type="button"
-                      appearance="base"
-                      aria-label="more about periodically sync hardware"
-                      className="u-no-margin--bottom u-no-padding"
-                    >
-                      <Icon name="information" />
-                    </Button>
-                  </Tooltip>{" "}
+                  <TooltipButton
+                    aria-label="more about periodically sync hardware"
+                    message={`Enable this to make MAAS periodically check the
+                    hardware configuration of this machine and reflect any
+                    possible change after the deployment.`}
+                  />{" "}
                   <a
                     href={docsUrls.customisingDeployedMachines}
                     rel="noopener noreferrer"

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -216,6 +216,7 @@ export const DeployFormFields = (): JSX.Element => {
                     message={`Enable this to make MAAS periodically check the
                     hardware configuration of this machine and reflect any
                     possible change after the deployment.`}
+                    positionElementClassName="u-display--inline"
                   />{" "}
                   <a
                     href={docsUrls.customisingDeployedMachines}

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 
-import { Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
@@ -11,6 +10,7 @@ import PowerIcon from "app/base/components/PowerIcon";
 import ScriptStatus from "app/base/components/ScriptStatus";
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
+import TooltipButton from "app/base/components/TooltipButton";
 import { useMachineActions } from "app/base/hooks";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
 import { MachineHeaderViews } from "app/machines/constants";
@@ -110,13 +110,12 @@ const MachineHeader = ({
           <div className="u-flex--wrap">
             <div className="u-nudge-left">
               {machine.locked ? (
-                <Tooltip
+                <TooltipButton
                   className="u-nudge-left--small"
+                  iconName="locked"
                   message="This machine is locked. You have to unlock it to perform any actions."
                   position="btm-left"
-                >
-                  <Icon name="locked" />
-                </Tooltip>
+                />
               ) : null}
               {machine.status}
             </div>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.tsx
@@ -1,4 +1,4 @@
-import { Col, Icon, Row, Select, Tooltip } from "@canonical/react-components";
+import { Col, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { BridgeFormValues } from "../AddBridgeForm/types";
@@ -8,6 +8,7 @@ import FormikField from "app/base/components/FormikField";
 import MacAddressField from "app/base/components/MacAddressField";
 import SwitchField from "app/base/components/SwitchField";
 import TagNameField from "app/base/components/TagNameField";
+import TooltipButton from "app/base/components/TooltipButton";
 import { BridgeType, NetworkInterfaceTypes } from "app/store/types/enum";
 
 type Props = {
@@ -41,12 +42,11 @@ const BridgeFormFields = ({ typeDisabled }: Props): JSX.Element | null => {
           label={
             <>
               STP{" "}
-              <Tooltip
+              <TooltipButton
+                iconName="help"
                 message="Controls the participation of this bridge in the spanning tree protocol."
                 position="top-left"
-              >
-                <Icon name="help" />
-              </Tooltip>
+              />
             </>
           }
           name="bridge_stp"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -1,10 +1,10 @@
-import { Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import type { SetExpanded } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
 import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
 import TableMenu from "app/base/components/TableMenu";
 import type { Props as TableMenuProps } from "app/base/components/TableMenu/TableMenu";
+import TooltipButton from "app/base/components/TooltipButton";
 import { useIsAllNetworkingDisabled } from "app/base/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
@@ -117,9 +117,11 @@ const NetworkTableActions = ({
           children: item.tooltip ? (
             <span className="u-flex">
               <span className="u-flex--grow">{item.label}</span>
-              <Tooltip message={item.tooltip} position="top-right">
-                <Icon className="u-no-margin--right" name="help" />
-              </Tooltip>
+              <TooltipButton
+                iconName="help"
+                message={item.tooltip}
+                position="top-right"
+              />
             </span>
           ) : (
             item.label

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SpeedColumn/SpeedColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SpeedColumn/SpeedColumn.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 
-import { Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import TooltipButton from "app/base/components/TooltipButton";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -40,16 +40,20 @@ const SpeedColumn = ({ link, nic, systemId }: Props): JSX.Element | null => {
 
   if (!isConnected) {
     icon = (
-      <Tooltip position="top-left" message="This interface is disconnected.">
-        <Icon name="disconnected" />
-      </Tooltip>
+      <TooltipButton
+        iconName="disconnected"
+        message="This interface is disconnected."
+        position="top-left"
+      />
     );
   }
   if (isConnected && nic.link_speed < nic.interface_speed) {
     icon = (
-      <Tooltip position="top-left" message="Link connected to slow interface.">
-        <Icon name="warning" />
-      </Tooltip>
+      <TooltipButton
+        iconName="warning"
+        message="Link connected to slow interface."
+        position="top-left"
+      />
     );
   }
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
@@ -23,8 +23,11 @@ describe("NumaNodes", () => {
     const wrapper = mount(<NumaNodes disk={disk} />);
 
     expect(wrapper.find("[data-testid='numa-nodes']").text()).toBe("0, 1");
-    expect(wrapper.find("[data-testid='numa-warning']").prop("message")).toBe(
-      "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
-    );
+    expect(
+      wrapper
+        .find("[role='tooltip']")
+        .text()
+        .match(/This volume is spread over multiple NUMA nodes/)
+    ).toBeTruthy();
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
@@ -1,5 +1,4 @@
-import { Tooltip } from "@canonical/react-components";
-
+import TooltipButton from "app/base/components/TooltipButton";
 import type { Disk } from "app/store/types/node";
 
 type Props = { disk: Disk };
@@ -15,14 +14,13 @@ const NumaNodes = ({ disk }: Props): JSX.Element => {
   return (
     <>
       {numaNodes.length > 1 && (
-        <Tooltip
-          data-testid="numa-warning"
+        <TooltipButton
+          className="u-nudge-left--x-small"
+          iconName="warning"
           message={
             "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
           }
-        >
-          <i className="p-icon--warning is-inline"></i>
-        </Tooltip>
+        />
       )}
       <span data-testid="numa-nodes">{numaNodes.join(", ") || "—"}</span>
     </>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,7 +1,8 @@
-import { Button, Icon, Tooltip } from "@canonical/react-components";
+import { Tooltip } from "@canonical/react-components";
 import { formatDuration, intervalToDuration } from "date-fns";
 import { useSelector } from "react-redux";
 
+import TooltipButton from "app/base/components/TooltipButton";
 import docsUrls from "app/base/docsUrls";
 import type { Seconds } from "app/base/types";
 import { PowerTypeNames } from "app/store/general/constants";
@@ -101,7 +102,12 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
             <hr />
             <p className="u-text--muted">
               Periodic hardware sync enabled{" "}
-              <Tooltip
+              <TooltipButton
+                buttonProps={{
+                  "aria-label": "more about periodic hardware sync",
+                }}
+                className="u-nudge-right--small"
+                iconName="help"
                 position="right"
                 message={
                   <>
@@ -120,16 +126,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
                     .
                   </>
                 }
-              >
-                <Button
-                  aria-label="more about periodic hardware sync"
-                  appearance="base"
-                  dense
-                  hasIcon
-                >
-                  <Icon name="help" />
-                </Button>
-              </Tooltip>
+              />
             </p>
           </>
         ) : null}

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -103,9 +103,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
             <p className="u-text--muted">
               Periodic hardware sync enabled{" "}
               <TooltipButton
-                buttonProps={{
-                  "aria-label": "more about periodic hardware sync",
-                }}
+                aria-label="more about periodic hardware sync"
                 className="u-nudge-right--small"
                 iconName="help"
                 position="right"

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
@@ -1,14 +1,9 @@
-import {
-  Card,
-  Icon,
-  Link,
-  Spinner,
-  Tooltip,
-} from "@canonical/react-components";
+import { Card, Link, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Link as RouterLink } from "react-router-dom";
 
 import LabelledList from "app/base/components/LabelledList";
+import TooltipButton from "app/base/components/TooltipButton";
 import { useSendAnalytics } from "app/base/hooks";
 import machineURLs from "app/machines/urls";
 import machineSelectors from "app/store/machine/selectors";
@@ -81,12 +76,11 @@ const WorkloadCard = ({ id }: Props): JSX.Element => {
           <div className="u-sv1">
             <strong className="p-muted-heading">Workload annotations</strong>
             <span className="u-nudge-right--small">
-              <Tooltip
+              <TooltipButton
+                iconName="help"
                 message="MAAS removes workload annotations when the machine is released."
                 position="top-center"
-              >
-                <Icon name="help" />
-              </Tooltip>
+              />
             </span>
           </div>
           <Link

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineTestStatus/MachineTestStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineTestStatus/MachineTestStatus.test.tsx
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import MachineTestStatus from "./MachineTestStatus";
 
@@ -24,7 +24,7 @@ describe("MachineTestStatus", () => {
   });
 
   it("shows a failed icon with tooltip if tests have failed", () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <MachineTestStatus status={TestStatusStatus.FAILED}>
         Tests have failed
       </MachineTestStatus>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineTestStatus/MachineTestStatus.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineTestStatus/MachineTestStatus.tsx
@@ -1,4 +1,3 @@
-import { Tooltip } from "@canonical/react-components";
 import type { Position } from "@canonical/react-components/dist/components/Tooltip/Tooltip";
 
 import ScriptStatus from "app/base/components/ScriptStatus";
@@ -22,13 +21,13 @@ const MachineTestStatus = ({
 
     case TestStatusStatus.FAILED:
       return (
-        <Tooltip
-          message="Machine has failed tests."
-          position={tooltipPosition}
-          positionElementClassName="p-double-row__tooltip-inner"
+        <ScriptStatus
+          status={status}
+          tooltipMessage="Machine has failed tests."
+          tooltipPosition={tooltipPosition}
         >
-          <ScriptStatus status={status}>{children}</ScriptStatus>
-        </Tooltip>
+          {children}
+        </ScriptStatus>
       );
 
     default:

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -6,6 +6,7 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import TooltipButton from "app/base/components/TooltipButton";
 import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
@@ -43,12 +44,12 @@ const getStatusIcon = (machine: Machine) => {
     !hideFailedTestWarningStatuses.includes(machine.status_code)
   ) {
     return (
-      <Tooltip
+      <TooltipButton
+        iconName="warning"
+        iconProps={{ "data-testid": "status-icon" }}
         message="Machine has failed tests; use with caution."
         position="top-left"
-      >
-        <i className="p-icon--warning" data-testid="status-icon" />
-      </Tooltip>
+      />
     );
   }
   return "";

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEvent } from "react";
 
-import { Link, Select, Tooltip } from "@canonical/react-components";
+import { Link, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import type { CommissioningFormValues } from "../CommissioningForm";
 
 import FormikField from "app/base/components/FormikField";
+import TooltipButton from "app/base/components/TooltipButton";
 import docsUrls from "app/base/docsUrls";
 import configSelectors from "app/store/config/selectors";
 import { osInfo as osInfoSelectors } from "app/store/general/selectors";
@@ -87,9 +88,10 @@ const CommissioningFormFields = (): JSX.Element => {
         label={
           <>
             K_g BMC key&nbsp;
-            <Tooltip message="Once set, the IPMI K_g BMC key is REQUIRED after next commissioning.">
-              <i className="p-icon--help"></i>
-            </Tooltip>
+            <TooltipButton
+              iconName="help"
+              message="Once set, the IPMI K_g BMC key is REQUIRED after next commissioning."
+            />
           </>
         }
         name="maas_auto_ipmi_k_g_bmc_key"

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.tsx
@@ -9,7 +9,7 @@ const ProxyAccessLabel = ({ allowProxy }: Props): JSX.Element => (
   <>
     Proxy access{" "}
     <TooltipButton
-      buttonProps={{ "aria-label": "More about proxy access" }}
+      aria-label="More about proxy access"
       message={`MAAS will ${
         allowProxy ? "" : "not"
       } allow clients from this subnet to access the MAAS proxy.`}

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/components/SubnetSpace/SubnetSpace.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/components/SubnetSpace/SubnetSpace.tsx
@@ -15,7 +15,7 @@ const SubnetSpace = ({ spaceId }: Props): JSX.Element | null => {
         <SpaceLink id={spaceId} />{" "}
         {isId(spaceId) ? null : (
           <TooltipButton
-            iconProps={{ name: "warning" }}
+            iconName="warning"
             message={`This subnet does not belong to a space. MAAS integrations
             require a space in order to determine the purpose of a network.`}
             position="btm-right"

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.tsx
@@ -1,13 +1,13 @@
-import { Icon, Spinner, Tooltip } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";
+import TooltipButton from "app/base/components/TooltipButton";
 import controllerSelectors from "app/store/controller/selectors";
 import type { RootState } from "app/store/root/types";
 import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN, VLANMeta } from "app/store/vlan/types";
-import { breakLines } from "app/utils";
 
 type Props = {
   id: VLAN[VLANMeta.PK] | null;
@@ -42,14 +42,11 @@ const VLANControllers = ({ id }: Props): JSX.Element | null => {
       label={
         <>
           Rack controllers
-          <Tooltip
+          <TooltipButton
             className="u-nudge-right--small"
-            message={breakLines(
-              "A rack controller controls hosts and images and runs network services like DHCP for connected VLANs."
-            )}
-          >
-            <Icon name="information" />
-          </Tooltip>
+            message={`A rack controller controls hosts and images and runs
+            network services like DHCP for connected VLANs.`}
+          />
         </>
       }
     >

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -5,7 +5,7 @@ import type {
   MainTableProps,
   PropsWithSpread,
 } from "@canonical/react-components";
-import { Icon, MainTable, Strip, Tooltip } from "@canonical/react-components";
+import { Icon, MainTable, Strip } from "@canonical/react-components";
 import type { History } from "history";
 import { useDispatch } from "react-redux";
 import { Link, useHistory } from "react-router-dom";
@@ -14,6 +14,7 @@ import { TAGS_PER_PAGE } from "../constants";
 
 import TableActions from "app/base/components/TableActions";
 import TableHeader from "app/base/components/TableHeader";
+import TooltipButton from "app/base/components/TooltipButton";
 import docsUrls from "app/base/docsUrls";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
@@ -23,7 +24,7 @@ import type { Tag } from "app/store/tag/types";
 import { TagMeta } from "app/store/tag/types";
 import AppliedTo from "app/tags/components/AppliedTo";
 import tagURLs from "app/tags/urls";
-import { breakLines, isComparable, unindentString } from "app/utils";
+import { isComparable } from "app/utils";
 
 type Props = PropsWithSpread<
   {
@@ -213,17 +214,15 @@ const TagTable = ({
             content: (
               <>
                 {Label.Auto}{" "}
-                <Tooltip
+                <TooltipButton
                   message={
                     <>
-                      {breakLines(
-                        unindentString(
-                          `Automatic tags are automatically applied to every 
-                        machine that matches their definition.`
-                        )
-                      )}
+                      Automatic tags are automatically applied to every
+                      <br />
+                      machine that matches their definition.
                       <br />
                       <a
+                        className="is-on-dark"
                         href={docsUrls.tagsAutomatic}
                         rel="noreferrer noopener"
                         target="_blank"
@@ -233,9 +232,7 @@ const TagTable = ({
                     </>
                   }
                   position="top-center"
-                >
-                  <Icon name="information" />
-                </Tooltip>
+                />
               </>
             ),
           },

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -215,6 +215,7 @@ const TagTable = ({
               <>
                 {Label.Auto}{" "}
                 <TooltipButton
+                  aria-label="More about automatic tags"
                   message={
                     <>
                       Automatic tags are automatically applied to every

--- a/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListTitle/ZonesListTitle.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListTitle/ZonesListTitle.tsx
@@ -1,19 +1,16 @@
-import { Tooltip, Icon, Button } from "@canonical/react-components";
+import TooltipButton from "app/base/components/TooltipButton";
 
 const ZonesListTitle = (): JSX.Element => {
   return (
     <>
       Availability zones
-      <span className="u-nudge-right">
-        <Tooltip
-          message="A representation of a grouping of nodes, typically by physical
-            location."
-        >
-          <Button className="p-button--base u-no-margin--bottom u-no-padding u-match-h3">
-            <Icon name="help">About availability zones</Icon>
-          </Button>
-        </Tooltip>
-      </span>
+      <TooltipButton
+        buttonProps={{ className: "u-no-border u-no-margin u-match-h3" }}
+        className="u-nudge-right--small"
+        iconName="help"
+        iconProps={{ children: "About availability zones" }}
+        message="A representation of a grouping of nodes, typically by physical location."
+      />
     </>
   );
 };

--- a/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListTitle/ZonesListTitle.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListTitle/ZonesListTitle.tsx
@@ -5,10 +5,10 @@ const ZonesListTitle = (): JSX.Element => {
     <>
       Availability zones
       <TooltipButton
+        aria-label="About availability zones"
         buttonProps={{ className: "u-no-border u-no-margin u-match-h3" }}
         className="u-nudge-right--small"
         iconName="help"
-        iconProps={{ children: "About availability zones" }}
         message="A representation of a grouping of nodes, typically by physical location."
       />
     </>

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -187,8 +187,8 @@
   }
 
   .u-text--default-size {
-    font-size: map-get($base-font-sizes, base);
-    font-weight: $font-weight-regular-text;
+    font-size: map-get($base-font-sizes, base) !important;
+    font-weight: $font-weight-regular-text !important;
   }
 
   .u-text--light {

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -199,6 +199,10 @@
     text-transform: capitalize !important;
   }
 
+  .u-no-line-height {
+    line-height: 0 !important;
+  }
+
   .u-visually-hidden:not(:focus):not(:active) {
     clip: rect(0 0 0 0);
     clip-path: inset(50%);


### PR DESCRIPTION
## Done

- Used `TooltipButton` component wherever we had an icon show a tooltip on hover
- Slightly updated `TooltipButton` prop shape so that `iconName` is exposed at the top-level

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate around the app and check that every instance of an icon tooltip is attached to a button

## Fixes

Fixes canonical-web-and-design/app-tribe#869
Fixes canonical-web-and-design/app-tribe#894