### PR TITLE
add e2e test for device tagging

### DIFF
--- a/integration/cypress/integration/with-users/devices/list.spec.ts
+++ b/integration/cypress/integration/with-users/devices/list.spec.ts
@@ -1,4 +1,5 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateMac } from "../utils";
 
 context("Device listing", () => {
   beforeEach(() => {
@@ -16,5 +17,38 @@ context("Device listing", () => {
       "href",
       generateNewURL("/devices")
     );
+  });
+
+  it("can add a tag to the device", () => {
+    // can add a device
+    cy.findByRole("button", { name: /Add device/ }).click();
+    const mac = generateMac();
+    cy.findByLabelText(/Device name/).type("cypress-device");
+    cy.get("input[placeholder='00:00:00:00:00:00']").type(mac);
+    cy.findByRole("button", { name: /Save device/ }).click();
+
+    // can view device details on click of device details link
+    cy.findByRole("link", { name: /cypress-device/ }).click();
+
+    cy.findByRole("link", {
+      name: /Configuration/,
+    }).click();
+    cy.findByRole("button", {
+      name: /Edit/,
+    }).click();
+    cy.get("input[placeholder='Create or remove tags']").type("device-tag");
+
+    cy.findByRole("button", {
+      name: /Create tag "device-tag"/,
+    }).click();
+
+    cy.findByRole("button", {
+      name: /Create and add to tag changes/,
+    }).click();
+
+    cy.findByRole("button", { name: /Save changes/ }).click();
+
+    cy.findByRole("link", { name: /Summary/ }).click();
+    cy.findByText(/device-tag/).should("exist");
   });
 });


### PR DESCRIPTION
## Done

- add e2e test for device tagging

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
