### PR TITLE
fix: display consistent dhcp snippet type

### DIFF
--- a/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -8,6 +8,7 @@ import TitledSection from "../TitledSection";
 
 import EditDHCP from "./EditDHCP";
 
+import DhcpSnippetType from "app/base/components/DhcpSnippetType";
 import TableActions from "app/base/components/TableActions";
 import docsUrls from "app/base/docsUrls";
 import settingsURLs from "app/settings/urls";
@@ -64,7 +65,12 @@ const generateRows = (
           role: "rowheader",
         },
         {
-          content: typeLabel,
+          content: (
+            <DhcpSnippetType
+              nodeId={dhcpsnippet.node}
+              subnetId={dhcpsnippet.subnet}
+            />
+          ),
         },
         {
           content: appliesTo,

--- a/ui/src/app/base/components/DhcpSnippetType/DhcpSnippetType.test.tsx
+++ b/ui/src/app/base/components/DhcpSnippetType/DhcpSnippetType.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import DhcpType from "./DhcpSnippetType";
+import DhcpSnippetType from "./DhcpSnippetType";
 
 import type { RootState } from "app/store/root/types";
 import {
@@ -77,7 +77,7 @@ it("displays a loading component if loading", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <DhcpType subnetId={808} />
+      <DhcpSnippetType subnetId={808} />
     </Provider>
   );
   expect(screen.getByText("Loading")).toBeInTheDocument();
@@ -87,7 +87,7 @@ it("displays a global type", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <DhcpType subnetId={null} nodeId={null} />
+      <DhcpSnippetType subnetId={null} nodeId={null} />
     </Provider>
   );
   expect(screen.getByText("Global")).toBeInTheDocument();
@@ -97,7 +97,7 @@ it("can display a Machine type", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <DhcpType nodeId="xyz" />
+      <DhcpSnippetType nodeId="xyz" />
     </Provider>
   );
   expect(screen.getByText("Machine")).toBeInTheDocument();

--- a/ui/src/app/base/components/DhcpSnippetType/DhcpSnippetType.tsx
+++ b/ui/src/app/base/components/DhcpSnippetType/DhcpSnippetType.tsx
@@ -1,0 +1,30 @@
+import { Spinner } from "@canonical/react-components";
+
+import { useDhcpTarget } from "app/settings/hooks";
+import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
+
+type Props = {
+  nodeId?: DHCPSnippet["node"];
+  subnetId?: DHCPSnippet["subnet"];
+};
+
+const dhcpTypeLabels = {
+  controller: "Controller",
+  device: "Device",
+  global: "Global",
+  machine: "Machine",
+  subnet: "Subnet",
+};
+
+const DhcpSnippetType = ({ nodeId, subnetId }: Props): JSX.Element | null => {
+  const { loading, loaded, type } = useDhcpTarget(nodeId || null, subnetId);
+
+  if (!nodeId && !subnetId) return <>{dhcpTypeLabels.global}</>;
+
+  if (loading || !loaded) {
+    return <Spinner className="u-no-margin u-no-padding" />;
+  }
+  return <>{type ? dhcpTypeLabels[type] : null}</>;
+};
+
+export default DhcpSnippetType;

--- a/ui/src/app/base/components/DhcpSnippetType/DhcpType.test.tsx
+++ b/ui/src/app/base/components/DhcpSnippetType/DhcpType.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DhcpType from "./DhcpSnippetType";
+
+import type { RootState } from "app/store/root/types";
+import {
+  controllerState as controllerStateFactory,
+  deviceState as deviceStateFactory,
+  dhcpSnippet as dhcpSnippetFactory,
+  dhcpSnippetState as dhcpSnippetStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  modelRef as modelRefFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+let state: RootState;
+
+beforeEach(() => {
+  state = rootStateFactory({
+    controller: controllerStateFactory({
+      loaded: true,
+    }),
+    device: deviceStateFactory({
+      loaded: true,
+    }),
+    dhcpsnippet: dhcpSnippetStateFactory({
+      loaded: true,
+      items: [
+        dhcpSnippetFactory({ id: 1, name: "class", description: "" }),
+        dhcpSnippetFactory({
+          id: 2,
+          name: "lease",
+          subnet: 2,
+          description: "",
+        }),
+        dhcpSnippetFactory({
+          id: 3,
+          name: "boot",
+          node: "xyz",
+          description: "",
+        }),
+      ],
+    }),
+    machine: machineStateFactory({
+      loaded: true,
+      items: [
+        machineFactory({
+          system_id: "xyz",
+          hostname: "machine1",
+          domain: modelRefFactory({ name: "test" }),
+        }),
+      ],
+    }),
+    subnet: subnetStateFactory({
+      loaded: true,
+      items: [
+        subnetFactory({ id: 1, name: "10.0.0.99" }),
+        subnetFactory({ id: 2, name: "test.maas" }),
+      ],
+    }),
+  });
+});
+
+it("displays a loading component if loading", () => {
+  state.controller.loading = true;
+  state.device.loading = true;
+  state.dhcpsnippet.loading = true;
+  state.machine.loading = true;
+  state.subnet.loading = true;
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DhcpType subnetId={808} />
+    </Provider>
+  );
+  expect(screen.getByText("Loading")).toBeInTheDocument();
+});
+
+it("displays a global type", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DhcpType subnetId={null} nodeId={null} />
+    </Provider>
+  );
+  expect(screen.getByText("Global")).toBeInTheDocument();
+});
+
+it("can display a Machine type", () => {
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DhcpType nodeId="xyz" />
+    </Provider>
+  );
+  expect(screen.getByText("Machine")).toBeInTheDocument();
+});

--- a/ui/src/app/base/components/DhcpSnippetType/index.ts
+++ b/ui/src/app/base/components/DhcpSnippetType/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DhcpSnippetType";

--- a/ui/src/app/settings/hooks.ts
+++ b/ui/src/app/settings/hooks.ts
@@ -1,13 +1,19 @@
-import { useSelector } from "react-redux";
+import { useEffect } from "react";
 
+import { useDispatch, useSelector } from "react-redux";
+
+import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller } from "app/store/controller/types";
+import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet } from "app/store/subnet/types";
 
@@ -20,6 +26,8 @@ export const useDhcpTarget = (
   target: Subnet | Machine | Device | Controller | null;
   type: "subnet" | "controller" | "device" | "machine" | null;
 } => {
+  const dispatch = useDispatch();
+
   const subnetLoading = useSelector(subnetSelectors.loading);
   const subnetLoaded = useSelector(subnetSelectors.loaded);
   const subnet = useSelector((state: RootState) =>
@@ -46,6 +54,13 @@ export const useDhcpTarget = (
   const hasLoaded =
     (!!subnetId && subnetLoaded) ||
     (!!nodeId && controllerLoaded && deviceLoaded && machineLoaded);
+
+  useEffect(() => {
+    dispatch(subnetActions.fetch());
+    dispatch(controllerActions.fetch());
+    dispatch(deviceActions.fetch());
+    dispatch(machineActions.fetch());
+  }, [dispatch]);
 
   return {
     loading: isLoading,

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 
 import ColumnToggle from "app/base/components/ColumnToggle";
+import DhcpSnippetType from "app/base/components/DhcpSnippetType";
 import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import docsUrls from "app/base/docsUrls";
@@ -108,7 +109,12 @@ const generateRows = (
           role: "rowheader",
         },
         {
-          content: type,
+          content: (
+            <DhcpSnippetType
+              nodeId={dhcpsnippet.node}
+              subnetId={dhcpsnippet.subnet}
+            />
+          ),
         },
         {
           content: (dhcpsnippet.node || dhcpsnippet.subnet) && (


### PR DESCRIPTION
## Done

- display consistent dhcp snippet type

## Screenshot
### Before

![image](https://user-images.githubusercontent.com/7452681/166661387-a149acaf-a43f-4194-b240-fcfe9ebb5052.png)

### After
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/7452681/166722120-b37061a8-4fcf-4e69-be5a-708007331012.png">


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Add a DHCP snippet for each type via settings - `MAAS/r/settings/dhcp` (machine, device, subnet and global) and apply to one of the items on the list
-  verify that a correct type is displayed on the details page (e.g. subnet details) page and in the settings

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/899

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
