### PR TITLE
fix(shared): improve status bar display on small viewports

### DIFF
--- a/legacy/src/scss/_patterns_status-bar.scss
+++ b/legacy/src/scss/_patterns_status-bar.scss
@@ -11,4 +11,20 @@
     background-color: $color-mid-x-light;
     padding: $spv--small 0;
   }
+
+  .p-status-bar__row {
+    @extend %fixed-width-container;
+    column-gap: $sph--small;
+    flex-direction: column;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      flex-direction: row;
+    }
+  }
+
+  .p-status-bar__secondary {
+    @media only screen and (min-width: $breakpoint-large) {
+      justify-content: flex-end;
+    }
+  }
 }

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -15,13 +15,17 @@ export const StatusBar = ({
 }: Props): JSX.Element => {
   return (
     <aside className="p-status-bar" aria-label="status bar">
-      <div className="row">
-        <div className="col-4">
-          <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
+      <div className="p-status-bar__row u-flex">
+        <div className="p-status-bar__primary u-flex--no-shrink u-flex--wrap">
+          <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>
+          :&nbsp;
           <span data-testid="status-bar-version">{version}</span>
         </div>
         {status && (
-          <div className="col-8 u-align--right" data-testid="status-bar-status">
+          <div
+            className="p-status-bar__secondary u-flex--grow u-flex--wrap"
+            data-testid="status-bar-status"
+          >
             {status}
           </div>
         )}

--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -49,9 +49,7 @@ it("can show if a machine is currently commissioning", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-    "test.maas: Commissioning in progress..."
-  );
+  expect(screen.getByText(/Commissioning in progress.../)).toBeInTheDocument();
 });
 
 it("can show if a machine has not been commissioned yet", () => {
@@ -65,9 +63,7 @@ it("can show if a machine has not been commissioned yet", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-    "test.maas: Not yet commissioned"
-  );
+  expect(screen.getByText(/Not yet commissioned/)).toBeInTheDocument();
 });
 
 it("can show the last time a machine was commissioned", () => {
@@ -83,9 +79,9 @@ it("can show the last time a machine was commissioned", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-    "test.maas: Last commissioned 1 minute ago"
-  );
+  expect(
+    screen.getByText(/Last commissioned: 1 minute ago/)
+  ).toBeInTheDocument();
 });
 
 it("can handle an incorrectly formatted commissioning timestamp", () => {
@@ -101,9 +97,9 @@ it("can handle an incorrectly formatted commissioning timestamp", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-    "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
-  );
+  expect(
+    screen.getByText(/Unable to parse commissioning timestamp/)
+  ).toBeInTheDocument();
 });
 
 it("displays Last and Next sync instead of Last commissioned date for deployed machines with hardware sync enabled ", () => {

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -1,7 +1,9 @@
 export {
-  isMachineDetails,
+  getHasSyncFailed,
   getMachineFieldScopes,
   getTagCountsForMachines,
+  isDeployedWithHardwareSync,
+  isMachineDetails,
 } from "./common";
 export type { TagIdCountMap } from "./common";
 

--- a/ui/src/scss/_patterns_status-bar.scss
+++ b/ui/src/scss/_patterns_status-bar.scss
@@ -8,4 +8,20 @@
     right: 0;
     z-index: 1;
   }
+
+  .p-status-bar__row {
+    @extend %fixed-width-container;
+    column-gap: $sph--small;
+    flex-direction: column;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      flex-direction: row;
+    }
+  }
+
+  .p-status-bar__secondary {
+    @media only screen and (min-width: $breakpoint-large) {
+      justify-content: flex-end;
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Improved status bar display on small viewports
- Changed machine commissioned status to function identically to hardware sync status

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the full app using `yarn start`
- Go to the details page of a machine that has been commissioned
- Check that the status looks good at all viewport sizes
- Go to the details page of a machine that has hardware sync enabled and check the same

## Fixes

Fixes canonical-web-and-design/app-tribe#871