### PR TITLE
fix(ui): initialise zone in node set zone form

### DIFF
--- a/ui/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
+++ b/ui/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
@@ -1,4 +1,5 @@
-import { mount } from "enzyme";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -7,53 +8,92 @@ import SetZoneForm from "./SetZoneForm";
 import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
+  modelRef as modelRefFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
 
 const mockStore = configureStore();
 
-describe("SetZoneForm", () => {
-  let state: RootState;
-  beforeEach(() => {
-    state = rootStateFactory({
-      zone: zoneStateFactory({
-        items: [
-          zoneFactory({ id: 0, name: "default" }),
-          zoneFactory({ id: 1, name: "zone-1" }),
-        ],
-        loaded: true,
-      }),
-    });
+let state: RootState;
+beforeEach(() => {
+  state = rootStateFactory({
+    zone: zoneStateFactory({
+      items: [
+        zoneFactory({ id: 0, name: "default" }),
+        zoneFactory({ id: 1, name: "zone-1" }),
+      ],
+      loaded: true,
+    }),
   });
+});
 
-  it("correctly runs function to set zones of given nodes", () => {
-    const onSubmit = jest.fn();
-    const nodes = [
-      machineFactory({ system_id: "abc123" }),
-      machineFactory({ system_id: "def456" }),
-    ];
+it("initialises zone value if exactly one node provided", () => {
+  const nodes = [machineFactory({ zone: modelRefFactory({ id: 1 }) })];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <SetZoneForm
+        clearHeaderContent={jest.fn()}
+        modelName="machine"
+        nodes={nodes}
+        onSubmit={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      />
+    </Provider>
+  );
 
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <SetZoneForm
-          clearHeaderContent={jest.fn()}
-          modelName="machine"
-          nodes={nodes}
-          onSubmit={onSubmit}
-          processingCount={0}
-          viewingDetails={false}
-        />
-      </Provider>
-    );
+  expect(screen.getByRole("combobox", { name: "Zone" })).toHaveValue("1");
+});
 
-    submitFormikForm(wrapper, {
-      zone: 1,
-    });
+it("does not initialise zone value if more than one node provided", () => {
+  const nodes = [
+    machineFactory({ zone: modelRefFactory({ id: 0 }) }),
+    machineFactory({ zone: modelRefFactory({ id: 1 }) }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <SetZoneForm
+        clearHeaderContent={jest.fn()}
+        modelName="machine"
+        nodes={nodes}
+        onSubmit={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      />
+    </Provider>
+  );
 
-    expect(onSubmit).toHaveBeenCalledWith(1);
+  expect(screen.getByRole("combobox", { name: "Zone" })).toHaveValue("");
+});
+
+it("correctly runs function to set zones of given nodes", async () => {
+  const onSubmit = jest.fn();
+  const nodes = [
+    machineFactory({ system_id: "abc123" }),
+    machineFactory({ system_id: "def456" }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <SetZoneForm
+        clearHeaderContent={jest.fn()}
+        modelName="machine"
+        nodes={nodes}
+        onSubmit={onSubmit}
+        processingCount={0}
+        viewingDetails={false}
+      />
+    </Provider>
+  );
+
+  userEvent.selectOptions(screen.getByRole("combobox", { name: "Zone" }), "1");
+  userEvent.click(screen.getByRole("button", { name: /Set zone/ }));
+
+  await waitFor(() => {
+    expect(onSubmit).toHaveBeenCalledWith("1");
   });
 });

--- a/ui/src/app/base/components/node/SetZoneForm/SetZoneForm.tsx
+++ b/ui/src/app/base/components/node/SetZoneForm/SetZoneForm.tsx
@@ -5,7 +5,9 @@ import type { NodeActionFormProps } from "../types";
 
 import ActionForm from "app/base/components/ActionForm";
 import ZoneSelect from "app/base/components/ZoneSelect";
+import type { Node } from "app/store/types/node";
 import { NodeActions } from "app/store/types/node";
+import { nodeIsDevice, nodeIsMachine } from "app/store/utils";
 import type { Zone } from "app/store/zone/types";
 import { capitaliseFirst } from "app/utils";
 
@@ -15,6 +17,16 @@ type Props<E = null> = NodeActionFormProps<E> & {
 
 export type SetZoneFormValues = {
   zone: Zone["id"] | "";
+};
+
+const getInitialZoneValue = (nodes: Node[]): SetZoneFormValues["zone"] => {
+  if (
+    nodes.length === 1 &&
+    (nodeIsDevice(nodes[0]) || nodeIsMachine(nodes[0]))
+  ) {
+    return nodes[0].zone.id;
+  }
+  return "";
 };
 
 const SetZoneSchema = Yup.object().shape({
@@ -36,7 +48,9 @@ export const SetZoneForm = <E,>({
       actionName={NodeActions.SET_ZONE}
       cleanup={cleanup}
       errors={errors}
-      initialValues={{ zone: "" }}
+      initialValues={{
+        zone: getInitialZoneValue(nodes),
+      }}
       modelName={modelName}
       onCancel={clearHeaderContent}
       onSaveAnalytics={{


### PR DESCRIPTION
## Done

- initialise zone in node set zone form if one node provided

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- For machines and devices, when opening the "Set zone" form:
  - Check that the zone is initialised if on details page or 1 selected in list page
  - Check that the zone is not initialised if more than 1 selected in list page

## Fixes

Fixes canonical-web-and-design/app-tribe#900
