### PR TITLE
test(ui): enable accessibility error reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility-failure.md
+++ b/.github/ISSUE_TEMPLATE/accessibility-failure.md
@@ -1,0 +1,9 @@
+---
+name: accessibility failure
+about: ''
+title: '{{ env.BRANCH_NAME }} accessibility test run failed'
+assignees: ''
+
+---
+
+cypress-axe [failed](https://github.com/{{ env.REPO }}/actions/runs/{{ env.RUN_ID }}) for the {{ env.BRANCH_NAME }} branch.

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,47 @@
+name: accessibility
+on: [push]
+jobs:
+  cypress-axe:
+    name: cypress-axe
+    runs-on: ubuntu-20.04
+    env:
+      MAAS_URL: http://localhost:5240
+    steps:
+      - uses: actions/checkout@main
+      - name: Get branch name
+        uses: nelonoel/branch-name@v1.0.1
+      - name: Install MAAS
+        run: |
+          sudo systemctl enable snapd
+          sudo snap install maas --channel=latest/edge
+          sudo snap install maas-test-db --channel=latest/edge
+      - name: Initialise MAAS
+        run: sudo maas init region+rack --maas-url=${{env.MAAS_URL}}/MAAS --database-uri maas-test-db:///
+      - name: Install Cypress
+        uses: cypress-io/github-action@master
+        with:
+          runTests: false
+      - name: Build shared
+        run: |
+          sudo apt install yarn
+          yarn build-shared
+      - name: Create MAAS admin
+        run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
+      - name: Run cypress-axe accessibility tests
+        uses: cypress-io/github-action@master
+        with:
+          config: baseUrl=${{env.MAAS_URL}},pageLoadTimeout=100000
+          install: false
+          spec: "**/accessibility/**/*.spec.ts"
+          wait-on: "${{env.MAAS_URL}}/MAAS/r/machines"
+          working-directory: integration
+      - name: Create issue on failure
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/accessibility-failure.md
+          update_existing: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![CI](https://github.com/canonical-web-and-design/maas-ui/workflows/CI/badge.svg)
 ![Cypress](https://github.com/canonical-web-and-design/maas-ui/workflows/Cypress/badge.svg)
+![accessibility](https://github.com/canonical-web-and-design/maas-ui/workflows/accessibility/badge.svg)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 - [About](#about)

--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -6,7 +6,7 @@
     "password": "test",
     "nonAdminUsername": "user",
     "nonAdminPassword": "test",
-    "skipA11yFailures": true
+    "skipA11yFailures": false
   },
   "projectId": "gp2cox",
   "video": false,

--- a/integration/cypress/integration/accessibility/accessibility.spec.ts
+++ b/integration/cypress/integration/accessibility/accessibility.spec.ts
@@ -1,5 +1,5 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
-import { pages } from "../../../constants";
+import { pages } from "../../constants";
 
 pages.forEach(({ heading, url }) => {
   it(

--- a/integration/cypress/support/commands.ts
+++ b/integration/cypress/support/commands.ts
@@ -67,7 +67,12 @@ Cypress.Commands.add("testA11y", (pageContext) => {
   cy.injectAxe();
   cy.checkA11y(
     undefined,
-    undefined,
+    {
+      runOnly: {
+        type: "tag",
+        values: ["wcag21aa"],
+      },
+    },
     (violations) => logViolations(violations, pageContext),
     Cypress.env("skipA11yFailures")
   );


### PR DESCRIPTION
## Done

- enable accessibility tests error reporting
- log errors for WCAG 2.1 AA violations only
- add accessibility badge to README
- create separate accessibility GitHub Action
 
<img width="549" alt="image" src="https://user-images.githubusercontent.com/7452681/167084574-5e1224b3-f9a6-4f58-86e8-b9717837ad3b.png">


 
https://github.com/canonical-web-and-design/maas-ui/tree/accessibility-test-github-job


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3425

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
