### PR TITLE
test: fix cypress failures

### DIFF
--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -9,5 +9,9 @@
     "skipA11yFailures": true
   },
   "projectId": "gp2cox",
-  "video": false
+  "video": false,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/integration/cypress/integration/with-users/controllers/list.spec.ts
+++ b/integration/cypress/integration/with-users/controllers/list.spec.ts
@@ -19,6 +19,8 @@ context("Controller listing", () => {
   });
 
   it("can add a tag to the controller", () => {
+    const tagName = "new-tag";
+
     // displays the controller details page on click of the controller name
     cy.findByRole("gridcell", { name: "Name" }).within(() => {
       cy.findByRole("link").click();
@@ -35,19 +37,20 @@ context("Controller listing", () => {
     })
       .first()
       .click();
-    cy.get("input[placeholder='Add a tag']").type("test-tag");
+
+    cy.get("input[placeholder='Add a tag']").type(`${tagName}{enter}{esc}`);
     cy.findByRole("button", { name: /Save changes/ }).click();
 
     cy.findByRole("tab", { name: /Controller summary/ }).click();
-    cy.findByRole("link", { name: "new-tag" }).should("exist");
+    cy.findByRole("link", { name: tagName }).should("exist");
 
     // displays the controller listing page filtered by tag on click of the tag name
-    cy.findByRole("link", { name: "new-tag" }).click();
+    cy.findByRole("link", { name: tagName }).click();
 
     // displays the correct tag in the searchbox
     cy.findByRole("searchbox", { name: /Search/ }).should(
       "have.value",
-      "tag:(new-tag)"
+      `tags:(${tagName})`
     );
 
     // displays the correct number of controllers

--- a/integration/cypress/integration/with-users/devices/list.spec.ts
+++ b/integration/cypress/integration/with-users/devices/list.spec.ts
@@ -1,5 +1,5 @@
 import { generateNewURL } from "@maas-ui/maas-ui-shared";
-import { generateMac } from "../utils";
+import { generateMac } from "../../utils";
 
 context("Device listing", () => {
   beforeEach(() => {

--- a/integration/cypress/integration/with-users/subnets/add.spec.ts
+++ b/integration/cypress/integration/with-users/subnets/add.spec.ts
@@ -91,15 +91,15 @@ context("Subnets - Add", () => {
 
     cy.url().should("include", generateNewURL("/space"));
 
-    cy.findByRole("button", { name: "Delete" }).click();
+    cy.findByRole("button", { name: "Delete space" }).click();
 
-    cy.findByText(`Are you sure you want to delete ${name} space?`).should(
+    cy.findByText(`Are you sure you want to delete this space?`).should(
       "be.visible"
     );
 
-    cy.findByRole("button", { name: "Yes, delete space" }).click();
+    cy.findByRole("button", { name: "Delete space" }).click();
 
-    cy.url().should("include", generateNewURL("/networks?by=space"));
+    cy.url().should("include", generateNewURL("/networks?by=fabric"));
     cy.findByRole("table", { name: /Subnets/ }).within(() => {
       cy.findByRole("link", { name }).should("not.exist");
     });


### PR DESCRIPTION
## Done

- test: fix cypress failures
- set global retries for run mode to 2 (Cypress will run a test a maximum 3 times before reporting a failure)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3854

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
