### PR TITLE
fix(ui): fix login via external auth

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
   },
   "bugs": "https://github.com/canonical-web-and-design/maas-ui/issues",
   "dependencies": {
-    "@canonical/macaroon-bakery": "1.0.0",
+    "@canonical/macaroon-bakery": "1.1.0",
     "@canonical/react-components": "0.36.0",
     "@maas-ui/maas-ui-shared": "3.2.0",
     "@reduxjs/toolkit": "1.8.1",

--- a/ui/src/bakery.ts
+++ b/ui/src/bakery.ts
@@ -11,6 +11,7 @@ const visit = (error: { Info: { VisitURL: string } }) => {
 };
 
 const bakery = new Bakery({
+  protocolVersion: 1,
   storage: new BakeryStorage(localStorage, {}),
   visitPage: visit,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2348,10 +2348,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.3.0.tgz#14fcd8a80051eb65fb274a0cec086e9aca3f19f0"
   integrity sha512-VwGcZo9LGzdeQ/sKt+5TQttIibTxjZEpsEtuWbbsacbqqzqVfqZhDsZkkg/7WNxKQ2lpnyq+4mLT70u9YbYSYA==
 
-"@canonical/macaroon-bakery@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.0.0.tgz#b13324cf2cf5527cd827fb7b257146a133451405"
-  integrity sha512-eooOtBcvCtkBHL2T/2PAMiOyJwt7lzGmoPmsSHvyL4oGQRm3KdgDu7fb4VSlF7N/uV9SuaHZxzdEvbmffCcYOg==
+"@canonical/macaroon-bakery@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.1.0.tgz#5928a354a4a316916aae6f14a6509c70fcacd574"
+  integrity sha512-LAaNdUHPHkLGfspOqDw/MC/Y3navmzadJCB1hGqlGrcjeLis9q5j+RdH8NwsbbUQqomoeZLQutLfMOjLK9kwzw==
   dependencies:
     macaroon "3.0.4"
 


### PR DESCRIPTION
## Done

- Set the correct macaroon protocol version when authenticating with candid.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ask me.

## Fixes

Fixes: #3884.