### PR TITLE
fix(ui): set aria attributes on the homepage anchor element

### DIFF
--- a/shared/src/components/Header/Header.test.tsx
+++ b/shared/src/components/Header/Header.test.tsx
@@ -321,9 +321,10 @@ describe("Header", () => {
         logout={jest.fn()}
       />
     );
-    expect(
-      within(screen.getByLabelText("Homepage")).getByRole("link")
-    ).toHaveAttribute("href", "/dashboard");
+    expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute(
+      "href",
+      "/dashboard"
+    );
   });
 
   it("links from the logo to the machine list for non admins", () => {
@@ -344,8 +345,9 @@ describe("Header", () => {
         logout={jest.fn()}
       />
     );
-    expect(
-      within(screen.getByLabelText("Homepage")).getByRole("link")
-    ).toHaveAttribute("href", "/machines");
+    expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute(
+      "href",
+      "/machines"
+    );
   });
 });

--- a/shared/src/components/Navigation/Navigation.test.tsx
+++ b/shared/src/components/Navigation/Navigation.test.tsx
@@ -45,20 +45,21 @@ it("can display a standard logo", () => {
   render(
     <Navigation
       logo={{
+        "aria-label": "Homepage",
         src: "http://this.is.the.logo.svg",
         title: "This is the site name",
         url: "/this/is/the/logo/link",
       }}
     />
   );
-  expect(
-    screen.getByRole("link", { name: "This is the site name" })
-  ).toHaveAttribute("href", "/this/is/the/logo/link");
-  // eslint-disable-next-line testing-library/no-node-access
-  expect(document.querySelector("img.p-navigation__logo-icon")).toHaveAttribute(
-    "src",
-    "http://this.is.the.logo.svg"
-  );
+  const homePageLink = screen.getByRole("link", { name: "Homepage" });
+  expect(homePageLink).toBeInTheDocument();
+  expect(homePageLink).toHaveAttribute("href", "/this/is/the/logo/link");
+  expect(homePageLink).toHaveTextContent("This is the site name");
+
+  const homepageLogo = within(homePageLink).getByRole("img");
+  expect(homepageLogo).toHaveAttribute("src", "http://this.is.the.logo.svg");
+  expect(homepageLogo).toHaveAttribute("class", "p-navigation__logo-icon");
 });
 
 it("can display a standard logo with a generated link", () => {
@@ -70,15 +71,20 @@ it("can display a standard logo with a generated link", () => {
         </a>
       )}
       logo={{
+        "aria-label": "Homepage",
         src: "http://this.is.the.logo.svg",
         title: "This is the site name",
         url: "/this/is/the/logo/link",
       }}
     />
   );
-  expect(
-    screen.getByRole("link", { name: "This is the site name" })
-  ).toHaveAttribute("aria-current", "page");
+  const homePageLink = screen.getByRole("link", { name: "Homepage" });
+  expect(homePageLink).toBeInTheDocument();
+  expect(homePageLink).toHaveTextContent("This is the site name");
+
+  const homepageLogo = within(homePageLink).getByRole("img");
+  expect(homepageLogo).toHaveAttribute("src", "http://this.is.the.logo.svg");
+  expect(homepageLogo).toHaveAttribute("class", "p-navigation__logo-icon");
 });
 
 it("can provide a custom logo", () => {

--- a/shared/src/components/Navigation/Navigation.tsx
+++ b/shared/src/components/Navigation/Navigation.tsx
@@ -81,7 +81,15 @@ const isLogoProps = (logo: Props["logo"]): logo is LogoProps =>
  */
 const generateLogo = (logo: Props["logo"], generateLink: GenerateLink) => {
   if (isLogoProps(logo)) {
-    const { url, src, title, icon, ...logoProps } = logo;
+    const {
+      url,
+      src,
+      title,
+      icon,
+      "aria-current": ariaCurrent,
+      "aria-label": ariaLabel,
+      ...logoProps
+    } = logo;
     const content = (
       <>
         <div className="p-navigation__logo-tag">
@@ -92,17 +100,14 @@ const generateLogo = (logo: Props["logo"], generateLink: GenerateLink) => {
     );
     return (
       <div className="p-navigation__tagged-logo" {...logoProps}>
-        {generateLink ? (
-          generateLink({
-            className: "p-navigation__link",
-            label: content,
-            url,
-          })
-        ) : (
-          <a className="p-navigation__link" href={url}>
-            {content}
-          </a>
-        )}
+        <NavigationLink
+          className="p-navigation__link"
+          url={url}
+          label={content}
+          aria-label={ariaLabel}
+          generateLink={generateLink}
+          isSelected={!!ariaCurrent}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Done

- fix: set aria attributes on the homepage anchor element
- add tests
- fix eslint-disable-next-line testing-library/no-node-access error

### before
![image](https://user-images.githubusercontent.com/7452681/167128368-3d71107a-e6eb-43e9-bc35-a4b2eadffd50.png)

### after
![image](https://user-images.githubusercontent.com/7452681/167128378-f32abc3b-aa67-463b-9309-0e439e138f0e.png)


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes https://github.com/canonical-web-and-design/maas-ui/issues/3906

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
