### PR TITLE
fix(ui): add auto icon aria label

### DIFF
--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -79,7 +79,9 @@ const generateRows = (
         },
         {
           "aria-label": Label.Auto,
-          content: !!tag.definition ? <Icon name="success-grey" /> : null,
+          content: !!tag.definition ? (
+            <Icon aria-label="Automatic tag" name="success-grey" />
+          ) : null,
         },
         {
           "aria-label": Label.AppliedTo,


### PR DESCRIPTION
## Done

- Add an aria label when displaying an automatic tag icon.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tag list page.
- Find an automatic tag in the list.
- Check that the tick icon in the auto row has an aria label.

## Fixes

Fixes: canonical-web-and-design/app-tribe#889.