### PR TITLE
fix(ui): add Vanilla mobile drawer to SideNav component

### DIFF
--- a/ui/src/app/base/components/SideNav/SideNav.test.tsx
+++ b/ui/src/app/base/components/SideNav/SideNav.test.tsx
@@ -1,63 +1,127 @@
-import { mount } from "enzyme";
+import { screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { RouteProps } from "react-router-dom";
 import { MemoryRouter, Route } from "react-router-dom";
 
 import type { NavItem } from "./SideNav";
 import { SideNav } from "./SideNav";
 
-describe("SideNav", () => {
-  let items: NavItem[];
+let items: NavItem[];
 
-  beforeEach(() => {
-    items = [
-      {
-        label: "Configuration",
-        subNav: [
-          { path: "/settings/configuration/general", label: "General" },
-          {
-            path: "/settings/configuration/commissioning",
-            label: "Commissioning",
-          },
-          { path: "/settings/configuration/deploy", label: "Deploy" },
-          {
-            path: "/settings/configuration/kernel-parameters",
-            label: "Kernel parameters",
-          },
-        ],
-      },
-      {
-        path: "/settings/users",
-        label: "Users",
-      },
-    ];
-  });
-  it("renders", () => {
-    const wrapper = mount(
-      <MemoryRouter
-        initialEntries={[{ pathname: "/settings", key: "testKey" }]}
-        initialIndex={0}
-      >
-        <Route
-          render={(props: RouteProps) => <SideNav {...props} items={items} />}
-          path="/settings"
-        />
-      </MemoryRouter>
-    );
-    expect(wrapper.find("SideNav")).toMatchSnapshot();
-  });
+beforeEach(() => {
+  items = [
+    {
+      label: "Configuration",
+      subNav: [
+        { path: "/settings/configuration/general", label: "General" },
+        {
+          path: "/settings/configuration/commissioning",
+          label: "Commissioning",
+        },
+        { path: "/settings/configuration/deploy", label: "Deploy" },
+        {
+          path: "/settings/configuration/kernel-parameters",
+          label: "Kernel parameters",
+        },
+      ],
+    },
+    {
+      path: "/settings/users",
+      label: "Users",
+    },
+  ];
+});
 
-  it("can set an active item", () => {
-    const wrapper = mount(
-      <MemoryRouter
-        initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
-        initialIndex={0}
-      >
-        <Route
-          render={(props: RouteProps) => <SideNav {...props} items={items} />}
-          path="/settings"
-        />
-      </MemoryRouter>
-    );
-    expect(wrapper.find("a.is-active").text()).toEqual("Users");
-  });
+it("matches the snapshot", () => {
+  render(
+    <MemoryRouter
+      initialEntries={[{ pathname: "/settings", key: "testKey" }]}
+      initialIndex={0}
+    >
+      <Route
+        render={(props: RouteProps) => <SideNav {...props} items={items} />}
+        path="/settings"
+      />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole("navigation")).toMatchSnapshot();
+});
+
+it("can set an active item", () => {
+  render(
+    <MemoryRouter
+      initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
+      initialIndex={0}
+    >
+      <Route
+        render={(props: RouteProps) => <SideNav {...props} items={items} />}
+        path="/settings"
+      />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole("link", { name: "Users" })).toHaveClass("is-active");
+});
+
+it("can be given different toggle texts", () => {
+  render(
+    <MemoryRouter>
+      <SideNav
+        closeToggleText="Get me out!"
+        items={items}
+        openToggleText="Let me in!"
+      />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByTestId("sidenav-toggle-open").textContent).toBe(
+    "Let me in!"
+  );
+  expect(screen.getByTestId("sidenav-toggle-close").textContent).toBe(
+    "Get me out!"
+  );
+});
+
+it("can open and close the navigation drawer by clicking the toggles", () => {
+  render(
+    <MemoryRouter>
+      <SideNav items={items} />
+    </MemoryRouter>
+  );
+  const nav = screen.getByRole("navigation");
+
+  // The collapsed class is only applied after the navigation has expanded at
+  // least once.
+  expect(nav).not.toHaveClass("is-collapsed");
+  expect(nav).not.toHaveClass("is-expanded");
+
+  userEvent.click(screen.getByTestId("sidenav-toggle-open"));
+
+  expect(nav).not.toHaveClass("is-collapsed");
+  expect(nav).toHaveClass("is-expanded");
+
+  userEvent.click(screen.getByTestId("sidenav-toggle-close"));
+
+  expect(nav).toHaveClass("is-collapsed");
+  expect(nav).not.toHaveClass("is-expanded");
+});
+
+it("can close the navigation drawer by pressing the esc key", () => {
+  render(
+    <MemoryRouter>
+      <SideNav items={items} />
+    </MemoryRouter>
+  );
+  const nav = screen.getByRole("navigation");
+
+  userEvent.click(screen.getByTestId("sidenav-toggle-open"));
+
+  expect(nav).not.toHaveClass("is-collapsed");
+  expect(nav).toHaveClass("is-expanded");
+
+  userEvent.keyboard("{esc}");
+
+  expect(nav).toHaveClass("is-collapsed");
+  expect(nav).not.toHaveClass("is-expanded");
 });

--- a/ui/src/app/base/components/SideNav/__snapshots__/SideNav.test.tsx.snap
+++ b/ui/src/app/base/components/SideNav/__snapshots__/SideNav.test.tsx.snap
@@ -1,219 +1,104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SideNav renders 1`] = `
-<SideNav
-  history={
-    Object {
-      "action": "POP",
-      "block": [Function],
-      "canGo": [Function],
-      "createHref": [Function],
-      "entries": Array [
-        Object {
-          "hash": "",
-          "key": "testKey",
-          "pathname": "/settings",
-          "search": "",
-        },
-      ],
-      "go": [Function],
-      "goBack": [Function],
-      "goForward": [Function],
-      "index": 0,
-      "length": 1,
-      "listen": [Function],
-      "location": Object {
-        "hash": "",
-        "key": "testKey",
-        "pathname": "/settings",
-        "search": "",
-      },
-      "push": [Function],
-      "replace": [Function],
-    }
-  }
-  items={
-    Array [
-      Object {
-        "label": "Configuration",
-        "subNav": Array [
-          Object {
-            "label": "General",
-            "path": "/settings/configuration/general",
-          },
-          Object {
-            "label": "Commissioning",
-            "path": "/settings/configuration/commissioning",
-          },
-          Object {
-            "label": "Deploy",
-            "path": "/settings/configuration/deploy",
-          },
-          Object {
-            "label": "Kernel parameters",
-            "path": "/settings/configuration/kernel-parameters",
-          },
-        ],
-      },
-      Object {
-        "label": "Users",
-        "path": "/settings/users",
-      },
-    ]
-  }
-  location={
-    Object {
-      "hash": "",
-      "key": "testKey",
-      "pathname": "/settings",
-      "search": "",
-    }
-  }
-  match={
-    Object {
-      "isExact": true,
-      "params": Object {},
-      "path": "/settings",
-      "url": "/settings",
-    }
-  }
+exports[`matches the snapshot 1`] = `
+<nav
+  class="p-side-navigation"
 >
-  <nav
-    className="p-side-navigation"
+  <button
+    aria-controls="side-navigation-drawer"
+    aria-expanded="false"
+    class="p-side-navigation__toggle"
+    data-testid="sidenav-toggle-open"
   >
+    Toggle side navigation
+  </button>
+  <div
+    aria-controls="side-navigation-drawer"
+    aria-expanded="false"
+    class="p-side-navigation__overlay"
+  />
+  <div
+    class="p-side-navigation__drawer"
+  >
+    <div
+      class="p-navigation__drawer-header"
+    >
+      <button
+        aria-controls="side-navigation-drawer"
+        aria-expanded="false"
+        class="p-side-navigation__toggle--in-drawer"
+        data-testid="sidenav-toggle-close"
+      >
+        Toggle side navigation
+      </button>
+    </div>
     <ul
-      className="p-side-navigation__list"
+      class="p-side-navigation__list"
     >
       <li
-        className="p-side-navigation__item"
-        key="Configuration"
+        class="p-side-navigation__item"
       >
         <span
-          className="p-side-navigation__text p-side-navigation__item--title"
+          class="p-side-navigation__text p-side-navigation__item--title"
         >
           Configuration
         </span>
         <ul
-          className="p-side-navigation__list"
+          class="p-side-navigation__list"
         >
           <li
-            className="p-side-navigation__item"
-            key="/settings/configuration/general"
+            class="p-side-navigation__item"
           >
-            <Link
-              className="p-side-navigation__link"
-              to="/settings/configuration/general"
+            <a
+              class="p-side-navigation__link"
+              href="/settings/configuration/general"
             >
-              <LinkAnchor
-                className="p-side-navigation__link"
-                href="/settings/configuration/general"
-                navigate={[Function]}
-              >
-                <a
-                  className="p-side-navigation__link"
-                  href="/settings/configuration/general"
-                  onClick={[Function]}
-                >
-                  General
-                </a>
-              </LinkAnchor>
-            </Link>
+              General
+            </a>
           </li>
           <li
-            className="p-side-navigation__item"
-            key="/settings/configuration/commissioning"
+            class="p-side-navigation__item"
           >
-            <Link
-              className="p-side-navigation__link"
-              to="/settings/configuration/commissioning"
+            <a
+              class="p-side-navigation__link"
+              href="/settings/configuration/commissioning"
             >
-              <LinkAnchor
-                className="p-side-navigation__link"
-                href="/settings/configuration/commissioning"
-                navigate={[Function]}
-              >
-                <a
-                  className="p-side-navigation__link"
-                  href="/settings/configuration/commissioning"
-                  onClick={[Function]}
-                >
-                  Commissioning
-                </a>
-              </LinkAnchor>
-            </Link>
+              Commissioning
+            </a>
           </li>
           <li
-            className="p-side-navigation__item"
-            key="/settings/configuration/deploy"
+            class="p-side-navigation__item"
           >
-            <Link
-              className="p-side-navigation__link"
-              to="/settings/configuration/deploy"
+            <a
+              class="p-side-navigation__link"
+              href="/settings/configuration/deploy"
             >
-              <LinkAnchor
-                className="p-side-navigation__link"
-                href="/settings/configuration/deploy"
-                navigate={[Function]}
-              >
-                <a
-                  className="p-side-navigation__link"
-                  href="/settings/configuration/deploy"
-                  onClick={[Function]}
-                >
-                  Deploy
-                </a>
-              </LinkAnchor>
-            </Link>
+              Deploy
+            </a>
           </li>
           <li
-            className="p-side-navigation__item"
-            key="/settings/configuration/kernel-parameters"
+            class="p-side-navigation__item"
           >
-            <Link
-              className="p-side-navigation__link"
-              to="/settings/configuration/kernel-parameters"
+            <a
+              class="p-side-navigation__link"
+              href="/settings/configuration/kernel-parameters"
             >
-              <LinkAnchor
-                className="p-side-navigation__link"
-                href="/settings/configuration/kernel-parameters"
-                navigate={[Function]}
-              >
-                <a
-                  className="p-side-navigation__link"
-                  href="/settings/configuration/kernel-parameters"
-                  onClick={[Function]}
-                >
-                  Kernel parameters
-                </a>
-              </LinkAnchor>
-            </Link>
+              Kernel parameters
+            </a>
           </li>
         </ul>
       </li>
       <li
-        className="p-side-navigation__item--title"
-        key="/settings/users"
+        class="p-side-navigation__item--title"
       >
-        <Link
-          className="p-side-navigation__link"
-          to="/settings/users"
+        <a
+          class="p-side-navigation__link"
+          href="/settings/users"
         >
-          <LinkAnchor
-            className="p-side-navigation__link"
-            href="/settings/users"
-            navigate={[Function]}
-          >
-            <a
-              className="p-side-navigation__link"
-              href="/settings/users"
-              onClick={[Function]}
-            >
-              Users
-            </a>
-          </LinkAnchor>
-        </Link>
+          Users
+        </a>
       </li>
     </ul>
-  </nav>
-</SideNav>
+  </div>
+</nav>
 `;

--- a/ui/src/app/preferences/components/Nav/Nav.tsx
+++ b/ui/src/app/preferences/components/Nav/Nav.tsx
@@ -3,6 +3,7 @@ import prefsURLs from "app/preferences/urls";
 
 export const Nav = (): JSX.Element => (
   <SideNav
+    closeToggleText="Close preferences menu"
     items={[
       {
         path: prefsURLs.details,
@@ -21,6 +22,7 @@ export const Nav = (): JSX.Element => (
         label: "SSL keys",
       },
     ]}
+    openToggleText="Preferences menu"
   />
 );
 

--- a/ui/src/app/settings/components/Nav/Nav.tsx
+++ b/ui/src/app/settings/components/Nav/Nav.tsx
@@ -3,6 +3,7 @@ import settingsURLs from "app/settings/urls";
 
 export const Nav = (): JSX.Element => (
   <SideNav
+    closeToggleText="Close settings menu"
     items={[
       {
         label: "Configuration",
@@ -78,6 +79,7 @@ export const Nav = (): JSX.Element => (
         label: "Package repos",
       },
     ]}
+    openToggleText="Settings menu"
   />
 );
 

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -30,3 +30,11 @@ button.p-navigation__link {
     width: 100%;
   }
 }
+
+// 09-05-2022 Caleb: Side nav sets background to white on full-screen
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/4458
+.p-side-navigation .p-side-navigation__drawer {
+  @media screen and (min-width: $breakpoint-large) {
+    background-color: transparent;
+  }
+}


### PR DESCRIPTION
## Done

- Added Vanilla mobile drawer to the SideNav component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Settings or user prefs and check that the side nav looks the same as before
- Resize the viewport to small and check that the side nav is replaced with a "Toggle side navigation" button
- Check that you can open and close the drawer using the toggle buttons
- Check that you can close the drawer using the esc key

## Fixes

Fixes canonical-web-and-design/app-tribe#923

## Screenshot
![Peek 2022-05-09 16-04](https://user-images.githubusercontent.com/25733845/167350261-f25a1e9b-80b4-4c63-9aa7-e2ab23fbcd02.gif)

