### PR TITLE
fix(ui): fix actions from the machine list

### DIFF
--- a/ui/src/app/base/hooks.test.tsx
+++ b/ui/src/app/base/hooks.test.tsx
@@ -1,20 +1,31 @@
 import { renderHook } from "@testing-library/react-hooks";
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import TestRenderer from "react-test-renderer";
 import configureStore from "redux-mock-store";
 
+import type { MachineMenuAction } from "./hooks";
 import {
   useCompletedIntro,
   useCompletedUserIntro,
   useCycled,
+  useMachineActions,
   useScrollOnRender,
 } from "./hooks";
 
+import { actions as machineActions } from "app/store/machine";
+import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import { getCookie } from "app/utils";
 import {
   authState as authStateFactory,
   config as configFactory,
   configState as configStateFactory,
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineAction as machineActionFactory,
+  machineActionsState as machineActionsStateFactory,
+  machineState as machineStateFactory,
   rootState as rootStateFactory,
   user as userFactory,
   userState as userStateFactory,
@@ -259,6 +270,166 @@ describe("hooks", () => {
       });
       expect(result.current).toBe(true);
       getCookieMock.mockReset();
+    });
+  });
+
+  describe("useMachineActions", () => {
+    let state: RootState;
+    const HookWrapper = ({ action }: { action: MachineMenuAction }) => {
+      const actions = useMachineActions("abc123", [action]);
+      return (
+        <>
+          {actions.map((action, i) => (
+            <button {...action} key={i} />
+          ))}
+        </>
+      );
+    };
+
+    const dispatchAction = (
+      action: MachineMenuAction,
+      expectedType: string
+    ) => {
+      state.general.machineActions.data[0].name = action;
+      state.machine.items[0].actions = [action];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <HookWrapper action={action} />
+        </Provider>
+      );
+      wrapper.find("button").simulate("click");
+      return store.getActions().find((action) => action.type === expectedType);
+    };
+
+    beforeEach(() => {
+      state = rootStateFactory({
+        general: generalStateFactory({
+          machineActions: machineActionsStateFactory({
+            data: [machineActionFactory()],
+          }),
+        }),
+        machine: machineStateFactory({
+          items: [
+            machineFactory({
+              system_id: "abc123",
+              actions: [],
+            }),
+          ],
+        }),
+      });
+    });
+
+    it("can dispatch an abort action", () => {
+      const action = NodeActions.ABORT;
+      const expected = machineActions.abort("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch an acquire action", () => {
+      const action = NodeActions.ACQUIRE;
+      const expected = machineActions.acquire("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a commission action", () => {
+      const action = NodeActions.COMMISSION;
+      const expected = machineActions.commission({ systemId: "abc123" });
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a delete action", () => {
+      const action = NodeActions.DELETE;
+      const expected = machineActions.delete("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a deploy action", () => {
+      const action = NodeActions.DEPLOY;
+      const expected = machineActions.deploy({ systemId: "abc123" });
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch an exit-rescue-mode action", () => {
+      const action = NodeActions.EXIT_RESCUE_MODE;
+      const expected = machineActions.exitRescueMode("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a lock action", () => {
+      const action = NodeActions.LOCK;
+      const expected = machineActions.lock("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a mark-broken action", () => {
+      const action = NodeActions.MARK_BROKEN;
+      const expected = machineActions.markBroken({ systemId: "abc123" });
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a mark-fixed action", () => {
+      const action = NodeActions.MARK_FIXED;
+      const expected = machineActions.markFixed("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch an off action", () => {
+      const action = NodeActions.OFF;
+      const expected = machineActions.off("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch an on action", () => {
+      const action = NodeActions.ON;
+      const expected = machineActions.on("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch an override-failed-testing action", () => {
+      const action = NodeActions.OVERRIDE_FAILED_TESTING;
+      const expected = machineActions.overrideFailedTesting("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a release action", () => {
+      const action = NodeActions.RELEASE;
+      const expected = machineActions.release({ systemId: "abc123" });
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a rescue-mode action", () => {
+      const action = NodeActions.RESCUE_MODE;
+      const expected = machineActions.rescueMode("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch a test action", () => {
+      const action = NodeActions.TEST;
+      const expected = machineActions.test({ systemId: "abc123" });
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
+    });
+
+    it("can dispatch an unlock action", () => {
+      const action = NodeActions.UNLOCK;
+      const expected = machineActions.unlock("abc123");
+      const dispatched = dispatchAction(action, expected.type);
+      expect(dispatched).toStrictEqual(expected);
     });
   });
 });

--- a/ui/src/app/base/hooks.test.tsx
+++ b/ui/src/app/base/hooks.test.tsx
@@ -279,8 +279,8 @@ describe("hooks", () => {
       const actions = useMachineActions("abc123", [action]);
       return (
         <>
-          {actions.map((action, i) => (
-            <button {...action} key={i} />
+          {actions.map((buttonProps, i) => (
+            <button {...buttonProps} key={i} />
           ))}
         </>
       );

--- a/ui/src/app/store/machine/types/actions.ts
+++ b/ui/src/app/store/machine/types/actions.ts
@@ -32,15 +32,15 @@ export type CloneParams = {
 
 export type CommissionParams = {
   systemId: Machine[MachineMeta.PK];
-  enableSSH: boolean;
-  skipBMCConfig: boolean;
-  skipNetworking: boolean;
-  skipStorage: boolean;
-  updateFirmware: boolean;
-  configureHBA: boolean;
-  commissioningScripts: Script[];
-  testingScripts: Script[];
-  scriptInputs: ScriptInput;
+  enableSSH?: boolean;
+  skipBMCConfig?: boolean;
+  skipNetworking?: boolean;
+  skipStorage?: boolean;
+  updateFirmware?: boolean;
+  configureHBA?: boolean;
+  commissioningScripts?: Script[];
+  testingScripts?: Script[];
+  scriptInputs?: ScriptInput;
 };
 
 export type CreateBcacheParams = {
@@ -249,7 +249,7 @@ export type LinkSubnetParams = {
 
 export type MarkBrokenParams = {
   systemId: Machine[MachineMeta.PK];
-  message: string;
+  message?: string;
 };
 
 export type MountSpecialParams = {
@@ -267,7 +267,7 @@ export type OptionalFilesystemParams = {
 
 export type ReleaseParams = {
   systemId: Machine[MachineMeta.PK];
-  extra: {
+  extra?: {
     erase?: boolean;
     quick_erase?: boolean;
     secure_erase?: boolean;
@@ -301,8 +301,8 @@ export type TagParams = {
 export type TestParams = {
   systemId: Machine[MachineMeta.PK];
   scripts?: Script[];
-  enableSSH: boolean;
-  scriptInputs: ScriptInput;
+  enableSSH?: boolean;
+  scriptInputs?: ScriptInput;
 };
 
 export type UnlinkSubnetParams = {


### PR DESCRIPTION
## Done

- Fix actions made from the machine list table menus.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- In the status column open the menu and make sure you can preform the following actions: abort, acquire, commission, deploy, exit rescue mode, lock, mark broken, mark fixed, override failed testing, release, rescue mode, test and unlock

## Fixes

Fixes: #3935.