### PR TITLE
feat: PR demos for MAAS UI - WIP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:experimental
+
+# Build stage: Install yarn dependencies
+# ===
+FROM node:14 AS yarn-dependencies
+WORKDIR /srv
+COPY . .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn CYPRESS_INSTALL_BINARY=0 yarn install
+
+# Build stage: Run "yarn build"
+# ===
+FROM yarn-dependencies AS build-js
+RUN yarn run build-all
+
+
+# Build the production image
+# ===
+# FROM ubuntu:focal
+
+# # Set up environment
+# ENV LANG C.UTF-8
+# WORKDIR /srv
+
+# RUN apt-get update && apt-get install --no-install-recommends --yes python3 yarn
+
+# Import code, build assets and mirror list
+# ADD . .
+# RUN rm -rf yarn.lock
+# COPY --from=build-js /srv/build /srv/build
+
+# Setup commands to run server
+CMD yarn run serve-static-demo

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,0 +1,3 @@
+domain: maas-ui.demos.haus
+image: prod-web-team-demos.docker-registry.canonical.com/maas-ui.demos.haus
+readinessPath: "/"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "commit": "git-cz",
     "release": "cd ui && yarn run release",
     "serve": "cd proxy && yarn start",
+    "serve-proxy": "cd proxy && yarn serve-proxy",
+    "serve-static-demo": "cd proxy && yarn serve-static-demo",
     "start": "yarn serve",
     "clean": "yarn clean-all",
     "clean-all": "rm -rf build && yarn clean-monorepo && yarn clean-proxy && yarn clean-shared && yarn clean-legacy && yarn clean-ui && yarn clean-root",

--- a/proxy/.env
+++ b/proxy/.env
@@ -1,3 +1,3 @@
-MAAS_URL = "http://bolla.internal:5240/"
+MAAS_URL = "http://polong.internal:5240/"
 MAAS_WEBSOCKET_HOST=
 MAAS_WEBSOCKET_PORT=

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -6,13 +6,17 @@ const { BASENAME, REACT_BASENAME } = require("@maas-ui/maas-ui-shared");
 
 var app = express();
 
-const PROXY_PORT = 8400;
+const PROXY_PORT = process.env.PROXY_PORT || 8400;
 const UI_PORT = 8401;
 const LEGACY_PORT = 8402;
 const ROOT_PORT = 8404;
 
 app.get(BASENAME, (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
 app.get("/", (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
+if (process.env.STATIC_DEMO === "true") {
+  app.use(`${BASENAME}${REACT_BASENAME}`, express.static('../build'));
+}
+
 app.get(`${BASENAME}/`, (req, res) =>
   res.redirect(`${BASENAME}${REACT_BASENAME}`)
 );
@@ -69,11 +73,14 @@ app.use(
 );
 
 // Proxy to the single-spa root app.
-app.use(
-  createProxyMiddleware("/", {
-    target: `http://localhost:${ROOT_PORT}/`,
-  })
-);
+if (process.env.STATIC_DEMO !== "true") {
+  app.use(
+    createProxyMiddleware("/", {
+      target: `http://localhost:${ROOT_PORT}/`,
+    })
+  );
+} 
+
 
 app.listen(PROXY_PORT);
 

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -12,6 +12,7 @@
     "serve-base": "concurrently \"yarn serve-root\" \"yarn serve-proxy\"",
     "serve-base-wait": "wait-on http://0.0.0.0:8401 && wait-on http://0.0.0.0:8402 && yarn serve-base",
     "serve-proxy": "nodemon ./index.js",
+    "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=80 nodemon ./index.js",
     "serve-legacy": "cd ../legacy && yarn run start",
     "serve-root": "cd ../root && yarn start",
     "serve-ui": "cd ../ui && BROWSER=none PORT=8401 yarn run start",


### PR DESCRIPTION
## Done

- Spike for enabling PR demos for MAAS UI (work in progress)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the demo link https://maas-ui-3950.demos.haus/
- Open the browser console and verify the site hash is the same as commit hash in this pull request 

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/977

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
