### PR TITLE
fix: inconsistent docs redirect failures

### DIFF
--- a/integration/cypress/integration/docs-links/docs-links.spec.ts
+++ b/integration/cypress/integration/docs-links/docs-links.spec.ts
@@ -21,16 +21,8 @@ context("docs resource exists", () => {
 context("docs resources have no redirects", () => {
   urls.forEach((url) => {
     it(url, () => {
-      cy.request({
-        url: url,
-        followRedirect: false,
-      }).then((resp) => {
-        Cypress.log({
-          name: `UNEXPECTED REDIRECT TO:`,
-          message: resp.redirectedToUrl,
-        });
-        expect(resp.redirectedToUrl).to.eq(undefined);
-      });
+      cy.visit(url);
+      cy.url().should("equal", url);
     });
   });
 });


### PR DESCRIPTION
## Done

- fix: inconsistent docs redirect failures

### Background
We were using [cy.request](https://docs.cypress.io/api/commands/request#Request-a-page-while-disabling-auto-redirect) to test for documentation urls redirects. `cy.request` is a little faster than regular `cy.visit`, which needs to load the page in a browser, but it proved to be flaky.

I was able to reproduce the issue locally but it happened quite rarely and it wasn't obvious what's the cause. `cy.visit` gave consistent results over multiple runs.


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3947

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
