### PR TITLE
refactor(ui): use React Router v6 Link components

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "react-dropzone": "12.1.0",
     "react-redux": "7.2.8",
     "react-router-dom": "5.3.1",
-    "react-router-dom-v5-compat": "^6.3.0",
+    "react-router-dom-v5-compat": "6.3.0",
     "react-router-prop-types": "1.0.5",
     "react-scripts": "4.0.3",
     "react-storage-hooks": "4.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
     "react-dropzone": "12.1.0",
     "react-redux": "7.2.8",
     "react-router-dom": "5.3.1",
+    "react-router-dom-v5-compat": "^6.3.0",
     "react-router-prop-types": "1.0.5",
     "react-scripts": "4.0.3",
     "react-storage-hooks": "4.0.1",

--- a/ui/src/app/App.test.tsx
+++ b/ui/src/app/App.test.tsx
@@ -2,6 +2,7 @@ import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { App } from "./App";
@@ -38,7 +39,9 @@ describe("App", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -52,7 +55,9 @@ describe("App", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +72,9 @@ describe("App", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -80,7 +87,9 @@ describe("App", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -93,7 +102,9 @@ describe("App", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +117,9 @@ describe("App", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -124,7 +137,9 @@ describe("App", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -140,7 +155,9 @@ describe("App", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -152,7 +169,9 @@ describe("App", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -175,7 +194,9 @@ describe("App", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <App />
+          <CompatRouter>
+            <App />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -6,7 +6,8 @@ import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import Routes from "app/Routes";
 import Login from "app/base/components/Login";

--- a/ui/src/app/Routes.test.tsx
+++ b/ui/src/app/Routes.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Routes from "./Routes";
@@ -141,7 +142,9 @@ describe("Routes", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Routes />
+            <CompatRouter>
+              <Routes />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DHCPTable from "./DHCPTable";
@@ -57,10 +58,12 @@ describe("DHCPTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DHCPTable
-            node={state.machine.items[0]}
-            modelName={MachineMeta.MODEL}
-          />
+          <CompatRouter>
+            <DHCPTable
+              node={state.machine.items[0]}
+              modelName={MachineMeta.MODEL}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -82,10 +85,12 @@ describe("DHCPTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DHCPTable
-            node={state.machine.items[0]}
-            modelName={MachineMeta.MODEL}
-          />
+          <CompatRouter>
+            <DHCPTable
+              node={state.machine.items[0]}
+              modelName={MachineMeta.MODEL}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -108,7 +113,9 @@ describe("DHCPTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DHCPTable subnets={subnets} modelName={MachineMeta.MODEL} />
+          <CompatRouter>
+            <DHCPTable subnets={subnets} modelName={MachineMeta.MODEL} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,10 +145,12 @@ describe("DHCPTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DHCPTable
-            node={state.machine.items[0]}
-            modelName={MachineMeta.MODEL}
-          />
+          <CompatRouter>
+            <DHCPTable
+              node={state.machine.items[0]}
+              modelName={MachineMeta.MODEL}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { List, MainTable, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import TitledSection from "../TitledSection";
 

--- a/ui/src/app/base/components/DeviceLink/DeviceLink.test.tsx
+++ b/ui/src/app/base/components/DeviceLink/DeviceLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceLink from "./DeviceLink";
@@ -22,7 +23,9 @@ it("handles when devices are loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DeviceLink systemId="abc123" />
+        <CompatRouter>
+          <DeviceLink systemId="abc123" />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +41,9 @@ it("handles when a device does not exist", () => {
   const { container } = render(
     <Provider store={store}>
       <MemoryRouter>
-        <DeviceLink systemId="abc123" />
+        <CompatRouter>
+          <DeviceLink systemId="abc123" />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,7 +60,9 @@ it("renders a link if devices have loaded and it exists", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DeviceLink systemId={device.system_id} />
+        <CompatRouter>
+          <DeviceLink systemId={device.system_id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/DeviceLink/DeviceLink.tsx
+++ b/ui/src/app/base/components/DeviceLink/DeviceLink.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import deviceURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";

--- a/ui/src/app/base/components/FabricLink/FabricLink.test.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricLink from "./FabricLink";
@@ -22,7 +23,9 @@ it("handles when fabrics are loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricLink id={1} />
+        <CompatRouter>
+          <FabricLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +41,9 @@ it("handles when a fabric does not exist", () => {
   const { container } = render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricLink id={1} />
+        <CompatRouter>
+          <FabricLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,7 +60,9 @@ it("renders a link if fabrics have loaded and it exists", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricLink id={fabric.id} />
+        <CompatRouter>
+          <FabricLink id={fabric.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/FabricLink/FabricLink.tsx
+++ b/ui/src/app/base/components/FabricLink/FabricLink.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";

--- a/ui/src/app/base/components/MachineLink/MachineLink.test.tsx
+++ b/ui/src/app/base/components/MachineLink/MachineLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineLink from "./MachineLink";
@@ -22,7 +23,9 @@ it("handles when machines are loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <MachineLink systemId="abc123" />
+        <CompatRouter>
+          <MachineLink systemId="abc123" />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +41,9 @@ it("handles when a machine does not exist", () => {
   const { container } = render(
     <Provider store={store}>
       <MemoryRouter>
-        <MachineLink systemId="abc123" />
+        <CompatRouter>
+          <MachineLink systemId="abc123" />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,7 +60,9 @@ it("renders a link if machines have loaded and it exists", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <MachineLink systemId={machine.system_id} />
+        <CompatRouter>
+          <MachineLink systemId={machine.system_id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/ui/src/app/base/components/MachineLink/MachineLink.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import machineURLs from "app/machines/urls";
 import { actions as machineActions } from "app/store/machine";

--- a/ui/src/app/base/components/ModelNotFound/ModelNotFound.test.tsx
+++ b/ui/src/app/base/components/ModelNotFound/ModelNotFound.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ModelNotFound from "./ModelNotFound";
@@ -16,7 +17,9 @@ describe("ModelNotFound", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <ModelNotFound id={1} linkURL="www.url.com" modelName="model" />
+          <CompatRouter>
+            <ModelNotFound id={1} linkURL="www.url.com" modelName="model" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -32,7 +35,9 @@ describe("ModelNotFound", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <ModelNotFound id={1} linkURL="www.url.com" modelName="model" />
+          <CompatRouter>
+            <ModelNotFound id={1} linkURL="www.url.com" modelName="model" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -47,12 +52,14 @@ describe("ModelNotFound", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <ModelNotFound
-            id={1}
-            linkText="Click here to win $500"
-            linkURL="www.url.com"
-            modelName="model"
-          />
+          <CompatRouter>
+            <ModelNotFound
+              id={1}
+              linkText="Click here to win $500"
+              linkURL="www.url.com"
+              modelName="model"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/ModelNotFound/ModelNotFound.tsx
+++ b/ui/src/app/base/components/ModelNotFound/ModelNotFound.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";

--- a/ui/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.test.tsx
+++ b/ui/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NodeSummaryNetworkCard from "./NodeSummaryNetworkCard";
@@ -30,7 +31,9 @@ describe("NodeSummaryNetworkCard", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NodeSummaryNetworkCard interfaces={[]} networkURL="url" />
+          <CompatRouter>
+            <NodeSummaryNetworkCard interfaces={[]} networkURL="url" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -45,7 +48,9 @@ describe("NodeSummaryNetworkCard", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NodeSummaryNetworkCard interfaces={null} networkURL="url" />
+          <CompatRouter>
+            <NodeSummaryNetworkCard interfaces={null} networkURL="url" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +77,9 @@ describe("NodeSummaryNetworkCard", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NodeSummaryNetworkCard interfaces={interfaces} networkURL="url" />
+          <CompatRouter>
+            <NodeSummaryNetworkCard interfaces={interfaces} networkURL="url" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -124,7 +131,9 @@ describe("NodeSummaryNetworkCard", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NodeSummaryNetworkCard interfaces={interfaces} networkURL="url" />
+          <CompatRouter>
+            <NodeSummaryNetworkCard interfaces={interfaces} networkURL="url" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -140,9 +149,11 @@ describe("NodeSummaryNetworkCard", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NodeSummaryNetworkCard interfaces={[]} networkURL="url">
-            <span data-testid="child">Hi</span>
-          </NodeSummaryNetworkCard>
+          <CompatRouter>
+            <NodeSummaryNetworkCard interfaces={[]} networkURL="url">
+              <span data-testid="child">Hi</span>
+            </NodeSummaryNetworkCard>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.tsx
+++ b/ui/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.tsx
@@ -3,7 +3,7 @@ import { Fragment, useEffect } from "react";
 
 import { Card, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import NetworkCardTable from "./NetworkCardTable";
 

--- a/ui/src/app/base/components/SideNav/SideNav.test.tsx
+++ b/ui/src/app/base/components/SideNav/SideNav.test.tsx
@@ -2,6 +2,7 @@ import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { RouteProps } from "react-router-dom";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import type { NavItem } from "./SideNav";
 import { SideNav } from "./SideNav";
@@ -38,10 +39,12 @@ it("matches the snapshot", () => {
       initialEntries={[{ pathname: "/settings", key: "testKey" }]}
       initialIndex={0}
     >
-      <Route
-        render={(props: RouteProps) => <SideNav {...props} items={items} />}
-        path="/settings"
-      />
+      <CompatRouter>
+        <Route
+          render={(props: RouteProps) => <SideNav {...props} items={items} />}
+          path="/settings"
+        />
+      </CompatRouter>
     </MemoryRouter>
   );
 
@@ -54,10 +57,12 @@ it("can set an active item", () => {
       initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
       initialIndex={0}
     >
-      <Route
-        render={(props: RouteProps) => <SideNav {...props} items={items} />}
-        path="/settings"
-      />
+      <CompatRouter>
+        <Route
+          render={(props: RouteProps) => <SideNav {...props} items={items} />}
+          path="/settings"
+        />
+      </CompatRouter>
     </MemoryRouter>
   );
 
@@ -67,11 +72,13 @@ it("can set an active item", () => {
 it("can be given different toggle texts", () => {
   render(
     <MemoryRouter>
-      <SideNav
-        closeToggleText="Get me out!"
-        items={items}
-        openToggleText="Let me in!"
-      />
+      <CompatRouter>
+        <SideNav
+          closeToggleText="Get me out!"
+          items={items}
+          openToggleText="Let me in!"
+        />
+      </CompatRouter>
     </MemoryRouter>
   );
 
@@ -86,7 +93,9 @@ it("can be given different toggle texts", () => {
 it("can open and close the navigation drawer by clicking the toggles", async () => {
   render(
     <MemoryRouter>
-      <SideNav items={items} />
+      <CompatRouter>
+        <SideNav items={items} />
+      </CompatRouter>
     </MemoryRouter>
   );
   const nav = screen.getByRole("navigation");
@@ -110,7 +119,9 @@ it("can open and close the navigation drawer by clicking the toggles", async () 
 it("can close the navigation drawer by pressing the esc key", async () => {
   render(
     <MemoryRouter>
-      <SideNav items={items} />
+      <CompatRouter>
+        <SideNav items={items} />
+      </CompatRouter>
     </MemoryRouter>
   );
   const nav = screen.getByRole("navigation");

--- a/ui/src/app/base/components/SideNav/SideNav.tsx
+++ b/ui/src/app/base/components/SideNav/SideNav.tsx
@@ -3,7 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 
 import classNames from "classnames";
 import type { Location } from "history";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import { useCycled } from "app/base/hooks";
 

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.test.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SpaceLink from "./SpaceLink";
@@ -22,7 +23,9 @@ it("handles when spaces are loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <SpaceLink id={1} />
+        <CompatRouter>
+          <SpaceLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +41,9 @@ it("handles when a space does not exist", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <SpaceLink id={1} />
+        <CompatRouter>
+          <SpaceLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -56,7 +61,9 @@ it("renders a link if spaces have loaded and it exists", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <SpaceLink id={space.id} />
+        <CompatRouter>
+          <SpaceLink id={space.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
+++ b/ui/src/app/base/components/SpaceLink/SpaceLink.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { RootState } from "app/store/root/types";
 import { actions as spaceActions } from "app/store/space";

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.test.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SubnetLink from "./SubnetLink";
@@ -22,7 +23,9 @@ it("handles when subnets are loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <SubnetLink id={1} />
+        <CompatRouter>
+          <SubnetLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +41,9 @@ it("handles when a subnet does not exist", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <SubnetLink id={1} />
+        <CompatRouter>
+          <SubnetLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -56,7 +61,9 @@ it("renders a link if subnets have loaded and it exists", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <SubnetLink id={subnet.id} />
+        <CompatRouter>
+          <SubnetLink id={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
+++ b/ui/src/app/base/components/SubnetLink/SubnetLink.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";

--- a/ui/src/app/base/components/TableActions/TableActions.tsx
+++ b/ui/src/app/base/components/TableActions/TableActions.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import CopyButton from "app/base/components/CopyButton";
 

--- a/ui/src/app/base/components/TagLinks/TagLinks.test.tsx
+++ b/ui/src/app/base/components/TagLinks/TagLinks.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import TagLinks from "./TagLinks";
 
@@ -9,10 +10,12 @@ describe("TagLinks", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
       >
-        <TagLinks
-          getLinkURL={(tag) => `www.tags.com/${tag}`}
-          tags={["tag-1", "tag-2"]}
-        />
+        <CompatRouter>
+          <TagLinks
+            getLinkURL={(tag) => `www.tags.com/${tag}`}
+            tags={["tag-1", "tag-2"]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     );
 

--- a/ui/src/app/base/components/TagLinks/TagLinks.tsx
+++ b/ui/src/app/base/components/TagLinks/TagLinks.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { Tag } from "app/store/tag/types";
 

--- a/ui/src/app/base/components/TagLinks/__snapshots__/TagLinks.test.tsx.snap
+++ b/ui/src/app/base/components/TagLinks/__snapshots__/TagLinks.test.tsx.snap
@@ -19,17 +19,12 @@ exports[`TagLinks renders 1`] = `
       <Link
         to="www.tags.com/tag-1"
       >
-        <LinkAnchor
-          href="/machine/www.tags.com/tag-1"
-          navigate={[Function]}
+        <a
+          href="/www.tags.com/tag-1"
+          onClick={[Function]}
         >
-          <a
-            href="/machine/www.tags.com/tag-1"
-            onClick={[Function]}
-          >
-            tag-1
-          </a>
-        </LinkAnchor>
+          tag-1
+        </a>
       </Link>
       , 
     </span>
@@ -39,17 +34,12 @@ exports[`TagLinks renders 1`] = `
       <Link
         to="www.tags.com/tag-2"
       >
-        <LinkAnchor
-          href="/machine/www.tags.com/tag-2"
-          navigate={[Function]}
+        <a
+          href="/www.tags.com/tag-2"
+          onClick={[Function]}
         >
-          <a
-            href="/machine/www.tags.com/tag-2"
-            onClick={[Function]}
-          >
-            tag-2
-          </a>
-        </LinkAnchor>
+          tag-2
+        </a>
       </Link>
     </span>
   </span>

--- a/ui/src/app/base/components/VLANLink/VLANLink.test.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VLANLink from "./VLANLink";
@@ -22,7 +23,9 @@ it("handles when VLANs are loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANLink id={1} />
+        <CompatRouter>
+          <VLANLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +41,9 @@ it("handles when a VLAN does not exist", () => {
   const { container } = render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANLink id={1} />
+        <CompatRouter>
+          <VLANLink id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,7 +60,9 @@ it("renders a link if VLANs have loaded and it exists", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANLink id={vlan.id} />
+        <CompatRouter>
+          <VLANLink id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/VLANLink/VLANLink.tsx
+++ b/ui/src/app/base/components/VLANLink/VLANLink.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { RootState } from "app/store/root/types";
 import { actions as vlanActions } from "app/store/vlan";

--- a/ui/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/ui/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachinesHeader from "./MachinesHeader";
@@ -60,7 +61,9 @@ describe("MachinesHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachinesHeader />
+          <CompatRouter>
+            <MachinesHeader />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/ui/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";

--- a/ui/src/app/base/components/node/NodeLink/NodeLink.test.tsx
+++ b/ui/src/app/base/components/node/NodeLink/NodeLink.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NodeLink from "./NodeLink";
@@ -31,10 +32,12 @@ it("can render a controller link", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <NodeLink
-          nodeType={NodeType.RACK_CONTROLLER}
-          systemId={controller.system_id}
-        />
+        <CompatRouter>
+          <NodeLink
+            nodeType={NodeType.RACK_CONTROLLER}
+            systemId={controller.system_id}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -54,7 +57,9 @@ it("can render a device link", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <NodeLink nodeType={NodeType.DEVICE} systemId={device.system_id} />
+        <CompatRouter>
+          <NodeLink nodeType={NodeType.DEVICE} systemId={device.system_id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -74,7 +79,9 @@ it("can render a machine link", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <NodeLink nodeType={NodeType.MACHINE} systemId={machine.system_id} />
+        <CompatRouter>
+          <NodeLink nodeType={NodeType.MACHINE} systemId={machine.system_id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.test.tsx
+++ b/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricColumn from "./FabricColumn";
@@ -49,7 +50,9 @@ describe("FabricColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <FabricColumn nic={nic} node={state.machine.items[0]} />
+          <CompatRouter>
+            <FabricColumn nic={nic} node={state.machine.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -74,7 +77,9 @@ describe("FabricColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <FabricColumn nic={nic} node={state.machine.items[0]} />
+          <CompatRouter>
+            <FabricColumn nic={nic} node={state.machine.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.tsx
+++ b/ui/src/app/base/components/node/networking/FabricColumn/FabricColumn.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import fabricSelectors from "app/store/fabric/selectors";

--- a/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.test.tsx
+++ b/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SubnetColumn from "./SubnetColumn";
@@ -56,7 +57,9 @@ describe("SubnetColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+          <CompatRouter>
+            <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -88,7 +91,9 @@ describe("SubnetColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <SubnetColumn link={link} nic={nic} node={state.device.items[0]} />
+          <CompatRouter>
+            <SubnetColumn link={link} nic={nic} node={state.device.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,7 +123,9 @@ describe("SubnetColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+          <CompatRouter>
+            <SubnetColumn link={link} nic={nic} node={state.machine.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -149,7 +156,9 @@ describe("SubnetColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <SubnetColumn nic={nic} node={state.machine.items[0]} />
+          <CompatRouter>
+            <SubnetColumn nic={nic} node={state.machine.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
+++ b/ui/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import { useIsAllNetworkingDisabled } from "app/base/hooks";

--- a/ui/src/app/dashboard/views/Dashboard.test.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Dashboard from "./Dashboard";
@@ -50,7 +51,9 @@ describe("Dashboard", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Dashboard />
+            <CompatRouter>
+              <Dashboard />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -66,7 +69,9 @@ describe("Dashboard", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/dashboard" }]}>
-          <Dashboard />
+          <CompatRouter>
+            <Dashboard />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +88,9 @@ describe("Dashboard", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/dashboard" }]}>
-          <Dashboard />
+          <CompatRouter>
+            <Dashboard />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -102,7 +109,9 @@ describe("Dashboard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings", key: "testKey" }]}
         >
-          <Dashboard />
+          <CompatRouter>
+            <Dashboard />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DashboardConfigurationSubnetForm from "./DashboardConfigurationSubnetForm";
@@ -28,7 +29,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DashboardConfigurationSubnetForm />
+          <CompatRouter>
+            <DashboardConfigurationSubnetForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -44,7 +47,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DashboardConfigurationSubnetForm />
+          <CompatRouter>
+            <DashboardConfigurationSubnetForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -61,7 +66,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DashboardConfigurationSubnetForm />
+          <CompatRouter>
+            <DashboardConfigurationSubnetForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +90,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DashboardConfigurationSubnetForm />
+          <CompatRouter>
+            <DashboardConfigurationSubnetForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -102,7 +111,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DashboardConfigurationSubnetForm />
+          <CompatRouter>
+            <DashboardConfigurationSubnetForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -130,7 +141,9 @@ describe("DashboardConfigurationSubnetForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DashboardConfigurationSubnetForm />
+          <CompatRouter>
+            <DashboardConfigurationSubnetForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.tsx
+++ b/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";

--- a/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DashboardHeader from "./DashboardHeader";
@@ -41,7 +42,9 @@ describe("DashboardHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DashboardHeader />
+          <CompatRouter>
+            <DashboardHeader />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -58,7 +61,9 @@ describe("DashboardHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DashboardHeader />
+          <CompatRouter>
+            <DashboardHeader />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +77,9 @@ describe("DashboardHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DashboardHeader />
+          <CompatRouter>
+            <DashboardHeader />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from "react";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector, useDispatch } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import ClearAllForm from "./ClearAllForm";
 

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DiscoveryAddForm from "./DiscoveryAddForm";
@@ -56,7 +57,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -86,7 +89,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -101,7 +106,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -117,7 +124,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -158,7 +167,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -195,7 +206,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -218,7 +231,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -240,7 +255,9 @@ describe("DiscoveryAddForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          <CompatRouter>
+            <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
@@ -4,6 +4,7 @@ import { Formik } from "formik";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { DeviceType } from "../types";
@@ -44,16 +45,18 @@ describe("DiscoveryAddFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ type: DeviceType.DEVICE }}
-            onSubmit={jest.fn()}
-          >
-            <DiscoveryAddFormFields
-              discovery={discovery}
-              setDevice={jest.fn()}
-              setDeviceType={jest.fn()}
-            />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ type: DeviceType.DEVICE }}
+              onSubmit={jest.fn()}
+            >
+              <DiscoveryAddFormFields
+                discovery={discovery}
+                setDevice={jest.fn()}
+                setDeviceType={jest.fn()}
+              />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -69,16 +72,18 @@ describe("DiscoveryAddFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ type: DeviceType.INTERFACE }}
-            onSubmit={jest.fn()}
-          >
-            <DiscoveryAddFormFields
-              discovery={discovery}
-              setDevice={jest.fn()}
-              setDeviceType={jest.fn()}
-            />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ type: DeviceType.INTERFACE }}
+              onSubmit={jest.fn()}
+            >
+              <DiscoveryAddFormFields
+                discovery={discovery}
+                setDevice={jest.fn()}
+                setDeviceType={jest.fn()}
+              />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -95,13 +100,15 @@ describe("DiscoveryAddFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <DiscoveryAddFormFields
-              discovery={discovery}
-              setDevice={jest.fn()}
-              setDeviceType={jest.fn()}
-            />
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <DiscoveryAddFormFields
+                discovery={discovery}
+                setDevice={jest.fn()}
+                setDeviceType={jest.fn()}
+              />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -122,13 +129,15 @@ describe("DiscoveryAddFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <DiscoveryAddFormFields
-              discovery={discovery}
-              setDevice={jest.fn()}
-              setDeviceType={jest.fn()}
-            />
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <DiscoveryAddFormFields
+                discovery={discovery}
+                setDevice={jest.fn()}
+                setDeviceType={jest.fn()}
+              />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -156,16 +165,18 @@ describe("DiscoveryAddFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ type: DeviceType.INTERFACE }}
-            onSubmit={jest.fn()}
-          >
-            <DiscoveryAddFormFields
-              discovery={discovery}
-              setDevice={setDevice}
-              setDeviceType={setDeviceType}
-            />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ type: DeviceType.INTERFACE }}
+              onSubmit={jest.fn()}
+            >
+              <DiscoveryAddFormFields
+                discovery={discovery}
+                setDevice={setDevice}
+                setDeviceType={setDeviceType}
+              />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -196,16 +207,18 @@ describe("DiscoveryAddFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ type: DeviceType.INTERFACE }}
-            onSubmit={jest.fn()}
-          >
-            <DiscoveryAddFormFields
-              discovery={discovery}
-              setDevice={setDevice}
-              setDeviceType={jest.fn()}
-            />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ type: DeviceType.INTERFACE }}
+              onSubmit={jest.fn()}
+            >
+              <DiscoveryAddFormFields
+                discovery={discovery}
+                setDevice={setDevice}
+                setDeviceType={jest.fn()}
+              />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -1,7 +1,7 @@
 import { Col, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { DiscoveryAddValues } from "../types";
 import { DeviceType } from "../types";

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceDetails from "./DeviceDetails";
@@ -49,10 +50,12 @@ describe("DeviceDetails", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Route
-              path={deviceURLs.device.index(null, true)}
-              render={() => <DeviceDetails />}
-            />
+            <CompatRouter>
+              <Route
+                path={deviceURLs.device.index(null, true)}
+                render={() => <DeviceDetails />}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -69,11 +72,13 @@ describe("DeviceDetails", () => {
             { pathname: deviceURLs.device.index({ id: device.system_id }) },
           ]}
         >
-          <Route
-            exact
-            path={deviceURLs.device.index(null, true)}
-            render={() => <DeviceDetails />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path={deviceURLs.device.index(null, true)}
+              render={() => <DeviceDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -101,11 +106,13 @@ describe("DeviceDetails", () => {
             { pathname: deviceURLs.device.index({ id: device.system_id }) },
           ]}
         >
-          <Route
-            exact
-            path={deviceURLs.device.index(null, true)}
-            render={() => <DeviceDetails />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path={deviceURLs.device.index(null, true)}
+              render={() => <DeviceDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -139,11 +146,13 @@ describe("DeviceDetails", () => {
             { pathname: deviceURLs.device.index({ id: device.system_id }) },
           ]}
         >
-          <Route
-            exact
-            path={deviceURLs.device.index(null, true)}
-            render={() => <DeviceDetails />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path={deviceURLs.device.index(null, true)}
+              render={() => <DeviceDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceDetailsHeader from "./DeviceDetailsHeader";
@@ -33,11 +34,13 @@ describe("DeviceDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceDetailsHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceDetailsHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -54,11 +57,13 @@ describe("DeviceDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceDetailsHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceDetailsHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,11 +80,13 @@ describe("DeviceDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceDetailsHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceDetailsHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -93,11 +100,13 @@ describe("DeviceDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceDetailsHeader
-            headerContent={{ view: DeviceHeaderViews.DELETE_DEVICE }}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceDetailsHeader
+              headerContent={{ view: DeviceHeaderViews.DELETE_DEVICE }}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -111,11 +120,13 @@ describe("DeviceDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceDetailsHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceDetailsHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DeviceName from "./DeviceName";
 

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceNetwork from "./DeviceNetwork";
@@ -26,7 +27,9 @@ describe("DeviceNetwork", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/device/abc123", key: "testKey" }]}
         >
-          <DeviceNetwork systemId="abc123" />
+          <CompatRouter>
+            <DeviceNetwork systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -46,7 +49,9 @@ describe("DeviceNetwork", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/device/abc123", key: "testKey" }]}
         >
-          <DeviceNetwork systemId="abc123" />
+          <CompatRouter>
+            <DeviceNetwork systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceNetworkTable from "./DeviceNetworkTable";
@@ -54,11 +55,13 @@ describe("DeviceNetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceNetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceNetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -70,11 +73,13 @@ describe("DeviceNetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceNetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceNetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -108,11 +113,13 @@ describe("DeviceNetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceNetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceNetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -151,11 +158,13 @@ describe("DeviceNetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceNetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceNetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -181,11 +190,13 @@ describe("DeviceNetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceNetworkTable
-            expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceNetworkTable
+              expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -214,11 +225,13 @@ describe("DeviceNetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceNetworkTable
-            expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <DeviceNetworkTable
+              expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditInterfaceTable from "./EditInterfaceTable";
@@ -57,7 +58,9 @@ describe("EditInterfaceTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+          <CompatRouter>
+            <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -69,7 +72,9 @@ describe("EditInterfaceTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+          <CompatRouter>
+            <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -102,7 +107,9 @@ describe("EditInterfaceTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+          <CompatRouter>
+            <EditInterfaceTable nicId={nic.id} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceSummary.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceSummary.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceSummary from "./DeviceSummary";
@@ -22,7 +23,9 @@ describe("DeviceSummary", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceSummary systemId="abc123" />
+          <CompatRouter>
+            <DeviceSummary systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -41,7 +44,9 @@ describe("DeviceSummary", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceSummary systemId="abc123" />
+          <CompatRouter>
+            <DeviceSummary systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
@@ -2,6 +2,7 @@ import type { ReactWrapper } from "enzyme";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceListTable from "./DeviceListTable";
@@ -47,11 +48,13 @@ describe("DeviceListTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceListTable
-            devices={[device]}
-            onSelectedChange={jest.fn()}
-            selectedIDs={[]}
-          />
+          <CompatRouter>
+            <DeviceListTable
+              devices={[device]}
+              onSelectedChange={jest.fn()}
+              selectedIDs={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -68,11 +71,13 @@ describe("DeviceListTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceListTable
-            devices={[device]}
-            onSelectedChange={jest.fn()}
-            selectedIDs={[]}
-          />
+          <CompatRouter>
+            <DeviceListTable
+              devices={[device]}
+              onSelectedChange={jest.fn()}
+              selectedIDs={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -88,11 +93,13 @@ describe("DeviceListTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceListTable
-            devices={[device]}
-            onSelectedChange={jest.fn()}
-            selectedIDs={[]}
-          />
+          <CompatRouter>
+            <DeviceListTable
+              devices={[device]}
+              onSelectedChange={jest.fn()}
+              selectedIDs={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -116,11 +123,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={jest.fn()}
-              selectedIDs={[]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={jest.fn()}
+                selectedIDs={[]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -156,11 +165,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={jest.fn()}
-              selectedIDs={[]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={jest.fn()}
+                selectedIDs={[]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -188,11 +199,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={jest.fn()}
-              selectedIDs={[]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={jest.fn()}
+                selectedIDs={[]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -220,11 +233,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={jest.fn()}
-              selectedIDs={[]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={jest.fn()}
+                selectedIDs={[]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -251,11 +266,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={onSelectedChange}
-              selectedIDs={[]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={onSelectedChange}
+                selectedIDs={[]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -275,11 +292,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={onSelectedChange}
-              selectedIDs={["abc123"]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={onSelectedChange}
+                selectedIDs={["abc123"]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -302,11 +321,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={onSelectedChange}
-              selectedIDs={[]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={onSelectedChange}
+                selectedIDs={[]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -328,11 +349,13 @@ describe("DeviceListTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <DeviceListTable
-              devices={devices}
-              onSelectedChange={onSelectedChange}
-              selectedIDs={["abc123", "def456"]}
-            />
+            <CompatRouter>
+              <DeviceListTable
+                devices={devices}
+                onSelectedChange={onSelectedChange}
+                selectedIDs={["abc123", "def456"]}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -1,5 +1,5 @@
 import { MainTable, Spinner } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import OwnerColumn from "./OwnerColumn";
 

--- a/ui/src/app/devices/views/Devices.test.tsx
+++ b/ui/src/app/devices/views/Devices.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Devices from "./Devices";
@@ -42,7 +43,9 @@ describe("Devices", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Devices />
+            <CompatRouter>
+              <Devices />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainDetails from "./DomainDetails";
@@ -26,7 +27,9 @@ describe("DomainDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
         >
-          <Route exact path="/domain/:id" render={() => <DomainDetails />} />
+          <CompatRouter>
+            <Route exact path="/domain/:id" render={() => <DomainDetails />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DeleteRecordForm from "./DeleteRecordForm";
 import EditRecordForm from "./EditRecordForm";

--- a/ui/src/app/domains/views/Domains.test.tsx
+++ b/ui/src/app/domains/views/Domains.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Domains from "./Domains";
@@ -30,7 +31,9 @@ describe("Domains", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Domains />
+            <CompatRouter>
+              <Domains />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainsList from "./DomainsList";
@@ -31,7 +32,9 @@ describe("DomainsList", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <DomainsList />
+            <CompatRouter>
+              <DomainsList />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -47,7 +50,9 @@ describe("DomainsList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainsList />
+          <CompatRouter>
+            <DomainsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +77,9 @@ describe("DomainsList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainsList />
+          <CompatRouter>
+            <DomainsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -2,6 +2,7 @@ import type { ReactWrapper } from "enzyme";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainsTable from "./DomainsTable";
@@ -56,7 +57,9 @@ describe("DomainsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainsTable />
+          <CompatRouter>
+            <DomainsTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -93,7 +96,9 @@ describe("DomainsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainsTable />
+          <CompatRouter>
+            <DomainsTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -109,7 +114,9 @@ describe("DomainsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainsTable />
+          <CompatRouter>
+            <DomainsTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { MainTable, ContextualMenu } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import TableConfirm from "app/base/components/TableConfirm";
 import domainURLs from "app/domains/urls";

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ImagesIntro from "./ImagesIntro";
@@ -36,7 +37,9 @@ describe("ImagesIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
-          <ImagesIntro />
+          <CompatRouter>
+            <ImagesIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -50,7 +53,9 @@ describe("ImagesIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
-          <ImagesIntro />
+          <CompatRouter>
+            <ImagesIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +77,9 @@ describe("ImagesIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
-          <ImagesIntro />
+          <CompatRouter>
+            <ImagesIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -99,7 +106,9 @@ describe("ImagesIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
-          <ImagesIntro />
+          <CompatRouter>
+            <ImagesIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 
 import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import SyncedImages from "app/images/views/ImageList/SyncedImages";
 import IntroCard from "app/intro/components/IntroCard";

--- a/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MaasIntroSuccess from "./MaasIntroSuccess";
@@ -46,7 +47,9 @@ describe("MaasIntroSuccess", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
         >
-          <MaasIntroSuccess />
+          <CompatRouter>
+            <MaasIntroSuccess />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,7 +68,9 @@ describe("MaasIntroSuccess", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
         >
-          <MaasIntroSuccess />
+          <CompatRouter>
+            <MaasIntroSuccess />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -84,7 +89,9 @@ describe("MaasIntroSuccess", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
         >
-          <MaasIntroSuccess />
+          <CompatRouter>
+            <MaasIntroSuccess />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,7 +107,9 @@ describe("MaasIntroSuccess", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
         >
-          <MaasIntroSuccess />
+          <CompatRouter>
+            <MaasIntroSuccess />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
+++ b/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
@@ -1,6 +1,6 @@
 import { Button, List } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import IntroCard from "app/intro/components/IntroCard";
 import IntroSection from "app/intro/components/IntroSection";

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import type { NewPodValues } from "../../types";
@@ -54,12 +55,14 @@ describe("SelectProjectFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ existingProject: "", newProject: "" }}
-            onSubmit={jest.fn()}
-          >
-            <SelectProjectFormFields newPodValues={newPodValues} />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ existingProject: "", newProject: "" }}
+              onSubmit={jest.fn()}
+            >
+              <SelectProjectFormFields newPodValues={newPodValues} />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -107,12 +110,14 @@ describe("SelectProjectFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ existingProject: "", newProject: "" }}
-            onSubmit={jest.fn()}
-          >
-            <SelectProjectFormFields newPodValues={newPodValues} />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ existingProject: "", newProject: "" }}
+              onSubmit={jest.fn()}
+            >
+              <SelectProjectFormFields newPodValues={newPodValues} />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -172,12 +177,14 @@ describe("SelectProjectFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ existingProject: "", newProject: "" }}
-            onSubmit={jest.fn()}
-          >
-            <SelectProjectFormFields newPodValues={newPodValues} />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ existingProject: "", newProject: "" }}
+              onSubmit={jest.fn()}
+            >
+              <SelectProjectFormFields newPodValues={newPodValues} />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -211,12 +218,14 @@ describe("SelectProjectFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <Formik
-            initialValues={{ existingProject: "", newProject: "" }}
-            onSubmit={jest.fn()}
-          >
-            <SelectProjectFormFields newPodValues={newPodValues} />
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={{ existingProject: "", newProject: "" }}
+              onSubmit={jest.fn()}
+            >
+              <SelectProjectFormFields newPodValues={newPodValues} />
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -9,7 +9,7 @@ import {
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { NewPodValues } from "../../types";
 

--- a/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDHostToolbar from "./LXDHostToolbar";
@@ -55,12 +56,14 @@ describe("LXDHostToolbar", () => {
             { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
           ]}
         >
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -79,12 +82,14 @@ describe("LXDHostToolbar", () => {
             { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
           ]}
         >
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -107,13 +112,15 @@ describe("LXDHostToolbar", () => {
             },
           ]}
         >
-          <LXDHostToolbar
-            clusterId={2}
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              clusterId={2}
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -122,12 +129,14 @@ describe("LXDHostToolbar", () => {
       wrapper.find("Link[data-testid='settings-link']").prop("to")
     ).toStrictEqual({
       pathname: kvmURLs.lxd.cluster.host.edit({ clusterId: 2, hostId: 1 }),
-      state: {
-        from: kvmURLs.lxd.cluster.vms.host({
-          clusterId: 2,
-          hostId: 1,
-        }),
-      },
+    });
+    expect(
+      wrapper.find("Link[data-testid='settings-link']").prop("state")
+    ).toStrictEqual({
+      from: kvmURLs.lxd.cluster.vms.host({
+        clusterId: 2,
+        hostId: 1,
+      }),
     });
   });
 
@@ -140,12 +149,14 @@ describe("LXDHostToolbar", () => {
             { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
           ]}
         >
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -162,12 +173,14 @@ describe("LXDHostToolbar", () => {
             { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
           ]}
         >
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -185,12 +198,14 @@ describe("LXDHostToolbar", () => {
             { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
           ]}
         >
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={setHeaderContent}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={setHeaderContent}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -213,12 +228,14 @@ describe("LXDHostToolbar", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -251,12 +268,14 @@ describe("LXDHostToolbar", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <LXDHostToolbar
-            hostId={1}
-            setHeaderContent={jest.fn()}
-            setViewByNuma={jest.fn()}
-            viewByNuma={false}
-          />
+          <CompatRouter>
+            <LXDHostToolbar
+              hostId={1}
+              setHeaderContent={jest.fn()}
+              setViewByNuma={jest.fn()}
+              viewByNuma={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -278,7 +297,9 @@ describe("LXDHostToolbar", () => {
             { pathname: kvmURLs.lxd.single.vms({ id: 1 }), key: "testKey" },
           ]}
         >
-          <LXDHostToolbar hostId={1} showBasic />
+          <CompatRouter>
+            <LXDHostToolbar hostId={1} showBasic />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
+++ b/ui/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 
 import { Button, Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import Switch from "app/base/components/Switch";
 import { useSendAnalytics } from "app/base/hooks";
@@ -74,12 +75,12 @@ const LXDHostToolbar = ({
           <div className="u-nudge-up--x-small u-truncate">
             <Link
               data-testid="settings-link"
+              state={{ from: location.pathname }}
               to={{
                 pathname: kvmURLs.lxd.cluster.host.edit({
                   clusterId,
                   hostId,
                 }),
-                state: { from: location.pathname },
               }}
             >
               <Icon name="settings" />

--- a/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
+++ b/ui/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDHostToolbar from "../LXDHostToolbar";
@@ -36,13 +37,15 @@ describe("LXDHostVMs", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <LXDHostVMs
-            hostId={1}
-            onRefreshClick={jest.fn()}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDHostVMs
+              hostId={1}
+              onRefreshClick={jest.fn()}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,13 +81,15 @@ describe("LXDHostVMs", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <LXDHostVMs
-            hostId={1}
-            onRefreshClick={jest.fn()}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDHostVMs
+              hostId={1}
+              onRefreshClick={jest.fn()}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -115,13 +120,15 @@ describe("LXDHostVMs", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <LXDHostVMs
-            hostId={1}
-            onRefreshClick={jest.fn()}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDHostVMs
+              hostId={1}
+              onRefreshClick={jest.fn()}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -151,14 +158,16 @@ describe("LXDHostVMs", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <LXDHostVMs
-            clusterId={2}
-            hostId={1}
-            onRefreshClick={jest.fn()}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDHostVMs
+              clusterId={2}
+              hostId={1}
+              onRefreshClick={jest.fn()}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -177,13 +186,15 @@ describe("LXDHostVMs", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <LXDHostVMs
-            hostId={1}
-            onRefreshClick={jest.fn()}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDHostVMs
+              hostId={1}
+              onRefreshClick={jest.fn()}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NameColumn from "./NameColumn";
@@ -26,7 +27,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <NameColumn systemId="abc123" />
+          <CompatRouter>
+            <NameColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -46,7 +49,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <NameColumn systemId="abc123" />
+          <CompatRouter>
+            <NameColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import RowCheckbox from "app/base/components/RowCheckbox";

--- a/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { VMS_PER_PAGE } from "../LXDVMsTable";
@@ -40,12 +41,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getResources={getResources}
-            searchFilter=""
-            vms={[]}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getResources={getResources}
+              searchFilter=""
+              vms={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -70,12 +73,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getResources={getResources}
-            searchFilter=""
-            vms={vms}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getResources={getResources}
+              searchFilter=""
+              vms={vms}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -121,12 +126,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getResources={getResources}
-            searchFilter=""
-            vms={vms}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getResources={getResources}
+              searchFilter=""
+              vms={vms}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -163,12 +170,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getResources={getResources}
-            searchFilter=""
-            vms={vms}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getResources={getResources}
+              searchFilter=""
+              vms={vms}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -202,12 +211,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={currentPage}
-            getResources={getResources}
-            searchFilter=""
-            vms={vms}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={currentPage}
+              getResources={getResources}
+              searchFilter=""
+              vms={vms}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -231,12 +242,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getResources={getResources}
-            searchFilter="system_id:(=ghi789)"
-            vms={[]}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getResources={getResources}
+              searchFilter="system_id:(=ghi789)"
+              vms={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -259,13 +272,15 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            displayForCluster
-            getResources={getResources}
-            searchFilter="system_id:(=ghi789)"
-            vms={[]}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              displayForCluster
+              getResources={getResources}
+              searchFilter="system_id:(=ghi789)"
+              vms={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -284,13 +299,15 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getHostColumn={jest.fn()}
-            getResources={getResources}
-            searchFilter=""
-            vms={[]}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getHostColumn={jest.fn()}
+              getResources={getResources}
+              searchFilter=""
+              vms={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -306,13 +323,15 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getHostColumn={undefined}
-            getResources={getResources}
-            searchFilter=""
-            vms={[]}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getHostColumn={undefined}
+              getResources={getResources}
+              searchFilter=""
+              vms={[]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -339,12 +358,14 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable
-            currentPage={1}
-            getResources={getResources}
-            searchFilter=""
-            vms={vms}
-          />
+          <CompatRouter>
+            <VMsTable
+              currentPage={1}
+              getResources={getResources}
+              searchFilter=""
+              vms={vms}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/components/NameColumn/NameColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NameColumn from "./NameColumn";
@@ -31,11 +32,13 @@ describe("NameColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <NameColumn
-            name={pod.name}
-            secondary={pod.power_parameters.project}
-            url={kvmURLs.virsh.details.index({ id: 1 })}
-          />
+          <CompatRouter>
+            <NameColumn
+              name={pod.name}
+              secondary={pod.power_parameters.project}
+              url={kvmURLs.virsh.details.index({ id: 1 })}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -54,11 +57,13 @@ describe("NameColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <NameColumn
-            name={pod.name}
-            secondary={pod.power_parameters.project}
-            url={kvmURLs.lxd.single.index({ id: 1 })}
-          />
+          <CompatRouter>
+            <NameColumn
+              name={pod.name}
+              secondary={pod.power_parameters.project}
+              url={kvmURLs.lxd.single.index({ id: 1 })}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -84,11 +89,13 @@ describe("NameColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <NameColumn
-            name={pod.name}
-            secondary={pod.power_parameters.project}
-            url={kvmURLs.virsh.details.index({ id: 1 })}
-          />
+          <CompatRouter>
+            <NameColumn
+              name={pod.name}
+              secondary={pod.power_parameters.project}
+              url={kvmURLs.virsh.details.index({ id: 1 })}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/components/NameColumn/NameColumn.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 

--- a/ui/src/app/kvm/views/KVM.test.tsx
+++ b/ui/src/app/kvm/views/KVM.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVM from "./KVM";
@@ -94,7 +95,9 @@ describe("KVM", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <KVM />
+            <CompatRouter>
+              <KVM />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { Router } from "react-router";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVMList from "./KVMList";
@@ -25,7 +26,9 @@ describe("KVMList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -55,7 +58,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.lxd.index, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,7 +80,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.lxd.index, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +101,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.virsh.index, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -114,7 +123,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -135,7 +146,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.lxd.index, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -161,7 +174,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.virsh.index, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -187,7 +202,9 @@ describe("KVMList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
         >
-          <KVMList />
+          <CompatRouter>
+            <KVMList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVMListHeader from "./KVMListHeader";
@@ -38,7 +39,9 @@ describe("KVMListHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -51,7 +54,9 @@ describe("KVMListHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +72,9 @@ describe("KVMListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.lxd.index, key: "testKey" }]}
         >
-          <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +90,9 @@ describe("KVMListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.virsh.index, key: "testKey" }]}
         >
-          <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <KVMListHeader headerContent={null} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,10 +109,12 @@ describe("KVMListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.lxd.index, key: "testKey" }]}
         >
-          <KVMListHeader
-            headerContent={null}
-            setHeaderContent={setHeaderContent}
-          />
+          <CompatRouter>
+            <KVMListHeader
+              headerContent={null}
+              setHeaderContent={setHeaderContent}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -124,10 +135,12 @@ describe("KVMListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: kvmURLs.virsh.index, key: "testKey" }]}
         >
-          <KVMListHeader
-            headerContent={null}
-            setHeaderContent={setHeaderContent}
-          />
+          <CompatRouter>
+            <KVMListHeader
+              headerContent={null}
+              setHeaderContent={setHeaderContent}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -3,7 +3,8 @@ import { useEffect } from "react";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import KVMHeaderForms from "app/kvm/components/KVMHeaderForms";

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { generateClusterRows, generateSingleHostRows } from "../LxdTable";
@@ -54,7 +55,9 @@ describe("LxdKVMHostTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
+          <CompatRouter>
+            <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -115,7 +118,9 @@ describe("LxdKVMHostTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
+          <CompatRouter>
+            <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -154,7 +159,9 @@ describe("LxdKVMHostTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
+          <CompatRouter>
+            <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -178,7 +185,11 @@ describe("LxdKVMHostTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <LxdKVMHostTable rows={generateClusterRows(state.vmcluster.items)} />
+          <CompatRouter>
+            <LxdKVMHostTable
+              rows={generateClusterRows(state.vmcluster.items)}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LxdTable from "./LxdTable";
@@ -25,7 +26,9 @@ describe("LxdTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <LxdTable />
+          <CompatRouter>
+            <LxdTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -50,7 +53,9 @@ describe("LxdTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <LxdTable />
+          <CompatRouter>
+            <LxdTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VirshTable from "./VirshTable";
@@ -52,7 +53,9 @@ describe("VirshTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <VirshTable />
+          <CompatRouter>
+            <VirshTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -73,7 +76,9 @@ describe("VirshTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <VirshTable />
+          <CompatRouter>
+            <VirshTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -139,7 +144,9 @@ describe("VirshTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <VirshTable />
+          <CompatRouter>
+            <VirshTable />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterDetails from "./LXDClusterDetails";
@@ -67,10 +68,12 @@ describe("LXDClusterDetails", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Route
-              path={route || "*/:clusterId/*"}
-              render={() => <LXDClusterDetails />}
-            />
+            <CompatRouter>
+              <Route
+                path={route || "*/:clusterId/*"}
+                render={() => <LXDClusterDetails />}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
@@ -53,12 +54,14 @@ describe("LXDClusterDetailsHeader", () => {
             },
           ]}
         >
-          <LXDClusterDetailsHeader
-            clusterId={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterDetailsHeader
+              clusterId={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,12 +81,14 @@ describe("LXDClusterDetailsHeader", () => {
             },
           ]}
         >
-          <LXDClusterDetailsHeader
-            clusterId={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterDetailsHeader
+              clusterId={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -109,12 +114,14 @@ describe("LXDClusterDetailsHeader", () => {
             },
           ]}
         >
-          <LXDClusterDetailsHeader
-            clusterId={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterDetailsHeader
+              clusterId={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -135,12 +142,14 @@ describe("LXDClusterDetailsHeader", () => {
             },
           ]}
         >
-          <LXDClusterDetailsHeader
-            clusterId={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterDetailsHeader
+              clusterId={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -161,12 +170,14 @@ describe("LXDClusterDetailsHeader", () => {
             },
           ]}
         >
-          <LXDClusterDetailsHeader
-            clusterId={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterDetailsHeader
+              clusterId={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -4,7 +4,8 @@ import { useEffect } from "react";
 import { Icon, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { SetSearchFilter } from "app/base/types";
 import KVMDetailsHeader from "app/kvm/components/KVMDetailsHeader";

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterHostsTable from "./LXDClusterHostsTable";
@@ -65,13 +66,15 @@ describe("LXDClusterHostsTable", () => {
             },
           ]}
         >
-          <LXDClusterHostsTable
-            clusterId={1}
-            currentPage={1}
-            hosts={state.pod.items}
-            searchFilter=""
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostsTable
+              clusterId={1}
+              currentPage={1}
+              hosts={state.pod.items}
+              searchFilter=""
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -90,13 +93,15 @@ describe("LXDClusterHostsTable", () => {
             },
           ]}
         >
-          <LXDClusterHostsTable
-            clusterId={1}
-            currentPage={1}
-            hosts={state.pod.items}
-            searchFilter=""
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostsTable
+              clusterId={1}
+              currentPage={1}
+              hosts={state.pod.items}
+              searchFilter=""
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -117,13 +122,15 @@ describe("LXDClusterHostsTable", () => {
             },
           ]}
         >
-          <LXDClusterHostsTable
-            clusterId={1}
-            currentPage={1}
-            hosts={state.pod.items}
-            searchFilter=""
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostsTable
+              clusterId={1}
+              currentPage={1}
+              hosts={state.pod.items}
+              searchFilter=""
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -145,13 +152,15 @@ describe("LXDClusterHostsTable", () => {
             },
           ]}
         >
-          <LXDClusterHostsTable
-            clusterId={1}
-            currentPage={1}
-            hosts={state.pod.items}
-            searchFilter=""
-            setHeaderContent={setHeaderContent}
-          />
+          <CompatRouter>
+            <LXDClusterHostsTable
+              clusterId={1}
+              currentPage={1}
+              hosts={state.pod.items}
+              searchFilter=""
+              setHeaderContent={setHeaderContent}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -174,13 +183,15 @@ describe("LXDClusterHostsTable", () => {
             },
           ]}
         >
-          <LXDClusterHostsTable
-            clusterId={1}
-            currentPage={1}
-            hosts={state.pod.items}
-            searchFilter=""
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostsTable
+              clusterId={1}
+              currentPage={1}
+              hosts={state.pod.items}
+              searchFilter=""
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -188,9 +199,11 @@ describe("LXDClusterHostsTable", () => {
       wrapper.find("Link[data-testid='vm-host-settings']").prop("to")
     ).toStrictEqual({
       pathname: kvmURLs.lxd.cluster.host.edit({ clusterId: 1, hostId: 22 }),
-      state: {
-        from: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
-      },
+    });
+    expect(
+      wrapper.find("Link[data-testid='vm-host-settings']").prop("state")
+    ).toStrictEqual({
+      from: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }),
     });
   });
 
@@ -206,13 +219,15 @@ describe("LXDClusterHostsTable", () => {
             },
           ]}
         >
-          <LXDClusterHostsTable
-            clusterId={1}
-            currentPage={1}
-            hosts={[]}
-            searchFilter="nothing"
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostsTable
+              clusterId={1}
+              currentPage={1}
+              hosts={[]}
+              searchFilter="nothing"
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
@@ -11,7 +11,8 @@ import {
 } from "@canonical/react-components";
 import type { Location } from "history";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
@@ -150,12 +151,12 @@ const generateRows = (
                 <Link
                   className="p-button no-background has-icon u-no-margin"
                   data-testid="vm-host-settings"
+                  state={{ from: location.pathname }}
                   to={{
                     pathname: kvmURLs.lxd.cluster.host.edit({
                       clusterId,
                       hostId: host.id,
                     }),
-                    state: { from: location.pathname },
                   }}
                 >
                   <Icon name="settings" />

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterVMs from "./LXDClusterVMs";
@@ -49,12 +50,14 @@ describe("LXDClusterVMs", () => {
             },
           ]}
         >
-          <LXDClusterVMs
-            clusterId={1}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterVMs
+              clusterId={1}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,12 +103,14 @@ describe("LXDClusterVMs", () => {
             },
           ]}
         >
-          <LXDClusterVMs
-            clusterId={1}
-            searchFilter=""
-            setSearchFilter={jest.fn()}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterVMs
+              clusterId={1}
+              searchFilter=""
+              setSearchFilter={jest.fn()}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDSingleDetails from "./LXDSingleDetails";
@@ -47,10 +48,12 @@ describe("LXDSingleDetails", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Route
-              path={kvmURLs.lxd.single.index(null, true)}
-              render={() => <LXDSingleDetails />}
-            />
+            <CompatRouter>
+              <Route
+                path={kvmURLs.lxd.single.index(null, true)}
+                render={() => <LXDSingleDetails />}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDSingleDetailsHeader from "./LXDSingleDetailsHeader";
@@ -53,12 +54,14 @@ describe("LXDSingleDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <LXDSingleDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDSingleDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,12 +78,14 @@ describe("LXDSingleDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
         >
-          <LXDSingleDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDSingleDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -99,12 +104,14 @@ describe("LXDSingleDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
         >
-          <LXDSingleDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDSingleDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -122,12 +129,14 @@ describe("LXDSingleDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
         >
-          <LXDSingleDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDSingleDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
@@ -3,7 +3,8 @@ import { useEffect } from "react";
 
 import { Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { SetSearchFilter } from "app/base/types";
 import KVMDetailsHeader from "app/kvm/components/KVMDetailsHeader";

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VirshDetails from "./VirshDetails";
@@ -43,7 +44,9 @@ describe("VirshDetails", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Route path="*/:id/*" render={() => <VirshDetails />} />
+            <CompatRouter>
+              <Route path="*/:id/*" render={() => <VirshDetails />} />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VirshDetailsHeader from "./VirshDetailsHeader";
@@ -53,11 +54,13 @@ describe("VirshDetailsHeader", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <VirshDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <VirshDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -74,11 +77,13 @@ describe("VirshDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
         >
-          <VirshDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <VirshDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -97,11 +102,13 @@ describe("VirshDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
         >
-          <VirshDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <VirshDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -119,11 +126,13 @@ describe("VirshDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
         >
-          <VirshDetailsHeader
-            id={1}
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <VirshDetailsHeader
+              id={1}
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.tsx
@@ -3,7 +3,8 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import VirshDetailsActionMenu from "./VirshDetailsActionMenu";
 

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CloneResults, { CloneErrorCodes } from "./CloneResults";
@@ -36,11 +37,13 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            sourceMachine={machine}
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              sourceMachine={machine}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -66,11 +69,13 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            sourceMachine={machine}
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              sourceMachine={machine}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -107,11 +112,13 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            sourceMachine={machine}
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              sourceMachine={machine}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -145,11 +152,13 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            sourceMachine={machine}
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              sourceMachine={machine}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -195,11 +204,13 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            sourceMachine={machine}
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              sourceMachine={machine}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -237,12 +248,14 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            setSearchFilter={setSearchFilter}
-            sourceMachine={machine}
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              setSearchFilter={setSearchFilter}
+              sourceMachine={machine}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -278,13 +291,15 @@ describe("CloneResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CloneResults
-            closeForm={jest.fn()}
-            destinations={["def456", "ghi789"]}
-            setSearchFilter={setSearchFilter}
-            sourceMachine={machine}
-            viewingDetails
-          />
+          <CompatRouter>
+            <CloneResults
+              closeForm={jest.fn()}
+              destinations={["def456", "ghi789"]}
+              setSearchFilter={setSearchFilter}
+              sourceMachine={machine}
+              viewingDetails
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
@@ -11,7 +11,8 @@ import {
 } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { APIError, SetSearchFilter } from "app/base/types";
 import machineURLs from "app/machines/urls";

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeployForm from "../DeployForm";
@@ -136,12 +137,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -158,12 +161,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -183,12 +188,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -209,12 +216,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -243,12 +252,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -287,12 +298,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -322,12 +335,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -346,12 +361,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -373,12 +390,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -405,12 +424,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -441,12 +462,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -469,12 +492,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -490,12 +515,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -524,12 +551,14 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -11,7 +11,7 @@ import {
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { DeployFormValues } from "../DeployForm";
 

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import OverrideTestForm from "./OverrideTestForm";
@@ -83,12 +84,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -112,12 +115,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -139,12 +144,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -164,12 +171,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -186,12 +195,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -246,12 +257,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -270,12 +283,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -302,12 +317,14 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <OverrideTestForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { Col, Row, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagFormChanges, { Label, RowType } from "./TagFormChanges";
@@ -41,9 +42,14 @@ it("displays manual tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormChanges machines={state.machine.items} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={state.machine.items} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -67,9 +73,14 @@ it("displays automatic tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormChanges machines={state.machine.items} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={state.machine.items} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -95,15 +106,17 @@ it("displays added tags, with a 'NEW' prefix for newly created tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik
-          initialValues={{ added: [tags[0].id, tags[1].id], removed: [] }}
-          onSubmit={jest.fn()}
-        >
-          <TagFormChanges
-            machines={[state.machine.items[0]]}
-            newTags={[tags[1].id]}
-          />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [tags[0].id, tags[1].id], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges
+              machines={[state.machine.items[0]]}
+              newTags={[tags[1].id]}
+            />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -127,12 +140,14 @@ it("discards added tags", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik
-          initialValues={{ added: [tags[0].id, tags[1].id], removed: [] }}
-          onSubmit={jest.fn()}
-        >
-          <TagFormChanges machines={[state.machine.items[0]]} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [tags[0].id, tags[1].id], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={[state.machine.items[0]]} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -152,9 +167,14 @@ it("displays a tag details modal when chips are clicked", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormChanges machines={state.machine.items} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={state.machine.items} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -167,9 +187,14 @@ it("can remove manual tags", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormChanges machines={state.machine.items} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={state.machine.items} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -193,12 +218,14 @@ it("displays removed tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik
-          initialValues={{ added: [], removed: [tags[0].id, tags[1].id] }}
-          onSubmit={jest.fn()}
-        >
-          <TagFormChanges machines={[state.machine.items[0]]} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [tags[0].id, tags[1].id] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={[state.machine.items[0]]} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -223,12 +250,14 @@ it("discards removed tags", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik
-          initialValues={{ added: [], removed: [tags[0].id, tags[1].id] }}
-          onSubmit={jest.fn()}
-        >
-          <TagFormChanges machines={[state.machine.items[0]]} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [tags[0].id, tags[1].id] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={[state.machine.items[0]]} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -262,9 +291,14 @@ it("shows a message if no tags are assigned to the selected machines", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormChanges machines={state.machine.items} newTags={[]} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormChanges machines={state.machine.items} newTags={[]} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -5,7 +5,7 @@ import type { ChipProps } from "@canonical/react-components";
 import { Modal, Button, Icon, ModularTable } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import usePortal from "react-useportal";
 
 import TagChip from "../TagChip";

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagForm from "./TagForm";
@@ -56,7 +57,9 @@ describe("TagForm", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <TagForm systemId="abc123" />
+          <CompatRouter>
+            <TagForm systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +75,9 @@ describe("TagForm", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <TagForm systemId="abc123" />
+          <CompatRouter>
+            <TagForm systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -88,7 +93,9 @@ describe("TagForm", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <TagForm systemId="abc123" />
+          <CompatRouter>
+            <TagForm systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { Link, MemoryRouter, Route } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter, Link } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineDetails from "./MachineDetails";
@@ -120,10 +121,12 @@ describe("MachineDetails", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Route
-              path={route || "*/:id/*"}
-              render={() => <MachineDetails />}
-            />
+            <CompatRouter>
+              <Route
+                path={route || "*/:id/*"}
+                render={() => <MachineDetails />}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -138,7 +141,13 @@ describe("MachineDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route exact path="/machine/:id" render={() => <MachineDetails />} />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id"
+              render={() => <MachineDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -169,7 +178,9 @@ describe("MachineDetails", () => {
             { pathname: "/machine/not-valid-id", key: "testKey" },
           ]}
         >
-          <MachineDetails />
+          <CompatRouter>
+            <MachineDetails />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -183,7 +194,13 @@ describe("MachineDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Route exact path="/machine/:id" render={() => <MachineDetails />} />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id"
+              render={() => <MachineDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -200,8 +217,10 @@ describe("MachineDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <Link to="/machine/abc123/commissioning" />
-          <Route path="/machine/:id" render={() => <MachineDetails />} />
+          <CompatRouter>
+            <Link to="/machine/abc123/commissioning" />
+            <Route path="/machine/:id" render={() => <MachineDetails />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineHeader from "./MachineHeader";
@@ -46,11 +47,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,11 +68,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,11 +88,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -104,11 +111,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,11 +136,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -151,11 +162,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -174,11 +187,13 @@ describe("MachineHeader", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <MachineHeader
-              headerContent={null}
-              setHeaderContent={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <MachineHeader
+                headerContent={null}
+                setHeaderContent={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -204,11 +219,13 @@ describe("MachineHeader", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <MachineHeader
-              headerContent={null}
-              setHeaderContent={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <MachineHeader
+                headerContent={null}
+                setHeaderContent={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -234,11 +251,13 @@ describe("MachineHeader", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
           >
-            <MachineHeader
-              headerContent={null}
-              setHeaderContent={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <MachineHeader
+                headerContent={null}
+                setHeaderContent={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -270,11 +289,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -305,11 +326,13 @@ describe("MachineHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <MachineHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import MachineName from "./MachineName";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineLogs from "./MachineLogs";
@@ -38,7 +39,9 @@ describe("MachineLogs", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineLogs systemId="abc123" />
+          <CompatRouter>
+            <MachineLogs systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -64,7 +67,9 @@ describe("MachineLogs", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <MachineLogs systemId="abc123" />
+            <CompatRouter>
+              <MachineLogs systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -81,7 +86,9 @@ describe("MachineLogs", () => {
             { pathname: "/machine/abc123/logs/events", key: "testKey" },
           ]}
         >
-          <MachineLogs systemId="abc123" />
+          <CompatRouter>
+            <MachineLogs systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -1,6 +1,7 @@
 import { Spinner, Tabs } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link, Route, useLocation } from "react-router-dom";
+import { Route, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DownloadMenu from "./DownloadMenu";
 import EventLogs from "./EventLogs";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { LinkMonitoring } from "../BondForm/types";
@@ -81,12 +82,14 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[{ nicId: 9 }, { nicId: 10 }]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[{ nicId: 9 }, { nicId: 10 }]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -119,12 +122,14 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={selected}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={selected}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -182,15 +187,17 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[
-              { nicId: interfaces[0].id },
-              { nicId: interfaces[1].id },
-            ]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[
+                { nicId: interfaces[0].id },
+                { nicId: interfaces[1].id },
+              ]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -234,16 +241,18 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[
-              { nicId: interfaces[0].id },
-              { nicId: interfaces[1].id },
-            ]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            {...props}
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[
+                { nicId: interfaces[0].id },
+                { nicId: interfaces[1].id },
+              ]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              {...props}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -262,12 +271,14 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -287,12 +298,14 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -312,12 +325,14 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -351,12 +366,14 @@ describe("AddBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBondForm
-            close={jest.fn()}
-            selected={[{ nicId: 9 }, { nicId: 10 }]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBondForm
+              close={jest.fn()}
+              selected={[{ nicId: 9 }, { nicId: 10 }]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { LinkMonitoring } from "../BondForm/types";
@@ -72,13 +73,15 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -111,13 +114,15 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={selected}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={selected}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -175,16 +180,18 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={[
-              { nicId: interfaces[0].id },
-              { nicId: interfaces[1].id },
-            ]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={[
+                { nicId: interfaces[0].id },
+                { nicId: interfaces[1].id },
+              ]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -228,17 +235,19 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={[
-              { nicId: interfaces[0].id },
-              { nicId: interfaces[1].id },
-            ]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            {...props}
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={[
+                { nicId: interfaces[0].id },
+                { nicId: interfaces[1].id },
+              ]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              {...props}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -279,17 +288,19 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={[
-              { nicId: interfaces[0].id },
-              { nicId: interfaces[1].id },
-            ]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            {...props}
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={[
+                { nicId: interfaces[0].id },
+                { nicId: interfaces[1].id },
+              ]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              {...props}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -315,13 +326,15 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -341,13 +354,15 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={nic}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={nic}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -385,13 +400,15 @@ describe("EditBondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBondForm
-            close={jest.fn()}
-            nic={bond}
-            selected={[{ nicId: 9 }, { nicId: 10 }]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBondForm
+              close={jest.fn()}
+              nic={bond}
+              selected={[{ nicId: 9 }, { nicId: 10 }]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineNetwork from "./MachineNetwork";
@@ -26,7 +27,9 @@ describe("MachineNetwork", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -46,7 +49,9 @@ describe("MachineNetwork", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NetworkTable from "./NetworkTable";
@@ -54,13 +55,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,13 +75,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -112,13 +117,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -159,13 +166,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -210,13 +219,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={null}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={null}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -246,13 +257,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -281,13 +294,15 @@ describe("NetworkTable", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <NetworkTable
-            expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
-            setExpanded={jest.fn()}
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NetworkTable
+              expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
+              setExpanded={jest.fn()}
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -325,13 +340,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -344,13 +361,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -364,13 +383,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -382,13 +403,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -400,13 +423,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -418,13 +443,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -436,13 +463,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -454,13 +483,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -521,13 +552,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -554,13 +587,15 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter>
-            <NetworkTable
-              expanded={null}
-              setExpanded={jest.fn()}
-              selected={[]}
-              setSelected={jest.fn()}
-              systemId="abc123"
-            />
+            <CompatRouter>
+              <NetworkTable
+                expanded={null}
+                setExpanded={jest.fn()}
+                selected={[]}
+                setSelected={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineStorage from "./MachineStorage";
@@ -36,7 +37,9 @@ describe("MachineStorage", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineStorage />
+          <CompatRouter>
+            <MachineStorage />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,11 +68,13 @@ describe("MachineStorage", () => {
             { pathname: "/machine/abc123/storage", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/storage"
-            render={() => <MachineStorage />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/storage"
+              render={() => <MachineStorage />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,11 +111,13 @@ describe("MachineStorage", () => {
             { pathname: "/machine/abc123/storage", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/storage"
-            render={() => <MachineStorage />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/storage"
+              render={() => <MachineStorage />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -146,11 +153,13 @@ describe("MachineStorage", () => {
             { pathname: "/machine/abc123/storage", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/storage"
-            render={() => <MachineStorage />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/storage"
+              render={() => <MachineStorage />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -177,11 +186,13 @@ describe("MachineStorage", () => {
             { pathname: "/machine/abc123/storage", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/storage"
-            render={() => <MachineStorage />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/storage"
+              render={() => <MachineStorage />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -1,6 +1,6 @@
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import AvailableStorageTable from "./AvailableStorageTable";
 import CacheSetsTable from "./CacheSetsTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineSummary from "./MachineSummary";
@@ -33,7 +34,9 @@ describe("MachineSummary", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineSummary setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MachineSummary setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -47,7 +50,9 @@ describe("MachineSummary", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineSummary setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MachineSummary setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -69,11 +74,13 @@ describe("MachineSummary", () => {
             { pathname: "/machine/abc123/summary", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/summary"
-            render={() => <MachineSummary setHeaderContent={jest.fn()} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/summary"
+              render={() => <MachineSummary setHeaderContent={jest.fn()} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -95,11 +102,13 @@ describe("MachineSummary", () => {
             { pathname: "/machine/abc123/summary", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/summary"
-            render={() => <MachineSummary setHeaderContent={jest.fn()} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/summary"
+              render={() => <MachineSummary setHeaderContent={jest.fn()} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,11 +127,13 @@ describe("MachineSummary", () => {
             { pathname: "/machine/abc123/summary", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/summary"
-            render={() => <MachineSummary setHeaderContent={jest.fn()} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/summary"
+              render={() => <MachineSummary setHeaderContent={jest.fn()} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CpuCard from "./CpuCard";
@@ -35,7 +36,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -55,7 +58,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,7 +83,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -102,7 +109,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -125,7 +134,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -148,7 +159,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -169,7 +182,9 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <CpuCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DetailsCard from "./DetailsCard";
@@ -49,7 +50,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +70,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -95,7 +100,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -126,7 +133,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -150,7 +159,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -172,7 +183,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -196,7 +209,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -222,7 +237,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -256,7 +273,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -281,7 +300,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -311,7 +332,9 @@ describe("DetailsCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <DetailsCard machine={machine} />
+          <CompatRouter>
+            <DetailsCard machine={machine} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { Spinner } from "@canonical/react-components";
 import { extractPowerType } from "@maas-ui/maas-ui-shared";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import { useCanEdit, useSendAnalytics } from "app/base/hooks";
 import kvmURLs from "app/kvm/urls";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MemoryCard from "./MemoryCard";
@@ -38,7 +39,9 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -62,7 +65,9 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -85,7 +90,9 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -108,7 +115,9 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -129,7 +138,9 @@ describe("MemoryCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <MemoryCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import StorageCard from "./StorageCard";
@@ -36,7 +37,9 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -60,7 +63,9 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +88,9 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +113,9 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,7 +136,9 @@ describe("StorageCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <StorageCard machine={machine} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SummaryNotifications from "./SummaryNotifications";
@@ -53,7 +54,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +86,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,7 +105,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,7 +125,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,7 +147,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -156,7 +167,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -180,7 +193,9 @@ describe("SummaryNotifications", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <SummaryNotifications id="abc123" />
+          <CompatRouter>
+            <SummaryNotifications id="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import { useCanEdit, useIsRackControllerConnected } from "app/base/hooks";
 import imagesURLs from "app/images/urls";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TestResults from "./TestResults";
@@ -37,11 +38,13 @@ describe("TestResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestResults
-            machine={machine}
-            hardwareType={HardwareType.CPU}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <TestResults
+              machine={machine}
+              hardwareType={HardwareType.CPU}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,11 +68,13 @@ describe("TestResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestResults
-            machine={machine}
-            hardwareType={HardwareType.Memory}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <TestResults
+              machine={machine}
+              hardwareType={HardwareType.Memory}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -92,11 +97,13 @@ describe("TestResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestResults
-            machine={machine}
-            hardwareType={HardwareType.Storage}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <TestResults
+              machine={machine}
+              hardwareType={HardwareType.Storage}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -119,11 +126,13 @@ describe("TestResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestResults
-            machine={machine}
-            hardwareType={HardwareType.CPU}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <TestResults
+              machine={machine}
+              hardwareType={HardwareType.CPU}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -144,11 +153,13 @@ describe("TestResults", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestResults
-            machine={machine}
-            hardwareType={HardwareType.Network}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <TestResults
+              machine={machine}
+              hardwareType={HardwareType.Network}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineTestsDetails from ".";
@@ -45,7 +46,9 @@ describe("MachineTestDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineTestsDetails />
+          <CompatRouter>
+            <MachineTestsDetails />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -59,10 +62,12 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,10 +80,12 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -94,10 +101,12 @@ describe("MachineTestDetails", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -126,10 +135,12 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -155,10 +166,12 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -183,10 +196,12 @@ describe("MachineTestDetails", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -223,10 +238,12 @@ describe("MachineTestDetails", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
-          <Route
-            path="/machine/:id/testing/:scriptResultId/details"
-            render={() => <MachineTestsDetails />}
-          />
+          <CompatRouter>
+            <Route
+              path="/machine/:id/testing/:scriptResultId/details"
+              render={() => <MachineTestsDetails />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 
 import { Col, Row, Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import MachineTestsDetailsLogs from "./MachineTestsDetailsLogs";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/__snapshots__/MachineTestsDetails.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/__snapshots__/MachineTestsDetails.test.tsx.snap
@@ -55,13 +55,59 @@ exports[`MachineTestDetails renders 1`] = `
         }
       }
     >
-      <MachineTestsDetails>
-        <h4
-          data-testid="not-found"
+      <CompatRouter>
+        <Router
+          location={
+            Object {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/machine/abc123",
+              "search": "",
+            }
+          }
+          navigationType="POP"
+          navigator={
+            Object {
+              "action": "POP",
+              "block": [Function],
+              "canGo": [Function],
+              "createHref": [Function],
+              "entries": Array [
+                Object {
+                  "hash": "",
+                  "key": "testKey",
+                  "pathname": "/machine/abc123",
+                  "search": "",
+                },
+              ],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "index": 0,
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "key": "testKey",
+                "pathname": "/machine/abc123",
+                "search": "",
+              },
+              "push": [Function],
+              "replace": [Function],
+            }
+          }
         >
-          Script result could not be found.
-        </h4>
-      </MachineTestsDetails>
+          <Routes>
+            <MachineTestsDetails>
+              <h4
+                data-testid="not-found"
+              >
+                Script result could not be found.
+              </h4>
+            </MachineTestsDetails>
+          </Routes>
+        </Router>
+      </CompatRouter>
     </Router>
   </MemoryRouter>
 </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
@@ -135,7 +135,16 @@ const MachineTestsTable = ({
         {
           className: "actions-col u-align--right",
           content: (
-            <TestActions scriptResult={result} setExpanded={setExpanded} />
+            <TestActions
+              machineId={machineId}
+              resultType={
+                containsTesting
+                  ? ScriptResultType.TESTING
+                  : ScriptResultType.COMMISSIONING
+              }
+              scriptResult={result}
+              setExpanded={setExpanded}
+            />
           ),
         },
       ],

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactWrapper } from "enzyme";
 import { mount } from "enzyme";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import TestActions from "./TestActions";
 
@@ -40,7 +41,9 @@ describe("TestActions", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machine/abc123/commissioning" }]}
       >
-        <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        <CompatRouter>
+          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     );
 
@@ -60,7 +63,9 @@ describe("TestActions", () => {
     });
     const wrapper = mount(
       <MemoryRouter initialEntries={[{ pathname: "/machine/abc123/testing" }]}>
-        <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        <CompatRouter>
+          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     );
 
@@ -79,7 +84,9 @@ describe("TestActions", () => {
     });
     const wrapper = mount(
       <MemoryRouter>
-        <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        <CompatRouter>
+          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     );
 
@@ -91,7 +98,9 @@ describe("TestActions", () => {
     const scriptResult = scriptResultFactory();
     const wrapper = mount(
       <MemoryRouter>
-        <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        <CompatRouter>
+          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     );
 
@@ -110,7 +119,9 @@ describe("TestActions", () => {
     const scriptResult = scriptResultFactory();
     const wrapper = mount(
       <MemoryRouter>
-        <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        <CompatRouter>
+          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx
@@ -6,7 +6,10 @@ import { CompatRouter } from "react-router-dom-v5-compat";
 import TestActions from "./TestActions";
 
 import * as hooks from "app/base/hooks/analytics";
-import { ScriptResultStatus } from "app/store/scriptresult/types";
+import {
+  ScriptResultStatus,
+  ScriptResultType,
+} from "app/store/scriptresult/types";
 import {
   scriptResult as scriptResultFactory,
   scriptResultResult as scriptResultResultFactory,
@@ -42,7 +45,12 @@ describe("TestActions", () => {
         initialEntries={[{ pathname: "/machine/abc123/commissioning" }]}
       >
         <CompatRouter>
-          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+          <TestActions
+            machineId="abc123"
+            resultType={ScriptResultType.COMMISSIONING}
+            scriptResult={scriptResult}
+            setExpanded={jest.fn()}
+          />
         </CompatRouter>
       </MemoryRouter>
     );
@@ -52,7 +60,7 @@ describe("TestActions", () => {
       true
     );
     expect(wrapper.find("Link[data-testid='view-details']").prop("to")).toBe(
-      "commissioning/1/details"
+      "/machine/abc123/commissioning/1/details"
     );
   });
 
@@ -64,7 +72,12 @@ describe("TestActions", () => {
     const wrapper = mount(
       <MemoryRouter initialEntries={[{ pathname: "/machine/abc123/testing" }]}>
         <CompatRouter>
-          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+          <TestActions
+            machineId="abc123"
+            resultType={ScriptResultType.TESTING}
+            scriptResult={scriptResult}
+            setExpanded={jest.fn()}
+          />
         </CompatRouter>
       </MemoryRouter>
     );
@@ -74,7 +87,7 @@ describe("TestActions", () => {
       true
     );
     expect(wrapper.find("Link[data-testid='view-details']").prop("to")).toBe(
-      "testing/1/details"
+      "/machine/abc123/testing/1/details"
     );
   });
 
@@ -85,7 +98,12 @@ describe("TestActions", () => {
     const wrapper = mount(
       <MemoryRouter>
         <CompatRouter>
-          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+          <TestActions
+            machineId="abc123"
+            resultType={ScriptResultType.TESTING}
+            scriptResult={scriptResult}
+            setExpanded={jest.fn()}
+          />
         </CompatRouter>
       </MemoryRouter>
     );
@@ -99,7 +117,12 @@ describe("TestActions", () => {
     const wrapper = mount(
       <MemoryRouter>
         <CompatRouter>
-          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+          <TestActions
+            machineId="abc123"
+            resultType={ScriptResultType.TESTING}
+            scriptResult={scriptResult}
+            setExpanded={jest.fn()}
+          />
         </CompatRouter>
       </MemoryRouter>
     );
@@ -120,7 +143,12 @@ describe("TestActions", () => {
     const wrapper = mount(
       <MemoryRouter>
         <CompatRouter>
-          <TestActions scriptResult={scriptResult} setExpanded={jest.fn()} />
+          <TestActions
+            machineId="abc123"
+            resultType={ScriptResultType.TESTING}
+            scriptResult={scriptResult}
+            setExpanded={jest.fn()}
+          />
         </CompatRouter>
       </MemoryRouter>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.tsx
@@ -1,6 +1,5 @@
 import type { ContextualMenuProps } from "@canonical/react-components";
 import type { LinkProps } from "react-router-dom";
-import { useLocation } from "react-router-dom";
 import { Link } from "react-router-dom-v5-compat";
 
 import type { SetExpanded } from "../MachineTestsTable";
@@ -9,30 +8,44 @@ import { ScriptResultAction } from "../MachineTestsTable";
 import TableMenu from "app/base/components/TableMenu";
 import { useSendAnalytics } from "app/base/hooks";
 import type { DataTestElement } from "app/base/types";
+import machineURLs from "app/machines/urls";
+import type { Machine } from "app/store/machine/types";
 import type { ScriptResult } from "app/store/scriptresult/types";
+import { ScriptResultType } from "app/store/scriptresult/types";
 import { scriptResultInProgress } from "app/store/scriptresult/utils";
 
 type Props = {
+  machineId: Machine["system_id"];
+  resultType: ScriptResultType.TESTING | ScriptResultType.COMMISSIONING;
   scriptResult: ScriptResult;
   setExpanded: SetExpanded;
 };
 
 type LinkWithDataTest = DataTestElement<LinkProps>;
 
-const TestActions = ({ scriptResult, setExpanded }: Props): JSX.Element => {
+const TestActions = ({
+  machineId,
+  resultType,
+  scriptResult,
+  setExpanded,
+}: Props): JSX.Element => {
   const sendAnalytics = useSendAnalytics();
-  const location = useLocation();
   const canViewDetails = !scriptResultInProgress(scriptResult.status);
   const hasMetrics = scriptResult.results.length > 0;
   const links: ContextualMenuProps<LinkWithDataTest>["links"] = [];
+  const isTesting = resultType === ScriptResultType.TESTING;
 
   if (canViewDetails) {
-    const urlStem = location?.pathname?.split("/")?.[3] || "testing";
     links.push({
       children: "View details...",
       "data-testid": "view-details",
       element: Link,
-      to: `${urlStem}/${scriptResult.id}/details`,
+      to: machineURLs.machine[
+        isTesting ? "testing" : "commissioning"
+      ].scriptResult({
+        id: machineId,
+        scriptResultId: scriptResult.id,
+      }),
     });
   }
 
@@ -45,7 +58,7 @@ const TestActions = ({ scriptResult, setExpanded }: Props): JSX.Element => {
         content: ScriptResultAction.VIEW_PREVIOUS_TESTS,
       });
       sendAnalytics(
-        "Machine testing",
+        `Machine ${isTesting ? "testing" : "commissioning"}`,
         "View testing script history",
         "View previous tests"
       );
@@ -62,7 +75,11 @@ const TestActions = ({ scriptResult, setExpanded }: Props): JSX.Element => {
           content: ScriptResultAction.VIEW_METRICS,
         });
         sendAnalytics(
-          "Machine testing",
+          `Machine ${
+            resultType === ScriptResultType.TESTING
+              ? "testing"
+              : "commissioning"
+          }`,
           "View testing script metrics",
           "View metrics"
         );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.tsx
@@ -1,6 +1,7 @@
 import type { ContextualMenuProps } from "@canonical/react-components";
 import type { LinkProps } from "react-router-dom";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { SetExpanded } from "../MachineTestsTable";
 import { ScriptResultAction } from "../MachineTestsTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TestHistory from "./TestHistory";
@@ -47,7 +48,9 @@ describe("TestHistory", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          <CompatRouter>
+            <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -80,7 +83,9 @@ describe("TestHistory", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          <CompatRouter>
+            <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,7 +105,9 @@ describe("TestHistory", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          <CompatRouter>
+            <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -120,7 +127,9 @@ describe("TestHistory", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          <CompatRouter>
+            <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -140,7 +149,9 @@ describe("TestHistory", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          <CompatRouter>
+            <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import { Button, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom-v5-compat";
 
 import ScriptStatus from "app/base/components/ScriptStatus";
 import type { RootState } from "app/store/root/types";
@@ -19,6 +19,7 @@ type Props = {
 
 const TestHistory = ({ close, scriptResult }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const location = useLocation();
   const history = useSelector((state: RootState) =>
     scriptResultSelectors.getHistoryById(state, scriptResult.id)
   );
@@ -56,9 +57,7 @@ const TestHistory = ({ close, scriptResult }: Props): JSX.Element => {
                       {historyResult.status_name}{" "}
                       <Link
                         data-testid="details-link"
-                        to={(location) =>
-                          `${location.pathname}/${historyResult.id}/details`
-                        }
+                        to={`${location.pathname}/${historyResult.id}/details`}
                       >
                         View log
                       </Link>

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NodeDevices from "./NodeDevices";
@@ -167,11 +168,13 @@ describe("NodeDevices", () => {
             { pathname: "/machine/abc123/pci-devices", key: "testKey" },
           ]}
         >
-          <NodeDevices
-            bus={NodeDeviceBus.PCIE}
-            machine={machine}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeDevices
+              bus={NodeDeviceBus.PCIE}
+              machine={machine}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -231,11 +234,13 @@ describe("NodeDevices", () => {
             { pathname: "/machine/abc123/pci-devices", key: "testKey" },
           ]}
         >
-          <NodeDevices
-            bus={NodeDeviceBus.PCIE}
-            machine={machine}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeDevices
+              bus={NodeDeviceBus.PCIE}
+              machine={machine}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -273,11 +278,13 @@ describe("NodeDevices", () => {
             { pathname: "/machine/abc123/pci-devices", key: "testKey" },
           ]}
         >
-          <NodeDevices
-            bus={NodeDeviceBus.PCIE}
-            machine={machine}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeDevices
+              bus={NodeDeviceBus.PCIE}
+              machine={machine}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import classNames from "classnames";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import NodeDevicesWarning from "./NodeDevicesWarning";
 

--- a/ui/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineList from "./MachineList";
@@ -194,7 +195,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -211,7 +214,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -229,7 +234,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -254,7 +261,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -275,7 +284,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -293,7 +304,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -308,7 +321,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -323,7 +338,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -339,7 +356,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -357,7 +376,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -375,7 +396,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -392,10 +415,12 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList
-            searchFilter="this does not match anything"
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineList
+              searchFilter="this does not match anything"
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -411,7 +436,9 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList setSearchFilter={jest.fn()} />
+          <CompatRouter>
+            <MachineList setSearchFilter={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -2,6 +2,7 @@ import { ContextualMenu } from "@canonical/react-components";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineListHeader from "./MachineListHeader";
@@ -49,11 +50,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -68,11 +71,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -91,11 +96,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={setSearchFilter}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={setSearchFilter}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -117,11 +124,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,11 +147,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -161,11 +172,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -187,11 +200,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -222,11 +237,13 @@ describe("MachineListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListHeader
+              headerContent={null}
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { FabricColumn } from "./FabricColumn";
@@ -46,7 +47,9 @@ describe("FabricColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FabricColumn systemId="abc123" />
+          <CompatRouter>
+            <FabricColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -73,7 +76,9 @@ describe("FabricColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FabricColumn systemId="abc123" />
+          <CompatRouter>
+            <FabricColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -95,7 +100,9 @@ describe("FabricColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FabricColumn systemId="abc123" />
+          <CompatRouter>
+            <FabricColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -122,7 +129,9 @@ describe("FabricColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FabricColumn systemId="abc123" />
+          <CompatRouter>
+            <FabricColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import MachineTestStatus from "../MachineTestStatus";
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.tsx.snap
@@ -66,19 +66,13 @@ exports[`FabricColumn renders 1`] = `
                     className="p-link--soft"
                     to="/fabric/0"
                   >
-                    <LinkAnchor
+                    <a
                       className="p-link--soft"
                       href="/fabric/0"
-                      navigate={[Function]}
+                      onClick={[Function]}
                     >
-                      <a
-                        className="p-link--soft"
-                        href="/fabric/0"
-                        onClick={[Function]}
-                      >
-                        fabric-0
-                      </a>
-                    </LinkAnchor>
+                      fabric-0
+                    </a>
                   </Link>
                 </span>
               </ScriptStatus>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { MachineListTable } from "./MachineListTable";
@@ -220,14 +221,16 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter=""
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -247,14 +250,16 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter=""
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -282,14 +287,16 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter=""
-            grouping="none"
-            hiddenGroups={[]}
-            machines={machines}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="none"
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -327,14 +334,16 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter=""
-            grouping="none"
-            hiddenGroups={[]}
-            machines={machines}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="none"
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -388,15 +397,17 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter=""
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            selectedIDs={[machines[0].system_id]}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              selectedIDs={[machines[0].system_id]}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -416,15 +427,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -441,15 +454,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123", "ghi789"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123", "ghi789"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -472,15 +487,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123", "def456", "ghi789"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123", "def456", "ghi789"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -503,14 +520,16 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -538,15 +557,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -574,15 +595,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={[]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={[]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -610,15 +633,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123", "def456", "ghi789"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123", "def456", "ghi789"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -646,15 +671,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -673,15 +700,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={[]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={[]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -709,15 +738,17 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={machines}
-              selectedIDs={["abc123", "def456", "ghi789"]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={machines}
+                selectedIDs={["abc123", "def456", "ghi789"]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -745,14 +776,16 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              filter=""
-              grouping="status"
-              hiddenGroups={[]}
-              machines={[]}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-            />
+            <CompatRouter>
+              <MachineListTable
+                filter=""
+                grouping="status"
+                hiddenGroups={[]}
+                machines={[]}
+                setHiddenGroups={jest.fn()}
+                setSearchFilter={jest.fn()}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -776,15 +809,17 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter=""
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            selectedIDs={["abc123"]}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              selectedIDs={["abc123"]}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -804,15 +839,17 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter="in:selected"
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            selectedIDs={["abc123"]}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={setSearchFilter}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter="in:selected"
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              selectedIDs={["abc123"]}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={setSearchFilter}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -833,15 +870,17 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter="in:selected"
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            selectedIDs={["abc123"]}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={setSearchFilter}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter="in:selected"
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              selectedIDs={["abc123"]}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={setSearchFilter}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -862,15 +901,17 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable
-            filter="in:selected"
-            grouping="status"
-            hiddenGroups={[]}
-            machines={machines}
-            selectedIDs={["abc123", "def456", "ghi789"]}
-            setHiddenGroups={jest.fn()}
-            setSearchFilter={setSearchFilter}
-          />
+          <CompatRouter>
+            <MachineListTable
+              filter="in:selected"
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              selectedIDs={["abc123", "def456", "ghi789"]}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={setSearchFilter}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -890,7 +931,9 @@ describe("MachineListTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineListTable machines={machines} showActions={false} />
+          <CompatRouter>
+            <MachineListTable machines={machines} showActions={false} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -913,10 +956,12 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              hiddenColumns={["power", "zone"]}
-              machines={machines}
-            />
+            <CompatRouter>
+              <MachineListTable
+                hiddenColumns={["power", "zone"]}
+                machines={machines}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -936,11 +981,13 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              hiddenColumns={["fqdn"]}
-              machines={machines}
-              showActions
-            />
+            <CompatRouter>
+              <MachineListTable
+                hiddenColumns={["fqdn"]}
+                machines={machines}
+                showActions
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -956,11 +1003,13 @@ describe("MachineListTable", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <MachineListTable
-              hiddenColumns={["fqdn"]}
-              machines={machines}
-              showActions={false}
-            />
+            <CompatRouter>
+              <MachineListTable
+                hiddenColumns={["fqdn"]}
+                machines={machines}
+                showActions={false}
+              />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { NameColumn } from "./NameColumn";
@@ -49,11 +50,13 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn
-            selected={[]}
-            handleCheckbox={jest.fn()}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NameColumn
+              selected={[]}
+              handleCheckbox={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -68,7 +71,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -82,7 +87,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -97,7 +104,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -119,7 +128,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,7 +149,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -158,7 +171,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -176,7 +191,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} showMAC={true} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} showMAC={true} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -191,7 +208,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} showMAC={true} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} showMAC={true} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -214,7 +233,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -236,7 +257,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} showMAC={true} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} showMAC={true} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -250,12 +273,14 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn
-            handleCheckbox={jest.fn()}
-            selected={["abc123"]}
-            showMAC={true}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <NameColumn
+              handleCheckbox={jest.fn()}
+              selected={["abc123"]}
+              showMAC={true}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -269,7 +294,9 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn selected={[]} systemId="abc123" />
+          <CompatRouter>
+            <NameColumn selected={[]} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 
 import { Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import NonBreakingSpace from "app/base/components/NonBreakingSpace";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
@@ -181,27 +181,21 @@ exports[`NameColumn renders 1`] = `
                                 title="test.maas"
                                 to="/machine/abc123"
                               >
-                                <LinkAnchor
+                                <a
                                   href="/machine/abc123"
-                                  navigate={[Function]}
+                                  onClick={[Function]}
                                   title="test.maas"
                                 >
-                                  <a
-                                    href="/machine/abc123"
-                                    onClick={[Function]}
-                                    title="test.maas"
+                                  <strong
+                                    data-testid="hostname"
                                   >
-                                    <strong
-                                      data-testid="hostname"
-                                    >
-                                      koala
-                                    </strong>
-                                    <small>
-                                      .
-                                      example
-                                    </small>
-                                  </a>
-                                </LinkAnchor>
+                                    koala
+                                  </strong>
+                                  <small>
+                                    .
+                                    example
+                                  </small>
+                                </a>
                               </Link>
                             </span>
                           </label>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { PoolColumn } from "./PoolColumn";
@@ -58,7 +59,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -74,7 +77,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -90,7 +95,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -113,7 +120,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -133,7 +142,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -152,7 +163,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -188,7 +201,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -209,7 +224,9 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <CompatRouter>
+            <PoolColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import { useToggleMenu } from "app/machines/hooks";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.tsx.snap
@@ -63,19 +63,13 @@ exports[`PoolColumn renders 1`] = `
                 className="p-link--soft"
                 to="/pools"
               >
-                <LinkAnchor
+                <a
                   className="p-link--soft"
                   href="/pools"
-                  navigate={[Function]}
+                  onClick={[Function]}
                 >
-                  <a
-                    className="p-link--soft"
-                    href="/pools"
-                    onClick={[Function]}
-                  >
-                    default
-                  </a>
-                </LinkAnchor>
+                  default
+                </a>
               </Link>
             </span>
           </div>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { StatusColumn } from "./StatusColumn";
@@ -73,7 +74,9 @@ describe("StatusColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -90,7 +93,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -109,7 +114,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -130,7 +137,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -151,7 +160,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -172,7 +183,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -194,7 +207,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -215,7 +230,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -234,7 +251,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -253,7 +272,9 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            <CompatRouter>
+              <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -285,7 +306,9 @@ describe("StatusColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -301,7 +324,9 @@ describe("StatusColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <StatusColumn systemId="abc123" />
+          <CompatRouter>
+            <StatusColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Spinner, Tooltip } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TooltipButton from "app/base/components/TooltipButton";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
@@ -184,13 +184,6 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
       element={
         Object {
           "$$typeof": Symbol(react.forward_ref),
-          "propTypes": Object {
-            "innerRef": [Function],
-            "onClick": [Function],
-            "replace": [Function],
-            "target": [Function],
-            "to": [Function],
-          },
           "render": [Function],
         }
       }
@@ -203,20 +196,13 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         onClick={null}
         to="/machine/abc123/logs"
       >
-        <LinkAnchor
+        <a
           className="p-button p-contextual-menu__link"
           href="/machine/abc123/logs"
-          navigate={[Function]}
-          onClick={null}
+          onClick={[Function]}
         >
-          <a
-            className="p-button p-contextual-menu__link"
-            href="/machine/abc123/logs"
-            onClick={[Function]}
-          >
-            See logs
-          </a>
-        </LinkAnchor>
+          See logs
+        </a>
       </Link>
     </Button>
   </span>
@@ -239,13 +225,6 @@ exports[`StatusColumn renders 1`] = `
             "children": "See logs",
             "element": Object {
               "$$typeof": Symbol(react.forward_ref),
-              "propTypes": Object {
-                "innerRef": [Function],
-                "onClick": [Function],
-                "replace": [Function],
-                "target": [Function],
-                "to": [Function],
-              },
               "render": [Function],
             },
             "to": "/machine/abc123/logs",
@@ -314,13 +293,6 @@ exports[`StatusColumn renders 1`] = `
                     "children": "See logs",
                     "element": Object {
                       "$$typeof": Symbol(react.forward_ref),
-                      "propTypes": Object {
-                        "innerRef": [Function],
-                        "onClick": [Function],
-                        "replace": [Function],
-                        "target": [Function],
-                        "to": [Function],
-                      },
                       "render": [Function],
                     },
                     "to": "/machine/abc123/logs",
@@ -344,13 +316,6 @@ exports[`StatusColumn renders 1`] = `
                       "children": "See logs",
                       "element": Object {
                         "$$typeof": Symbol(react.forward_ref),
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
                         "render": [Function],
                       },
                       "to": "/machine/abc123/logs",

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { ZoneColumn } from "./ZoneColumn";
@@ -57,7 +58,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -73,7 +76,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -89,7 +94,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +112,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -121,7 +130,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -139,7 +150,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -158,7 +171,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -194,7 +209,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -215,7 +232,9 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <CompatRouter>
+            <ZoneColumn systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from "react";
 
 import { Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import { useToggleMenu } from "app/machines/hooks";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.tsx.snap
@@ -59,19 +59,13 @@ exports[`ZoneColumn renders 1`] = `
                 className="p-link--soft"
                 to="/zone/0"
               >
-                <LinkAnchor
+                <a
                   className="p-link--soft"
                   href="/zone/0"
-                  navigate={[Function]}
+                  onClick={[Function]}
                 >
-                  <a
-                    className="p-link--soft"
-                    href="/zone/0"
-                    onClick={[Function]}
-                  >
-                    zone-north
-                  </a>
-                </LinkAnchor>
+                  zone-north
+                </a>
               </Link>
             </span>
           </div>

--- a/ui/src/app/machines/views/Machines.test.tsx
+++ b/ui/src/app/machines/views/Machines.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, useLocation } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineList from "./MachineList";
@@ -79,7 +80,9 @@ describe("Machines", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Machines />
+            <CompatRouter>
+              <Machines />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );
@@ -96,7 +99,9 @@ describe("Machines", () => {
             { pathname: "/machines", search: "?q=test+search", key: "testKey" },
           ]}
         >
-          <Machines />
+          <CompatRouter>
+            <Machines />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -120,8 +125,10 @@ describe("Machines", () => {
             { pathname: "/machines", search: "?q=test+search", key: "testKey" },
           ]}
         >
-          <Machines />
-          <Route path="*" render={() => <FetchRoute />} />
+          <CompatRouter>
+            <Machines />
+            <Route path="*" render={() => <FetchRoute />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -139,7 +146,9 @@ describe("Machines", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <Machines />
+          <CompatRouter>
+            <Machines />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -163,7 +172,9 @@ describe("Machines", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <Machines />
+          <CompatRouter>
+            <Machines />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/pools/views/PoolList/PoolList.test.tsx
+++ b/ui/src/app/pools/views/PoolList/PoolList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import PoolList from "./PoolList";
@@ -33,7 +34,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -48,7 +51,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -63,7 +68,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -87,7 +94,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,7 +127,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -163,7 +174,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -185,7 +198,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -198,7 +213,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -213,7 +230,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -234,7 +253,9 @@ describe("PoolList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <PoolList />
+          <CompatRouter>
+            <PoolList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/pools/views/PoolList/PoolList.tsx
+++ b/ui/src/app/pools/views/PoolList/PoolList.tsx
@@ -8,7 +8,7 @@ import {
   Row,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import type { Dispatch } from "redux";
 
 import TableActions from "app/base/components/TableActions";

--- a/ui/src/app/pools/views/Pools.test.tsx
+++ b/ui/src/app/pools/views/Pools.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Pools from "./Pools";
@@ -34,7 +35,9 @@ describe("Pools", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Pools />
+            <CompatRouter>
+              <Pools />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/pools/views/Pools.tsx
+++ b/ui/src/app/pools/views/Pools.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@canonical/react-components";
-import { Link, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import PoolList from "./PoolList";
 

--- a/ui/src/app/preferences/components/Nav/Nav.test.tsx
+++ b/ui/src/app/preferences/components/Nav/Nav.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import { Nav } from "./Nav";
 
@@ -10,7 +11,9 @@ describe("Nav", () => {
         initialEntries={[{ pathname: "/prefs", key: "testKey" }]}
         initialIndex={0}
       >
-        <Route render={() => <Nav />} path="/prefs" />
+        <CompatRouter>
+          <Route render={() => <Nav />} path="/prefs" />
+        </CompatRouter>
       </MemoryRouter>
     );
     expect(wrapper.find("SideNav").exists()).toBe(true);

--- a/ui/src/app/preferences/components/Routes.test.tsx
+++ b/ui/src/app/preferences/components/Routes.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Routes from "./Routes";
@@ -54,7 +55,9 @@ describe("Routes", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Routes />
+            <CompatRouter>
+              <Routes />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.test.tsx
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import APIKeyList from "./APIKeyList";
@@ -45,7 +46,9 @@ describe("APIKeyList", () => {
             { pathname: "/account/prefs/api-keys", key: "testKey" },
           ]}
         >
-          <APIKeyList />
+          <CompatRouter>
+            <APIKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/Preferences.test.tsx
+++ b/ui/src/app/preferences/views/Preferences.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Preferences from "./Preferences";
@@ -28,7 +29,9 @@ describe("Preferences", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/preferences", key: "testKey" }]}
         >
-          <Preferences />
+          <CompatRouter>
+            <Preferences />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SSHKeyList from "./SSHKeyList";
@@ -58,7 +59,9 @@ describe("SSHKeyList", () => {
             { pathname: "/account/prefs/ssh-keys", key: "testKey" },
           ]}
         >
-          <SSHKeyList />
+          <CompatRouter>
+            <SSHKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SSLKeyList from "./SSLKeyList";
@@ -55,7 +56,9 @@ describe("SSLKeyList", () => {
             { pathname: "/account/prefs/ssl-keys", key: "testKey" },
           ]}
         >
-          <SSLKeyList />
+          <CompatRouter>
+            <SSLKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +75,9 @@ describe("SSLKeyList", () => {
             { pathname: "/account/prefs/ssl-keys", key: "testKey" },
           ]}
         >
-          <SSLKeyList />
+          <CompatRouter>
+            <SSLKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -90,7 +95,9 @@ describe("SSLKeyList", () => {
             { pathname: "/account/prefs/ssl-keys", key: "testKey" },
           ]}
         >
-          <SSLKeyList />
+          <CompatRouter>
+            <SSLKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +113,9 @@ describe("SSLKeyList", () => {
             { pathname: "/account/prefs/ssl-keys", key: "testKey" },
           ]}
         >
-          <SSLKeyList />
+          <CompatRouter>
+            <SSLKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,7 +136,9 @@ describe("SSLKeyList", () => {
             { pathname: "/account/prefs/ssl-keys", key: "testKey" },
           ]}
         >
-          <SSLKeyList />
+          <CompatRouter>
+            <SSLKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -169,7 +180,9 @@ describe("SSLKeyList", () => {
             { pathname: "/account/prefs/ssl-keys", key: "testKey" },
           ]}
         >
-          <SSLKeyList />
+          <CompatRouter>
+            <SSLKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/components/Nav/Nav.test.tsx
+++ b/ui/src/app/settings/components/Nav/Nav.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import { Nav } from "./Nav";
 
@@ -10,7 +11,9 @@ describe("Nav", () => {
         initialEntries={[{ pathname: "/settings", key: "testKey" }]}
         initialIndex={0}
       >
-        <Route render={() => <Nav />} path="/settings" />
+        <CompatRouter>
+          <Route render={() => <Nav />} path="/settings" />
+        </CompatRouter>
       </MemoryRouter>
     );
     expect(wrapper.find("SideNav").exists()).toBe(true);

--- a/ui/src/app/settings/components/Routes/Routes.test.tsx
+++ b/ui/src/app/settings/components/Routes/Routes.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Routes from "./Routes";
@@ -141,7 +142,9 @@ describe("Routes", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Routes />
+            <CompatRouter>
+              <Routes />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/settings/components/SettingsTable/SettingsTable.tsx
+++ b/ui/src/app/settings/components/SettingsTable/SettingsTable.tsx
@@ -8,7 +8,7 @@ import {
 } from "@canonical/react-components";
 import type { MainTableProps } from "@canonical/react-components";
 import classNames from "classnames";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 export type TableButtons = {
   disabled?: boolean;

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DhcpList from "./DhcpList";
@@ -75,7 +76,9 @@ describe("DhcpList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpList />
+          <CompatRouter>
+            <DhcpList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -92,7 +95,9 @@ describe("DhcpList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpList />
+          <CompatRouter>
+            <DhcpList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -130,7 +135,9 @@ describe("DhcpList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpList />
+          <CompatRouter>
+            <DhcpList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -159,7 +166,9 @@ describe("DhcpList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpList />
+          <CompatRouter>
+            <DhcpList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -176,7 +185,9 @@ describe("DhcpList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpList />
+          <CompatRouter>
+            <DhcpList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DhcpTarget from "./DhcpTarget";
@@ -80,7 +81,9 @@ describe("DhcpTarget", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpTarget subnetId={808} />
+          <CompatRouter>
+            <DhcpTarget subnetId={808} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -92,7 +95,9 @@ describe("DhcpTarget", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpTarget subnetId={1} />
+          <CompatRouter>
+            <DhcpTarget subnetId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +111,9 @@ describe("DhcpTarget", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <DhcpTarget nodeId="xyz" />
+          <CompatRouter>
+            <DhcpTarget nodeId="xyz" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Spinner } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import LegacyLink from "app/base/components/LegacyLink";
 import controllersURLs from "app/controllers/urls";

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.tsx.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.tsx.snap
@@ -4,20 +4,15 @@ exports[`DhcpTarget can display a node link 1`] = `
 <Link
   to="/machine/xyz"
 >
-  <LinkAnchor
+  <a
     href="/machine/xyz"
-    navigate={[Function]}
+    onClick={[Function]}
   >
-    <a
-      href="/machine/xyz"
-      onClick={[Function]}
-    >
-      machine1
-      <small>
-        .
-        test
-      </small>
-    </a>
-  </LinkAnchor>
+    machine1
+    <small>
+      .
+      test
+    </small>
+  </a>
 </Link>
 `;

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LicenseKeyList from ".";
@@ -51,7 +52,9 @@ describe("LicenseKeyList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <LicenseKeyList />
+          <CompatRouter>
+            <LicenseKeyList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RepositoriesList from "./RepositoriesList";
@@ -65,7 +66,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -82,7 +85,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -98,7 +103,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -119,7 +126,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -156,7 +165,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -179,7 +190,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -205,7 +218,9 @@ describe("RepositoriesList", () => {
             { pathname: "/settings/repositories", key: "testKey" },
           ]}
         >
-          <RepositoriesList />
+          <CompatRouter>
+            <RepositoriesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ScriptsList from ".";
@@ -52,7 +53,9 @@ describe("ScriptsList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -69,7 +72,9 @@ describe("ScriptsList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -85,7 +90,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -109,7 +116,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList type="testing" />
+          <CompatRouter>
+            <ScriptsList type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -141,7 +150,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -175,7 +186,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList type="testing" />
+          <CompatRouter>
+            <ScriptsList type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -193,7 +206,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -228,7 +243,9 @@ describe("ScriptsList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -245,7 +262,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList />
+          <CompatRouter>
+            <ScriptsList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -278,7 +297,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList type="testing" />
+          <CompatRouter>
+            <ScriptsList type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -304,7 +325,9 @@ describe("ScriptsList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsList type="testing" />
+          <CompatRouter>
+            <ScriptsList type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.tsx
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import UsersList from "./UsersList";
@@ -62,7 +63,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -86,7 +89,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -119,7 +124,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -135,7 +142,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -152,7 +161,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -168,7 +179,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -191,7 +204,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -216,7 +231,9 @@ describe("UsersList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UsersList />
+          <CompatRouter>
+            <UsersList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricDetails from "./FabricDetails";
@@ -23,11 +24,13 @@ it("dispatches actions to fetch necessary data and set fabric as active on mount
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.fabric.index(null, true)}
-          component={() => <FabricDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.fabric.index(null, true)}
+            component={() => <FabricDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,11 +58,13 @@ it("dispatches actions to unset active fabric and clean up on unmount", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.fabric.index(null, true)}
-          component={() => <FabricDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.fabric.index(null, true)}
+            component={() => <FabricDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -96,11 +101,13 @@ it("displays a message if the fabric does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.fabric.index(null, true)}
-          component={() => <FabricDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.fabric.index(null, true)}
+            component={() => <FabricDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -121,11 +128,13 @@ it("shows a spinner if the fabric has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.fabric.index(null, true)}
-          component={() => <FabricDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.fabric.index(null, true)}
+            component={() => <FabricDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricVLANs from "./FabricVLANs";
@@ -39,11 +40,13 @@ it("renders correct details", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.fabric.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.fabric.index({ id: fabric.id })}
-          component={() => <FabricVLANs fabric={fabric} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.fabric.index({ id: fabric.id })}
+            component={() => <FabricVLANs fabric={fabric} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -116,7 +119,9 @@ it("handles a VLAN without any subnets", () => {
           { pathname: subnetsURLs.fabric.index({ id: fabric.id }) },
         ]}
       >
-        <FabricVLANs fabric={fabric} />
+        <CompatRouter>
+          <FabricVLANs fabric={fabric} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -163,7 +168,9 @@ it("handles a VLAN with multiple subnets", () => {
           { pathname: subnetsURLs.fabric.index({ id: fabric.id }) },
         ]}
       >
-        <FabricVLANs fabric={fabric} />
+        <CompatRouter>
+          <FabricVLANs fabric={fabric} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SpaceDetails from "./SpaceDetails";
@@ -23,11 +24,13 @@ it("dispatches actions to get and set space as active on mount", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index(null, true)}
-          component={() => <SpaceDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index(null, true)}
+            component={() => <SpaceDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -51,11 +54,13 @@ it("dispatches actions to unset active space and clean up on unmount", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index(null, true)}
-          component={() => <SpaceDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index(null, true)}
+            component={() => <SpaceDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -92,11 +97,13 @@ it("displays a message if the space does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index(null, true)}
-          component={() => <SpaceDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index(null, true)}
+            component={() => <SpaceDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -117,11 +124,13 @@ it("shows a spinner if the space has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index(null, true)}
-          component={() => <SpaceDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index(null, true)}
+            component={() => <SpaceDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -149,11 +158,13 @@ it("displays space details", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index(null, true)}
-          component={() => <SpaceDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index(null, true)}
+            component={() => <SpaceDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SpaceSubnets from "./SpaceSubnets";
@@ -54,11 +55,13 @@ it("displays a message when there are no subnets", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index({ id: space.id })}
-          component={() => <SpaceSubnets space={space} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index({ id: space.id })}
+            component={() => <SpaceSubnets space={space} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -90,11 +93,13 @@ it("displays subnet details correctly", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.space.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.space.index({ id: space.id })}
-          component={() => <SpaceSubnets space={space} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.space.index({ id: space.id })}
+            component={() => <SpaceSubnets space={space} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SubnetDetails from "./SubnetDetails";
@@ -23,11 +24,13 @@ it("dispatches actions to fetch necessary data and set subnet as active on mount
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.subnet.index(null, true)}
-          component={() => <SubnetDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.subnet.index(null, true)}
+            component={() => <SubnetDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,11 +58,13 @@ it("dispatches actions to unset active subnet and clean up on unmount", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.subnet.index(null, true)}
-          component={() => <SubnetDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.subnet.index(null, true)}
+            component={() => <SubnetDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -96,11 +101,13 @@ it("displays a message if the subnet does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.subnet.index(null, true)}
-          component={() => <SubnetDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.subnet.index(null, true)}
+            component={() => <SubnetDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -121,11 +128,13 @@ it("shows a spinner if the subnet has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.subnet.index(null, true)}
-          component={() => <SubnetDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.subnet.index(null, true)}
+            component={() => <SubnetDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MapSubnet from "./MapSubnet";
@@ -20,7 +21,9 @@ it("shows a spinner while subnet is loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <MapSubnet id={1} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <MapSubnet id={1} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -37,7 +40,9 @@ it("shows an error if the subnet is IPv6", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <MapSubnet id={subnet.id} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <MapSubnet id={subnet.id} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -57,7 +62,9 @@ it("can map an IPv4 subnet", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <MapSubnet id={subnet.id} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <MapSubnet id={subnet.id} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { Notification, Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import FormikForm from "app/base/components/FormikForm";
 import { useCycled } from "app/base/hooks";

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SubnetSummary from "./SubnetSummary";
@@ -88,7 +89,9 @@ it("renders correct section heading", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <SubnetSummary id={subnet.id} />
+        <CompatRouter>
+          <SubnetSummary id={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -104,7 +107,9 @@ it("renders current values for static fields", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <SubnetSummary id={subnet.id} />
+        <CompatRouter>
+          <SubnetSummary id={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -130,7 +135,9 @@ it("renders the correct value for 'VLAN'", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <SubnetSummary id={subnet.id} />
+        <CompatRouter>
+          <SubnetSummary id={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -144,7 +151,9 @@ it("renders the correct value for 'Fabric'", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.subnet.index({ id: 1 }) }]}
       >
-        <SubnetSummary id={subnet.id} />
+        <CompatRouter>
+          <SubnetSummary id={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/Subnets.test.tsx
+++ b/ui/src/app/subnets/views/Subnets.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Subnets from "./Subnets";
@@ -42,7 +43,9 @@ describe("Subnets", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Subnets />
+            <CompatRouter>
+              <Subnets />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SubnetsTable from "./SubnetsTable";
@@ -44,12 +45,14 @@ it("renders a single table variant at a time", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -65,12 +68,14 @@ it("renders Subnets by Fabric table when grouping by Fabric", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -87,12 +92,14 @@ it("renders Subnets by Space table when grouping by Space", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="space"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="space"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -109,12 +116,14 @@ it("displays a correct number of pages", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -146,12 +155,14 @@ it("updates the list of items correctly when navigating to another page", async 
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -204,12 +215,14 @@ it("doesn't display pagination if rows are within items per page limit", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -238,12 +251,14 @@ it("displays correctly paginated rows", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -300,12 +315,14 @@ it("displays the last available page once the currently active has no items", as
   const { rerender } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -337,12 +354,14 @@ it("displays the last available page once the currently active has no items", as
   rerender(
     <Provider store={updatedStore}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -371,12 +390,14 @@ it("remains on the same page once the data is updated and page is still availabl
   const { rerender } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -405,12 +426,14 @@ it("remains on the same page once the data is updated and page is still availabl
   rerender(
     <Provider store={updatedStore}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
-        <SubnetsTable
-          groupBy="fabric"
-          setGroupBy={jest.fn()}
-          searchText=""
-          setSearchText={jest.fn()}
-        />
+        <CompatRouter>
+          <SubnetsTable
+            groupBy="fabric"
+            setGroupBy={jest.fn()}
+            searchText=""
+            setSearchText={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from "react";
 import { useState } from "react";
 
 import { Button } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import type { SubnetsTableColumn } from "./types";
 

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -8,6 +8,7 @@ import {
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import type { ConfigureDHCPValues } from "../ConfigureDHCP";
@@ -52,9 +53,11 @@ it("does not render if DHCP is selected to be disabled", () => {
   const { container } = render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <DHCPReservedRanges id={1} />
-        </Formik>
+        <CompatRouter>
+          <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+            <DHCPReservedRanges id={1} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -80,9 +83,11 @@ it("renders a table of IP ranges if the VLAN has any defined", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <DHCPReservedRanges id={vlan.id} />
-        </Formik>
+        <CompatRouter>
+          <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+            <DHCPReservedRanges id={vlan.id} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -116,9 +121,11 @@ it(`renders only a subnet select field if no IP ranges exist and no subnet is
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <DHCPReservedRanges id={vlan.id} />
-        </Formik>
+        <CompatRouter>
+          <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+            <DHCPReservedRanges id={vlan.id} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -162,9 +169,11 @@ it(`renders a subnet select field and prepopulated fields for a reserved range
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
-          <DHCPReservedRanges id={vlan.id} />
-        </Formik>
+        <CompatRouter>
+          <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+            <DHCPReservedRanges id={vlan.id} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -2,6 +2,7 @@ import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DHCPStatus from "./DHCPStatus";
@@ -30,7 +31,9 @@ it("shows a spinner if data is loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={1} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={1} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -49,7 +52,9 @@ it(`shows a warning and disables Configure DHCP button if there are no subnets
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -76,7 +81,9 @@ it("does not show a warning if there are subnets attached to the VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -102,7 +109,9 @@ it("renders correctly when a VLAN does not have DHCP enabled", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -126,7 +135,9 @@ it("renders correctly when a VLAN has external DHCP", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -158,7 +169,9 @@ it("renders correctly when a VLAN has relayed DHCP", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -188,7 +201,9 @@ it("renders correctly when a VLAN has MAAS-configured DHCP without high availabi
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -234,7 +249,9 @@ it("renders correctly when a VLAN has MAAS-configured DHCP with high availabilit
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        <CompatRouter>
+          <DHCPStatus id={vlan.id} openForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -8,7 +8,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import Definition from "app/base/components/Definition";

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VLANDetails from "./VLANDetails";
@@ -27,11 +28,13 @@ it("dispatches actions to fetch necessary data and set vlan as active on mount",
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.vlan.index(null, true)}
-          component={() => <VLANDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.vlan.index(null, true)}
+            component={() => <VLANDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,11 +58,13 @@ it("dispatches actions to unset active vlan and clean up on unmount", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.vlan.index(null, true)}
-          component={() => <VLANDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.vlan.index(null, true)}
+            component={() => <VLANDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -93,11 +98,13 @@ it("displays a message if the vlan does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.vlan.index(null, true)}
-          component={() => <VLANDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.vlan.index(null, true)}
+            component={() => <VLANDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -118,11 +125,13 @@ it("shows a spinner if the vlan has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: subnetsURLs.vlan.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={subnetsURLs.vlan.index(null, true)}
-          component={() => <VLANDetails />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.vlan.index(null, true)}
+            component={() => <VLANDetails />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VLANDeleteForm from "./VLANDeleteForm";
@@ -36,7 +37,9 @@ it("does not allow deletion if the VLAN is the default VLAN in its fabric", () =
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANDeleteForm closeForm={jest.fn()} id={vlan.id} />
+        <CompatRouter>
+          <VLANDeleteForm closeForm={jest.fn()} id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -67,7 +70,9 @@ it("displays a delete confirmation if the VLAN is not the default for its fabric
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANDeleteForm closeForm={jest.fn()} id={vlan.id} />
+        <CompatRouter>
+          <VLANDeleteForm closeForm={jest.fn()} id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -96,7 +101,9 @@ it("deletes the VLAN when confirmed", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANDeleteForm closeForm={jest.fn()} id={vlan.id} />
+        <CompatRouter>
+          <VLANDeleteForm closeForm={jest.fn()} id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VLANSubnets from "./VLANSubnets";
@@ -34,7 +35,9 @@ it("renders correct details", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANSubnets id={vlan.id} />
+        <CompatRouter>
+          <VLANSubnets id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VLANSummary from "./VLANSummary";
@@ -71,7 +72,9 @@ it("renders correct details", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANSummary id={vlan.id} />
+        <CompatRouter>
+          <VLANSummary id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -97,7 +100,9 @@ it("can display the edit form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <VLANSummary id={vlan.id} />
+        <CompatRouter>
+          <VLANSummary id={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
+++ b/ui/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AppliedTo from "./AppliedTo";
@@ -47,7 +48,9 @@ it("links to nodes", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <AppliedTo id={1} />
+        <CompatRouter>
+          <AppliedTo id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -93,7 +96,9 @@ it("displays a message if there are no nodes", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <AppliedTo id={1} />
+        <CompatRouter>
+          <AppliedTo id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
+++ b/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import NodesTagsLink from "./NodesTagsLink";
 
@@ -13,7 +14,13 @@ import { MachineMeta } from "app/store/machine/types";
 it("create a link to machines", () => {
   render(
     <MemoryRouter>
-      <NodesTagsLink count={1} nodeType={MachineMeta.MODEL} tags={["a-tag"]} />
+      <CompatRouter>
+        <NodesTagsLink
+          count={1}
+          nodeType={MachineMeta.MODEL}
+          tags={["a-tag"]}
+        />
+      </CompatRouter>
     </MemoryRouter>
   );
   const machineLink = screen.getByRole("link", {
@@ -29,11 +36,13 @@ it("create a link to machines", () => {
 it("create a link to controllers", () => {
   render(
     <MemoryRouter>
-      <NodesTagsLink
-        count={3}
-        nodeType={ControllerMeta.MODEL}
-        tags={["a-tag"]}
-      />
+      <CompatRouter>
+        <NodesTagsLink
+          count={3}
+          nodeType={ControllerMeta.MODEL}
+          tags={["a-tag"]}
+        />
+      </CompatRouter>
     </MemoryRouter>
   );
   const controllerLink = screen.getByRole("link", {
@@ -49,7 +58,9 @@ it("create a link to controllers", () => {
 it("create a link to devices", () => {
   render(
     <MemoryRouter>
-      <NodesTagsLink count={2} nodeType={DeviceMeta.MODEL} tags={["a-tag"]} />
+      <CompatRouter>
+        <NodesTagsLink count={2} nodeType={DeviceMeta.MODEL} tags={["a-tag"]} />
+      </CompatRouter>
     </MemoryRouter>
   );
   const deviceLink = screen.getByRole("link", {

--- a/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
+++ b/ui/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
@@ -1,5 +1,5 @@
 import pluralize from "pluralize";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import controllerURLs from "app/controllers/urls";
 import deviceURLs from "app/devices/urls";

--- a/ui/src/app/tags/components/TagDetails/TagDetails.test.tsx
+++ b/ui/src/app/tags/components/TagDetails/TagDetails.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagDetails from "./TagDetails";
@@ -41,11 +42,13 @@ it("dispatches actions to fetch necessary data", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails id={1} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -74,11 +77,13 @@ it("displays a message if the tag does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails id={1} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -99,11 +104,13 @@ it("shows a spinner if the tag has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails id={1} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -118,11 +125,13 @@ it("displays the tag name when not narrow", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails id={1} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -136,11 +145,13 @@ it("does not display the tag name when narrow", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails id={1} narrow />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails id={1} narrow />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteTagForm from "./DeleteTagForm";
@@ -54,7 +55,9 @@ it("dispatches an action to delete a tag", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagForm id={1} onClose={jest.fn()} />
+        <CompatRouter>
+          <DeleteTagForm id={1} onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -76,7 +79,9 @@ it("dispatches an action to add a notification when tag successfully deleted", a
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagForm id={1} onClose={jest.fn()} />
+        <CompatRouter>
+          <DeleteTagForm id={1} onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -98,7 +103,9 @@ it("displays a message when deleting a tag on a machine", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagForm id={1} onClose={jest.fn()} />
+        <CompatRouter>
+          <DeleteTagForm id={1} onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -121,7 +128,9 @@ it("displays a message when deleting a tag not on a machine", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagForm id={1} onClose={jest.fn()} />
+        <CompatRouter>
+          <DeleteTagForm id={1} onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -150,11 +159,13 @@ it("can return to the list on cancel", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={path}
-          component={() => <DeleteTagForm id={1} onClose={onClose} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={path}
+            component={() => <DeleteTagForm id={1} onClose={onClose} />}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -181,13 +192,15 @@ it("can return to the details on cancel", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={path}
-          component={() => (
-            <DeleteTagForm fromDetails id={1} onClose={onClose} />
-          )}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={path}
+            component={() => (
+              <DeleteTagForm fromDetails id={1} onClose={onClose} />
+            )}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteTagFormWarnings from "./DeleteTagFormWarnings";
@@ -59,7 +60,9 @@ it("does not display a kernel options warning for non-deployed machines", async 
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -81,7 +84,9 @@ it("displays warning when deleting a tag with kernel options", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -109,7 +114,9 @@ it("displays a kernel options warning with multiple machines", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -131,7 +138,9 @@ it("displays a kernel options warning with one machine", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -153,7 +162,9 @@ it("links to a page to display deployed machines", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -174,7 +185,9 @@ it("displays warning when deleting a tag applied to devices", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -195,7 +208,9 @@ it("displays warning when deleting a tag applied to controllers", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -216,7 +231,9 @@ it("generates the correct sentence for multiple nodes", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <DeleteTagFormWarnings id={1} />
+        <CompatRouter>
+          <DeleteTagFormWarnings id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
@@ -1,7 +1,7 @@
 import { Notification } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";

--- a/ui/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagsHeader from "./TagsHeader";
@@ -30,10 +31,12 @@ it("can display the add tag form", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagsHeader
-          headerContent={{ view: TagHeaderViews.AddTag }}
-          setHeaderContent={jest.fn()}
-        />
+        <CompatRouter>
+          <TagsHeader
+            headerContent={{ view: TagHeaderViews.AddTag }}
+            setHeaderContent={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -61,10 +64,15 @@ it("can display the delete tag form", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagsHeader
-          headerContent={{ view: TagHeaderViews.DeleteTag, extras: { id: 1 } }}
-          setHeaderContent={jest.fn()}
-        />
+        <CompatRouter>
+          <TagsHeader
+            headerContent={{
+              view: TagHeaderViews.DeleteTag,
+              extras: { id: 1 },
+            }}
+            setHeaderContent={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -82,7 +90,9 @@ it("displays the default title", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagsHeader headerContent={null} setHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <TagsHeader headerContent={null} setHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Label } from "../TagUpdate/TagUpdate";
@@ -46,11 +47,13 @@ it("dispatches actions to fetch necessary data", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails onDelete={jest.fn()} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails onDelete={jest.fn()} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -79,11 +82,13 @@ it("displays a message if the tag does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails onDelete={jest.fn()} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails onDelete={jest.fn()} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -104,11 +109,13 @@ it("shows a spinner if the tag has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails onDelete={jest.fn()} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails onDelete={jest.fn()} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -123,16 +130,18 @@ it("can display the edit form", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.update({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.update(null, true)}
-          component={() => (
-            <TagDetails
-              tagViewState={TagViewState.Updating}
-              onDelete={jest.fn()}
-            />
-          )}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.update(null, true)}
+            component={() => (
+              <TagDetails
+                tagViewState={TagViewState.Updating}
+                onDelete={jest.fn()}
+              />
+            )}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -148,11 +157,13 @@ it("can go to the tag edit page", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagDetails onDelete={jest.fn()} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagDetails onDelete={jest.fn()} />}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );

--- a/ui/src/app/tags/views/TagDetails/TagDetails.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Button, Col, Icon, Row, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import TagUpdate from "../TagUpdate";
 
@@ -84,9 +84,9 @@ const TagDetails = ({ onDelete, tagViewState }: Props): JSX.Element => {
               <Button
                 element={Link}
                 hasIcon
+                state={{ canGoBack: true }}
                 to={{
                   pathname: tagURLs.tag.update({ id: tag.id }),
-                  state: { canGoBack: true },
                 }}
               >
                 <Icon className="is-light" name="edit" />{" "}

--- a/ui/src/app/tags/views/TagList/TagList.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagList.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagList from "./TagList";
@@ -35,7 +36,9 @@ it("renders", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagList onDelete={jest.fn()} />
+        <CompatRouter>
+          <TagList onDelete={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagTable, { Label, TestId } from "./TagTable";
@@ -58,14 +59,16 @@ it("displays tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -82,14 +85,16 @@ it("displays the tags in order", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -105,14 +110,16 @@ it("can change the sort order", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -149,14 +156,16 @@ it("displays the tags for the current page", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={2}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={2}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -174,14 +183,16 @@ it("shows an icon for automatic tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -198,14 +209,16 @@ it("does not show an icon for manual tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -222,14 +235,16 @@ it("shows an icon for kernel options", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -246,14 +261,16 @@ it("does not show an icon for tags without kernel options", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -278,14 +295,16 @@ it("can link to nodes", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={tags}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={tags}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -324,14 +343,16 @@ it("does not display a message if there are tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -343,14 +364,16 @@ it("displays a message if there are no automatic tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.Auto}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.Auto}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -364,14 +387,16 @@ it("displays a message if there are no manual tags", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.Manual}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={jest.fn()}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.Manual}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={jest.fn()}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -385,14 +410,16 @@ it("displays a message if none match the search terms", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText="nothing"
-          setCurrentPage={jest.fn()}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText="nothing"
+            setCurrentPage={jest.fn()}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -406,14 +433,16 @@ it("displays a message if none match the filter and search terms", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.Auto}
-          onDelete={jest.fn()}
-          searchText="nothing"
-          setCurrentPage={jest.fn()}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.Auto}
+            onDelete={jest.fn()}
+            searchText="nothing"
+            setCurrentPage={jest.fn()}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -428,28 +457,32 @@ it("returns to the first page if the search changes", () => {
   const { rerender } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.Auto}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={setCurrentPage}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.Auto}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={setCurrentPage}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
   rerender(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.Auto}
-          onDelete={jest.fn()}
-          searchText="new"
-          setCurrentPage={setCurrentPage}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.Auto}
+            onDelete={jest.fn()}
+            searchText="new"
+            setCurrentPage={setCurrentPage}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -462,28 +495,32 @@ it("returns to the first page if the filter changes", () => {
   const { rerender } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.All}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={setCurrentPage}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.All}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={setCurrentPage}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
   rerender(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <TagTable
-          currentPage={1}
-          filter={TagSearchFilter.Manual}
-          onDelete={jest.fn()}
-          searchText=""
-          setCurrentPage={setCurrentPage}
-          tags={[]}
-        />
+        <CompatRouter>
+          <TagTable
+            currentPage={1}
+            filter={TagSearchFilter.Manual}
+            onDelete={jest.fn()}
+            searchText=""
+            setCurrentPage={setCurrentPage}
+            tags={[]}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -499,20 +536,22 @@ it("can go to the tag edit page", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={path}
-          component={() => (
-            <TagTable
-              currentPage={1}
-              filter={TagSearchFilter.All}
-              onDelete={jest.fn()}
-              searchText=""
-              setCurrentPage={jest.fn()}
-              tags={tags}
-            />
-          )}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={path}
+            component={() => (
+              <TagTable
+                currentPage={1}
+                filter={TagSearchFilter.All}
+                onDelete={jest.fn()}
+                searchText=""
+                setCurrentPage={jest.fn()}
+                tags={tags}
+              />
+            )}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -8,7 +8,8 @@ import type {
 import { Icon, MainTable, Strip } from "@canonical/react-components";
 import type { History } from "history";
 import { useDispatch } from "react-redux";
-import { Link, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import { TAGS_PER_PAGE } from "../constants";
 

--- a/ui/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/ui/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagMachines, { Label } from "./TagMachines";
@@ -54,11 +55,13 @@ it("dispatches actions to fetch necessary data", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagMachines />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagMachines />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -86,11 +89,13 @@ it("displays a message if the tag does not exist", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagMachines />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagMachines />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -110,11 +115,13 @@ it("shows a spinner if the tag has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagMachines />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagMachines />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -128,11 +135,13 @@ it("displays the machine list", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagMachines />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagMachines />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/zones/views/Zones.test.tsx
+++ b/ui/src/app/zones/views/Zones.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Zones from "./Zones";
@@ -30,7 +31,9 @@ describe("Zones", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Zones />
+            <CompatRouter>
+              <Zones />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/zones/views/ZonesList/ZonesList.test.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ZonesList from "./ZonesList";
@@ -20,7 +21,9 @@ describe("ZonesList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/zones", key: "testKey" }]}>
-          <ZonesList />
+          <CompatRouter>
+            <ZonesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -43,7 +46,9 @@ describe("ZonesList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/zones", key: "testKey" }]}>
-          <ZonesList />
+          <CompatRouter>
+            <ZonesList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { MainTable } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 
 import controllersURLs from "app/controllers/urls";
 import deviceURLs from "app/devices/urls";

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -6,6 +6,7 @@ import { createBrowserHistory } from "history";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import { createReduxHistoryContext } from "redux-first-history";
 import createSagaMiddleware from "redux-saga";
 
@@ -52,9 +53,11 @@ const Root = (): JSX.Element => {
   return (
     <Provider store={store}>
       <Router history={history}>
-        <StrictMode>
-          <App />
-        </StrictMode>
+        <CompatRouter>
+          <StrictMode>
+            <App />
+          </StrictMode>
+        </CompatRouter>
       </Router>
     </Provider>
   );

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -12,6 +12,7 @@ import configureStore from "redux-mock-store";
 import FormikForm from "app/base/components/FormikForm";
 import type { AnyObject } from "app/base/types";
 import type { RootState } from "app/store/root/types";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 /**
  * Assert that some JSX from Enzyme is equal to some provided JSX.
@@ -113,7 +114,9 @@ const BrowserRouterWithProvider = ({
 
   return (
     <Provider store={getMockStore(state)}>
-      <BrowserRouter>{children}</BrowserRouter>
+      <BrowserRouter>
+        <CompatRouter>{children}</CompatRouter>
+      </BrowserRouter>
     </Provider>
   );
 };

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -7,12 +7,12 @@ import type { FormikHelpers } from "formik";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FormikForm from "app/base/components/FormikForm";
 import type { AnyObject } from "app/base/types";
 import type { RootState } from "app/store/root/types";
-import { CompatRouter } from "react-router-dom-v5-compat";
 
 /**
  * Assert that some JSX from Enzyme is equal to some provided JSX.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.0.tgz#6d77142a19cb6088f0af662af1ada37a604d34ae"
+  integrity sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.14.5", "@babel/template@^7.3.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
@@ -9886,6 +9893,13 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
+history@^5.2.0, history@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -15490,6 +15504,14 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
+react-router-dom-v5-compat@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz#a6b1bf18a42e3c1b902711931c4b496920740815"
+  integrity sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==
+  dependencies:
+    history "^5.3.0"
+    react-router "6.3.0"
+
 react-router-dom@5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.1.tgz#0151baf2365c5fcd8493f6ec9b9b31f34d0f8ae1"
@@ -15526,6 +15548,13 @@ react-router@5.3.1:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@4.0.3:
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15504,7 +15504,7 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom-v5-compat@^6.3.0:
+react-router-dom-v5-compat@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz#a6b1bf18a42e3c1b902711931c4b496920740815"
   integrity sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==


### PR DESCRIPTION
## Done

- Update React Router Links to the v6 components
- Update tests to support the v6 compatibility router.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load the React client.
- Make sure you can navigate through the app via the header links and links within the content.

## Fixes

Fixes: #3958.