### PR TITLE
refactor(ui): replace useHistory with useNavigate

### DIFF
--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -325,7 +325,6 @@ Header.propTypes = {
   logout: PropTypes.func.isRequired,
   rootScope: PropTypes.object,
   showRSD: PropTypes.bool,
-  urlChange: PropTypes.func,
   uuid: PropTypes.string,
   version: PropTypes.string,
 };

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -6,8 +6,8 @@ import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory, useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom-v5-compat";
 
 import Routes from "app/Routes";
 import Login from "app/base/components/Login";
@@ -34,7 +34,7 @@ declare global {
 
 export const App = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const authenticated = useSelector(status.authenticated);
@@ -85,9 +85,9 @@ export const App = (): JSX.Element => {
   useEffect(() => {
     if (configLoaded) {
       if (!completedIntro) {
-        history.push({ pathname: introURLs.index });
+        navigate({ pathname: introURLs.index }, { replace: true });
       } else if (!!authUser && !completedUserIntro) {
-        history.push({ pathname: introURLs.user });
+        navigate({ pathname: introURLs.user }, { replace: true });
       }
     }
   }, [
@@ -96,7 +96,7 @@ export const App = (): JSX.Element => {
     completedIntro,
     completedUserIntro,
     configLoaded,
-    history,
+    navigate,
   ]);
 
   let content: ReactNode = null;
@@ -153,7 +153,6 @@ export const App = (): JSX.Element => {
             window.legacyWS.close();
           }
         }}
-        urlChange={history.listen}
         uuid={uuid as string}
         version={version}
       />

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NotificationGroupNotification from "./Notification";
@@ -47,10 +48,14 @@ describe("NotificationGroupNotification", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroupNotification
-          id={notification.id}
-          severity="negative"
-        />
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <CompatRouter>
+            <NotificationGroupNotification
+              id={notification.id}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("NotificationGroupNotification")).toMatchSnapshot();
@@ -67,10 +72,14 @@ describe("NotificationGroupNotification", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroupNotification
-          id={notification.id}
-          severity="negative"
-        />
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <CompatRouter>
+            <NotificationGroupNotification
+              id={notification.id}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper
@@ -91,10 +100,14 @@ describe("NotificationGroupNotification", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroupNotification
-          id={notification.id}
-          severity="negative"
-        />
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <CompatRouter>
+            <NotificationGroupNotification
+              id={notification.id}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(
@@ -118,10 +131,12 @@ describe("NotificationGroupNotification", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <NotificationGroupNotification
-            id={notification.id}
-            severity="negative"
-          />
+          <CompatRouter>
+            <NotificationGroupNotification
+              id={notification.id}
+              severity="negative"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -148,10 +163,12 @@ describe("NotificationGroupNotification", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <NotificationGroupNotification
-            id={notification.id}
-            severity="negative"
-          />
+          <CompatRouter>
+            <NotificationGroupNotification
+              id={notification.id}
+              severity="negative"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -181,10 +198,12 @@ describe("NotificationGroupNotification", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <NotificationGroupNotification
-            id={notification.id}
-            severity="negative"
-          />
+          <CompatRouter>
+            <NotificationGroupNotification
+              id={notification.id}
+              severity="negative"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -1,7 +1,7 @@
 import { Notification } from "@canonical/react-components";
 import type { NotificationProps } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import settingsURLs from "app/settings/urls";
 import authSelectors from "app/store/auth/selectors";
@@ -26,7 +26,7 @@ const NotificationGroupNotification = ({
   severity,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const isAdmin = useSelector(authSelectors.isAdmin);
   const notification = useSelector((state: RootState) =>
     notificationSelectors.getById(state, id)
@@ -44,7 +44,7 @@ const NotificationGroupNotification = ({
               {
                 label: "See settings",
                 onClick: () => {
-                  history.push({
+                  navigate({
                     pathname: settingsURLs.configuration.general,
                   });
                 },

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NotificationGroup from "./NotificationGroup";
@@ -24,7 +26,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="negative" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -42,7 +51,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="negative" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -62,7 +78,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="negative" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -84,7 +107,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="negative" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -109,7 +139,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="negative" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -134,7 +171,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="caution" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="caution"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -159,7 +203,14 @@ describe("NotificationGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NotificationGroup notifications={notifications} severity="negative" />
+        <MemoryRouter>
+          <CompatRouter>
+            <NotificationGroup
+              notifications={notifications}
+              severity="negative"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NotificationList from "./NotificationList";
@@ -55,7 +56,9 @@ describe("NotificationList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/machines" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +70,9 @@ describe("NotificationList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/machines" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -89,7 +94,9 @@ describe("NotificationList", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/machines" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -108,7 +115,9 @@ describe("NotificationList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/machines" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,7 +147,9 @@ describe("NotificationList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/machines" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -175,7 +186,9 @@ describe("NotificationList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/settings/general" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -204,7 +217,9 @@ describe("NotificationList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm" }]}>
-          <NotificationList />
+          <CompatRouter>
+            <NotificationList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { useLocation } from "react-router";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ControllerList from "./ControllerList";
@@ -32,7 +33,9 @@ describe("ControllerList", () => {
             },
           ]}
         >
-          <ControllerList />
+          <CompatRouter>
+            <ControllerList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -57,8 +60,10 @@ describe("ControllerList", () => {
             { pathname: "/machines", search: "?q=test+search", key: "testKey" },
           ]}
         >
-          <ControllerList />
-          <Route path="*" render={() => <FetchRoute />} />
+          <CompatRouter>
+            <ControllerList />
+            <Route path="*" render={() => <FetchRoute />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/controllers/views/ControllerList/ControllerList.tsx
+++ b/ui/src/app/controllers/views/ControllerList/ControllerList.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory, useLocation } from "react-router";
+import { useLocation } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import ControllerListControls from "./ControllerListControls";
 import ControllerListHeader from "./ControllerListHeader";
@@ -18,7 +19,7 @@ import { actions as tagActions } from "app/store/tag";
 
 const ControllerList = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const currentFilters = FilterControllers.queryStringToFilters(
     location.search
@@ -46,9 +47,9 @@ const ControllerList = (): JSX.Element => {
     (searchText) => {
       setFilter(searchText);
       const filters = FilterControllers.getCurrentFilters(searchText);
-      history.push({ search: FilterControllers.filtersToQueryString(filters) });
+      navigate({ search: FilterControllers.filtersToQueryString(filters) });
     },
-    [history, setFilter]
+    [navigate, setFilter]
   );
 
   return (

--- a/ui/src/app/controllers/views/Controllers.test.tsx
+++ b/ui/src/app/controllers/views/Controllers.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Controllers from "./Controllers";
@@ -26,7 +27,9 @@ describe("Controllers", () => {
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <Controllers />
+            <CompatRouter>
+              <Controllers />
+            </CompatRouter>
           </MemoryRouter>
         </Provider>
       );

--- a/ui/src/app/devices/views/DeviceList/DeviceList.test.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { useLocation } from "react-router";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceList from "./DeviceList";
@@ -28,7 +29,9 @@ describe("DeviceList", () => {
             { pathname: "/devices", search: "?q=test+search", key: "testKey" },
           ]}
         >
-          <DeviceList />
+          <CompatRouter>
+            <DeviceList />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -51,8 +54,10 @@ describe("DeviceList", () => {
             { pathname: "/machines", search: "?q=test+search", key: "testKey" },
           ]}
         >
-          <DeviceList />
-          <Route path="*" render={() => <FetchRoute />} />
+          <CompatRouter>
+            <DeviceList />
+            <Route path="*" render={() => <FetchRoute />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/ui/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory, useLocation } from "react-router";
+import { useLocation } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import DeviceListControls from "./DeviceListControls";
 import DeviceListHeader from "./DeviceListHeader";
@@ -18,7 +19,7 @@ import { actions as tagActions } from "app/store/tag";
 
 const DeviceList = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const currentFilters = FilterDevices.queryStringToFilters(location.search);
   const [headerContent, setHeaderContent] =
@@ -44,9 +45,9 @@ const DeviceList = (): JSX.Element => {
     (searchText) => {
       setFilter(searchText);
       const filters = FilterDevices.getCurrentFilters(searchText);
-      history.push({ search: FilterDevices.filtersToQueryString(filters) });
+      navigate({ search: FilterDevices.filtersToQueryString(filters) });
     },
-    [history, setFilter]
+    [navigate, setFilter]
   );
 
   return (

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -2,8 +2,7 @@ import { useEffect } from "react";
 
 import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { useNavigate, Link } from "react-router-dom-v5-compat";
 
 import SyncedImages from "app/images/views/ImageList/SyncedImages";
 import IntroCard from "app/intro/components/IntroCard";
@@ -14,7 +13,7 @@ import bootResourceSelectors from "app/store/bootresource/selectors";
 
 const ImagesIntro = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const resources = useSelector(bootResourceSelectors.resources);
 
@@ -43,7 +42,7 @@ const ImagesIntro = (): JSX.Element => {
           data-testid="images-intro-continue"
           disabled={incomplete}
           hasIcon
-          onClick={() => history.push({ pathname: introURLs.success })}
+          onClick={() => navigate({ pathname: introURLs.success })}
         >
           Continue
           {incomplete && (

--- a/ui/src/app/intro/views/Intro.test.tsx
+++ b/ui/src/app/intro/views/Intro.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Intro from "./Intro";
@@ -39,7 +40,9 @@ describe("Intro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/intro" }]}>
-          <Intro />
+          <CompatRouter>
+            <Intro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -56,7 +59,9 @@ describe("Intro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/intro" }]}>
-          <Intro />
+          <CompatRouter>
+            <Intro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -76,7 +81,9 @@ describe("Intro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: introURLs.index }]}>
-          <Intro />
+          <CompatRouter>
+            <Intro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -88,7 +95,9 @@ describe("Intro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: introURLs.user }]}>
-          <Intro />
+          <CompatRouter>
+            <Intro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +114,9 @@ describe("Intro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: introURLs.index }]}>
-          <Intro />
+          <CompatRouter>
+            <Intro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MaasIntro from "./MaasIntro";
@@ -62,7 +63,11 @@ describe("MaasIntro", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MaasIntro />
+        <MemoryRouter initialEntries={[{ pathname: "/intro", key: "testKey" }]}>
+          <CompatRouter>
+            <MaasIntro />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -72,7 +77,11 @@ describe("MaasIntro", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MaasIntro />
+        <MemoryRouter initialEntries={[{ pathname: "/intro", key: "testKey" }]}>
+          <CompatRouter>
+            <MaasIntro />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -104,7 +113,11 @@ describe("MaasIntro", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MaasIntro />
+        <MemoryRouter initialEntries={[{ pathname: "/intro", key: "testKey" }]}>
+          <CompatRouter>
+            <MaasIntro />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -138,7 +151,9 @@ describe("MaasIntro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/intro", key: "testKey" }]}>
-          <MaasIntro />
+          <CompatRouter>
+            <MaasIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Card, Icon } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import ConnectivityCard from "./ConnectivityCard";
@@ -36,7 +36,7 @@ export const MaasIntroSchema = Yup.object()
 
 const MaasIntro = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const authLoading = useSelector(authSelectors.loading);
   const authUser = useSelector(authSelectors.get);
   const httpProxy = useSelector(configSelectors.httpProxy);
@@ -147,9 +147,9 @@ const MaasIntro = (): JSX.Element => {
               onConfirm={() => {
                 dispatch(configActions.update({ completed_intro: true }));
                 if (!authUser?.completed_intro) {
-                  history.push({ pathname: introURLs.user });
+                  navigate({ pathname: introURLs.user });
                 } else {
-                  history.push({
+                  navigate({
                     pathname: exitURL,
                   });
                 }

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteForm from "./DeleteForm";
@@ -43,7 +44,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -69,7 +72,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -95,7 +100,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -117,7 +124,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -139,7 +148,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -161,7 +172,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -199,7 +212,9 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -237,7 +252,9 @@ describe("DeleteForm", () => {
     const Proxy = () => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -270,7 +287,9 @@ describe("DeleteForm", () => {
     const Proxy = () => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -303,7 +322,9 @@ describe("DeleteForm", () => {
     const Proxy = () => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -342,7 +363,9 @@ describe("DeleteForm", () => {
     const Proxy = () => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -7,7 +7,7 @@ import {
   Strip,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
@@ -44,7 +44,7 @@ const DeleteForm = ({
   hostId,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, hostId)
   );
@@ -118,7 +118,7 @@ const DeleteForm = ({
             NotificationSeverity.INFORMATION
           )
         );
-        history.push({ pathname: kvmURLs.kvm });
+        navigate({ pathname: kvmURLs.kvm });
         clearHeaderContent();
       }}
       processingCount={deletingCount}

--- a/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVMHeaderForms from "./KVMHeaderForms";
@@ -40,7 +41,9 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms headerContent={null} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <KVMHeaderForms headerContent={null} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -54,10 +57,12 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{ view: KVMHeaderViews.ADD_LXD_HOST }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{ view: KVMHeaderViews.ADD_LXD_HOST }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -70,10 +75,12 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{ view: KVMHeaderViews.ADD_VIRSH_HOST }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{ view: KVMHeaderViews.ADD_VIRSH_HOST }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -86,13 +93,15 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{
-              view: KVMHeaderViews.COMPOSE_VM,
-              extras: { hostId: 1 },
-            }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{
+                view: KVMHeaderViews.COMPOSE_VM,
+                extras: { hostId: 1 },
+              }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -104,13 +113,15 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{
-              view: KVMHeaderViews.DELETE_KVM,
-              extras: { hostId: 1 },
-            }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{
+                view: KVMHeaderViews.DELETE_KVM,
+                extras: { hostId: 1 },
+              }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -122,13 +133,15 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{
-              view: KVMHeaderViews.DELETE_KVM,
-              extras: { clusterId: 1 },
-            }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{
+                view: KVMHeaderViews.DELETE_KVM,
+                extras: { clusterId: 1 },
+              }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -140,13 +153,15 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{
-              view: KVMHeaderViews.REFRESH_KVM,
-              extras: { hostIds: [1] },
-            }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{
+                view: KVMHeaderViews.REFRESH_KVM,
+                extras: { hostIds: [1] },
+              }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -158,10 +173,12 @@ describe("KVMHeaderForms", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <KVMHeaderForms
-            headerContent={{ view: MachineHeaderViews.COMMISSION_MACHINE }}
-            setHeaderContent={jest.fn()}
-          />
+          <CompatRouter>
+            <KVMHeaderForms
+              headerContent={{ view: MachineHeaderViews.COMMISSION_MACHINE }}
+              setHeaderContent={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/SettingsBackLink/SettingsBackLink.test.tsx
+++ b/ui/src/app/kvm/components/SettingsBackLink/SettingsBackLink.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import SettingsBackLink from "./SettingsBackLink";
 
@@ -9,7 +10,9 @@ describe("SettingsBackLink", () => {
     const history = createMemoryHistory();
     const wrapper = mount(
       <Router history={history}>
-        <SettingsBackLink />
+        <CompatRouter>
+          <SettingsBackLink />
+        </CompatRouter>
       </Router>
     );
 
@@ -24,7 +27,9 @@ describe("SettingsBackLink", () => {
 
     const wrapper = mount(
       <Router history={history}>
-        <SettingsBackLink />
+        <CompatRouter>
+          <SettingsBackLink />
+        </CompatRouter>
       </Router>
     );
 

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -1,13 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import {
-  Redirect,
-  Route,
-  Switch,
-  useHistory,
-  useLocation,
-} from "react-router-dom";
+import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
 import LXDClusterHostSettings from "./LXDClusterHostSettings";
@@ -36,7 +31,7 @@ import { isId } from "app/utils";
 
 const LXDClusterDetails = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const clusterId = useGetURLId(VMClusterMeta.PK, "clusterId");
   const hostId = useGetURLId(PodMeta.PK, "hostId");
@@ -63,11 +58,14 @@ const LXDClusterDetails = (): JSX.Element => {
     FilterMachines.filtersToString(currentFilters)
   );
 
-  const setSearchFilter: SetSearchFilter = (searchFilter: string) => {
-    setFilter(searchFilter);
-    const filters = FilterMachines.getCurrentFilters(searchFilter);
-    history.push({ search: FilterMachines.filtersToQueryString(filters) });
-  };
+  const setSearchFilter: SetSearchFilter = useCallback(
+    (searchFilter: string) => {
+      setFilter(searchFilter);
+      const filters = FilterMachines.getCurrentFilters(searchFilter);
+      navigate({ search: FilterMachines.filtersToQueryString(filters) });
+    },
+    [setFilter, navigate]
+  );
 
   useEffect(() => {
     dispatch(podActions.fetch());

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterHosts from "./LXDClusterHosts";
@@ -53,7 +54,9 @@ describe("LXDClusterHosts", () => {
             { pathname: kvmURLs.lxd.cluster.hosts({ clusterId: 1 }) },
           ]}
         >
-          <LXDClusterHosts clusterId={1} setHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <LXDClusterHosts clusterId={1} setHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -1,13 +1,8 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { useSelector } from "react-redux";
-import {
-  Redirect,
-  Route,
-  Switch,
-  useHistory,
-  useLocation,
-} from "react-router-dom";
+import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import LXDSingleDetailsHeader from "./LXDSingleDetailsHeader";
 import LXDSingleResources from "./LXDSingleResources";
@@ -28,7 +23,7 @@ import type { RootState } from "app/store/root/types";
 import { isId } from "app/utils";
 
 const LXDSingleDetails = (): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const id = useGetURLId(PodMeta.PK);
   const pod = useSelector((state: RootState) =>
@@ -46,11 +41,14 @@ const LXDSingleDetails = (): JSX.Element => {
   useActivePod(id);
   const redirectURL = useKVMDetailsRedirect(id);
 
-  const setSearchFilter: SetSearchFilter = (searchFilter: string) => {
-    setFilter(searchFilter);
-    const filters = FilterMachines.getCurrentFilters(searchFilter);
-    history.push({ search: FilterMachines.filtersToQueryString(filters) });
-  };
+  const setSearchFilter: SetSearchFilter = useCallback(
+    (searchFilter: string) => {
+      setFilter(searchFilter);
+      const filters = FilterMachines.getCurrentFilters(searchFilter);
+      navigate({ search: FilterMachines.filtersToQueryString(filters) });
+    },
+    [setFilter, navigate]
+  );
 
   if (redirectURL) {
     return <Redirect to={redirectURL} />;

--- a/ui/src/app/machines/views/Machines.tsx
+++ b/ui/src/app/machines/views/Machines.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import { Route, Switch, useHistory, useLocation } from "react-router-dom";
+import { Route, Switch, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import MachineListHeader from "./MachineList/MachineListHeader";
 
@@ -13,7 +14,7 @@ import MachineList from "app/machines/views/MachineList";
 import { FilterMachines } from "app/store/machine/utils";
 
 const Machines = (): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const currentFilters = FilterMachines.queryStringToFilters(location.search);
   // The filter state is initialised from the URL.
@@ -29,9 +30,9 @@ const Machines = (): JSX.Element => {
     (searchText) => {
       setFilter(searchText);
       const filters = FilterMachines.getCurrentFilters(searchText);
-      history.push({ search: FilterMachines.filtersToQueryString(filters) });
+      navigate({ search: FilterMachines.filtersToQueryString(filters) });
     },
-    [history, setFilter]
+    [navigate, setFilter]
   );
 
   useEffect(() => {

--- a/ui/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/ui/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { PoolForm } from "./PoolForm";
@@ -37,7 +38,9 @@ describe("PoolForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <PoolForm />
+          <CompatRouter>
+            <PoolForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -51,7 +54,9 @@ describe("PoolForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <PoolForm />
+          <CompatRouter>
+            <PoolForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -70,7 +75,9 @@ describe("PoolForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/pool/add"]}>
-          <PoolForm />
+          <CompatRouter>
+            <PoolForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -85,7 +92,9 @@ describe("PoolForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/pools/add"]}>
-          <PoolForm />
+          <CompatRouter>
+            <PoolForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -103,7 +112,9 @@ describe("PoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/pools/", key: "testKey" }]}
         >
-          <PoolForm pool={pool} />
+          <CompatRouter>
+            <PoolForm pool={pool} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,7 +138,9 @@ describe("PoolForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <PoolForm />
+          <CompatRouter>
+            <PoolForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/pools/components/PoolForm/PoolForm.tsx
+++ b/ui/src/app/pools/components/PoolForm/PoolForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import FormCard from "app/base/components/FormCard";
@@ -29,7 +29,7 @@ const PoolSchema = Yup.object().shape({
 
 export const PoolForm = ({ pool }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const saved = useSelector(poolSelectors.saved);
   const saving = useSelector(poolSelectors.saving);
   const errors = useSelector(poolSelectors.errors);
@@ -66,7 +66,7 @@ export const PoolForm = ({ pool }: Props): JSX.Element => {
         cleanup={poolActions.cleanup}
         errors={errors}
         initialValues={initialValues}
-        onCancel={() => history.push({ pathname: poolsURLs.pools })}
+        onCancel={() => navigate({ pathname: poolsURLs.pools })}
         onSaveAnalytics={{
           action: "Saved",
           category: "Resource pool",

--- a/ui/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
+++ b/ui/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { PoolAdd } from "./PoolAdd";
@@ -24,7 +25,9 @@ describe("PoolAdd", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/pool/add", key: "testKey" }]}
         >
-          <PoolAdd />
+          <CompatRouter>
+            <PoolAdd />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { APIKeyEdit } from "./APIKeyEdit";
@@ -42,7 +43,9 @@ describe("APIKeyEdit", () => {
             { pathname: "/account/prefs/api-keys/1", key: "testKey" },
           ]}
         >
-          <APIKeyEdit />
+          <CompatRouter>
+            <APIKeyEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -59,7 +62,9 @@ describe("APIKeyEdit", () => {
             { pathname: "/account/prefs/api-keys/1", key: "testKey" },
           ]}
         >
-          <APIKeyEdit />
+          <CompatRouter>
+            <APIKeyEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,11 +80,13 @@ describe("APIKeyEdit", () => {
             { pathname: "/account/prefs/api-keys/1/edit", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/account/prefs/api-keys/:id/edit"
-            render={() => <APIKeyEdit />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/account/prefs/api-keys/:id/edit"
+              render={() => <APIKeyEdit />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { APIKeyForm } from "./APIKeyForm";
@@ -40,7 +41,9 @@ describe("APIKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <APIKeyForm />
+          <CompatRouter>
+            <APIKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -52,7 +55,9 @@ describe("APIKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <APIKeyForm />
+          <CompatRouter>
+            <APIKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -82,7 +87,9 @@ describe("APIKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <APIKeyForm token={state.token.items[0]} />
+          <CompatRouter>
+            <APIKeyForm token={state.token.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.tsx
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.tsx
@@ -1,6 +1,6 @@
 import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import FormCard from "app/base/components/FormCard";
@@ -27,7 +27,7 @@ const APIKeyEditSchema = Yup.object().shape({
 export const APIKeyForm = ({ token }: Props): JSX.Element => {
   const editing = !!token;
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const errors = useSelector(tokenSelectors.errors);
   const saved = useSelector(tokenSelectors.saved);
   const saving = useSelector(tokenSelectors.saving);
@@ -49,7 +49,7 @@ export const APIKeyForm = ({ token }: Props): JSX.Element => {
         initialValues={{
           name: token ? token.consumer.name : "",
         }}
-        onCancel={() => history.push({ pathname: prefsURLs.apiKeys.index })}
+        onCancel={() => navigate({ pathname: prefsURLs.apiKeys.index })}
         onSaveAnalytics={{
           action: "Saved",
           category: "API keys preferences",

--- a/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddSSHKey } from "./AddSSHKey";
@@ -31,7 +32,9 @@ describe("AddSSHKey", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSHKey />
+          <CompatRouter>
+            <AddSSHKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -44,7 +47,9 @@ describe("AddSSHKey", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSHKey />
+          <CompatRouter>
+            <AddSSHKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.tsx
@@ -1,4 +1,4 @@
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import FormCard from "app/base/components/FormCard";
 import SSHKeyForm from "app/base/components/SSHKeyForm";
@@ -9,14 +9,14 @@ import prefsURLs from "app/preferences/urls";
 const { CARD_TITLE, SIDEBAR, TOTAL } = COL_SIZES;
 
 export const AddSSHKey = (): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
   useWindowTitle("Add SSH key");
 
   return (
     <FormCard title="Add SSH key">
       <SSHKeyForm
         cols={TOTAL - SIDEBAR - CARD_TITLE}
-        onCancel={() => history.push({ pathname: prefsURLs.sshKeys.index })}
+        onCancel={() => navigate({ pathname: prefsURLs.sshKeys.index })}
         onSaveAnalytics={{
           action: "Saved",
           category: "SSH keys preferences",

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddSSLKey } from "./AddSSLKey";
@@ -33,7 +34,9 @@ describe("AddSSLKey", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSLKey />
+          <CompatRouter>
+            <AddSSLKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -45,7 +48,9 @@ describe("AddSSLKey", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSLKey />
+          <CompatRouter>
+            <AddSSLKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,7 +70,9 @@ describe("AddSSLKey", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSLKey />
+          <CompatRouter>
+            <AddSSLKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -77,7 +84,9 @@ describe("AddSSLKey", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSLKey />
+          <CompatRouter>
+            <AddSSLKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -108,7 +117,9 @@ describe("AddSSLKey", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <AddSSLKey />
+          <CompatRouter>
+            <AddSSLKey />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
@@ -1,7 +1,7 @@
 import { Col, Row, Textarea } from "@canonical/react-components";
 import type { TextareaProps } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import FormCard from "app/base/components/FormCard";
@@ -24,7 +24,7 @@ const SSLKeySchema = Yup.object().shape({
 
 export const AddSSLKey = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const saving = useSelector(sslkeySelectors.saving);
   const saved = useSelector(sslkeySelectors.saved);
   const errors = useSelector(sslkeySelectors.errors);
@@ -39,7 +39,7 @@ export const AddSSLKey = (): JSX.Element => {
         cleanup={sslkeyActions.cleanup}
         errors={errors}
         initialValues={{ key: "" }}
-        onCancel={() => history.push({ pathname: prefsURLs.sslKeys.index })}
+        onCancel={() => navigate({ pathname: prefsURLs.sslKeys.index })}
         onSaveAnalytics={{
           action: "Saved",
           category: "SSL keys preferences",

--- a/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { DhcpEdit } from "./DhcpEdit";
@@ -44,7 +45,9 @@ describe("DhcpEdit", () => {
             { pathname: "/settings/dhcp/1/edit", key: "testKey" },
           ]}
         >
-          <DhcpEdit />
+          <CompatRouter>
+            <DhcpEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -60,7 +63,9 @@ describe("DhcpEdit", () => {
             { pathname: "/settings/dhcp/99999/edit", key: "testKey" },
           ]}
         >
-          <DhcpEdit />
+          <CompatRouter>
+            <DhcpEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -76,11 +81,13 @@ describe("DhcpEdit", () => {
             { pathname: "/settings/dhcp/1/edit", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/settings/dhcp/:id/edit"
-            render={() => <DhcpEdit />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/settings/dhcp/:id/edit"
+              render={() => <DhcpEdit />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { DhcpForm } from "./DhcpForm";
@@ -45,7 +46,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm />
+          <CompatRouter>
+            <DhcpForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -58,7 +61,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm />
+          <CompatRouter>
+            <DhcpForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -70,7 +75,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm dhcpSnippet={state.dhcpsnippet.items[0]} />
+          <CompatRouter>
+            <DhcpForm dhcpSnippet={state.dhcpsnippet.items[0]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import BaseDhcpForm from "app/base/components/DhcpForm";
 import type { DHCPFormValues } from "app/base/components/DhcpForm/types";
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export const DhcpForm = ({ dhcpSnippet }: Props): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [name, setName] = useState<DHCPFormValues["name"]>();
   const editing = !!dhcpSnippet;
   const title = editing ? `Editing \`${name}\`` : "Add DHCP snippet";
@@ -26,7 +26,7 @@ export const DhcpForm = ({ dhcpSnippet }: Props): JSX.Element => {
       <BaseDhcpForm
         analyticsCategory="DHCP snippet settings"
         id={dhcpSnippet?.id}
-        onCancel={() => history.push({ pathname: settingsURLs.dhcp.index })}
+        onCancel={() => navigate({ pathname: settingsURLs.dhcp.index })}
         onValuesChanged={(values) => {
           setName(values.name);
         }}

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { LicenseKeyEdit } from "./LicenseKeyEdit";
@@ -74,7 +75,9 @@ describe("LicenseKeyEdit", () => {
             },
           ]}
         >
-          <LicenseKeyEdit />
+          <CompatRouter>
+            <LicenseKeyEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -90,7 +93,9 @@ describe("LicenseKeyEdit", () => {
             { pathname: "/settings/license-keys/foo/bar/edit", key: "testKey" },
           ]}
         >
-          <LicenseKeyEdit />
+          <CompatRouter>
+            <LicenseKeyEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -109,11 +114,13 @@ describe("LicenseKeyEdit", () => {
             },
           ]}
         >
-          <Route
-            exact
-            path="/settings/license-keys/:osystem/:distro_series/edit"
-            render={() => <LicenseKeyEdit />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/settings/license-keys/:osystem/:distro_series/edit"
+              render={() => <LicenseKeyEdit />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { LicenseKeyForm } from "./LicenseKeyForm";
@@ -50,7 +51,9 @@ describe("LicenseKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -64,7 +67,9 @@ describe("LicenseKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -84,7 +89,9 @@ describe("LicenseKeyForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,7 +107,9 @@ describe("LicenseKeyForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -116,7 +125,9 @@ describe("LicenseKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -129,7 +140,9 @@ describe("LicenseKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -162,7 +175,9 @@ describe("LicenseKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm licenseKey={licenseKey} />
+          <CompatRouter>
+            <LicenseKeyForm licenseKey={licenseKey} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -187,7 +202,9 @@ describe("LicenseKeyForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <LicenseKeyForm />
+          <CompatRouter>
+            <LicenseKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import LicenseKeyFormFields from "../LicenseKeyFormFields";
@@ -32,7 +32,7 @@ const LicenseKeySchema = Yup.object().shape({
 
 export const LicenseKeyForm = ({ licenseKey }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [savingLicenseKey, setSaving] = useState<string | null>(null);
   const saving = useSelector(licenseKeysSelectors.saving);
   const saved = useSelector(licenseKeysSelectors.saved);
@@ -81,7 +81,7 @@ export const LicenseKeyForm = ({ licenseKey }: Props): JSX.Element => {
             license_key: licenseKey ? licenseKey.license_key : "",
           }}
           onCancel={() =>
-            history.push({ pathname: settingsURLs.licenseKeys.index })
+            navigate({ pathname: settingsURLs.licenseKeys.index })
           }
           onSaveAnalytics={{
             action: "Saved",

--- a/ui/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RepositoryAdd from "./RepositoryAdd";
@@ -33,11 +34,13 @@ describe("RepositoryAdd", () => {
             { pathname: "/settings/repositories/add/ppa", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/settings/repositories/add/:type"
-            render={() => <RepositoryAdd />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/settings/repositories/add/:type"
+              render={() => <RepositoryAdd />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -58,11 +61,13 @@ describe("RepositoryAdd", () => {
             },
           ]}
         >
-          <Route
-            exact
-            path="/settings/repositories/add/:type"
-            render={() => <RepositoryAdd />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/settings/repositories/add/:type"
+              render={() => <RepositoryAdd />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RepositoryEdit from "./RepositoryEdit";
@@ -42,7 +43,9 @@ describe("RepositoryEdit", () => {
             { pathname: "/settings/repositories/1/edit", key: "testKey" },
           ]}
         >
-          <RepositoryEdit />
+          <CompatRouter>
+            <RepositoryEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -58,7 +61,9 @@ describe("RepositoryEdit", () => {
             { pathname: "/settings/repositories/100/edit", key: "testKey" },
           ]}
         >
-          <RepositoryEdit />
+          <CompatRouter>
+            <RepositoryEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -77,11 +82,13 @@ describe("RepositoryEdit", () => {
             },
           ]}
         >
-          <Route
-            exact
-            path="/settings/repositories/edit/:type/:id"
-            render={() => <RepositoryEdit />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/settings/repositories/edit/:type/:id"
+              render={() => <RepositoryEdit />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RepositoryForm from "./RepositoryForm";
@@ -53,7 +54,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="repository" />
+          <CompatRouter>
+            <RepositoryForm type="repository" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -104,7 +107,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="repository" />
+          <CompatRouter>
+            <RepositoryForm type="repository" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -115,7 +120,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="ppa" />
+          <CompatRouter>
+            <RepositoryForm type="ppa" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -126,10 +133,12 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -140,10 +149,12 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="ppa"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="ppa"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -157,7 +168,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="repository" />
+          <CompatRouter>
+            <RepositoryForm type="repository" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -179,7 +192,9 @@ describe("RepositoryForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <RepositoryForm type="repository" />
+          <CompatRouter>
+            <RepositoryForm type="repository" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -209,7 +224,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="repository" repository={repository} />
+          <CompatRouter>
+            <RepositoryForm type="repository" repository={repository} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -257,7 +274,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="repository" />
+          <CompatRouter>
+            <RepositoryForm type="repository" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -306,7 +325,9 @@ describe("RepositoryForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm type="repository" />
+          <CompatRouter>
+            <RepositoryForm type="repository" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import RepositoryFormFields from "../RepositoryFormFields";
@@ -48,7 +48,7 @@ const RepositorySchema = Yup.object().shape({
 
 export const RepositoryForm = ({ type, repository }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [savedRepo, setSavedRepo] = useState<string | null>(null);
   const componentsToDisableLoaded = useSelector(
     componentsToDisableSelectors.loaded
@@ -132,7 +132,7 @@ export const RepositoryForm = ({ type, repository }: Props): JSX.Element => {
             errors={errors}
             initialValues={initialValues}
             onCancel={() =>
-              history.push({ pathname: settingsURLs.repositories.index })
+              navigate({ pathname: settingsURLs.repositories.index })
             }
             onSaveAnalytics={{
               action: "Saved",

--- a/ui/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RepositoryForm from "../RepositoryForm";
@@ -50,10 +51,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,10 +68,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="ppa"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="ppa"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -87,10 +92,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -102,10 +109,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,10 +136,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -142,10 +153,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -161,10 +174,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -181,10 +196,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -201,10 +218,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -221,10 +240,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -243,10 +264,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -266,10 +289,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -291,10 +316,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -321,10 +348,12 @@ describe("RepositoryFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/repositories/add", key: "testKey" }]}
         >
-          <RepositoryForm
-            type="repository"
-            repository={state.packagerepository.items[0]}
-          />
+          <CompatRouter>
+            <RepositoryForm
+              type="repository"
+              repository={state.packagerepository.items[0]}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react-dom/test-utils";
 import type { FileWithPath } from "react-dropzone";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, useLocation } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import type { Dispatch } from "redux";
 import configureStore from "redux-mock-store";
 
@@ -55,7 +56,9 @@ describe("ScriptsUpload", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
+          <CompatRouter>
+            <ScriptsUpload type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,7 +81,9 @@ describe("ScriptsUpload", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
+          <CompatRouter>
+            <ScriptsUpload type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +111,9 @@ describe("ScriptsUpload", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
+          <CompatRouter>
+            <ScriptsUpload type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -148,7 +155,9 @@ describe("ScriptsUpload", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
+          <CompatRouter>
+            <ScriptsUpload type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -197,7 +206,9 @@ describe("ScriptsUpload", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
+          <CompatRouter>
+            <ScriptsUpload type="testing" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -237,8 +248,10 @@ describe("ScriptsUpload", () => {
             { pathname: "/settings/scripts/commissioning/upload" },
           ]}
         >
-          <ScriptsUpload type="commissioning" />
-          <Route path="*" render={() => <FetchRoute />} />
+          <CompatRouter>
+            <ScriptsUpload type="commissioning" />
+            <Route path="*" render={() => <FetchRoute />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -258,8 +271,10 @@ describe("ScriptsUpload", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/scripts/testing/upload" }]}
         >
-          <ScriptsUpload type="testing" />
-          <Route path="*" render={() => <FetchRoute />} />
+          <CompatRouter>
+            <ScriptsUpload type="testing" />
+            <Route path="*" render={() => <FetchRoute />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
@@ -6,7 +6,7 @@ import type { FileRejection, FileWithPath } from "react-dropzone";
 import { useDropzone } from "react-dropzone";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import type { ReadScriptResponse } from "./readScript";
 import readScript from "./readScript";
@@ -32,7 +32,7 @@ const ScriptsUpload = ({ type }: Props): JSX.Element => {
   const [savedScript, setSavedScript] = useState<string | null>(null);
   const [script, setScript] = useState<ReadScriptResponse | null>(null);
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const title = `Upload ${type} script`;
   const listLocation = `/settings/scripts/${type}`;
 
@@ -145,7 +145,7 @@ const ScriptsUpload = ({ type }: Props): JSX.Element => {
       <Row>
         <FormikForm
           initialValues={{}}
-          onCancel={() => history.push({ pathname: listLocation })}
+          onCancel={() => navigate({ pathname: listLocation })}
           onSubmit={() => {
             dispatch(scriptActions.cleanup());
             if (script?.script) {

--- a/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
+++ b/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { UserEdit } from "./UserEdit";
@@ -58,7 +59,9 @@ describe("UserEdit", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users/1", key: "testKey" }]}
         >
-          <UserEdit />
+          <CompatRouter>
+            <UserEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -73,7 +76,9 @@ describe("UserEdit", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users/1", key: "testKey" }]}
         >
-          <UserEdit />
+          <CompatRouter>
+            <UserEdit />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -89,11 +94,13 @@ describe("UserEdit", () => {
             { pathname: "/settings/users/1/edit", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/settings/users/:id/edit"
-            render={() => <UserEdit />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/settings/users/:id/edit"
+              render={() => <UserEdit />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { UserForm } from "./UserForm";
@@ -31,7 +32,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -45,7 +48,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +72,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -81,7 +88,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,7 +127,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -175,7 +186,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm />
+          <CompatRouter>
+            <UserForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -216,7 +229,9 @@ describe("UserForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -232,7 +247,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm user={user} />
+          <CompatRouter>
+            <UserForm user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import FormCard from "app/base/components/FormCard";
 import BaseUserForm from "app/base/components/UserForm";
@@ -18,7 +18,7 @@ type PropTypes = {
 };
 
 export const UserForm = ({ user }: PropTypes): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const saved = useSelector(userSelectors.saved);
   const [savingUser, setSaving] = useState<User["username"] | null>(null);
@@ -43,7 +43,7 @@ export const UserForm = ({ user }: PropTypes): JSX.Element => {
         cleanup={userActions.cleanup}
         includeUserType
         submitLabel="Save user"
-        onCancel={() => history.goBack()}
+        onCancel={() => navigate(-1)}
         onSaveAnalytics={{
           action: "Saved",
           category: "Users settings",

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback } from "react";
 
 import { ContextualMenu } from "@canonical/react-components";
-import { useHistory } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import SubnetsTable from "./SubnetsTable";
 import type { GroupByKey } from "./SubnetsTable/types";
@@ -18,24 +18,30 @@ const SubnetsList = (): JSX.Element => {
   useWindowTitle("Subnets");
   const [activeForm, setActiveForm] = React.useState<SubnetForm | null>(null);
   const query = useQuery();
-  const history = useHistory();
+  const navigate = useNavigate();
   const groupBy = query.get(SubnetsUrlParams.By);
   const searchText = query.get(SubnetsUrlParams.Q) || "";
   const setGroupBy = useCallback(
     (group: GroupByKey) =>
-      history.replace({
-        pathname: "/networks",
-        search: `?${SubnetsUrlParams.By}=${group}&${SubnetsUrlParams.Q}=${searchText}`,
-      }),
-    [history, searchText]
+      navigate(
+        {
+          pathname: "/networks",
+          search: `?${SubnetsUrlParams.By}=${group}&${SubnetsUrlParams.Q}=${searchText}`,
+        },
+        { replace: true }
+      ),
+    [navigate, searchText]
   );
   const setSearchText = useCallback(
     (searchText) =>
-      history.replace({
-        pathname: "/networks",
-        search: `?${SubnetsUrlParams.By}=${groupBy}&${SubnetsUrlParams.Q}=${searchText}`,
-      }),
-    [history, groupBy]
+      navigate(
+        {
+          pathname: "/networks",
+          search: `?${SubnetsUrlParams.By}=${groupBy}&${SubnetsUrlParams.Q}=${searchText}`,
+        },
+        { replace: true }
+      ),
+    [navigate, groupBy]
   );
 
   const hasValidGroupBy = groupBy && ["fabric", "space"].includes(groupBy);

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddTagForm, { Label } from "./AddTagForm";
@@ -43,7 +44,9 @@ it("dispatches an action to create a tag", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm onClose={jest.fn()} />
+        <CompatRouter>
+          <AddTagForm onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -86,11 +89,13 @@ it("redirects to the newly created tag on save", async () => {
   const TagForm = () => (
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={tagsURLs.tags.index}
-          component={() => <AddTagForm onClose={onClose} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagsURLs.tags.index}
+            component={() => <AddTagForm onClose={onClose} />}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -126,7 +131,9 @@ it("sends analytics when there is a definition", async () => {
   const TagForm = () => (
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm onClose={onClose} />
+        <CompatRouter>
+          <AddTagForm onClose={onClose} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -167,7 +174,9 @@ it("sends analytics when there is no definition", async () => {
   const TagForm = () => (
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm onClose={onClose} />
+        <CompatRouter>
+          <AddTagForm onClose={onClose} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -203,7 +212,9 @@ it("shows a confirmation when an automatic tag is added", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm onClose={jest.fn()} />
+        <CompatRouter>
+          <AddTagForm onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -238,7 +249,9 @@ it("shows an error if tag name is invalid", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm onClose={jest.fn()} />
+        <CompatRouter>
+          <AddTagForm onClose={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import FormikField from "app/base/components/FormikField";
@@ -40,7 +40,7 @@ const AddTagFormSchema = Yup.object().shape({
 
 export const AddTagForm = ({ onClose }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [savedName, setSavedName] = useState<Tag["name"] | null>(null);
   const saved = useSelector(tagSelectors.saved);
   const saving = useSelector(tagSelectors.saving);
@@ -54,7 +54,7 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
 
   useEffect(() => {
     if (tag) {
-      history.push({ pathname: tagsURLs.tag.index({ id: tag.id }) });
+      navigate({ pathname: tagsURLs.tag.index({ id: tag.id }) });
       if (tag.definition) {
         sendAnalytics("XPath tagging", "Valid XPath", "Save");
       } else {
@@ -62,7 +62,7 @@ export const AddTagForm = ({ onClose }: Props): JSX.Element => {
       }
       onClose();
     }
-  }, [history, onClose, tag, sendAnalytics]);
+  }, [navigate, onClose, tag, sendAnalytics]);
 
   return (
     <FormikForm<CreateParams>

--- a/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
+++ b/ui/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import DeleteTagFormWarnings from "./DeleteTagFormWarnings";
 
@@ -27,7 +27,7 @@ export const DeleteTagForm = ({
   onClose,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const saved = useSelector(tagSelectors.saved);
   const saving = useSelector(tagSelectors.saving);
   const errors = useSelector(tagSelectors.errors);
@@ -50,9 +50,9 @@ export const DeleteTagForm = ({
     if (fromDetails) {
       // Explicitly return to the page they user came from in case they have opened
       // the list of machines.
-      history.push({ pathname: tagsURLs.tag.index({ id: id }) });
+      navigate({ pathname: tagsURLs.tag.index({ id: id }) });
     } else {
-      history.push({ pathname: tagsURLs.tags.index });
+      navigate({ pathname: tagsURLs.tags.index });
     }
   };
   if (!tag) {

--- a/ui/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.test.tsx
+++ b/ui/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagHeaderForms from "./TagHeaderForms";
@@ -30,10 +31,12 @@ it("can display the add tag form", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagHeaderForms
-          headerContent={{ view: TagHeaderViews.AddTag }}
-          setHeaderContent={jest.fn()}
-        />
+        <CompatRouter>
+          <TagHeaderForms
+            headerContent={{ view: TagHeaderViews.AddTag }}
+            setHeaderContent={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,10 +58,15 @@ it("can display the delete tag form", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagHeaderForms
-          headerContent={{ view: TagHeaderViews.DeleteTag, extras: { id: 1 } }}
-          setHeaderContent={jest.fn()}
-        />
+        <CompatRouter>
+          <TagHeaderForms
+            headerContent={{
+              view: TagHeaderViews.DeleteTag,
+              extras: { id: 1 },
+            }}
+            setHeaderContent={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/ui/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -6,10 +6,9 @@ import type {
   PropsWithSpread,
 } from "@canonical/react-components";
 import { Icon, MainTable, Strip } from "@canonical/react-components";
-import type { History } from "history";
 import { useDispatch } from "react-redux";
-import { useHistory } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import type { NavigateFunction } from "react-router-dom-v5-compat";
+import { useNavigate, Link } from "react-router-dom-v5-compat";
 
 import { TAGS_PER_PAGE } from "../constants";
 
@@ -62,7 +61,7 @@ const getSortValue = (sortKey: SortKey, tag: Tag) => {
 const generateRows = (
   tags: Tag[],
   onDelete: Props["onDelete"],
-  history: History
+  navigate: NavigateFunction
 ) =>
   tags.map((tag) => {
     return {
@@ -100,8 +99,7 @@ const generateRows = (
                 onDelete(tag[TagMeta.PK]);
               }}
               onEdit={() =>
-                history.push({
-                  pathname: tagURLs.tag.update({ id: tag.id }),
+                navigate(tagURLs.tag.update({ id: tag.id }), {
                   state: { canGoBack: true },
                 })
               }
@@ -162,7 +160,7 @@ const TagTable = ({
   ...tableProps
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { currentSort, sortRows, updateSort } = useTableSort<Tag, SortKey>(
     getSortValue,
     {
@@ -251,7 +249,7 @@ const TagTable = ({
             className: "u-align--right",
           },
         ]}
-        rows={generateRows(paginatedTags, onDelete, history)}
+        rows={generateRows(paginatedTags, onDelete, navigate)}
       />
       {generateNoTagsMessage(tags.length === 0, filter, searchText)}
     </>

--- a/ui/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagUpdate from "./TagUpdate";
@@ -50,11 +51,13 @@ it("dispatches actions to fetch necessary data", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagUpdate id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagUpdate id={1} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -83,11 +86,13 @@ it("shows a spinner if the tag has not loaded yet", () => {
       <MemoryRouter
         initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
       >
-        <Route
-          exact
-          path={tagURLs.tag.index(null, true)}
-          component={() => <TagUpdate id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.index(null, true)}
+            component={() => <TagUpdate id={1} />}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -100,7 +105,9 @@ it("can update the tag", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagUpdate id={1} />
+        <CompatRouter>
+          <TagUpdate id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -142,11 +149,13 @@ it("can return to the previous page on save", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={tagURLs.tag.update(null, true)}
-          component={() => <TagUpdate id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.update(null, true)}
+            component={() => <TagUpdate id={1} />}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -180,11 +189,13 @@ it("goes to the tag details page if it can't go back", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={tagURLs.tag.update(null, true)}
-          component={() => <TagUpdate id={1} />}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagURLs.tag.update(null, true)}
+            component={() => <TagUpdate id={1} />}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -213,7 +224,9 @@ it("shows a confirmation when a tag's definition is updated", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <TagUpdate id={1} />
+        <CompatRouter>
+          <TagUpdate id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/tags/views/TagUpdate/TagUpdate.tsx
+++ b/ui/src/app/tags/views/TagUpdate/TagUpdate.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 
 import { NotificationSeverity, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import TagUpdateFormFields from "./TagUpdateFormFields";
@@ -41,7 +42,7 @@ const UpdateAutoTagFormSchema = Yup.object().shape({
 
 const TagUpdate = ({ id }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation<{ canGoBack?: boolean }>();
   const tag = useSelector((state: RootState) =>
     tagSelectors.getById(state, id)
@@ -61,11 +62,14 @@ const TagUpdate = ({ id }: Props): JSX.Element => {
   const isAuto = !!tag.definition;
   const onClose = () => {
     if (location.state?.canGoBack) {
-      history.goBack();
+      navigate(-1);
     } else {
-      history.replace({
-        pathname: tagURLs.tag.index({ id }),
-      });
+      navigate(
+        {
+          pathname: tagURLs.tag.index({ id }),
+        },
+        { replace: true }
+      );
     }
   };
 

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ZoneDetails from "./ZoneDetails";
@@ -52,7 +53,9 @@ describe("ZoneDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
         >
-          <Route exact path="/zone/:id" render={() => <ZoneDetails />} />
+          <CompatRouter>
+            <Route exact path="/zone/:id" render={() => <ZoneDetails />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -81,7 +84,9 @@ describe("ZoneDetails", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
         >
-          <Route exact path="/zone/:id" render={() => <ZoneDetails />} />
+          <CompatRouter>
+            <Route exact path="/zone/:id" render={() => <ZoneDetails />} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ZoneDetailsHeader from "./ZoneDetailsHeader";
@@ -55,11 +56,13 @@ describe("ZoneDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/zone/:id"
-            render={() => <ZoneDetailsHeader id={1} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/zone/:id"
+              render={() => <ZoneDetailsHeader id={1} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -76,11 +79,13 @@ describe("ZoneDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/3", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/zone/:id"
-            render={() => <ZoneDetailsHeader id={3} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/zone/:id"
+              render={() => <ZoneDetailsHeader id={3} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -97,11 +102,13 @@ describe("ZoneDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/2", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/zone/:id"
-            render={() => <ZoneDetailsHeader id={2} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/zone/:id"
+              render={() => <ZoneDetailsHeader id={2} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -116,11 +123,13 @@ describe("ZoneDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/zone/:id"
-            render={() => <ZoneDetailsHeader id={1} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/zone/:id"
+              render={() => <ZoneDetailsHeader id={1} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -142,11 +151,13 @@ describe("ZoneDetailsHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/zone/2", key: "testKey" }]}
         >
-          <Route
-            exact
-            path="/zone/:id"
-            render={() => <ZoneDetailsHeader id={2} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/zone/:id"
+              render={() => <ZoneDetailsHeader id={2} />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import DeleteConfirm from "./DeleteConfirm";
 
@@ -25,7 +25,7 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
     zoneSelectors.getById(state, Number(id))
   );
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   useEffect(() => {
     dispatch(zoneActions.fetch());
@@ -34,9 +34,9 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
   useEffect(() => {
     if (zonesSaved) {
       dispatch(zoneActions.cleanup());
-      history.push({ pathname: zonesURLs.index });
+      navigate({ pathname: zonesURLs.index });
     }
-  }, [dispatch, zonesSaved, history]);
+  }, [dispatch, zonesSaved, navigate]);
 
   const isAdmin = useSelector(authSelectors.isAdmin);
   const isDefaultZone = id === 1;


### PR DESCRIPTION
## Done

- Replace useHistory with useNavigate as a step towards React Router v6.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the different list searches update the url (e.g. machine, device, lxd, subnets etc.)
- Check that submitting forms or pressing cancel returns to the previous page.
- Create a new user and login and check that you get redirected to the intro.

## Fixes

Fixes: #3960.