### PR TITLE
feat(ui): create scaffolding components for controller details

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -57,14 +57,20 @@ const Routes = (): JSX.Element => (
         </ErrorBoundary>
       )}
     />
-    <Route
-      path={controllersURLs.controllers.index}
-      render={() => (
-        <ErrorBoundary>
-          <Controllers />
-        </ErrorBoundary>
-      )}
-    />
+    {[
+      controllersURLs.controllers.index,
+      controllersURLs.controller.index(null, true),
+    ].map((path) => (
+      <Route
+        key={path}
+        path={path}
+        render={() => (
+          <ErrorBoundary>
+            <Controllers />
+          </ErrorBoundary>
+        )}
+      />
+    ))}
     {[devicesURLs.devices.index, devicesURLs.device.index(null, true)].map(
       (path) => (
         <Route

--- a/ui/src/app/controllers/urls.ts
+++ b/ui/src/app/controllers/urls.ts
@@ -1,4 +1,4 @@
-import type { Controller } from "app/store/controller/types";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
 import { argPath } from "app/utils";
 
 const urls = {
@@ -6,7 +6,34 @@ const urls = {
     index: "/controllers",
   },
   controller: {
-    index: argPath<{ id: Controller["system_id"] }>("/controller/:id"),
+    commissioning: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/commissioning"
+    ),
+    configuration: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/configuration"
+    ),
+    index: argPath<{ id: Controller[ControllerMeta.PK] }>("/controller/:id"),
+    logs: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/logs"
+    ),
+    network: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/network"
+    ),
+    pciDevices: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/pci-devices"
+    ),
+    storage: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/storage"
+    ),
+    summary: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/summary"
+    ),
+    usbDevices: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/usb-devices"
+    ),
+    vlans: argPath<{ id: Controller[ControllerMeta.PK] }>(
+      "/controller/:id/vlans"
+    ),
   },
 };
 

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerCommissioning/ControllerCommissioning.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerCommissioning/ControllerCommissioning.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerCommissioning = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} commissioning`);
+
+  return <h4>Controller commissioning</h4>;
+};
+
+export default ControllerCommissioning;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerCommissioning/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerCommissioning/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerCommissioning";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerConfiguration = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} configuration`);
+
+  return <h4>Controller configuration</h4>;
+};
+
+export default ControllerConfiguration;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerConfiguration/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerConfiguration/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerConfiguration";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
+import configureStore from "redux-mock-store";
+
+import ControllerDetails from "./ControllerDetails";
+
+import controllerURLs from "app/controllers/urls";
+import { actions as controllerActions } from "app/store/controller";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("gets and sets the controller as active", () => {
+  const controller = controllerFactory({ system_id: "abc123" });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: controllerURLs.controller.index({
+              id: controller.system_id,
+            }),
+          },
+        ]}
+      >
+        <CompatRouter>
+          <Route
+            exact
+            path={controllerURLs.controller.index(null, true)}
+            render={() => <ControllerDetails />}
+          />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const expectedActions = [
+    controllerActions.get(controller.system_id),
+    controllerActions.setActive(controller.system_id),
+  ];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("unsets active controller and cleans up when unmounting", () => {
+  const controller = controllerFactory({ system_id: "abc123" });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  const { unmount } = render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: controllerURLs.controller.index({
+              id: controller.system_id,
+            }),
+          },
+        ]}
+      >
+        <CompatRouter>
+          <Route
+            exact
+            path={controllerURLs.controller.index(null, true)}
+            render={() => <ControllerDetails />}
+          />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  unmount();
+
+  const expectedActions = [
+    controllerActions.setActive(null),
+    controllerActions.cleanup(),
+  ];
+  const actualActions = store.getActions();
+  expectedActions.forEach((expectedAction) => {
+    expect(
+      actualActions.find(
+        (actualAction) =>
+          actualAction.type === expectedAction.type &&
+          // Check payload to differentiate "set" and "unset" active actions
+          actualAction.payload?.params === expectedAction.payload?.params
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});
+
+it("displays a message if the controller does not exist", () => {
+  const controller = controllerFactory({ system_id: "abc123" });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: controllerURLs.controller.index({
+              id: "missing-id",
+            }),
+          },
+        ]}
+      >
+        <CompatRouter>
+          <Route
+            exact
+            path={controllerURLs.controller.index(null, true)}
+            render={() => <ControllerDetails />}
+          />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByText(/Unable to find a controller with id/)
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
@@ -1,0 +1,118 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+import { Redirect, Route, Switch } from "react-router-dom";
+
+import ControllerCommissioning from "./ControllerCommissioning";
+import ControllerConfiguration from "./ControllerConfiguration";
+import ControllerDetailsHeader from "./ControllerDetailsHeader";
+import ControllerLogs from "./ControllerLogs";
+import ControllerNetwork from "./ControllerNetwork";
+import ControllerPCIDevices from "./ControllerPCIDevices";
+import ControllerStorage from "./ControllerStorage";
+import ControllerSummary from "./ControllerSummary";
+import ControllerUSBDevices from "./ControllerUSBDevices";
+import ControllerVLANs from "./ControllerVLANs";
+
+import ModelNotFound from "app/base/components/ModelNotFound";
+import Section from "app/base/components/Section";
+import { useGetURLId } from "app/base/hooks/urls";
+import controllerURLs from "app/controllers/urls";
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors from "app/store/controller/selectors";
+import { ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+import { isId } from "app/utils";
+
+const ControllerDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const id = useGetURLId(ControllerMeta.PK);
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, id)
+  );
+  const controllersLoading = useSelector(controllerSelectors.loading);
+
+  useEffect(() => {
+    if (isId(id)) {
+      // Set active controller on load to ensure all controller details are sent
+      // through the websocket.
+      dispatch(controllerActions.get(id));
+      dispatch(controllerActions.setActive(id));
+    }
+    // Unset active controller and cleanup state on unmount.
+    return () => {
+      dispatch(controllerActions.setActive(null));
+      dispatch(controllerActions.cleanup());
+    };
+  }, [dispatch, id]);
+
+  if (!isId(id) || (!controllersLoading && !controller)) {
+    return (
+      <ModelNotFound
+        id={id}
+        linkURL={controllerURLs.controllers.index}
+        modelName="controller"
+      />
+    );
+  }
+
+  return (
+    <Section header={<ControllerDetailsHeader systemId={id} />}>
+      {controller && (
+        <Switch>
+          <Route
+            exact
+            path={controllerURLs.controller.summary(null, true)}
+            render={() => <ControllerSummary systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.vlans(null, true)}
+            render={() => <ControllerVLANs systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.network(null, true)}
+            render={() => <ControllerNetwork systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.storage(null, true)}
+            render={() => <ControllerStorage systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.pciDevices(null, true)}
+            render={() => <ControllerPCIDevices systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.usbDevices(null, true)}
+            render={() => <ControllerUSBDevices systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.commissioning(null, true)}
+            render={() => <ControllerCommissioning systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.logs(null, true)}
+            render={() => <ControllerLogs systemId={id} />}
+          />
+          <Route
+            exact
+            path={controllerURLs.controller.configuration(null, true)}
+            render={() => <ControllerConfiguration systemId={id} />}
+          />
+          <Redirect
+            from={controllerURLs.controller.index(null, true)}
+            to={controllerURLs.controller.summary(null, true)}
+          />
+        </Switch>
+      )}
+    </Section>
+  );
+};
+
+export default ControllerDetails;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
+import configureStore from "redux-mock-store";
+
+import ControllerDetailsHeader from "./ControllerDetailsHeader";
+
+import {
+  controller as controllerFactory,
+  controllerDetails as controllerDetailsFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("displays a spinner as the title if controller has not loaded yet", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <ControllerDetailsHeader systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByTestId("section-header-title-spinner")
+  ).toBeInTheDocument();
+});
+
+it("displays a spinner as the subtitle if loaded controller is not the detailed type", () => {
+  const controller = controllerFactory();
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <ControllerDetailsHeader systemId={controller.system_id} />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByTestId("section-header-subtitle-spinner")
+  ).toBeInTheDocument();
+});
+
+it("displays the controller's FQDN once loaded and detailed type", () => {
+  const controllerDetails = controllerDetailsFactory();
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controllerDetails],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <ControllerDetailsHeader systemId={controllerDetails.system_id} />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("heading", { name: controllerDetails.fqdn })
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
@@ -1,0 +1,77 @@
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router";
+import { Link } from "react-router-dom-v5-compat";
+
+import SectionHeader from "app/base/components/SectionHeader";
+import controllerURLs from "app/controllers/urls";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller } from "app/store/controller/types";
+import { isControllerDetails } from "app/store/controller/utils";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller["system_id"];
+};
+
+const ControllerDetailsHeader = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  const { pathname } = useLocation();
+
+  if (!controller) {
+    return <SectionHeader loading />;
+  }
+
+  return (
+    <SectionHeader
+      subtitleLoading={!isControllerDetails(controller)}
+      tabLinks={[
+        {
+          label: "Summary",
+          url: controllerURLs.controller.summary({ id: systemId }),
+        },
+        {
+          label: "VLANs",
+          url: controllerURLs.controller.vlans({ id: systemId }),
+        },
+        {
+          label: "Network",
+          url: controllerURLs.controller.network({ id: systemId }),
+        },
+        {
+          label: "Storage",
+          url: controllerURLs.controller.storage({ id: systemId }),
+        },
+        {
+          label: "PCI devices",
+          url: controllerURLs.controller.pciDevices({ id: systemId }),
+        },
+        {
+          label: "USB",
+          url: controllerURLs.controller.usbDevices({ id: systemId }),
+        },
+        {
+          label: "Commissioning",
+          url: controllerURLs.controller.commissioning({ id: systemId }),
+        },
+        {
+          label: "Logs",
+          url: controllerURLs.controller.logs({ id: systemId }),
+        },
+        {
+          label: "Configuration",
+          url: controllerURLs.controller.configuration({ id: systemId }),
+        },
+      ].map((link) => ({
+        active: pathname.startsWith(link.url),
+        component: Link,
+        label: link.label,
+        to: link.url,
+      }))}
+      title={controller.fqdn}
+    />
+  );
+};
+
+export default ControllerDetailsHeader;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerDetailsHeader";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerLogs = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} logs`);
+
+  return <h4>Controller logs</h4>;
+};
+
+export default ControllerLogs;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerLogs/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerLogs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerLogs";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerNetwork = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} network`);
+
+  return <h4>Controller network</h4>;
+};
+
+export default ControllerNetwork;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerNetwork";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerPCIDevices/ControllerPCIDevices.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerPCIDevices/ControllerPCIDevices.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerPCIDevices = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} PCI devices`);
+
+  return <h4>Controller PCI devices</h4>;
+};
+
+export default ControllerPCIDevices;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerPCIDevices/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerPCIDevices/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerPCIDevices";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerStorage = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} storage`);
+
+  return <h4>Controller storage</h4>;
+};
+
+export default ControllerStorage;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerStorage";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ControllerSummary.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ControllerSummary.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerSummary = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} summary`);
+
+  return <h4>Controller summary</h4>;
+};
+
+export default ControllerSummary;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerSummary";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerUSBDevices/ControllerUSBDevices.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerUSBDevices/ControllerUSBDevices.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerUSBDevices = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} USB devices`);
+
+  return <h4>Controller USB devices</h4>;
+};
+
+export default ControllerUSBDevices;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerUSBDevices/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerUSBDevices/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerUSBDevices";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANs.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANs.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import controllerSelectors from "app/store/controller/selectors";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const ControllerVLANs = ({ systemId }: Props): JSX.Element => {
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  );
+  useWindowTitle(`${`${controller?.hostname}` || "Controller"} VLANs`);
+
+  return <h4>Controller VLANs</h4>;
+};
+
+export default ControllerVLANs;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerVLANs";

--- a/ui/src/app/controllers/views/ControllerDetails/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerDetails";

--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -1,5 +1,6 @@
 import { Route, Switch } from "react-router-dom";
 
+import ControllerDetails from "./ControllerDetails";
 import ControllerList from "./ControllerList";
 
 import NotFound from "app/base/views/NotFound";
@@ -13,6 +14,25 @@ const Controllers = (): JSX.Element => {
         path={controllersURLs.controllers.index}
         render={() => <ControllerList />}
       />
+      {[
+        controllersURLs.controller.commissioning(null, true),
+        controllersURLs.controller.configuration(null, true),
+        controllersURLs.controller.index(null, true),
+        controllersURLs.controller.logs(null, true),
+        controllersURLs.controller.network(null, true),
+        controllersURLs.controller.pciDevices(null, true),
+        controllersURLs.controller.storage(null, true),
+        controllersURLs.controller.summary(null, true),
+        controllersURLs.controller.usbDevices(null, true),
+        controllersURLs.controller.vlans(null, true),
+      ].map((path) => (
+        <Route
+          exact
+          key={path}
+          path={path}
+          render={() => <ControllerDetails />}
+        />
+      ))}
       <Route path="*" render={() => <NotFound />} />
     </Switch>
   );


### PR DESCRIPTION
## Done

- Added controller details routes
- Added scaffolding components for the controller details header and each of the tab components

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/MAAS/r/controller/<system_id>`
- Check that you can navigate to each tab and the window title updates accordingly
- Check that the controller has been set as active and the detailed version is stored in state

## Fixes

Fixes canonical-web-and-design/app-tribe#931
Fixes canonical-web-and-design/app-tribe#933
