### PR TITLE
refactor(ui): replace Redirect with useNavigate

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ActionForm from "./ActionForm";
@@ -20,15 +22,19 @@ describe("ActionForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ActionForm
-          actionName="action"
-          initialValues={{}}
-          loaded={false}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={0}
-          selectedCount={1}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              loaded={false}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              processingCount={0}
+              selectedCount={1}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -39,14 +45,18 @@ describe("ActionForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ActionForm
-          actionName="action"
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={0}
-          selectedCount={1}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              processingCount={0}
+              selectedCount={1}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -57,15 +67,19 @@ describe("ActionForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ActionForm
-          actionName="action"
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={0}
-          selectedCount={1}
-          submitLabel="Special save"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              processingCount={0}
+              selectedCount={1}
+              submitLabel="Special save"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -76,14 +90,18 @@ describe("ActionForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ActionForm
-          actionName="action"
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={1}
-          selectedCount={2}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              processingCount={1}
+              selectedCount={2}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper);
@@ -100,14 +118,18 @@ describe("ActionForm", () => {
     const store = mockStore(state);
     const Proxy = ({ selectedCount }: { selectedCount: number }) => (
       <Provider store={store}>
-        <ActionForm
-          actionName="action"
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={2}
-          selectedCount={selectedCount}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              processingCount={2}
+              selectedCount={selectedCount}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy selectedCount={2} />);
@@ -131,15 +153,19 @@ describe("ActionForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ActionForm
-          actionName="action"
-          initialValues={{}}
-          modelName="machine"
-          onSubmit={jest.fn()}
-          processingCount={1}
-          selectedCount={2}
-          showProcessingCount={false}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              processingCount={1}
+              selectedCount={2}
+              showProcessingCount={false}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper);

--- a/ui/src/app/base/components/DHCPTable/EditDHCP/EditDHCP.test.tsx
+++ b/ui/src/app/base/components/DHCPTable/EditDHCP/EditDHCP.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditDHCP from "./EditDHCP";
@@ -17,7 +18,9 @@ describe("EditDHCP", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <EditDHCP close={jest.fn()} id={1} />
+          <CompatRouter>
+            <EditDHCP close={jest.fn()} id={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/DhcpForm/DhcpForm.test.tsx
+++ b/ui/src/app/base/components/DhcpForm/DhcpForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { DhcpForm } from "./DhcpForm";
@@ -52,7 +53,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -64,7 +67,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,10 +88,12 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm
-            analyticsCategory="settings"
-            id={state.dhcpsnippet.items[0].id}
-          />
+          <CompatRouter>
+            <DhcpForm
+              analyticsCategory="settings"
+              id={state.dhcpsnippet.items[0].id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -121,7 +128,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -156,7 +165,9 @@ describe("DhcpForm", () => {
     const Proxy = ({ analyticsCategory }: { analyticsCategory: string }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm analyticsCategory={analyticsCategory} onSave={onSave} />
+          <CompatRouter>
+            <DhcpForm analyticsCategory={analyticsCategory} onSave={onSave} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -178,7 +189,9 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm analyticsCategory="settings" onSave={onSave} />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" onSave={onSave} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -196,7 +209,9 @@ describe("DhcpForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -212,10 +227,12 @@ describe("DhcpForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm
-            analyticsCategory="settings"
-            id={state.dhcpsnippet.items[0].id}
-          />
+          <CompatRouter>
+            <DhcpForm
+              analyticsCategory="settings"
+              id={state.dhcpsnippet.items[0].id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -244,10 +261,12 @@ describe("DhcpForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <DhcpForm
-            analyticsCategory="settings"
-            id={state.dhcpsnippet.items[0].id}
-          />
+          <CompatRouter>
+            <DhcpForm
+              analyticsCategory="settings"
+              id={state.dhcpsnippet.items[0].id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/ui/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DhcpForm from "app/base/components/DhcpForm";
@@ -70,7 +71,9 @@ describe("DhcpFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -82,10 +85,12 @@ describe("DhcpFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DhcpForm
-            analyticsCategory="settings"
-            id={state.dhcpsnippet.items[0].id}
-          />
+          <CompatRouter>
+            <DhcpForm
+              analyticsCategory="settings"
+              id={state.dhcpsnippet.items[0].id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +110,9 @@ describe("DhcpFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -129,7 +136,9 @@ describe("DhcpFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -153,7 +162,9 @@ describe("DhcpFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DhcpForm analyticsCategory="settings" />
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/FormikForm/FormikForm.test.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FormikForm from "./FormikForm";
@@ -28,13 +29,15 @@ describe("FormikForm", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <FormikForm
-            initialValues={{}}
-            onSubmit={jest.fn()}
-            aria-label="example"
-          >
-            Content
-          </FormikForm>
+          <CompatRouter>
+            <FormikForm
+              initialValues={{}}
+              onSubmit={jest.fn()}
+              aria-label="example"
+            >
+              Content
+            </FormikForm>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -2,7 +2,8 @@ import { mount } from "enzyme";
 import { Field, Formik } from "formik";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 import * as Yup from "yup";
 
@@ -34,9 +35,11 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent>Content</FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent>Content</FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -48,11 +51,13 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent onCancel={jest.fn()} saving>
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent onCancel={jest.fn()} saving>
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -66,15 +71,17 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              cancelDisabled={false}
-              onCancel={jest.fn()}
-              saving
-            >
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                cancelDisabled={false}
+                onCancel={jest.fn()}
+                saving
+              >
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -88,9 +95,11 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent errors="Uh oh!">Content</FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent errors="Uh oh!">Content</FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -102,11 +111,13 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent errors={{ __all__: ["Uh oh!"] }}>
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent errors={{ __all__: ["Uh oh!"] }}>
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,11 +129,13 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent errors={{ username: "Wrong username" }}>
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent errors={{ username: "Wrong username" }}>
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -134,11 +147,13 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{ username: "" }} onSubmit={jest.fn()}>
-            <FormikFormContent errors={{ username: "Wrong username" }}>
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{ username: "" }} onSubmit={jest.fn()}>
+              <FormikFormContent errors={{ username: "Wrong username" }}>
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -150,15 +165,17 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              errors={{
-                username: ["Wrong username", "Username must be provided"],
-              }}
-            >
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                errors={{
+                  username: ["Wrong username", "Username must be provided"],
+                }}
+              >
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -172,9 +189,11 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent inline>Content</FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent inline>Content</FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -186,9 +205,11 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent editable={false}>Content</FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent editable={false}>Content</FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -200,15 +221,19 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent saved={true} savedRedirect="/success">
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent saved={true} savedRedirect="/success">
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      "/success"
+    );
   });
 
   it("can clean up when unmounted", async () => {
@@ -219,9 +244,11 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent cleanup={cleanup}>Content</FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent cleanup={cleanup}>Content</FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -244,15 +271,17 @@ describe("FormikFormContent", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              onSaveAnalytics={eventData}
-              saved={true}
-              savedRedirect="/success"
-            >
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                onSaveAnalytics={eventData}
+                saved={true}
+                savedRedirect="/success"
+              >
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -277,15 +306,17 @@ describe("FormikFormContent", () => {
     const Proxy = ({ saved }: { saved: boolean }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik
-            initialValues={initialValues}
-            onSubmit={jest.fn()}
-            validationSchema={Schema}
-          >
-            <FormikFormContent resetOnSave saved={saved}>
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={initialValues}
+              onSubmit={jest.fn()}
+              validationSchema={Schema}
+            >
+              <FormikFormContent resetOnSave saved={saved}>
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -319,15 +350,17 @@ describe("FormikFormContent", () => {
     const Proxy = ({ saved }: { saved: boolean }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik
-            initialValues={initialValues}
-            onSubmit={jest.fn()}
-            validationSchema={Schema}
-          >
-            <FormikFormContent resetOnSave saved={saved}>
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik
+              initialValues={initialValues}
+              onSubmit={jest.fn()}
+              validationSchema={Schema}
+            >
+              <FormikFormContent resetOnSave saved={saved}>
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -355,11 +388,13 @@ describe("FormikFormContent", () => {
     const Proxy = ({ saved }: { saved: boolean }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent onSuccess={onSuccess} saved={saved}>
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent onSuccess={onSuccess} saved={saved}>
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -378,11 +413,17 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent errors={null} onSuccess={onSuccess} saved={true}>
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                errors={null}
+                onSuccess={onSuccess}
+                saved={true}
+              >
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -397,15 +438,17 @@ describe("FormikFormContent", () => {
     const Proxy = ({ errors, saved }: { errors?: string; saved: boolean }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              errors={errors}
-              onSuccess={onSuccess}
-              saved={saved}
-            >
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                errors={errors}
+                onSuccess={onSuccess}
+                saved={saved}
+              >
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -424,15 +467,17 @@ describe("FormikFormContent", () => {
     const Proxy = ({ saved, errors }: { saved: boolean; errors?: string }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              errors={errors}
-              onSuccess={onSuccess}
-              saved={saved}
-            >
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                errors={errors}
+                onSuccess={onSuccess}
+                saved={saved}
+              >
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -453,16 +498,18 @@ describe("FormikFormContent", () => {
     const Proxy = ({ saved, errors }: { saved: boolean; errors?: string }) => (
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              errors={errors}
-              onSuccess={onSuccess}
-              resetOnSave
-              saved={saved}
-            >
-              <Field name="val1" />
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                errors={errors}
+                onSuccess={onSuccess}
+                resetOnSave
+                saved={saved}
+              >
+                <Field name="val1" />
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -482,14 +529,16 @@ describe("FormikFormContent", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <FormikFormContent
-              onCancel={jest.fn()}
-              footer={<div data-testid="footer"></div>}
-            >
-              Content
-            </FormikFormContent>
-          </Formik>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+              <FormikFormContent
+                onCancel={jest.fn()}
+                footer={<div data-testid="footer"></div>}
+              >
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -5,7 +5,7 @@ import { Form, Notification } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { withFormikDevtools } from "formik-devtools-extension";
 import { useDispatch } from "react-redux";
-import { Redirect } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import type { FormikFormButtonsProps } from "app/base/components/FormikFormButtons";
 import FormikFormButtons from "app/base/components/FormikFormButtons";
@@ -98,6 +98,7 @@ const FormikFormContent = <V, E = null>({
     withFormikDevtools(formikContext);
   }
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const onSuccessCalled = useRef(false);
   const { handleSubmit, initialValues, resetForm, values } = formikContext;
   const formDisabled = useFormikFormDisabled<V>({
@@ -156,9 +157,11 @@ const FormikFormContent = <V, E = null>({
     };
   }, [cleanup, dispatch]);
 
-  if (savedRedirect && saved) {
-    return <Redirect to={savedRedirect} />;
-  }
+  useEffect(() => {
+    if (savedRedirect && saved) {
+      navigate(savedRedirect, { replace: true });
+    }
+  }, [navigate, savedRedirect, saved]);
 
   return (
     <Form

--- a/ui/src/app/base/components/Login/Login.test.tsx
+++ b/ui/src/app/base/components/Login/Login.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Login } from "./Login";
@@ -30,7 +31,9 @@ describe("Login", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Login />
+          <CompatRouter>
+            <Login />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -43,7 +46,9 @@ describe("Login", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Login />
+          <CompatRouter>
+            <Login />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -56,7 +61,9 @@ describe("Login", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Login />
+          <CompatRouter>
+            <Login />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -68,7 +75,9 @@ describe("Login", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Login />
+          <CompatRouter>
+            <Login />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -93,7 +102,9 @@ describe("Login", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Login />
+          <CompatRouter>
+            <Login />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/NodeName/NodeName.test.tsx
+++ b/ui/src/app/base/components/NodeName/NodeName.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NodeName from "./NodeName";
@@ -59,12 +60,14 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName
-            editingName={false}
-            node={null}
-            onSubmit={jest.fn()}
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeName
+              editingName={false}
+              node={null}
+              onSubmit={jest.fn()}
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -79,12 +82,14 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName
-            editingName={false}
-            node={machine}
-            onSubmit={jest.fn()}
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeName
+              editingName={false}
+              node={machine}
+              onSubmit={jest.fn()}
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -98,12 +103,14 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName
-            editingName={false}
-            node={machine}
-            onSubmit={jest.fn()}
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeName
+              editingName={false}
+              node={machine}
+              onSubmit={jest.fn()}
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,12 +125,14 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName
-            editingName={false}
-            node={machine}
-            onSubmit={jest.fn()}
-            setEditingName={setEditingName}
-          />
+          <CompatRouter>
+            <NodeName
+              editingName={false}
+              node={machine}
+              onSubmit={jest.fn()}
+              setEditingName={setEditingName}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,12 +147,14 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName
-            editingName={true}
-            node={machine}
-            onSubmit={jest.fn()}
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeName
+              editingName={true}
+              node={machine}
+              onSubmit={jest.fn()}
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -159,7 +170,9 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName {...props} />
+          <CompatRouter>
+            <NodeName {...props} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -187,12 +200,14 @@ describe("NodeName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NodeName
-            editingName={true}
-            node={machine}
-            onSubmit={jest.fn()}
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <NodeName
+              editingName={true}
+              node={machine}
+              onSubmit={jest.fn()}
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.test.tsx
+++ b/ui/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NodeNameFields from "./NodeNameFields";
@@ -44,15 +45,17 @@ describe("NodeNameFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <FormikForm
-            initialValues={{
-              domain: "",
-              hostname: "",
-            }}
-            onSubmit={jest.fn()}
-          >
-            <NodeNameFields setHostnameError={jest.fn()} />
-          </FormikForm>
+          <CompatRouter>
+            <FormikForm
+              initialValues={{
+                domain: "",
+                hostname: "",
+              }}
+              onSubmit={jest.fn()}
+            >
+              <NodeNameFields setHostnameError={jest.fn()} />
+            </FormikForm>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -66,15 +69,17 @@ describe("NodeNameFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <FormikForm
-            initialValues={{
-              domain: "",
-              hostname: "",
-            }}
-            onSubmit={jest.fn()}
-          >
-            <NodeNameFields setHostnameError={jest.fn()} />
-          </FormikForm>
+          <CompatRouter>
+            <FormikForm
+              initialValues={{
+                domain: "",
+                hostname: "",
+              }}
+              onSubmit={jest.fn()}
+            >
+              <NodeNameFields setHostnameError={jest.fn()} />
+            </FormikForm>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -88,15 +93,17 @@ describe("NodeNameFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <FormikForm
-            initialValues={{
-              domain: "",
-              hostname: "",
-            }}
-            onSubmit={jest.fn()}
-          >
-            <NodeNameFields saving setHostnameError={jest.fn()} />
-          </FormikForm>
+          <CompatRouter>
+            <FormikForm
+              initialValues={{
+                domain: "",
+                hostname: "",
+              }}
+              onSubmit={jest.fn()}
+            >
+              <NodeNameFields saving setHostnameError={jest.fn()} />
+            </FormikForm>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -113,16 +120,18 @@ describe("NodeNameFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <FormikForm
-            initialErrors={{ hostname: "Uh oh!" }}
-            initialValues={{
-              domain: "",
-              hostname: "",
-            }}
-            onSubmit={jest.fn()}
-          >
-            <NodeNameFields saving setHostnameError={setHostnameError} />
-          </FormikForm>
+          <CompatRouter>
+            <FormikForm
+              initialErrors={{ hostname: "Uh oh!" }}
+              initialValues={{
+                domain: "",
+                hostname: "",
+              }}
+              onSubmit={jest.fn()}
+            >
+              <NodeNameFields saving setHostnameError={setHostnameError} />
+            </FormikForm>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyForm.test.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { SSHKeyForm } from "./SSHKeyForm";
@@ -33,7 +34,9 @@ describe("SSHKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <SSHKeyForm />
+          <CompatRouter>
+            <SSHKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -45,7 +48,9 @@ describe("SSHKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <SSHKeyForm />
+          <CompatRouter>
+            <SSHKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -64,7 +69,9 @@ describe("SSHKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <SSHKeyForm />
+          <CompatRouter>
+            <SSHKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +101,9 @@ describe("SSHKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <SSHKeyForm />
+          <CompatRouter>
+            <SSHKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,7 +136,9 @@ describe("SSHKeyForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <SSHKeyForm />
+          <CompatRouter>
+            <SSHKeyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/UserForm/UserForm.test.tsx
+++ b/ui/src/app/base/components/UserForm/UserForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { UserForm } from "./UserForm";
@@ -36,7 +37,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm onSave={jest.fn()} />
+          <CompatRouter>
+            <UserForm onSave={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -50,7 +53,9 @@ describe("UserForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <UserForm onSave={onSave} user={user} />
+          <CompatRouter>
+            <UserForm onSave={onSave} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -84,7 +89,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm onSave={jest.fn()} user={user} />
+          <CompatRouter>
+            <UserForm onSave={jest.fn()} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +112,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm onSave={jest.fn()} user={user} />
+          <CompatRouter>
+            <UserForm onSave={jest.fn()} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -129,7 +138,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm includeCurrentPassword onSave={jest.fn()} user={user} />
+          <CompatRouter>
+            <UserForm includeCurrentPassword onSave={jest.fn()} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -154,7 +165,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm includeCurrentPassword onSave={jest.fn()} user={user} />
+          <CompatRouter>
+            <UserForm includeCurrentPassword onSave={jest.fn()} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -172,7 +185,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm onSave={jest.fn()} />
+          <CompatRouter>
+            <UserForm onSave={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -189,7 +204,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm onSave={onSave} user={user} />
+          <CompatRouter>
+            <UserForm onSave={onSave} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -220,7 +237,9 @@ describe("UserForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
         >
-          <UserForm onSave={onSave} user={user} />
+          <CompatRouter>
+            <UserForm onSave={onSave} user={user} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteForm from "./DeleteForm";
@@ -31,15 +32,17 @@ describe("DeleteForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <DeleteForm
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={nodes}
-            onSubmit={onSubmit}
-            processingCount={0}
-            redirectURL="www.url.com"
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeleteForm
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={nodes}
+              onSubmit={onSubmit}
+              processingCount={0}
+              redirectURL="/redirect"
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -55,15 +58,17 @@ describe("DeleteForm", () => {
     const Proxy = ({ processingCount }: { processingCount: number }) => (
       <Provider store={store}>
         <MemoryRouter>
-          <DeleteForm
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={nodes}
-            onSubmit={jest.fn()}
-            processingCount={processingCount}
-            redirectURL="www.url.com"
-            viewingDetails
-          />
+          <CompatRouter>
+            <DeleteForm
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={nodes}
+              onSubmit={jest.fn()}
+              processingCount={processingCount}
+              redirectURL="/redirect"
+              viewingDetails
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -71,10 +76,8 @@ describe("DeleteForm", () => {
 
     wrapper.setProps({ processingCount: 0 });
     wrapper.update();
-
-    expect(wrapper.find("[data-testid='delete-redirect']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='delete-redirect']").prop("to")).toBe(
-      "www.url.com"
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      "/redirect"
     );
   });
 
@@ -89,17 +92,19 @@ describe("DeleteForm", () => {
       processingCount: number;
     }) => (
       <Provider store={store}>
-        <MemoryRouter>
-          <DeleteForm
-            clearHeaderContent={jest.fn()}
-            errors={errors}
-            modelName="machine"
-            nodes={nodes}
-            onSubmit={jest.fn()}
-            processingCount={processingCount}
-            redirectURL="www.url.com"
-            viewingDetails
-          />
+        <MemoryRouter initialEntries={["/"]}>
+          <CompatRouter>
+            <DeleteForm
+              clearHeaderContent={jest.fn()}
+              errors={errors}
+              modelName="machine"
+              nodes={nodes}
+              onSubmit={jest.fn()}
+              processingCount={processingCount}
+              redirectURL="/redirect"
+              viewingDetails
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -107,9 +112,6 @@ describe("DeleteForm", () => {
 
     wrapper.setProps({ errors: "It didn't work", processingCount: 0 });
     wrapper.update();
-
-    expect(wrapper.find("[data-testid='delete-redirect']").exists()).toBe(
-      false
-    );
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe("/");
   });
 });

--- a/ui/src/app/base/components/node/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/base/components/node/DeleteForm/DeleteForm.tsx
@@ -1,4 +1,6 @@
-import { Redirect } from "react-router-dom";
+import { useEffect } from "react";
+
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import NodeActionConfirmationText from "../../NodeActionConfirmationText";
 import type { NodeActionFormProps } from "../types";
@@ -25,13 +27,17 @@ export const DeleteForm = <E,>({
   redirectURL,
   viewingDetails,
 }: Props<E>): JSX.Element => {
+  const navigate = useNavigate();
   const deleteComplete = useProcessing({
     hasErrors: !!errors,
     processingCount,
   });
-  if (deleteComplete && viewingDetails) {
-    return <Redirect data-testid="delete-redirect" to={redirectURL} />;
-  }
+
+  useEffect(() => {
+    if (deleteComplete && viewingDetails) {
+      navigate(redirectURL, { replace: true });
+    }
+  }, [navigate, deleteComplete, redirectURL, viewingDetails]);
 
   return (
     <ActionForm<EmptyObject, E>

--- a/ui/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
+++ b/ui/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FieldlessForm from "./FieldlessForm";
@@ -58,16 +59,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.ON}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={clearHeaderContent}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.ON}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={clearHeaderContent}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,16 +86,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.ABORT}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.ABORT}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -125,16 +130,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.ACQUIRE}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.ACQUIRE}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -167,16 +174,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.EXIT_RESCUE_MODE}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.EXIT_RESCUE_MODE}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -209,16 +218,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.LOCK}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.LOCK}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -251,16 +262,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.MARK_FIXED}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.MARK_FIXED}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -293,16 +306,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.OFF}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.OFF}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -335,16 +350,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.ON}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.ON}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -377,16 +394,18 @@ describe("FieldlessForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <FieldlessForm
-            action={NodeActions.UNLOCK}
-            actions={machineActions}
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <FieldlessForm
+              action={NodeActions.UNLOCK}
+              actions={machineActions}
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
+++ b/ui/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SetZoneForm from "./SetZoneForm";
@@ -34,14 +36,18 @@ it("initialises zone value if exactly one node provided", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <SetZoneForm
-        clearHeaderContent={jest.fn()}
-        modelName="machine"
-        nodes={nodes}
-        onSubmit={jest.fn()}
-        processingCount={0}
-        viewingDetails={false}
-      />
+      <MemoryRouter>
+        <CompatRouter>
+          <SetZoneForm
+            clearHeaderContent={jest.fn()}
+            modelName="machine"
+            nodes={nodes}
+            onSubmit={jest.fn()}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -56,14 +62,18 @@ it("does not initialise zone value if more than one node provided", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <SetZoneForm
-        clearHeaderContent={jest.fn()}
-        modelName="machine"
-        nodes={nodes}
-        onSubmit={jest.fn()}
-        processingCount={0}
-        viewingDetails={false}
-      />
+      <MemoryRouter>
+        <CompatRouter>
+          <SetZoneForm
+            clearHeaderContent={jest.fn()}
+            modelName="machine"
+            nodes={nodes}
+            onSubmit={jest.fn()}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -79,14 +89,18 @@ it("correctly runs function to set zones of given nodes", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <SetZoneForm
-        clearHeaderContent={jest.fn()}
-        modelName="machine"
-        nodes={nodes}
-        onSubmit={onSubmit}
-        processingCount={0}
-        viewingDetails={false}
-      />
+      <MemoryRouter>
+        <CompatRouter>
+          <SetZoneForm
+            clearHeaderContent={jest.fn()}
+            modelName="machine"
+            nodes={nodes}
+            onSubmit={onSubmit}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 

--- a/ui/src/app/base/components/node/TestForm/TestForm.test.tsx
+++ b/ui/src/app/base/components/node/TestForm/TestForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TestForm from "./TestForm";
@@ -79,15 +80,17 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TestForm
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={state.machine.items}
-            onTest={onTest}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <TestForm
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={state.machine.items}
+              onTest={onTest}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -146,16 +149,18 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TestForm
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            hardwareType={HardwareType.Network}
-            modelName="machine"
-            nodes={state.machine.items}
-            onTest={jest.fn()}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <TestForm
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              hardwareType={HardwareType.Network}
+              modelName="machine"
+              nodes={state.machine.items}
+              onTest={jest.fn()}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -194,16 +199,18 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TestForm
-            cleanup={machineActions.cleanup}
-            applyConfiguredNetworking={true}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={state.machine.items}
-            onTest={jest.fn()}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <TestForm
+              cleanup={machineActions.cleanup}
+              applyConfiguredNetworking={true}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={state.machine.items}
+              onTest={jest.fn()}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/base/components/node/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/base/components/node/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TestForm from "../TestForm";
@@ -75,15 +76,17 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <TestForm
-            cleanup={machineActions.cleanup}
-            clearHeaderContent={jest.fn()}
-            modelName="machine"
-            nodes={state.machine.items}
-            onTest={jest.fn()}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <TestForm
+              cleanup={machineActions.cleanup}
+              clearHeaderContent={jest.fn()}
+              modelName="machine"
+              nodes={state.machine.items}
+              onTest={jest.fn()}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ClearAllForm from "./ClearAllForm";
@@ -50,7 +51,9 @@ describe("ClearAllForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <ClearAllForm closeForm={jest.fn()} />
+          <CompatRouter>
+            <ClearAllForm closeForm={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +70,9 @@ describe("ClearAllForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <ClearAllForm closeForm={jest.fn()} />
+          <CompatRouter>
+            <ClearAllForm closeForm={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +88,9 @@ describe("ClearAllForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <ClearAllForm closeForm={jest.fn()} />
+          <CompatRouter>
+            <ClearAllForm closeForm={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -100,7 +107,9 @@ describe("ClearAllForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
         >
-          <ClearAllForm closeForm={jest.fn()} />
+          <CompatRouter>
+            <ClearAllForm closeForm={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/ui/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddDeviceForm from "./AddDeviceForm";
@@ -49,7 +50,9 @@ describe("AddDeviceForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter>
-          <AddDeviceForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddDeviceForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,7 +78,9 @@ describe("AddDeviceForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <AddDeviceForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddDeviceForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -87,7 +92,9 @@ describe("AddDeviceForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <AddDeviceForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddDeviceForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceConfiguration, { Label } from "./DeviceConfiguration";
@@ -52,7 +53,9 @@ describe("DeviceConfiguration", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceConfiguration systemId="abc123" />
+          <CompatRouter>
+            <DeviceConfiguration systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -65,7 +68,9 @@ describe("DeviceConfiguration", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceConfiguration systemId="abc123" />
+          <CompatRouter>
+            <DeviceConfiguration systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -81,7 +86,9 @@ describe("DeviceConfiguration", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceConfiguration systemId="abc123" />
+          <CompatRouter>
+            <DeviceConfiguration systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -101,7 +108,9 @@ describe("DeviceConfiguration", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <DeviceConfiguration systemId="abc123" />
+          <CompatRouter>
+            <DeviceConfiguration systemId="abc123" />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfigurationFields/DeviceConfigurationFields.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfigurationFields/DeviceConfigurationFields.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceConfigurationFields, { Label } from "./DeviceConfigurationFields";
@@ -56,9 +57,11 @@ it("can open a create tag form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ tags: [] }} onSubmit={jest.fn()}>
-          <DeviceConfigurationFields />
-        </Formik>
+        <CompatRouter>
+          <Formik initialValues={{ tags: [] }} onSubmit={jest.fn()}>
+            <DeviceConfigurationFields />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -78,9 +81,11 @@ it("updates the new tags after creating a tag", async () => {
   const Form = ({ tags }: { tags: Tag[TagMeta.PK][] }) => (
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ tags: tags }} onSubmit={jest.fn()}>
-          <DeviceConfigurationFields />
-        </Formik>
+        <CompatRouter>
+          <Formik initialValues={{ tags: tags }} onSubmit={jest.fn()}>
+            <DeviceConfigurationFields />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeviceName from "./DeviceName";
@@ -55,11 +56,13 @@ describe("DeviceName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/device/abc123", key: "testKey" }]}
         >
-          <DeviceName
-            editingName={true}
-            id="abc123"
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <DeviceName
+              editingName={true}
+              id="abc123"
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddInterface from "./AddInterface";
@@ -54,7 +56,11 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddInterface systemId="abc123" closeForm={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddInterface systemId="abc123" closeForm={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -67,7 +73,11 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddInterface closeForm={jest.fn()} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddInterface closeForm={jest.fn()} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const formValues = {
@@ -97,7 +107,11 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     const Proxy = ({ systemId = "abc123" }) => (
       <Provider store={store}>
-        <AddInterface closeForm={closeForm} systemId={systemId} />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddInterface closeForm={closeForm} systemId={systemId} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);
@@ -128,7 +142,11 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     const Proxy = ({ systemId = "abc123" }) => (
       <Provider store={store}>
-        <AddInterface closeForm={closeForm} systemId={systemId} />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddInterface closeForm={closeForm} systemId={systemId} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);
@@ -165,7 +183,11 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     const Proxy = ({ systemId = "abc123" }) => (
       <Provider store={store}>
-        <AddInterface closeForm={closeForm} systemId={systemId} />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddInterface closeForm={closeForm} systemId={systemId} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditInterface from "./EditInterface";
@@ -59,7 +61,15 @@ describe("EditInterface", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditInterface nicId={nic.id} systemId="abc123" closeForm={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditInterface
+              nicId={nic.id}
+              systemId="abc123"
+              closeForm={jest.fn()}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(
@@ -71,7 +81,15 @@ describe("EditInterface", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditInterface nicId={nic.id} closeForm={jest.fn()} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditInterface
+              nicId={nic.id}
+              closeForm={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const formValues = {
@@ -100,11 +118,15 @@ describe("EditInterface", () => {
     const store = mockStore(state);
     const Proxy = ({ systemId = "abc123" }) => (
       <Provider store={store}>
-        <EditInterface
-          nicId={nic.id}
-          closeForm={closeForm}
-          systemId={systemId}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditInterface
+              nicId={nic.id}
+              closeForm={closeForm}
+              systemId={systemId}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);
@@ -135,11 +157,15 @@ describe("EditInterface", () => {
     const store = mockStore(state);
     const Proxy = ({ systemId = "abc123" }) => (
       <Provider store={store}>
-        <EditInterface
-          nicId={nic.id}
-          closeForm={closeForm}
-          systemId={systemId}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditInterface
+              nicId={nic.id}
+              closeForm={closeForm}
+              systemId={systemId}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);
@@ -176,11 +202,15 @@ describe("EditInterface", () => {
     const store = mockStore(state);
     const Proxy = ({ systemId = "abc123" }) => (
       <Provider store={store}>
-        <EditInterface
-          nicId={nic.id}
-          closeForm={closeForm}
-          systemId={systemId}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditInterface
+              nicId={nic.id}
+              closeForm={closeForm}
+              systemId={systemId}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);

--- a/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.test.tsx
+++ b/ui/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import InterfaceForm from "./InterfaceForm";
@@ -59,12 +61,16 @@ describe("InterfaceForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceForm
-          nicId={nic.id}
-          onSubmit={jest.fn()}
-          systemId="abc123"
-          closeForm={jest.fn()}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <InterfaceForm
+              nicId={nic.id}
+              onSubmit={jest.fn()}
+              systemId="abc123"
+              closeForm={jest.fn()}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -104,13 +110,17 @@ describe("InterfaceForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceForm
-          nicId={nic.id}
-          linkId={link.id}
-          onSubmit={jest.fn()}
-          closeForm={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <InterfaceForm
+              nicId={nic.id}
+              linkId={link.id}
+              onSubmit={jest.fn()}
+              closeForm={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find(FormikForm).prop("initialValues")).toStrictEqual({
@@ -127,11 +137,15 @@ describe("InterfaceForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceForm
-          onSubmit={jest.fn()}
-          closeForm={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <InterfaceForm
+              onSubmit={jest.fn()}
+              closeForm={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find(FormikForm).prop("initialValues")).toStrictEqual({

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddRecordForm from "./AddRecordForm";
@@ -26,7 +28,11 @@ describe("AddRecordForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddRecordForm id={1} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddRecordForm id={1} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("button[data-testid='cancel-action']").simulate("click");
@@ -49,7 +55,11 @@ describe("AddRecordForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddRecordForm id={1} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddRecordForm id={1} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteDomainForm from "./DeleteDomainForm";
@@ -24,7 +26,11 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeleteDomainForm id={1} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeleteDomainForm id={1} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("button[data-testid='cancel-action']").simulate("click");
@@ -47,7 +53,11 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeleteDomainForm id={1} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeleteDomainForm id={1} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -89,7 +99,11 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeleteDomainForm id={1} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeleteDomainForm id={1} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainSummary from "./DomainSummary";
@@ -26,7 +28,11 @@ describe("DomainSummary", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <DomainSummary id={1} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DomainSummary id={1} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -43,7 +49,11 @@ describe("DomainSummary", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <DomainSummary id={1} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DomainSummary id={1} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -67,7 +77,11 @@ describe("DomainSummary", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DomainSummary id={1} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DomainSummary id={1} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -107,7 +121,11 @@ describe("DomainSummary", () => {
 
       const wrapper = mount(
         <Provider store={store}>
-          <DomainSummary id={1} />
+          <MemoryRouter>
+            <CompatRouter>
+              <DomainSummary id={1} />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
 
@@ -126,7 +144,11 @@ describe("DomainSummary", () => {
 
       const wrapper = mount(
         <Provider store={store}>
-          <DomainSummary id={1} />
+          <MemoryRouter>
+            <CompatRouter>
+              <DomainSummary id={1} />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
 
@@ -151,7 +173,11 @@ describe("DomainSummary", () => {
 
       const wrapper = mount(
         <Provider store={store}>
-          <DomainSummary id={1} />
+          <MemoryRouter>
+            <CompatRouter>
+              <DomainSummary id={1} />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
 
@@ -177,7 +203,11 @@ describe("DomainSummary", () => {
 
       const wrapper = mount(
         <Provider store={store}>
-          <DomainSummary id={1} />
+          <MemoryRouter>
+            <CompatRouter>
+              <DomainSummary id={1} />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
 

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteRecordForm from "./DeleteRecordForm";
@@ -29,11 +31,15 @@ describe("DeleteRecordForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <DeleteRecordForm
-          closeForm={closeForm}
-          id={domain.id}
-          resource={resource}
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeleteRecordForm
+              closeForm={closeForm}
+              id={domain.id}
+              resource={resource}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -56,7 +62,15 @@ describe("DeleteRecordForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeleteRecordForm closeForm={jest.fn()} id={1} resource={resource} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeleteRecordForm
+              closeForm={jest.fn()}
+              id={1}
+              resource={resource}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("form").simulate("submit");
@@ -84,7 +98,15 @@ describe("DeleteRecordForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DeleteRecordForm closeForm={jest.fn()} id={1} resource={resource} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeleteRecordForm
+              closeForm={jest.fn()}
+              id={1}
+              resource={resource}
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("form").simulate("submit");

--- a/ui/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditRecordForm from "./EditRecordForm";
@@ -54,7 +56,11 @@ describe("EditRecordForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <EditRecordForm id={1} resource={resourceA} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditRecordForm id={1} resource={resourceA} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -67,7 +73,11 @@ describe("EditRecordForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditRecordForm closeForm={jest.fn()} id={1} resource={resourceA} />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditRecordForm closeForm={jest.fn()} id={1} resource={resourceA} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainListHeader from "./DomainListHeader";
@@ -39,7 +40,9 @@ describe("DomainListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainListHeader />
+          <CompatRouter>
+            <DomainListHeader />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -55,7 +58,9 @@ describe("DomainListHeader", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/domains", key: "testKey" }]}
         >
-          <DomainListHeader />
+          <CompatRouter>
+            <DomainListHeader />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -69,7 +74,13 @@ describe("DomainListHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DomainListHeader />
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <DomainListHeader />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("DomainListHeaderForm").exists()).toBe(false);

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainListHeaderForm from "./DomainListHeaderForm";
@@ -22,7 +24,11 @@ describe("DomainListHeaderForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DomainListHeaderForm closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DomainListHeaderForm closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -34,7 +40,11 @@ describe("DomainListHeaderForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DomainListHeaderForm closeForm={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <DomainListHeaderForm closeForm={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     act(() =>

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -1,6 +1,8 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FetchImagesForm from "./FetchImagesForm";
@@ -35,7 +37,11 @@ describe("FetchImagesForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FetchImagesForm closeForm={jest.fn()} setSource={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <FetchImagesForm closeForm={jest.fn()} setSource={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -75,7 +81,11 @@ describe("FetchImagesForm", () => {
     const store = mockStore(state);
     const Proxy = () => (
       <Provider store={store}>
-        <FetchImagesForm closeForm={jest.fn()} setSource={setSource} />
+        <MemoryRouter>
+          <CompatRouter>
+            <FetchImagesForm closeForm={jest.fn()} setSource={setSource} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -1,6 +1,8 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FetchedImages from "./FetchedImages";
@@ -75,7 +77,11 @@ describe("FetchedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FetchedImages closeForm={jest.fn()} source={source} />
+        <MemoryRouter>
+          <CompatRouter>
+            <FetchedImages closeForm={jest.fn()} source={source} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -127,7 +133,11 @@ describe("FetchedImages", () => {
     const store = mockStore(state);
     const Proxy = () => (
       <Provider store={store}>
-        <FetchedImages closeForm={closeForm} source={source} />
+        <MemoryRouter>
+          <CompatRouter>
+            <FetchedImages closeForm={closeForm} source={source} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const wrapper = mount(<Proxy />);

--- a/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import OtherImages from "./OtherImages";
@@ -23,7 +25,11 @@ describe("OtherImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <OtherImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <OtherImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("ImagesTable").exists()).toBe(false);
@@ -62,7 +68,11 @@ describe("OtherImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <OtherImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <OtherImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Formik").prop("initialValues")).toStrictEqual({
@@ -88,7 +98,11 @@ describe("OtherImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <OtherImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <OtherImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -125,7 +139,11 @@ describe("OtherImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <OtherImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <OtherImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -147,7 +165,11 @@ describe("OtherImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <OtherImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <OtherImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("button[data-testid='secondary-submit']").simulate("click");

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SyncedImages from "./SyncedImages";
@@ -29,7 +31,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages formInCard />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyncedImages formInCard />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper
@@ -47,7 +53,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyncedImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("ChangeSource").exists()).toBe(true);
@@ -67,7 +77,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyncedImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("[data-testid='image-sync-text']").text()).toBe(
@@ -91,7 +105,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyncedImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("[data-testid='image-sync-text']").text()).toBe(
@@ -108,7 +126,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyncedImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("[data-testid='image-sync-text']").text()).toBe(
@@ -126,7 +148,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyncedImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import UbuntuCoreImages from "./UbuntuCoreImages";
@@ -23,7 +25,11 @@ describe("UbuntuCoreImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuCoreImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuCoreImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("ImagesTable").exists()).toBe(false);
@@ -62,7 +68,11 @@ describe("UbuntuCoreImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuCoreImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuCoreImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Formik").prop("initialValues")).toStrictEqual({
@@ -88,7 +98,11 @@ describe("UbuntuCoreImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuCoreImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuCoreImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -126,7 +140,11 @@ describe("UbuntuCoreImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuCoreImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuCoreImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -148,7 +166,11 @@ describe("UbuntuCoreImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuCoreImages />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuCoreImages />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("button[data-testid='secondary-submit']").simulate("click");

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import UbuntuImages from "./UbuntuImages";
@@ -73,7 +75,11 @@ describe("UbuntuImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuImages sources={[source]} />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuImages sources={[source]} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Formik").prop("initialValues")).toStrictEqual({
@@ -118,7 +124,11 @@ describe("UbuntuImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuImages sources={[source]} />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuImages sources={[source]} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -168,7 +178,11 @@ describe("UbuntuImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuImages sources={[source]} />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuImages sources={[source]} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -191,7 +205,11 @@ describe("UbuntuImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuImages sources={[source]} />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuImages sources={[source]} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("button[data-testid='secondary-submit']").simulate("click");
@@ -216,7 +234,11 @@ describe("UbuntuImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UbuntuImages sources={sources} />
+        <MemoryRouter>
+          <CompatRouter>
+            <UbuntuImages sources={sources} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("[data-testid='too-many-sources']").exists()).toBe(

--- a/ui/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/ui/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import IntroSection from "./IntroSection";
@@ -37,7 +38,9 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection loading={true}>Intro content</IntroSection>
+          <CompatRouter>
+            <IntroSection loading={true}>Intro content</IntroSection>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -56,11 +59,15 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
+          <CompatRouter>
+            <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      dashboardURLs.index
+    );
   });
 
   it("redirects to the dashboard for admins", () => {
@@ -75,11 +82,15 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
+          <CompatRouter>
+            <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").prop("to")).toBe(dashboardURLs.index);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      dashboardURLs.index
+    );
   });
 
   it("redirects to the machine list for non-admins", () => {
@@ -94,11 +105,13 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
+          <CompatRouter>
+            <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").prop("to")).toBe(
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
       machineURLs.machines.index
     );
   });
@@ -113,7 +126,9 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection errors="Uh oh!">Intro content</IntroSection>
+          <CompatRouter>
+            <IntroSection errors="Uh oh!">Intro content</IntroSection>
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/components/IntroSection/IntroSection.tsx
+++ b/ui/src/app/intro/components/IntroSection/IntroSection.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from "react";
+import { useEffect } from "react";
 
 import { Notification, Spinner } from "@canonical/react-components";
-import { Redirect } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import Section from "app/base/components/Section";
 import type { Props as SectionProps } from "app/base/components/Section/Section";
@@ -30,14 +31,17 @@ const IntroSection = ({
   windowTitle,
   ...props
 }: Props): JSX.Element => {
+  const navigate = useNavigate();
   const errorMessage = formatErrors(errors);
   const exitURL = useExitURL();
 
   useWindowTitle(windowTitle ? `Welcome - ${windowTitle}` : "Welcome");
 
-  if (shouldExitIntro) {
-    return <Redirect to={exitURL} />;
-  }
+  useEffect(() => {
+    if (shouldExitIntro) {
+      navigate(exitURL, { replace: true });
+    }
+  }, [navigate, exitURL, shouldExitIntro]);
 
   return (
     <Section {...props}>

--- a/ui/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
+++ b/ui/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import IncompleteCard from "./IncompleteCard";
@@ -23,7 +24,9 @@ describe("IncompleteCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IncompleteCard />
+          <CompatRouter>
+            <IncompleteCard />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/views/Intro.test.tsx
+++ b/ui/src/app/intro/views/Intro.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import Intro from "./Intro";
 
+import dashboardURLs from "app/dashboard/urls";
 import introURLs from "app/intro/urls";
 import type { RootState } from "app/store/root/types";
 import {
@@ -87,7 +88,9 @@ describe("Intro", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      dashboardURLs.index
+    );
   });
 
   it("returns to the start when loading the user intro and the main intro is incomplete", () => {

--- a/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -1,11 +1,13 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import UserIntro from "./UserIntro";
 
 import * as baseHooks from "app/base/hooks/base";
+import dashboardURLs from "app/dashboard/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as userActions } from "app/store/user";
 import {
@@ -46,7 +48,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -61,7 +65,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -80,11 +86,15 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      dashboardURLs.index
+    );
   });
 
   it("disables the continue button if there are no ssh keys", () => {
@@ -95,7 +105,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -114,7 +126,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -128,7 +142,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -142,7 +158,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -166,7 +184,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -184,11 +204,15 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      dashboardURLs.index
+    );
   });
 
   it("can skip the user setup", () => {
@@ -198,7 +222,9 @@ describe("UserIntro", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <UserIntro />
+          <CompatRouter>
+            <UserIntro />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVMConfigurationCard from "./KVMConfigurationCard";
@@ -50,7 +51,9 @@ it("can handle updating a lxd KVM", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
       >
-        <KVMConfigurationCard pod={pod} />
+        <CompatRouter>
+          <KVMConfigurationCard pod={pod} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -101,7 +104,9 @@ it("can handle updating a virsh KVM", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
       >
-        <KVMConfigurationCard pod={pod} />
+        <CompatRouter>
+          <KVMConfigurationCard pod={pod} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -155,7 +160,9 @@ it("enables the submit button if form values are different to pod values", async
       <MemoryRouter
         initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
       >
-        <KVMConfigurationCard pod={pod} />
+        <CompatRouter>
+          <KVMConfigurationCard pod={pod} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -185,7 +192,9 @@ it("enables the submit button if form values are different to pod values", async
       <MemoryRouter
         initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
       >
-        <KVMConfigurationCard pod={updatedPod} />
+        <CompatRouter>
+          <KVMConfigurationCard pod={updatedPod} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCardFields/KVMConfigurationCardFields.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVMConfigurationCard from "../KVMConfigurationCard";
@@ -41,7 +42,9 @@ describe("KVMConfigurationCardFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <KVMConfigurationCard pod={pod} />
+          <CompatRouter>
+            <KVMConfigurationCard pod={pod} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -80,7 +83,9 @@ describe("KVMConfigurationCardFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <KVMConfigurationCard pod={pod} />
+          <CompatRouter>
+            <KVMConfigurationCard pod={pod} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -117,7 +122,9 @@ describe("KVMConfigurationCardFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <KVMConfigurationCard pod={pod} zoneDisabled />
+          <CompatRouter>
+            <KVMConfigurationCard pod={pod} zoneDisabled />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddLxd from "./AddLxd";
@@ -75,7 +76,9 @@ describe("AddLxd", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddLxd clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddLxd clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -97,7 +100,9 @@ describe("AddLxd", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddLxd clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddLxd clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -126,7 +131,9 @@ describe("AddLxd", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddLxd clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddLxd clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -152,7 +159,9 @@ describe("AddLxd", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddLxd clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddLxd clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -176,7 +185,9 @@ describe("AddLxd", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddLxd clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddLxd clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddLxdSteps } from "../AddLxd";
@@ -74,12 +75,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={jest.fn()}
-            setStep={jest.fn()}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={jest.fn()}
+              setStep={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -108,12 +111,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={setNewPodValues}
-            setStep={jest.fn()}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={setNewPodValues}
+              setStep={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -148,12 +153,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={setNewPodValues}
-            setStep={jest.fn()}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={setNewPodValues}
+              setStep={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -191,12 +198,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -219,12 +228,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -244,12 +255,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -271,12 +284,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -291,12 +306,14 @@ describe("AuthenticationForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AuthenticationForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={jest.fn()}
-            setStep={jest.fn()}
-          />
+          <CompatRouter>
+            <AuthenticationForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={jest.fn()}
+              setStep={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/CredentialsForm/CredentialsForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/CredentialsForm/CredentialsForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddLxdSteps } from "../AddLxd";
@@ -71,13 +72,15 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={setNewPodValues}
-            setStep={jest.fn()}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={setNewPodValues}
+              setStep={jest.fn()}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -124,13 +127,15 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setNewPodValues={setNewPodValues}
-            setStep={jest.fn()}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setNewPodValues={setNewPodValues}
+              setStep={jest.fn()}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -183,21 +188,23 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={{
-              certificate: "",
-              key: "",
-              name: "my-favourite-kvm",
-              password: "",
-              pool: "0",
-              power_address: "192.168.1.1",
-              zone: "0",
-            }}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={{
+                certificate: "",
+                key: "",
+                name: "my-favourite-kvm",
+                password: "",
+                pool: "0",
+                power_address: "192.168.1.1",
+                zone: "0",
+              }}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -218,21 +225,23 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={{
-              certificate: "",
-              key: "",
-              name: "my-favourite-kvm",
-              password: "",
-              pool: "0",
-              power_address: "192.168.1.1",
-              zone: "0",
-            }}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={{
+                certificate: "",
+                key: "",
+                name: "my-favourite-kvm",
+                password: "",
+                pool: "0",
+                power_address: "192.168.1.1",
+                zone: "0",
+              }}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -251,21 +260,23 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={{
-              certificate: "certificate",
-              key: "key",
-              name: "my-favourite-kvm",
-              password: "",
-              pool: "0",
-              power_address: "192.168.1.1",
-              zone: "0",
-            }}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={{
+                certificate: "certificate",
+                key: "key",
+                name: "my-favourite-kvm",
+                password: "",
+                pool: "0",
+                power_address: "192.168.1.1",
+                zone: "0",
+              }}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -286,21 +297,23 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={{
-              certificate: "certificate",
-              key: "key",
-              name: "my-favourite-kvm",
-              password: "",
-              pool: "0",
-              power_address: "192.168.1.1",
-              zone: "0",
-            }}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={{
+                certificate: "certificate",
+                key: "key",
+                name: "my-favourite-kvm",
+                password: "",
+                pool: "0",
+                power_address: "192.168.1.1",
+                zone: "0",
+              }}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -327,21 +340,23 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={{
-              certificate: "certificate",
-              key: "key",
-              name: "my-favourite-kvm",
-              password: "",
-              pool: "0",
-              power_address: "192.168.1.1",
-              zone: "0",
-            }}
-            setNewPodValues={jest.fn()}
-            setStep={setStep}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={{
+                certificate: "certificate",
+                key: "key",
+                name: "my-favourite-kvm",
+                password: "",
+                pool: "0",
+                power_address: "192.168.1.1",
+                zone: "0",
+              }}
+              setNewPodValues={jest.fn()}
+              setStep={setStep}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -361,21 +376,23 @@ describe("CredentialsForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <CredentialsForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={{
-              certificate: "certificate",
-              key: "key",
-              name: "my-favourite-kvm",
-              password: "",
-              pool: "0",
-              power_address: "192.168.1.1",
-              zone: "0",
-            }}
-            setNewPodValues={jest.fn()}
-            setStep={jest.fn()}
-            setSubmissionErrors={setSubmissionErrors}
-          />
+          <CompatRouter>
+            <CredentialsForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={{
+                certificate: "certificate",
+                key: "key",
+                name: "my-favourite-kvm",
+                password: "",
+                pool: "0",
+                power_address: "192.168.1.1",
+                zone: "0",
+              }}
+              setNewPodValues={jest.fn()}
+              setStep={jest.fn()}
+              setSubmissionErrors={setSubmissionErrors}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddLxdSteps } from "../AddLxd";
@@ -64,12 +65,14 @@ describe("SelectProjectForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <SelectProjectForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setStep={jest.fn()}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <SelectProjectForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setStep={jest.fn()}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -90,12 +93,14 @@ describe("SelectProjectForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <SelectProjectForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setStep={jest.fn()}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <SelectProjectForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setStep={jest.fn()}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -124,12 +129,14 @@ describe("SelectProjectForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <SelectProjectForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setStep={jest.fn()}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <SelectProjectForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setStep={jest.fn()}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -168,12 +175,14 @@ describe("SelectProjectForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <SelectProjectForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setStep={jest.fn()}
-            setSubmissionErrors={jest.fn()}
-          />
+          <CompatRouter>
+            <SelectProjectForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setStep={jest.fn()}
+              setSubmissionErrors={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -210,12 +219,14 @@ describe("SelectProjectForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <SelectProjectForm
-            clearHeaderContent={jest.fn()}
-            newPodValues={newPodValues}
-            setStep={setStep}
-            setSubmissionErrors={setSubmissionErrors}
-          />
+          <CompatRouter>
+            <SelectProjectForm
+              clearHeaderContent={jest.fn()}
+              newPodValues={newPodValues}
+              setStep={setStep}
+              setSubmissionErrors={setSubmissionErrors}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddVirsh from "./AddVirsh";
@@ -71,7 +72,9 @@ describe("AddVirsh", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddVirsh clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddVirsh clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -98,7 +101,9 @@ describe("AddVirsh", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddVirsh clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddVirsh clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -114,7 +119,9 @@ describe("AddVirsh", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddVirsh clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddVirsh clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -130,7 +137,9 @@ describe("AddVirsh", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
         >
-          <AddVirsh clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddVirsh clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirshFields/AddVirshFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirshFields/AddVirshFields.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddVirsh from "../AddVirsh";
@@ -76,7 +77,9 @@ describe("AddVirshFields", () => {
             { pathname: "/machines/chassis/add", key: "testKey" },
           ]}
         >
-          <AddVirsh clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddVirsh clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ComposeForm, {
@@ -76,7 +77,9 @@ describe("ComposeForm", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -103,7 +106,9 @@ describe("ComposeForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -127,7 +132,9 @@ describe("ComposeForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -214,7 +221,9 @@ describe("ComposeForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ComposeForm from "../ComposeForm";
@@ -91,7 +92,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -126,7 +129,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -178,7 +183,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -389,7 +396,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -425,7 +434,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -453,7 +464,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -501,7 +514,9 @@ describe("ComposeFormFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          <CompatRouter>
+            <ComposeForm clearHeaderContent={jest.fn()} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import type { MockStore } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
@@ -38,7 +39,9 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
       <MemoryRouter
         initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
       >
-        <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        <CompatRouter>
+          <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import type { MockStore } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
@@ -41,7 +42,9 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
       <MemoryRouter
         initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
       >
-        <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        <CompatRouter>
+          <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import type { MockStore } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
@@ -38,7 +39,9 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
       <MemoryRouter
         initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
       >
-        <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        <CompatRouter>
+          <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import type { MockStore } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
@@ -37,7 +38,9 @@ const generateWrapper = (store: MockStore, pod: Pod) =>
       <MemoryRouter
         initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
       >
-        <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        <CompatRouter>
+          <ComposeForm clearHeaderContent={jest.fn()} hostId={pod.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/kvm/components/KVMHeaderForms/RefreshForm/RefreshForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RefreshForm from "./RefreshForm";
@@ -31,7 +32,9 @@ describe("RefreshForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <RefreshForm clearHeaderContent={jest.fn()} hostIds={[1]} />
+          <CompatRouter>
+            <RefreshForm clearHeaderContent={jest.fn()} hostIds={[1]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -57,7 +60,9 @@ describe("RefreshForm", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <RefreshForm clearHeaderContent={jest.fn()} hostIds={[1, 2]} />
+          <CompatRouter>
+            <RefreshForm clearHeaderContent={jest.fn()} hostIds={[1, 2]} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -152,7 +152,9 @@ describe("KVMList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(false);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      kvmURLs.lxd.index
+    );
     expect(wrapper.find("[data-testid='no-hosts']").exists()).toBe(true);
     expect(
       wrapper.find("[data-testid='no-hosts'] h4").text().includes("LXD")
@@ -180,7 +182,9 @@ describe("KVMList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(false);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      kvmURLs.virsh.index
+    );
     expect(wrapper.find("[data-testid='no-hosts']").exists()).toBe(true);
     expect(
       wrapper.find("[data-testid='no-hosts'] h4").text().includes("Virsh")
@@ -208,7 +212,9 @@ describe("KVMList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(false);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      kvmURLs.lxd.index
+    );
     expect(wrapper.find("[data-testid='no-hosts']").exists()).toBe(false);
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });

--- a/ui/src/app/kvm/views/KVMList/KVMList.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMList.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from "react";
 
 import { Col, Row, Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect, useLocation } from "react-router";
+import { useLocation } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import KVMListHeader from "./KVMListHeader";
 import LxdTable from "./LxdTable";
@@ -22,6 +23,7 @@ import { actions as zoneActions } from "app/store/zone";
 
 const KVMList = (): JSX.Element => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const location = useLocation();
   const podsLoading = useSelector(podSelectors.loading);
   const lxdKvms = useSelector(podSelectors.lxd);
@@ -45,9 +47,11 @@ const KVMList = (): JSX.Element => {
   }, [dispatch]);
 
   // Redirect to the appropriate tab when arriving at /kvm.
-  if (!showingLXD && !showingVirsh) {
-    return <Redirect to={kvmURLs.lxd.index} />;
-  }
+  useEffect(() => {
+    if (!showingLXD && !showingVirsh) {
+      navigate(kvmURLs.lxd.index, { replace: true });
+    }
+  }, [navigate, showingLXD, showingVirsh]);
 
   let content: ReactNode = null;
   if (podsLoading || vmclustersLoading) {

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterHostSettings from "./LXDClusterHostSettings";
@@ -33,7 +34,9 @@ describe("LXDClusterHostSettings", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <LXDClusterHostSettings clusterId={2} hostId={1} />
+          <CompatRouter>
+            <LXDClusterHostSettings clusterId={2} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -45,7 +48,9 @@ describe("LXDClusterHostSettings", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <LXDClusterHostSettings clusterId={2} hostId={1} />
+          <CompatRouter>
+            <LXDClusterHostSettings clusterId={2} hostId={1} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from "react";
+
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Redirect } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import { useWindowTitle } from "app/base/hooks";
 import KVMConfigurationCard from "app/kvm/components/KVMConfigurationCard";
@@ -20,6 +22,7 @@ type Props = {
 };
 
 const LXDClusterHostSettings = ({ clusterId, hostId }: Props): JSX.Element => {
+  const navigate = useNavigate();
   const cluster = useSelector((state: RootState) =>
     vmClusterSelectors.getById(state, clusterId)
   );
@@ -33,9 +36,12 @@ const LXDClusterHostSettings = ({ clusterId, hostId }: Props): JSX.Element => {
     `${pod?.name || "Host"} in ${cluster?.name || "cluster"} settings`
   );
 
-  if (redirectURL) {
-    return <Redirect to={redirectURL} />;
-  }
+  useEffect(() => {
+    if (redirectURL) {
+      navigate(redirectURL, { replace: true });
+    }
+  }, [navigate, redirectURL]);
+
   if (loading || !isPodDetails(pod)) {
     return <Spinner text="Loading..." />;
   }

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterHostVMs from "./LXDClusterHostVMs";
@@ -25,13 +26,15 @@ describe("LXDClusterHostVMs", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <LXDClusterHostVMs
-            clusterId={1}
-            hostId={2}
-            searchFilter=""
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostVMs
+              clusterId={1}
+              hostId={2}
+              searchFilter=""
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -48,13 +51,15 @@ describe("LXDClusterHostVMs", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
-          <LXDClusterHostVMs
-            clusterId={1}
-            hostId={2}
-            searchFilter=""
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-          />
+          <CompatRouter>
+            <LXDClusterHostVMs
+              clusterId={1}
+              hostId={2}
+              searchFilter=""
+              setHeaderContent={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
+++ b/ui/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Redirect } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
@@ -29,6 +31,7 @@ const LXDClusterHostVMs = ({
   setHeaderContent,
   setSearchFilter,
 }: Props): JSX.Element => {
+  const navigate = useNavigate();
   const cluster = useSelector((state: RootState) =>
     vmClusterSelectors.getById(state, clusterId)
   );
@@ -41,9 +44,12 @@ const LXDClusterHostVMs = ({
   useActivePod(hostId);
   const redirectURL = useKVMDetailsRedirect(hostId);
 
-  if (redirectURL) {
-    return <Redirect to={redirectURL} />;
-  }
+  useEffect(() => {
+    if (redirectURL) {
+      navigate(redirectURL, { replace: true });
+    }
+  }, [navigate, redirectURL]);
+
   if (!cluster) {
     return <Spinner text="Loading..." />;
   }

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useSelector } from "react-redux";
 import { Redirect, Route, Switch, useLocation } from "react-router-dom";
@@ -50,9 +50,12 @@ const LXDSingleDetails = (): JSX.Element => {
     [setFilter, navigate]
   );
 
-  if (redirectURL) {
-    return <Redirect to={redirectURL} />;
-  }
+  useEffect(() => {
+    if (redirectURL) {
+      navigate(redirectURL, { replace: true });
+    }
+  }, [navigate, redirectURL]);
+
   if (!isId(id) || (!loading && !pod)) {
     return (
       <ModelNotFound id={id} linkURL={kvmURLs.lxd.index} modelName="LXD host" />

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AuthenticationCard from "./AuthenticationCard";
@@ -45,7 +46,9 @@ describe("AuthenticationCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <AuthenticationCard hostId={pod.id} />
+          <CompatRouter>
+            <AuthenticationCard hostId={pod.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -59,7 +62,9 @@ describe("AuthenticationCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <AuthenticationCard hostId={pod.id} />
+          <CompatRouter>
+            <AuthenticationCard hostId={pod.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -81,7 +86,9 @@ describe("AuthenticationCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
         >
-          <AuthenticationCard hostId={pod.id} />
+          <CompatRouter>
+            <AuthenticationCard hostId={pod.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import UpdateCertificate from "./UpdateCertificate";
@@ -47,11 +48,13 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={jest.fn()}
-            hasCertificateData
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={jest.fn()}
+              hasCertificateData
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -75,12 +78,14 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={jest.fn()}
-            hasCertificateData
-            objectName="custom-name"
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={jest.fn()}
+              hasCertificateData
+              objectName="custom-name"
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -109,11 +114,13 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={jest.fn()}
-            hasCertificateData
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={jest.fn()}
+              hasCertificateData
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -142,11 +149,13 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={jest.fn()}
-            hasCertificateData
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={jest.fn()}
+              hasCertificateData
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -178,11 +187,13 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={closeForm}
-            hasCertificateData
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={closeForm}
+              hasCertificateData
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -201,11 +212,13 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={closeForm}
-            hasCertificateData={false}
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={closeForm}
+              hasCertificateData={false}
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -228,11 +241,13 @@ describe("UpdateCertificate", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/edit", key: "testKey" }]}
         >
-          <UpdateCertificate
-            closeForm={jest.fn()}
-            hasCertificateData={false}
-            pod={pod}
-          />
+          <CompatRouter>
+            <UpdateCertificate
+              closeForm={jest.fn()}
+              hasCertificateData={false}
+              pod={pod}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.test.tsx
+++ b/ui/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDSingleSettings from "./LXDSingleSettings";
@@ -43,7 +44,11 @@ describe("LXDSingleSettings", () => {
     mount(
       <MemoryRouter>
         <Provider store={store}>
-          <LXDSingleSettings id={1} setHeaderContent={jest.fn()} />
+          <MemoryRouter>
+            <CompatRouter>
+              <LXDSingleSettings id={1} setHeaderContent={jest.fn()} />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       </MemoryRouter>
     );
@@ -67,7 +72,11 @@ describe("LXDSingleSettings", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <LXDSingleSettings id={1} setHeaderContent={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <LXDSingleSettings id={1} setHeaderContent={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").length).toBe(1);

--- a/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshDetails.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useSelector } from "react-redux";
 import { Redirect, Route, Switch } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import VirshDetailsHeader from "./VirshDetailsHeader";
 import VirshResources from "./VirshResources";
@@ -19,6 +20,7 @@ import type { RootState } from "app/store/root/types";
 import { isId } from "app/utils";
 
 const VirshDetails = (): JSX.Element => {
+  const navigate = useNavigate();
   const id = useGetURLId(PodMeta.PK);
 
   const pod = useSelector((state: RootState) =>
@@ -31,9 +33,12 @@ const VirshDetails = (): JSX.Element => {
   useActivePod(id);
   const redirectURL = useKVMDetailsRedirect(id);
 
-  if (redirectURL) {
-    return <Redirect to={redirectURL} />;
-  }
+  useEffect(() => {
+    if (redirectURL) {
+      navigate(redirectURL, { replace: true });
+    }
+  }, [navigate, redirectURL]);
+
   if (!isId(id) || (!loading && !pod)) {
     return (
       <ModelNotFound

--- a/ui/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
+++ b/ui/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VirshSettings from "./VirshSettings";
@@ -43,7 +44,9 @@ describe("VirshSettings", () => {
     mount(
       <MemoryRouter>
         <Provider store={store}>
-          <VirshSettings id={1} />
+          <CompatRouter>
+            <VirshSettings id={1} />
+          </CompatRouter>
         </Provider>
       </MemoryRouter>
     );
@@ -67,7 +70,11 @@ describe("VirshSettings", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <VirshSettings id={1} />
+        <MemoryRouter>
+          <CompatRouter>
+            <VirshSettings id={1} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").length).toBe(1);

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ActionFormWrapper from "./ActionFormWrapper";
@@ -30,12 +31,14 @@ it("can set selected machines to those that can perform action", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <ActionFormWrapper
-          action={NodeActions.ABORT}
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <ActionFormWrapper
+            action={NodeActions.ABORT}
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -78,12 +81,14 @@ it("can show untag errors when the tag form is open", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <ActionFormWrapper
-          action={NodeActions.TAG}
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <ActionFormWrapper
+            action={NodeActions.TAG}
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CloneForm from "./CloneForm";
@@ -53,12 +54,14 @@ describe("CloneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <CloneForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -99,12 +102,14 @@ describe("CloneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <CloneForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -143,12 +148,14 @@ describe("CloneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CloneForm
-            clearHeaderContent={jest.fn()}
-            machines={[machines[0], machines[1]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <CloneForm
+              clearHeaderContent={jest.fn()}
+              machines={[machines[0], machines[1]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CommissionForm from "./CommissionForm";
@@ -70,12 +71,14 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CommissionForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <CommissionForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -92,12 +95,14 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CommissionForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <CommissionForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CommissionForm from "../CommissionForm";
@@ -74,12 +75,14 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <CommissionForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <CommissionForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeployForm from "./DeployForm";
@@ -108,12 +109,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -143,12 +146,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -166,12 +171,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -209,12 +216,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -248,12 +257,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -287,12 +298,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -327,12 +340,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -369,12 +384,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -406,12 +423,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -437,12 +456,14 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <DeployForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MarkBrokenForm from "./MarkBrokenForm";
@@ -43,12 +44,14 @@ describe("MarkBrokenForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MarkBrokenForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <MarkBrokenForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -106,12 +109,14 @@ describe("MarkBrokenForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MarkBrokenForm
-            clearHeaderContent={jest.fn()}
-            machines={[state.machine.items[0]]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <MarkBrokenForm
+              clearHeaderContent={jest.fn()}
+              machines={[state.machine.items[0]]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ReleaseForm from "./ReleaseForm";
@@ -61,12 +62,14 @@ describe("ReleaseForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReleaseForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <ReleaseForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -84,12 +87,14 @@ describe("ReleaseForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReleaseForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <ReleaseForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SetPoolForm from "./SetPoolForm";
@@ -60,12 +61,14 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <SetPoolForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -82,12 +85,14 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <SetPoolForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -144,12 +149,14 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm
-            clearHeaderContent={jest.fn()}
-            machines={state.machine.items}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <SetPoolForm
+              clearHeaderContent={jest.fn()}
+              machines={state.machine.items}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SetPoolForm from "../SetPoolForm";
@@ -51,12 +52,14 @@ describe("SetPoolFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <SetPoolForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -76,12 +79,14 @@ describe("SetPoolFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm
-            clearHeaderContent={jest.fn()}
-            machines={[]}
-            processingCount={0}
-            viewingDetails={false}
-          />
+          <CompatRouter>
+            <SetPoolForm
+              clearHeaderContent={jest.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TagForm, { Label } from "./TagForm";
@@ -47,12 +48,14 @@ it("dispatches action to fetch tags on load", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={[]}
-          processingCount={0}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={[]}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -73,12 +76,14 @@ it("correctly dispatches actions to tag machines", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          processingCount={0}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -111,12 +116,14 @@ it("correctly dispatches actions to untag machines", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          processingCount={0}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -148,12 +155,14 @@ it("correctly dispatches actions to tag and untag a machine", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          processingCount={0}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -192,13 +201,15 @@ it("shows saving label if not viewing from machine config page", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          processingCount={1}
-          viewingDetails={false}
-          viewingMachineConfig={false}
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            processingCount={1}
+            viewingDetails={false}
+            viewingMachineConfig={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -217,13 +228,15 @@ it("does not show saving label if viewing from machine config page", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          processingCount={1}
-          viewingDetails
-          viewingMachineConfig
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            processingCount={1}
+            viewingDetails
+            viewingMachineConfig
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -239,12 +252,14 @@ it("shows a notification on success", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines", key: "testKey" }]}
       >
-        <TagForm
-          clearHeaderContent={jest.fn()}
-          machines={machines}
-          processingCount={0}
-          viewingDetails={false}
-        />
+        <CompatRouter>
+          <TagForm
+            clearHeaderContent={jest.fn()}
+            machines={machines}
+            processingCount={0}
+            viewingDetails={false}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Label as TagFormChangesLabel } from "../TagFormChanges/TagFormChanges";
@@ -64,13 +65,18 @@ it("displays available tags in the dropdown", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormFields
-            machines={state.machine.items}
-            newTags={[]}
-            setNewTags={jest.fn()}
-          />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormFields
+              machines={state.machine.items}
+              newTags={[]}
+              setNewTags={jest.fn()}
+            />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -103,16 +109,18 @@ it("displays the tags to be added", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik
-          initialValues={{ added: [tags[0].id, tags[2].id], removed: [] }}
-          onSubmit={jest.fn()}
-        >
-          <TagFormFields
-            machines={state.machine.items}
-            newTags={[]}
-            setNewTags={jest.fn()}
-          />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [tags[0].id, tags[2].id], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormFields
+              machines={state.machine.items}
+              newTags={[]}
+              setNewTags={jest.fn()}
+            />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -132,9 +140,14 @@ it("can open a create tag form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <Formik initialValues={{ added: [], removed: [] }} onSubmit={jest.fn()}>
-          <TagFormFields machines={[]} newTags={[]} setNewTags={jest.fn()} />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: [], removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormFields machines={[]} newTags={[]} setNewTags={jest.fn()} />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -155,16 +168,18 @@ it("updates the new tags after creating a tag", async () => {
   const Form = ({ tags }: { tags: Tag[TagMeta.PK][] }) => (
     <Provider store={store}>
       <MemoryRouter>
-        <Formik
-          initialValues={{ added: tags, removed: [] }}
-          onSubmit={jest.fn()}
-        >
-          <TagFormFields
-            machines={state.machine.items}
-            newTags={[]}
-            setNewTags={setNewTags}
-          />
-        </Formik>
+        <CompatRouter>
+          <Formik
+            initialValues={{ added: tags, removed: [] }}
+            onSubmit={jest.fn()}
+          >
+            <TagFormFields
+              machines={state.machine.items}
+              newTags={[]}
+              setNewTags={setNewTags}
+            />
+          </Formik>
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddChassisForm from "./AddChassisForm";
@@ -152,7 +153,9 @@ describe("AddChassisForm", () => {
             { pathname: "/machines/chassis/add", key: "testKey" },
           ]}
         >
-          <AddChassisForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddChassisForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -174,7 +177,9 @@ describe("AddChassisForm", () => {
             { pathname: "/machines/chassis/add", key: "testKey" },
           ]}
         >
-          <AddChassisForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddChassisForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -188,7 +193,9 @@ describe("AddChassisForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <AddChassisForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddChassisForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisFormFields/AddChassisFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisFormFields/AddChassisFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddChassisForm from "../AddChassisForm";
@@ -47,7 +48,9 @@ describe("AddChassisFormFields", () => {
             { pathname: "/machines/chassis/add", key: "testKey" },
           ]}
         >
-          <AddChassisForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddChassisForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -99,7 +102,9 @@ describe("AddChassisFormFields", () => {
             { pathname: "/machines/chassis/add", key: "testKey" },
           ]}
         >
-          <AddChassisForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddChassisForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddMachineForm from "./AddMachineForm";
@@ -104,7 +105,9 @@ it("fetches the necessary data on load if not already loaded", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
       >
-        <AddMachineForm clearHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <AddMachineForm clearHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -131,7 +134,9 @@ it("displays a spinner if data has not loaded", () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
       >
-        <AddMachineForm clearHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <AddMachineForm clearHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -146,7 +151,9 @@ it("enables submit when a power type with no fields is chosen", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
       >
-        <AddMachineForm clearHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <AddMachineForm clearHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -171,7 +178,9 @@ it("can handle saving a machine", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
       >
-        <AddMachineForm clearHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <AddMachineForm clearHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -231,7 +240,9 @@ it("correctly trims power parameters before dispatching action", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
       >
-        <AddMachineForm clearHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <AddMachineForm clearHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -287,7 +298,9 @@ it("correctly filters empty extra mac fields", async () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
       >
-        <AddMachineForm clearHeaderContent={jest.fn()} />
+        <CompatRouter>
+          <AddMachineForm clearHeaderContent={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
+++ b/ui/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddMachineForm from "../AddMachineForm";
@@ -80,7 +81,9 @@ describe("AddMachineFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddMachineForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -96,7 +99,9 @@ describe("AddMachineFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddMachineForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -123,7 +128,9 @@ describe("AddMachineFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddMachineForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -146,7 +153,9 @@ describe("AddMachineFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <AddMachineForm clearHeaderContent={jest.fn()} />
+          <CompatRouter>
+            <AddMachineForm clearHeaderContent={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineForm from "./MachineForm";
@@ -49,7 +51,11 @@ describe("MachineForm", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <MachineForm systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <MachineForm systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -63,7 +69,11 @@ describe("MachineForm", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <MachineForm systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <MachineForm systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -76,7 +86,11 @@ describe("MachineForm", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <MachineForm systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <MachineForm systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -99,7 +113,11 @@ describe("MachineForm", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <MachineForm systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <MachineForm systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import PowerForm from "./PowerForm";
@@ -76,7 +78,11 @@ it("is not editable if machine does not have edit permission", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <PowerForm systemId="abc123" />
+      <MemoryRouter>
+        <CompatRouter>
+          <PowerForm systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -90,7 +96,11 @@ it("is editable if machine has edit permission", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <PowerForm systemId="abc123" />
+      <MemoryRouter>
+        <CompatRouter>
+          <PowerForm systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -103,7 +113,11 @@ it("renders read-only text fields until edit button is pressed", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <PowerForm systemId="abc123" />
+      <MemoryRouter>
+        <CompatRouter>
+          <PowerForm systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -130,7 +144,11 @@ it("correctly dispatches an action to update a machine's power", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <PowerForm systemId="abc123" />
+      <MemoryRouter>
+        <CompatRouter>
+          <PowerForm systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineName from "./MachineName";
@@ -55,11 +56,13 @@ describe("MachineName", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineName
-            editingName={true}
-            id="abc123"
-            setEditingName={jest.fn()}
-          />
+          <CompatRouter>
+            <MachineName
+              editingName={true}
+              id="abc123"
+              setEditingName={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineInstances from "./MachineInstances";
@@ -56,11 +57,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/fake123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,11 +81,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/abc123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -120,11 +125,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/abc123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -161,11 +168,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/abc123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -218,11 +227,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/abc123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -258,11 +269,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/abc123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -313,11 +326,13 @@ describe("MachineInstances", () => {
             { pathname: "/machine/abc123/instances", key: "testKey" },
           ]}
         >
-          <Route
-            exact
-            path="/machine/:id/instances"
-            render={() => <MachineInstances />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path="/machine/:id/instances"
+              render={() => <MachineInstances />}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from "react";
+
 import { Spinner, Row, Col, MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Redirect } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
@@ -82,6 +84,7 @@ const generateRows = (devices: NodeDeviceRef[]) => {
 };
 
 const MachineInstances = (): JSX.Element => {
+  const navigate = useNavigate();
   const id = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
@@ -89,14 +92,19 @@ const MachineInstances = (): JSX.Element => {
 
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} instances`);
 
-  if (!machine) {
-    return <Spinner text="Loading..." />;
-  }
+  useEffect(() => {
+    if (
+      machine &&
+      (!isMachineDetails(machine) || machine.devices.length === 0)
+    ) {
+      navigate(machineURLs.machine.summary({ id: machine.system_id }), {
+        replace: true,
+      });
+    }
+  }, [navigate, machine]);
 
-  if (!isMachineDetails(machine) || machine.devices.length === 0) {
-    return (
-      <Redirect to={machineURLs.machine.summary({ id: machine.system_id })} />
-    );
+  if (!machine || !isMachineDetails(machine)) {
+    return <Spinner text="Loading..." />;
   }
 
   return (

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddAliasOrVlan from "./AddAliasOrVlan";
@@ -53,11 +54,13 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -71,12 +74,14 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            interfaceType={NetworkInterfaceTypes.ALIAS}
-            nic={nic}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              interfaceType={NetworkInterfaceTypes.ALIAS}
+              nic={nic}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -109,12 +114,14 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            nic={nic}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              nic={nic}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -134,12 +141,14 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            nic={nic}
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              nic={nic}
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -183,12 +192,14 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            interfaceType={NetworkInterfaceTypes.ALIAS}
-            nic={nic}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              interfaceType={NetworkInterfaceTypes.ALIAS}
+              nic={nic}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -223,12 +234,14 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            nic={nic}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              nic={nic}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -269,12 +282,14 @@ describe("AddAliasOrVlan", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddAliasOrVlan
-            interfaceType={NetworkInterfaceTypes.ALIAS}
-            nic={nic}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <AddAliasOrVlan
+              interfaceType={NetworkInterfaceTypes.ALIAS}
+              nic={nic}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddBridgeForm from "./AddBridgeForm";
@@ -60,11 +61,13 @@ describe("AddBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBridgeForm
-            close={jest.fn()}
-            selected={selected}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBridgeForm
+              close={jest.fn()}
+              selected={selected}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -80,11 +83,13 @@ describe("AddBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBridgeForm
-            close={jest.fn()}
-            selected={[{ nicId: nic.id }]}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBridgeForm
+              close={jest.fn()}
+              selected={[{ nicId: nic.id }]}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -99,11 +104,13 @@ describe("AddBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBridgeForm
-            close={jest.fn()}
-            selected={[{ nicId: nic.id }]}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBridgeForm
+              close={jest.fn()}
+              selected={[{ nicId: nic.id }]}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -118,11 +125,13 @@ describe("AddBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddBridgeForm
-            close={jest.fn()}
-            selected={[{ nicId: nic.id }]}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <AddBridgeForm
+              close={jest.fn()}
+              selected={[{ nicId: nic.id }]}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddInterface from "./AddInterface";
@@ -61,7 +62,9 @@ describe("AddInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddInterface systemId="abc123" close={jest.fn()} />
+          <CompatRouter>
+            <AddInterface systemId="abc123" close={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -83,7 +86,9 @@ describe("AddInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddInterface systemId="abc123" close={jest.fn()} />
+          <CompatRouter>
+            <AddInterface systemId="abc123" close={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -99,7 +104,9 @@ describe("AddInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddInterface systemId="abc123" close={jest.fn()} />
+          <CompatRouter>
+            <AddInterface systemId="abc123" close={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditAliasOrVlanForm from "./EditAliasOrVlanForm";
@@ -69,12 +70,14 @@ describe("EditAliasOrVlanForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditAliasOrVlanForm
-            close={jest.fn()}
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditAliasOrVlanForm
+              close={jest.fn()}
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -96,12 +99,14 @@ describe("EditAliasOrVlanForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditAliasOrVlanForm
-            close={jest.fn()}
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditAliasOrVlanForm
+              close={jest.fn()}
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -115,12 +120,14 @@ describe("EditAliasOrVlanForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditAliasOrVlanForm
-            close={jest.fn()}
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditAliasOrVlanForm
+              close={jest.fn()}
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -136,13 +143,15 @@ describe("EditAliasOrVlanForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditAliasOrVlanForm
-            close={jest.fn()}
-            interfaceType={NetworkInterfaceTypes.ALIAS}
-            link={link}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditAliasOrVlanForm
+              close={jest.fn()}
+              interfaceType={NetworkInterfaceTypes.ALIAS}
+              link={link}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -189,13 +198,15 @@ describe("EditAliasOrVlanForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditAliasOrVlanForm
-            close={jest.fn()}
-            interfaceType={NetworkInterfaceTypes.VLAN}
-            link={link}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditAliasOrVlanForm
+              close={jest.fn()}
+              interfaceType={NetworkInterfaceTypes.VLAN}
+              link={link}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditBridgeForm from "./EditBridgeForm";
@@ -58,12 +59,14 @@ describe("EditBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBridgeForm
-            close={jest.fn()}
-            link={link}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBridgeForm
+              close={jest.fn()}
+              link={link}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,12 +81,14 @@ describe("EditBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBridgeForm
-            close={jest.fn()}
-            link={link}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBridgeForm
+              close={jest.fn()}
+              link={link}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -98,12 +103,14 @@ describe("EditBridgeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditBridgeForm
-            close={jest.fn()}
-            link={link}
-            nic={nic}
-            systemId="abc123"
-          />
+          <CompatRouter>
+            <EditBridgeForm
+              close={jest.fn()}
+              link={link}
+              nic={nic}
+              systemId="abc123"
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditInterface from "./EditInterface";
@@ -44,12 +45,14 @@ describe("EditInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditInterface
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            close={jest.fn()}
-          />
+          <CompatRouter>
+            <EditInterface
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              close={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,13 +75,15 @@ describe("EditInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditInterface
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            close={jest.fn()}
-            nicId={nic.id}
-          />
+          <CompatRouter>
+            <EditInterface
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              close={jest.fn()}
+              nicId={nic.id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -104,14 +109,16 @@ describe("EditInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditInterface
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            close={jest.fn()}
-            linkId={link.id}
-            nicId={nic.id}
-          />
+          <CompatRouter>
+            <EditInterface
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              close={jest.fn()}
+              linkId={link.id}
+              nicId={nic.id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -135,13 +142,15 @@ describe("EditInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditInterface
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            close={jest.fn()}
-            nicId={nic.id}
-          />
+          <CompatRouter>
+            <EditInterface
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              close={jest.fn()}
+              nicId={nic.id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -165,13 +174,15 @@ describe("EditInterface", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditInterface
-            selected={[]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-            close={jest.fn()}
-            nicId={nic.id}
-          />
+          <CompatRouter>
+            <EditInterface
+              selected={[]}
+              setSelected={jest.fn()}
+              systemId="abc123"
+              close={jest.fn()}
+              nicId={nic.id}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditPhysicalForm from "./EditPhysicalForm";
@@ -66,7 +67,9 @@ describe("EditPhysicalForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
+          <CompatRouter>
+            <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -87,7 +90,9 @@ describe("EditPhysicalForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
+          <CompatRouter>
+            <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -101,7 +106,9 @@ describe("EditPhysicalForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
+          <CompatRouter>
+            <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NetworkTableConfirmation from "./NetworkTableConfirmation";
@@ -44,12 +46,16 @@ describe("NetworkTableConfirmation", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={null}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <NetworkTableConfirmation
+              expanded={null}
+              nic={nic}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("ActionConfirm").exists()).toBe(false);
@@ -60,14 +66,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.REMOVE,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.REMOVE,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       const confirmation = wrapper.find("ActionConfirm");
@@ -82,14 +92,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.REMOVE,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.REMOVE,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       wrapper.find("ActionConfirm ActionButton").simulate("click");
@@ -130,15 +144,19 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.REMOVE,
-            }}
-            link={link}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.REMOVE,
+                }}
+                link={link}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       const confirmation = wrapper.find("ActionConfirm");
@@ -167,15 +185,19 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.REMOVE,
-            }}
-            link={link}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.REMOVE,
+                }}
+                link={link}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       wrapper.find("ActionConfirm ActionButton").simulate("click");
@@ -205,14 +227,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.MARK_CONNECTED,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.MARK_CONNECTED,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       const confirmation = wrapper.find("ActionConfirm");
@@ -226,14 +252,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.MARK_DISCONNECTED,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.MARK_DISCONNECTED,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       const confirmation = wrapper.find("ActionConfirm");
@@ -247,14 +277,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.DISCONNECTED_WARNING,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.DISCONNECTED_WARNING,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       const confirmation = wrapper.find("ActionConfirm");
@@ -268,14 +302,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.MARK_CONNECTED,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.MARK_CONNECTED,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       wrapper.find("ActionConfirm ActionButton").simulate("click");
@@ -303,14 +341,18 @@ describe("NetworkTableConfirmation", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTableConfirmation
-            expanded={{
-              content: ExpandedState.MARK_DISCONNECTED,
-            }}
-            nic={nic}
-            setExpanded={jest.fn()}
-            systemId="abc123"
-          />
+          <MemoryRouter>
+            <CompatRouter>
+              <NetworkTableConfirmation
+                expanded={{
+                  content: ExpandedState.MARK_DISCONNECTED,
+                }}
+                nic={nic}
+                setExpanded={jest.fn()}
+                systemId="abc123"
+              />
+            </CompatRouter>
+          </MemoryRouter>
         </Provider>
       );
       wrapper.find("ActionConfirm ActionButton").simulate("click");
@@ -339,14 +381,18 @@ describe("NetworkTableConfirmation", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={{
-            content: ExpandedState.ADD_ALIAS,
-          }}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <NetworkTableConfirmation
+              expanded={{
+                content: ExpandedState.ADD_ALIAS,
+              }}
+              nic={nic}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("AddAliasOrVlan").exists()).toBe(true);
@@ -359,14 +405,18 @@ describe("NetworkTableConfirmation", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={{
-            content: ExpandedState.ADD_VLAN,
-          }}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <NetworkTableConfirmation
+              expanded={{
+                content: ExpandedState.ADD_VLAN,
+              }}
+              nic={nic}
+              setExpanded={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("AddAliasOrVlan").exists()).toBe(true);

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddLogicalVolume from "./AddLogicalVolume";
@@ -62,11 +64,15 @@ describe("AddLogicalVolume", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddLogicalVolume
-          closeExpanded={jest.fn()}
-          disk={volumeGroup}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddLogicalVolume
+              closeExpanded={jest.fn()}
+              disk={volumeGroup}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -116,11 +122,15 @@ describe("AddLogicalVolume", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddLogicalVolume
-          closeExpanded={jest.fn()}
-          disk={volumeGroup}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddLogicalVolume
+              closeExpanded={jest.fn()}
+              disk={volumeGroup}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Input[name='size']").prop("value")).toBe(8);
@@ -143,11 +153,15 @@ describe("AddLogicalVolume", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddLogicalVolume
-          closeExpanded={jest.fn()}
-          disk={disk}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddLogicalVolume
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -190,11 +204,15 @@ describe("AddLogicalVolume", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddLogicalVolume
-          closeExpanded={jest.fn()}
-          disk={disk}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddLogicalVolume
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -231,11 +249,15 @@ describe("AddLogicalVolume", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddLogicalVolume
-          closeExpanded={jest.fn()}
-          disk={disk}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddLogicalVolume
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddPartition from "./AddPartition";
@@ -36,7 +38,15 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -63,7 +73,15 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Input[name='partitionSize']").prop("value")).toBe(8);
@@ -84,7 +102,15 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -126,7 +152,15 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -159,7 +193,15 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AvailableStorageTable, { uniqueId } from "./AvailableStorageTable";
@@ -34,7 +36,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -71,7 +77,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -100,7 +110,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -139,7 +153,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -174,7 +192,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage={false} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage={false} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -205,7 +227,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -232,7 +258,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -258,7 +288,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -286,7 +320,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -315,7 +353,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -352,7 +394,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -397,7 +443,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -447,7 +497,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -504,7 +558,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -546,7 +604,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -591,7 +653,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -645,7 +711,11 @@ describe("AvailableStorageTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AvailableStorageTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AvailableStorageTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { BulkAction } from "../AvailableStorageTable";
@@ -44,12 +46,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={null}
-          selected={selected}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={null}
+              selected={selected}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -81,12 +87,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={null}
-          selected={selected}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={null}
+              selected={selected}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -112,12 +122,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={null}
-          selected={[]}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={null}
+              selected={[]}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -145,12 +159,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={null}
-          selected={selected}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={null}
+              selected={selected}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -182,12 +200,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={null}
-          selected={[selected]}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={null}
+              selected={[selected]}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -212,12 +234,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={BulkAction.CREATE_DATASTORE}
-          selected={[]}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={BulkAction.CREATE_DATASTORE}
+              selected={[]}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -240,12 +266,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={BulkAction.CREATE_RAID}
-          selected={[]}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={BulkAction.CREATE_RAID}
+              selected={[]}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -268,12 +298,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={BulkAction.CREATE_VOLUME_GROUP}
-          selected={[]}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={BulkAction.CREATE_VOLUME_GROUP}
+              selected={[]}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -296,12 +330,16 @@ describe("BulkActions", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <BulkActions
-          bulkAction={BulkAction.UPDATE_DATASTORE}
-          selected={[]}
-          setBulkAction={jest.fn()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <BulkActions
+              bulkAction={BulkAction.UPDATE_DATASTORE}
+              selected={[]}
+              setBulkAction={jest.fn()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CreateDatastore from "./CreateDatastore";
@@ -52,11 +54,15 @@ describe("CreateDatastore", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateDatastore
-          closeForm={jest.fn()}
-          selected={[newDatastore]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateDatastore
+              closeForm={jest.fn()}
+              selected={[newDatastore]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -94,11 +100,15 @@ describe("CreateDatastore", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateDatastore
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateDatastore
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -132,11 +142,15 @@ describe("CreateDatastore", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateDatastore
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateDatastore
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -169,11 +183,15 @@ describe("CreateDatastore", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateDatastore
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateDatastore
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CreateRaid from "./CreateRaid";
@@ -50,11 +52,15 @@ describe("CreateRaid", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid
-          closeForm={jest.fn()}
-          selected={[physicalDisk]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={[physicalDisk]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -82,11 +88,15 @@ describe("CreateRaid", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CreateRaid from "../CreateRaid";
@@ -43,7 +45,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={disks}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -76,7 +86,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={disks}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -112,7 +130,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={disks}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -149,7 +175,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={disks}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -185,7 +219,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={disks}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -224,11 +266,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid
-          closeForm={jest.fn()}
-          selected={[disks[0], disks[1], ...partitions]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={[disks[0], disks[1], ...partitions]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const isActive = (i: number) =>
@@ -313,11 +359,15 @@ describe("CreateRaidFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateRaid
-          closeForm={jest.fn()}
-          selected={[disks[0], disks[1], ...partitions]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateRaid
+              closeForm={jest.fn()}
+              selected={[disks[0], disks[1], ...partitions]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     const isActive = (i: number) =>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CreateVolumeGroup from "./CreateVolumeGroup";
@@ -44,11 +46,15 @@ describe("CreateVolumeGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateVolumeGroup
-          closeForm={jest.fn()}
-          selected={[physicalDisk]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateVolumeGroup
+              closeForm={jest.fn()}
+              selected={[physicalDisk]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -80,11 +86,15 @@ describe("CreateVolumeGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateVolumeGroup
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateVolumeGroup
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -117,11 +127,15 @@ describe("CreateVolumeGroup", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateVolumeGroup
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateVolumeGroup
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import UpdateDatastore from "./UpdateDatastore";
@@ -55,11 +57,15 @@ describe("UpdateDatastore", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UpdateDatastore
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <UpdateDatastore
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -90,11 +96,15 @@ describe("UpdateDatastore", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <UpdateDatastore
-          closeForm={jest.fn()}
-          selected={[selectedDisk, selectedPartition]}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <UpdateDatastore
+              closeForm={jest.fn()}
+              selected={[selectedDisk, selectedPartition]}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CreateBcache from "./CreateBcache";
@@ -58,11 +60,15 @@ describe("CreateBcache", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateBcache
-          closeExpanded={jest.fn()}
-          storageDevice={diskFactory()}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateBcache
+              closeExpanded={jest.fn()}
+              storageDevice={diskFactory()}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -92,11 +98,15 @@ describe("CreateBcache", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CreateBcache
-          closeExpanded={jest.fn()}
-          storageDevice={backingDevice}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <CreateBcache
+              closeExpanded={jest.fn()}
+              storageDevice={backingDevice}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDisk.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDisk.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditDisk from "./EditDisk";
@@ -36,7 +38,11 @@ describe("EditDisk", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditDisk closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditDisk closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -61,7 +67,11 @@ describe("EditDisk", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditDisk closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditDisk closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditPartition from "./EditPartition";
@@ -40,12 +42,16 @@ describe("EditPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditPartition
-          closeExpanded={jest.fn()}
-          disk={disk}
-          partition={partition}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              partition={partition}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -68,12 +74,16 @@ describe("EditPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <EditPartition
-          closeExpanded={jest.fn()}
-          disk={disk}
-          partition={partition}
-          systemId="abc123"
-        />
+        <MemoryRouter>
+          <CompatRouter>
+            <EditPartition
+              closeExpanded={jest.fn()}
+              disk={disk}
+              partition={partition}
+              systemId="abc123"
+            />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ChangeStorageLayout from "./ChangeStorageLayout";
@@ -30,7 +32,11 @@ describe("ChangeStorageLayout", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ChangeStorageLayout systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <ChangeStorageLayout systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -69,7 +75,11 @@ describe("ChangeStorageLayout", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ChangeStorageLayout systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <ChangeStorageLayout systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -101,7 +111,11 @@ describe("ChangeStorageLayout", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ChangeStorageLayout systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <ChangeStorageLayout systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddSpecialFilesystem from "./AddSpecialFilesystem";
@@ -37,7 +39,11 @@ describe("AddSpecialFilesystem", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -68,7 +74,11 @@ describe("AddSpecialFilesystem", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -89,7 +99,11 @@ describe("AddSpecialFilesystem", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FilesystemsTable from "./FilesystemsTable";
@@ -38,7 +40,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -64,7 +70,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -98,7 +108,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -129,7 +143,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -153,7 +171,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -183,7 +205,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -236,7 +262,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -290,7 +320,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -343,7 +377,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -397,7 +435,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -451,7 +493,11 @@ describe("FilesystemsTable", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage={false} systemId="abc123" />
+        <MemoryRouter>
+          <CompatRouter>
+            <FilesystemsTable canEditStorage={false} systemId="abc123" />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(screen.getByRole("button", { name: /Take action/ })).toBeDisabled();

--- a/ui/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/ui/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -1,12 +1,13 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { PoolForm } from "./PoolForm";
 
+import poolsURLs from "app/pools/urls";
 import { actions } from "app/store/resourcepool";
 import type { RootState } from "app/store/root/types";
 import {
@@ -81,8 +82,9 @@ describe("PoolForm", () => {
         </MemoryRouter>
       </Provider>
     );
-
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      poolsURLs.pools
+    );
   });
 
   it("can create a resource pool", () => {

--- a/ui/src/app/preferences/views/Details/Details.test.tsx
+++ b/ui/src/app/preferences/views/Details/Details.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Details } from "./Details";
@@ -43,7 +44,9 @@ describe("Details", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Details />
+          <CompatRouter>
+            <Details />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -55,7 +58,9 @@ describe("Details", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Details />
+          <CompatRouter>
+            <Details />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -74,7 +79,9 @@ describe("Details", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Details />
+          <CompatRouter>
+            <Details />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -111,7 +118,9 @@ describe("Details", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Details />
+          <CompatRouter>
+            <Details />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -150,7 +159,9 @@ describe("Details", () => {
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Details />
+          <CompatRouter>
+            <Details />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -164,7 +175,9 @@ describe("Details", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
-          <Details />
+          <CompatRouter>
+            <Details />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
@@ -1,11 +1,12 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddSSHKey } from "./AddSSHKey";
 
+import prefsURLs from "app/preferences/urls";
 import type { RootState } from "app/store/root/types";
 import {
   sshKeyState as sshKeyStateFactory,
@@ -53,6 +54,8 @@ describe("AddSSHKey", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      prefsURLs.sshKeys.index
+    );
   });
 });

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
@@ -1,12 +1,13 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddSSLKey } from "./AddSSLKey";
 
+import prefsURLs from "app/preferences/urls";
 import type { RootState } from "app/store/root/types";
 import {
   sslKeyState as sslKeyStateFactory,
@@ -76,7 +77,9 @@ describe("AddSSLKey", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      prefsURLs.sslKeys.index
+    );
   });
 
   it("can create a SSL key", () => {

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Commissioning from "./Commissioning";
@@ -47,7 +49,11 @@ describe("Commissioning", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <Commissioning />
+        <MemoryRouter>
+          <CompatRouter>
+            <Commissioning />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -60,7 +66,11 @@ describe("Commissioning", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <Commissioning />
+        <MemoryRouter>
+          <CompatRouter>
+            <Commissioning />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -74,7 +84,11 @@ describe("Commissioning", () => {
 
     mount(
       <Provider store={store}>
-        <Commissioning />
+        <MemoryRouter>
+          <CompatRouter>
+            <Commissioning />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CommissioningForm from "./CommissioningForm";
@@ -67,7 +69,11 @@ describe("CommissioningForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CommissioningForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <CommissioningForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CommissioningForm from "../CommissioningForm";
@@ -80,7 +82,11 @@ describe("CommissioningFormFields", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <CommissioningForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <CommissioningForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -95,7 +101,11 @@ describe("CommissioningFormFields", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <CommissioningForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <CommissioningForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -110,7 +120,11 @@ describe("CommissioningFormFields", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <CommissioningForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <CommissioningForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -125,7 +139,11 @@ describe("CommissioningFormFields", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <CommissioningForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <CommissioningForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeployForm from "./DeployForm";
@@ -67,7 +68,9 @@ describe("DeployFormFields", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DeployForm />
+          <CompatRouter>
+            <DeployForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -103,7 +106,9 @@ describe("DeployFormFields", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <DeployForm />
+          <CompatRouter>
+            <DeployForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -117,7 +122,11 @@ describe("DeployFormFields", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <DeployForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeployForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -156,7 +165,11 @@ describe("DeployFormFields", () => {
     const store = mockStore(state);
     render(
       <Provider store={store}>
-        <DeployForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <DeployForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Configuration/General/General.test.tsx
+++ b/ui/src/app/settings/views/Configuration/General/General.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import General from "./General";
@@ -42,7 +44,11 @@ describe("General", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <General />
+        <MemoryRouter>
+          <CompatRouter>
+            <General />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -55,7 +61,11 @@ describe("General", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <General />
+        <MemoryRouter>
+          <CompatRouter>
+            <General />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -68,7 +78,11 @@ describe("General", () => {
 
     mount(
       <Provider store={store}>
-        <General />
+        <MemoryRouter>
+          <CompatRouter>
+            <General />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -1,5 +1,7 @@
 import { shallow, mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import GeneralForm from "./GeneralForm";
@@ -33,7 +35,11 @@ describe("GeneralForm", () => {
 
     const wrapper = shallow(
       <Provider store={store}>
-        <GeneralForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <GeneralForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("GeneralForm").exists()).toBe(true);
@@ -44,7 +50,11 @@ describe("GeneralForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <GeneralForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <GeneralForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("input[name='maas_name']").props().value).toBe(
@@ -57,7 +67,11 @@ describe("GeneralForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <GeneralForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <GeneralForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("input[name='enable_analytics']").props().value).toBe(
@@ -70,7 +84,11 @@ describe("GeneralForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <GeneralForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <GeneralForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(
@@ -83,7 +101,11 @@ describe("GeneralForm", () => {
     window.usabilla_live = jest.fn();
     const wrapper = mount(
       <Provider store={store}>
-        <GeneralForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <GeneralForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {

--- a/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
+++ b/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KernelParameters from "./KernelParameters";
@@ -35,7 +37,11 @@ describe("KernelParameters", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <KernelParameters />
+        <MemoryRouter>
+          <CompatRouter>
+            <KernelParameters />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -49,7 +55,11 @@ describe("KernelParameters", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <KernelParameters />
+        <MemoryRouter>
+          <CompatRouter>
+            <KernelParameters />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -63,7 +73,11 @@ describe("KernelParameters", () => {
 
     mount(
       <Provider store={store}>
-        <KernelParameters />
+        <MemoryRouter>
+          <CompatRouter>
+            <KernelParameters />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KernelParametersForm from "./KernelParametersForm";
@@ -34,7 +36,11 @@ describe("KernelParametersForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <KernelParametersForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <KernelParametersForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(

--- a/ui/src/app/settings/views/Configuration/Security/Security.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/Security.test.tsx
@@ -8,7 +8,7 @@ import {
   tlsCertificate as tlsCertificateFactory,
   tlsCertificateState as tlsCertificateStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { renderWithBrowserRouter } from "testing/utils";
 
 it("displays loading text if TLS certificate has not loaded", () => {
   const state = rootStateFactory({
@@ -19,7 +19,7 @@ it("displays loading text if TLS certificate has not loaded", () => {
       }),
     }),
   });
-  renderWithMockStore(<Security />, { state });
+  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
 
   expect(screen.getByText(/Loading.../)).toBeInTheDocument();
 });
@@ -33,7 +33,7 @@ it("renders TLS disabled section if no TLS certificate is present", () => {
       }),
     }),
   });
-  renderWithMockStore(<Security />, { state });
+  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
 
   expect(screen.getByText(/TLS disabled/)).toBeInTheDocument();
   expect(screen.queryByText(/TLS enabled/)).not.toBeInTheDocument();
@@ -48,7 +48,7 @@ it("renders TLS enabled section if TLS certificate is present", () => {
       }),
     }),
   });
-  renderWithMockStore(<Security />, { state });
+  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
 
   expect(screen.getByText(/TLS enabled/)).toBeInTheDocument();
   expect(screen.queryByText(/TLS disabled/)).not.toBeInTheDocument();

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import TLSEnabled, { Labels } from "./TLSEnabled";
@@ -26,7 +28,11 @@ it("displays a spinner while loading config", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -44,7 +50,11 @@ it("displays a spinner while loading the certificate", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -64,7 +74,11 @@ it("renders certificate content", () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -98,7 +112,11 @@ it("disables the interval field if notification is not enabled", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const slider = screen.getByRole("slider", { name: Labels.Interval });
@@ -138,7 +156,11 @@ it("shows an error if TLS notification is enabled but interval is invalid", asyn
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const intervalInput = screen.getByRole("spinbutton", {
@@ -180,7 +202,11 @@ it("dispatches an action to update TLS notification config with notification ena
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 
@@ -229,7 +255,11 @@ it("dispatches an action to update TLS notification config with notification dis
   const store = mockStore(state);
   render(
     <Provider store={store}>
-      <TLSEnabled />
+      <MemoryRouter>
+        <CompatRouter>
+          <TLSEnabled />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const notificationCheckbox = screen.getByRole("checkbox", {

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
@@ -1,11 +1,12 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { DhcpForm } from "./DhcpForm";
 
+import settingsURLs from "app/settings/urls";
 import type { RootState } from "app/store/root/types";
 import {
   dhcpSnippet as dhcpSnippetFactory,
@@ -67,7 +68,9 @@ describe("DhcpForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      settingsURLs.dhcp.index
+    );
   });
 
   it("shows the snippet name in the title when editing", () => {

--- a/ui/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
+++ b/ui/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ThirdPartyDrivers from "./ThirdPartyDrivers";
@@ -32,7 +34,11 @@ describe("ThirdPartyDrivers", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <ThirdPartyDrivers />
+        <MemoryRouter>
+          <CompatRouter>
+            <ThirdPartyDrivers />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -45,7 +51,11 @@ describe("ThirdPartyDrivers", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <ThirdPartyDrivers />
+        <MemoryRouter>
+          <CompatRouter>
+            <ThirdPartyDrivers />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
+++ b/ui/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ThirdPartyDriversForm from "./ThirdPartyDriversForm";
@@ -33,7 +35,11 @@ describe("ThirdPartyDriversForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <ThirdPartyDriversForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <ThirdPartyDriversForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(

--- a/ui/src/app/settings/views/Images/VMWare/VMWare.test.tsx
+++ b/ui/src/app/settings/views/Images/VMWare/VMWare.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VMWare from "./VMWare";
@@ -35,7 +37,11 @@ describe("VMWare", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <VMWare />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWare />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -48,7 +54,11 @@ describe("VMWare", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <VMWare />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWare />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -61,7 +71,11 @@ describe("VMWare", () => {
 
     mount(
       <Provider store={store}>
-        <VMWare />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWare />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
+++ b/ui/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import VMWareForm from "./VMWareForm";
@@ -45,7 +47,11 @@ describe("VMWareForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <VMWareForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWareForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("input[name='vcenter_server']").props().value).toBe(
@@ -58,7 +64,11 @@ describe("VMWareForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <VMWareForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWareForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("input[name='vcenter_username']").props().value).toBe(
@@ -71,7 +81,11 @@ describe("VMWareForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <VMWareForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWareForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("input[name='vcenter_password']").props().value).toBe(
@@ -84,7 +98,11 @@ describe("VMWareForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <VMWareForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <VMWareForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("input[name='vcenter_datacenter']").props().value).toBe(

--- a/ui/src/app/settings/views/Images/Windows/Windows.test.tsx
+++ b/ui/src/app/settings/views/Images/Windows/Windows.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Windows from "./Windows";
@@ -37,7 +39,11 @@ describe("Windows", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <Windows />
+        <MemoryRouter>
+          <CompatRouter>
+            <Windows />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -50,7 +56,11 @@ describe("Windows", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <Windows />
+        <MemoryRouter>
+          <CompatRouter>
+            <Windows />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -63,7 +73,11 @@ describe("Windows", () => {
 
     mount(
       <Provider store={store}>
-        <Windows />
+        <MemoryRouter>
+          <CompatRouter>
+            <Windows />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
+++ b/ui/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import WindowsForm from "./WindowsForm";
@@ -35,7 +37,11 @@ describe("WindowsForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <WindowsForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <WindowsForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
@@ -1,12 +1,13 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { LicenseKeyForm } from "./LicenseKeyForm";
 
+import settingsURLs from "app/settings/urls";
 import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
@@ -131,8 +132,9 @@ describe("LicenseKeyForm", () => {
         </MemoryRouter>
       </Provider>
     );
-
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      settingsURLs.licenseKeys.index
+    );
   });
 
   it("can add a key", () => {

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DnsForm from "./DnsForm";
@@ -46,7 +48,11 @@ describe("DnsForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <DnsForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <DnsForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -57,7 +63,11 @@ describe("DnsForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DnsForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <DnsForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -90,7 +100,11 @@ describe("DnsForm", () => {
 
     mount(
       <Provider store={store}>
-        <DnsForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <DnsForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";
@@ -55,7 +57,11 @@ describe("NetworkDiscoveryForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkDiscoveryForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <NetworkDiscoveryForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -66,7 +72,11 @@ describe("NetworkDiscoveryForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkDiscoveryForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <NetworkDiscoveryForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -103,7 +113,11 @@ describe("NetworkDiscoveryForm", () => {
 
     mount(
       <Provider store={store}>
-        <NetworkDiscoveryForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <NetworkDiscoveryForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import NtpForm from "./NtpForm";
@@ -37,7 +39,11 @@ describe("NtpForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <NtpForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <NtpForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -48,7 +54,11 @@ describe("NtpForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NtpForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <NtpForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -82,7 +92,11 @@ describe("NtpForm", () => {
 
     mount(
       <Provider store={store}>
-        <NtpForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <NtpForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
+++ b/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ProxyForm from "./ProxyForm";
@@ -45,7 +46,11 @@ describe("ProxyForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <ProxyForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <ProxyForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -65,7 +70,9 @@ describe("ProxyForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/network", key: "testKey" }]}
         >
-          <ProxyForm />
+          <CompatRouter>
+            <ProxyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -78,7 +85,11 @@ describe("ProxyForm", () => {
 
     mount(
       <Provider store={store}>
-        <ProxyForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <ProxyForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
+++ b/ui/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ProxyForm from "../ProxyForm";
@@ -45,7 +46,9 @@ describe("ProxyFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/settings/network", key: "testKey" }]}
         >
-          <ProxyForm />
+          <CompatRouter>
+            <ProxyForm />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SyslogForm from "./SyslogForm";
@@ -36,7 +38,11 @@ describe("SyslogForm", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <SyslogForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyslogForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -47,7 +53,11 @@ describe("SyslogForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyslogForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyslogForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -79,7 +89,11 @@ describe("SyslogForm", () => {
 
     mount(
       <Provider store={store}>
-        <SyslogForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <SyslogForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
@@ -1,12 +1,13 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import RepositoryForm from "./RepositoryForm";
 
+import settingsURLs from "app/settings/urls";
 import type { RootState } from "app/store/root/types";
 import {
   componentsToDisableState as componentsToDisableStateFactory,
@@ -198,7 +199,9 @@ describe("RepositoryForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      settingsURLs.repositories.index
+    );
   });
 
   it("can update a repository", () => {

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
@@ -5,7 +5,6 @@ import classNames from "classnames";
 import type { FileRejection, FileWithPath } from "react-dropzone";
 import { useDropzone } from "react-dropzone";
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect } from "react-router";
 import { useNavigate } from "react-router-dom-v5-compat";
 
 import type { ReadScriptResponse } from "./readScript";
@@ -113,10 +112,12 @@ const ScriptsUpload = ({ type }: Props): JSX.Element => {
     }
   }, [dispatch, saved, savedScript]);
 
-  if (saved) {
-    // The script was successfully uploaded so redirect to the scripts list.
-    return <Redirect to={listLocation} />;
-  }
+  useEffect(() => {
+    if (saved) {
+      // The script was successfully uploaded so redirect to the scripts list.
+      navigate(listLocation, { replace: true });
+    }
+  }, [navigate, listLocation, saved]);
 
   const uploadedFile: FileWithPath = acceptedFiles[0];
 

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import StorageForm from "./StorageForm";
@@ -53,7 +55,11 @@ describe("StorageForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <StorageForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <StorageForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     submitFormikForm(wrapper, {
@@ -89,7 +95,11 @@ describe("StorageForm", () => {
 
     mount(
       <Provider store={store}>
-        <StorageForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <StorageForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import StorageForm from "../StorageForm";
@@ -53,7 +55,11 @@ describe("StorageFormFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <StorageForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <StorageForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("select[name='default_storage_layout']").simulate("change", {
@@ -69,7 +75,11 @@ describe("StorageFormFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <StorageForm />
+        <MemoryRouter>
+          <CompatRouter>
+            <StorageForm />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     wrapper.find("select[name='default_storage_layout']").simulate("change", {

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -1,13 +1,14 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { UserForm } from "./UserForm";
 
 import BaseUserForm from "app/base/components/UserForm";
+import settingsURLs from "app/settings/urls";
 import type { RootState } from "app/store/root/types";
 import type { User } from "app/store/user/types";
 import {
@@ -78,8 +79,9 @@ describe("UserForm", () => {
         </MemoryRouter>
       </Provider>
     );
-
-    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
+      settingsURLs.users.index
+    );
   });
 
   it("can update a user", () => {

--- a/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ReservedRangeForm, { Labels } from "./ReservedRangeForm";
@@ -44,7 +45,9 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          <CompatRouter>
+            <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -58,7 +61,9 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm onClose={jest.fn()} />
+          <CompatRouter>
+            <ReservedRangeForm onClose={jest.fn()} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -72,7 +77,9 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          <CompatRouter>
+            <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -97,7 +104,9 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          <CompatRouter>
+            <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -116,11 +125,13 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm
-            createType={IPRangeType.Reserved}
-            onClose={jest.fn()}
-            subnetId={1}
-          />
+          <CompatRouter>
+            <ReservedRangeForm
+              createType={IPRangeType.Reserved}
+              onClose={jest.fn()}
+              subnetId={1}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -158,7 +169,9 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          <CompatRouter>
+            <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -185,7 +198,9 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          <CompatRouter>
+            <ReservedRangeForm onClose={jest.fn()} id={ipRange.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -213,10 +228,12 @@ describe("ReservedRangeForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ReservedRangeForm
-            createType={IPRangeType.Dynamic}
-            onClose={jest.fn()}
-          />
+          <CompatRouter>
+            <ReservedRangeForm
+              createType={IPRangeType.Dynamic}
+              onClose={jest.fn()}
+            />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/ui/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Labels as ReservedRangeFormLabels } from "../ReservedRangeForm/ReservedRangeForm";
@@ -64,7 +65,9 @@ it("renders for a subnet", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -101,7 +104,9 @@ it("renders for a vlan", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges vlanId={vlan.id} hasVLANSubnets />
+        <CompatRouter>
+          <ReservedRanges vlanId={vlan.id} hasVLANSubnets />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -132,7 +137,9 @@ it("displays an empty message for a subnet", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -147,7 +154,9 @@ it("displays an empty message for a vlan", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges vlanId={vlan.id} hasVLANSubnets />
+        <CompatRouter>
+          <ReservedRanges vlanId={vlan.id} hasVLANSubnets />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -162,7 +171,9 @@ it("displays a message if there are no subnets in a VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges vlanId={vlan.id} hasVLANSubnets={false} />
+        <CompatRouter>
+          <ReservedRanges vlanId={vlan.id} hasVLANSubnets={false} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -178,7 +189,9 @@ it("displays content when it is dynamic", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -206,7 +219,9 @@ it("displays content when it is reserved", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -232,7 +247,9 @@ it("displays an edit form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -250,7 +267,9 @@ it("displays confirm delete message", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -270,7 +289,9 @@ it("dispatches an action to delete a reserved range", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -294,7 +315,9 @@ it("displays an add button when it is reserved", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -312,7 +335,9 @@ it("displays an add button when it is dynamic", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -339,7 +364,9 @@ it("disables the add button if there are no subnets in a VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges vlanId={vlan.id} />
+        <CompatRouter>
+          <ReservedRanges vlanId={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -353,7 +380,9 @@ it("can display an add form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -381,7 +410,9 @@ it("displays the subnet column when the table is for a VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges hasVLANSubnets vlanId={vlan.id} />
+        <CompatRouter>
+          <ReservedRanges hasVLANSubnets vlanId={vlan.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -397,7 +428,9 @@ it("does not display the subnet column when the table is for a subnet", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ReservedRanges subnetId={subnet.id} />
+        <CompatRouter>
+          <ReservedRanges subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditFabric from "./EditFabric";
@@ -35,7 +37,11 @@ it("dispatches an update action on submit", async () => {
   const store = configureStore()(state);
   render(
     <Provider store={store}>
-      <EditFabric id={fabric.id} close={jest.fn()} />
+      <MemoryRouter>
+        <CompatRouter>
+          <EditFabric id={fabric.id} close={jest.fn()} />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const EditSummaryForm = screen.getByRole("form", {

--- a/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricDeleteForm from "./FabricDeleteForm";
@@ -28,7 +29,9 @@ it("does not allow deletion if the fabric is the default fabric", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        <CompatRouter>
+          <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -55,7 +58,9 @@ it("does not allow deletion if the fabric has subnets attached", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        <CompatRouter>
+          <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -77,7 +82,9 @@ it(`displays a delete confirmation if the fabric is not the default and has no
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        <CompatRouter>
+          <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -96,7 +103,9 @@ it("deletes the fabric when confirmed", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        <CompatRouter>
+          <FabricDeleteForm closeForm={jest.fn()} id={fabric.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricSummary from "./FabricSummary";
@@ -41,7 +42,9 @@ it("renders correct details", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <FabricSummary fabric={fabric} />
+        <CompatRouter>
+          <FabricSummary fabric={fabric} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -66,7 +69,11 @@ it("can open and close the Edit fabric summary form", async () => {
   const store = configureStore()(state);
   render(
     <Provider store={store}>
-      <FabricSummary fabric={fabric} />
+      <MemoryRouter>
+        <CompatRouter>
+          <FabricSummary fabric={fabric} />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const fabricSummary = screen.getByRole("region", { name: "Fabric summary" });

--- a/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddFabric from "./AddFabric";
@@ -18,7 +19,9 @@ const renderTestCase = () => {
       <MemoryRouter
         initialEntries={[{ pathname: "/networks", key: "testKey" }]}
       >
-        <AddFabric activeForm="Fabric" setActiveForm={setActiveForm} />
+        <CompatRouter>
+          <AddFabric activeForm="Fabric" setActiveForm={setActiveForm} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddSpace from "./AddSpace";
@@ -17,7 +18,9 @@ test("correctly dispatches space cleanup and create actions on form submit", asy
       <MemoryRouter
         initialEntries={[{ pathname: "/networks", key: "testKey" }]}
       >
-        <AddSpace activeForm="Space" setActiveForm={() => undefined} />
+        <CompatRouter>
+          <AddSpace activeForm="Space" setActiveForm={() => undefined} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddSubnet from "./AddSubnet";
@@ -46,7 +47,9 @@ it("correctly dispatches subnet cleanup and create actions on form submit", asyn
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <AddSubnet activeForm="Subnet" setActiveForm={() => undefined} />
+        <CompatRouter>
+          <AddSubnet activeForm="Subnet" setActiveForm={() => undefined} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/ui/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddVlan from "./AddVlan";
@@ -21,7 +22,9 @@ it("displays validation messages for VID", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <AddVlan activeForm="VLAN" setActiveForm={() => undefined} />
+        <CompatRouter>
+          <AddVlan activeForm="VLAN" setActiveForm={() => undefined} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -73,7 +76,9 @@ it("correctly dispatches VLAN cleanup and create actions on form submit", async 
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <AddVlan activeForm="VLAN" setActiveForm={() => undefined} />
+        <CompatRouter>
+          <AddVlan activeForm="VLAN" setActiveForm={() => undefined} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router, Route } from "react-router";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SpaceDetailsHeader from "./SpaceDetailsHeader";
@@ -38,11 +39,13 @@ const renderTestCase = (
     ...render(
       <Provider store={store}>
         <Router history={history}>
-          <Route
-            exact
-            path={subnetsURLs.space.index({ id: space.id })}
-            component={() => <SpaceDetailsHeader space={space} />}
-          />
+          <CompatRouter>
+            <Route
+              exact
+              path={subnetsURLs.space.index({ id: space.id })}
+              component={() => <SpaceDetailsHeader space={space} />}
+            />
+          </CompatRouter>
         </Router>
       </Provider>
     ),

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SpaceSummary from "./SpaceSummary";
@@ -48,7 +50,11 @@ it("can open and close the Edit space summary form", async () => {
   const store = configureStore()(state);
   render(
     <Provider store={store}>
-      <SpaceSummary space={state.space.items[0]} />
+      <MemoryRouter>
+        <CompatRouter>
+          <SpaceSummary space={state.space.items[0]} />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const spaceSummary = screen.getByRole("region", { name: "Space summary" });

--- a/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
+++ b/ui/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SpaceSummaryForm from "./SpaceSummaryForm";
@@ -35,7 +37,11 @@ it("dispatches an update action on submit", async () => {
   const store = configureStore()(state);
   render(
     <Provider store={store}>
-      <SpaceSummaryForm space={space} handleDismiss={jest.fn()} />
+      <MemoryRouter>
+        <CompatRouter>
+          <SpaceSummaryForm space={space} handleDismiss={jest.fn()} />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
   const spaceSummaryForm = screen.getByRole("form", {

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Labels } from "../StaticRoutes";
@@ -45,7 +46,9 @@ it("dispatches a correct action on add static route form submit", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <AddStaticRouteForm subnetId={subnet.id} handleDismiss={jest.fn()} />
+        <CompatRouter>
+          <AddStaticRouteForm subnetId={subnet.id} handleDismiss={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Labels } from "../StaticRoutes";
@@ -35,7 +36,9 @@ it("displays loading text on load", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <EditStaticRouteForm staticRouteId={1} handleDismiss={jest.fn()} />
+        <CompatRouter>
+          <EditStaticRouteForm staticRouteId={1} handleDismiss={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -76,10 +79,12 @@ it("dispatches a correct action on edit static route form submit", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <EditStaticRouteForm
-          staticRouteId={staticRoute.id}
-          handleDismiss={jest.fn()}
-        />
+        <CompatRouter>
+          <EditStaticRouteForm
+            staticRouteId={staticRoute.id}
+            handleDismiss={jest.fn()}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { AddStaticRouteFormLabels } from "./AddStaticRouteForm/AddStaticRouteForm";
@@ -45,7 +46,9 @@ it("renders for a subnet", () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <StaticRoutes subnetId={subnet.id} />
+        <CompatRouter>
+          <StaticRoutes subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -91,7 +94,9 @@ it("can open and close the add static route form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <StaticRoutes subnetId={subnet.id} />
+        <CompatRouter>
+          <StaticRoutes subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -152,7 +157,9 @@ it("can open and close the edit static route form", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <StaticRoutes subnetId={subnet.id} />
+        <CompatRouter>
+          <StaticRoutes subnetId={subnet.id} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
@@ -3,6 +3,7 @@ import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router } from "react-router";
 import { Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteSubnet from "./DeleteSubnet";
@@ -62,7 +63,9 @@ it("displays a correct error message for a subnet with IPs obtained through DHCP
   render(
     <Provider store={store}>
       <Router history={history}>
-        <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -87,7 +90,9 @@ it("displays a message if DHCP is disabled on the VLAN", () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -112,7 +117,9 @@ it("does not display a message if DHCP is enabled on the VLAN", () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -138,7 +145,9 @@ it("dispatches an action to load vlans and subnets if not loaded", () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -163,7 +172,9 @@ it("dispatches a delete action on submit", async () => {
   render(
     <Provider store={store}>
       <Router history={history}>
-        <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -192,13 +203,15 @@ it("redirects on save", async () => {
   const { rerender } = render(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={subnetsURLs.subnet.index({ id: subnetId })}
-          component={() => (
-            <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
-          )}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.subnet.index({ id: subnetId })}
+            component={() => (
+              <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+            )}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );
@@ -212,13 +225,15 @@ it("redirects on save", async () => {
   rerender(
     <Provider store={store}>
       <Router history={history}>
-        <Route
-          exact
-          path={subnetsURLs.subnet.index({ id: subnetId })}
-          component={() => (
-            <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
-          )}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={subnetsURLs.subnet.index({ id: subnetId })}
+            component={() => (
+              <DeleteSubnet id={subnetId} setActiveForm={jest.fn()} />
+            )}
+          />
+        </CompatRouter>
       </Router>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Headers } from "./BootArchitecturesTable";
@@ -36,7 +37,9 @@ it("shows a spinner while data is loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <EditBootArchitectures id={1} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <EditBootArchitectures id={1} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -65,7 +68,9 @@ it("initialises form data correctly", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <EditBootArchitectures id={subnet.id} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <EditBootArchitectures id={subnet.id} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -97,7 +102,9 @@ it("can update the arches to disable", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <EditBootArchitectures id={subnet.id} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <EditBootArchitectures id={subnet.id} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -133,7 +140,9 @@ it("can dispatch an action to update subnet's disabled boot architectures", asyn
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <EditBootArchitectures id={subnet.id} setActiveForm={jest.fn()} />
+        <CompatRouter>
+          <EditBootArchitectures id={subnet.id} setActiveForm={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/ui/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import SubnetSummaryForm from "./SubnetSummaryForm";
@@ -45,7 +47,11 @@ it("can dispatch an action to update the subnet", async () => {
   const store = configureStore()(state);
   render(
     <Provider store={store}>
-      <SubnetSummaryForm id={subnet.id} handleDismiss={jest.fn()} />
+      <MemoryRouter>
+        <CompatRouter>
+          <SubnetSummaryForm id={subnet.id} handleDismiss={jest.fn()} />
+        </CompatRouter>
+      </MemoryRouter>
     </Provider>
   );
 

--- a/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ConfigureDHCP from "./ConfigureDHCP";
@@ -32,7 +33,9 @@ it("shows a spinner while data is loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -60,7 +63,9 @@ it("correctly initialises data if the VLAN has DHCP from rack controllers", asyn
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -105,7 +110,9 @@ it("correctly initialises data if the VLAN has relayed DHCP", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -149,7 +156,9 @@ it("shows an error if no rack controllers are connected to the VLAN", async () =
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -191,7 +200,9 @@ it(`shows an error if the subnet selected for reserving a dynamic range has no
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -225,7 +236,9 @@ it("shows a warning when attempting to disable DHCP on a VLAN", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -261,7 +274,9 @@ it("can configure DHCP with rack controllers", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -306,7 +321,9 @@ it("can configure relayed DHCP", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -353,7 +370,9 @@ it("can configure DHCP while also defining a dynamic IP range", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        <CompatRouter>
+          <ConfigureDHCP closeForm={jest.fn()} id={1} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
+++ b/ui/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import EditVLAN from "./EditVLAN";
@@ -56,7 +57,9 @@ describe("EditVLAN", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditVLAN close={jest.fn()} id={vlan.id} />
+          <CompatRouter>
+            <EditVLAN close={jest.fn()} id={vlan.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -70,7 +73,9 @@ describe("EditVLAN", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditVLAN close={jest.fn()} id={vlan.id} />
+          <CompatRouter>
+            <EditVLAN close={jest.fn()} id={vlan.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -110,7 +115,9 @@ describe("EditVLAN", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditVLAN close={jest.fn()} id={vlan.id} />
+          <CompatRouter>
+            <EditVLAN close={jest.fn()} id={vlan.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
@@ -138,7 +145,9 @@ describe("EditVLAN", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <EditVLAN close={jest.fn()} id={vlan.id} />
+          <CompatRouter>
+            <EditVLAN close={jest.fn()} id={vlan.id} />
+          </CompatRouter>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/ui/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import AddTagForm, { Label } from "./AddTagForm";
@@ -39,7 +40,9 @@ it("dispatches an action to create a tag", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm name="new-tag" onTagCreated={jest.fn()} />
+        <CompatRouter>
+          <AddTagForm name="new-tag" onTagCreated={jest.fn()} />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
@@ -70,13 +73,15 @@ it("returns the newly created tag on save", async () => {
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <Route
-          exact
-          path={tagsURLs.tags.index}
-          component={() => (
-            <AddTagForm name="new-tag" onTagCreated={onTagCreated} />
-          )}
-        />
+        <CompatRouter>
+          <Route
+            exact
+            path={tagsURLs.tags.index}
+            component={() => (
+              <AddTagForm name="new-tag" onTagCreated={onTagCreated} />
+            )}
+          />
+        </CompatRouter>
       </MemoryRouter>
     </Provider>
   );

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ZoneDetailsForm from "./ZoneDetailsForm";
@@ -35,7 +37,11 @@ describe("ZoneDetailsForm", () => {
     const store = mockStore(initialState);
     const wrapper = mount(
       <Provider store={store}>
-        <ZoneDetailsForm id={testZone.id} closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <ZoneDetailsForm id={testZone.id} closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -47,7 +53,11 @@ describe("ZoneDetailsForm", () => {
     const store = mockStore(initialState);
     const wrapper = mount(
       <Provider store={store}>
-        <ZoneDetailsForm id={testZone.id} closeForm={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <ZoneDetailsForm id={testZone.id} closeForm={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     act(() =>

--- a/ui/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ZonesListForm from "./ZonesListForm";
@@ -22,7 +24,11 @@ describe("ZonesListForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ZonesListForm closeForm={closeForm} />
+        <MemoryRouter>
+          <CompatRouter>
+            <ZonesListForm closeForm={closeForm} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
 
@@ -34,7 +40,11 @@ describe("ZonesListForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ZonesListForm closeForm={jest.fn()} />
+        <MemoryRouter>
+          <CompatRouter>
+            <ZonesListForm closeForm={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     act(() =>

--- a/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.test.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import ZonesListHeader from "./ZonesListHeader";
@@ -19,7 +21,11 @@ describe("ZonesListHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ZonesListHeader />
+        <MemoryRouter>
+          <CompatRouter>
+            <ZonesListHeader />
+          </CompatRouter>
+        </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("ZonesListForm").exists()).toBe(false);

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -136,7 +136,7 @@ export const renderWithBrowserRouter = (
   ui: React.ReactElement,
   options: RenderOptions & {
     wrapperProps: WrapperProps;
-    route: string;
+    route?: string;
   }
 ): RenderResult => {
   window.history.pushState({}, "", options.route);


### PR DESCRIPTION
## Done

- Replace Redirect with useNavigate from React Router v6.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that it redirects to the scripts list after uploading a script in settings.
- Check that visiting the instances tab `/machine/:id/instances` for a machine without any instances redirects back to the summary.
- Click "KVM" in the header and you should be taken to /kvm/lxd.
- Check that KVM redirects work (try the QA steps here: https://github.com/canonical-web-and-design/maas-ui/pull/3179).
- Visit the /intro after having completed it and you should be redirected to the dashboard.
- Try saving some add forms and you should be redirected back to lists.

## Fixes

Fixes: #3962.