### PR TITLE
refactor: build VLANs tab

### DIFF
--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANs.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANs.tsx
@@ -1,5 +1,7 @@
 import { useSelector } from "react-redux";
 
+import ControllerVLANsTable from "./ControllerVLANsTable";
+
 import { useWindowTitle } from "app/base/hooks";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
@@ -15,7 +17,7 @@ const ControllerVLANs = ({ systemId }: Props): JSX.Element => {
   );
   useWindowTitle(`${`${controller?.hostname}` || "Controller"} VLANs`);
 
-  return <h4>Controller VLANs</h4>;
+  return <ControllerVLANsTable systemId={systemId} />;
 };
 
 export default ControllerVLANs;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
@@ -1,0 +1,219 @@
+import { screen, within } from "@testing-library/react";
+
+import ControllerVLANsTable from "./ControllerVLANsTable";
+import { ControllerVLANsColumns } from "./constants";
+
+import controllerURLs from "app/controllers/urls";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  vlanState as vlanStateFactory,
+  vlan as vlanFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  networkInterface as networkInterfaceFactory,
+  rootState as rootStateFactory,
+  controllerDetails as controllerDetailsFactory,
+  controllerState as controllerStateFactory,
+} from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
+
+const createNetwork = () => {
+  const systemId = "abc123";
+  const fabric0 = fabricFactory({
+    id: 0,
+  });
+  const vlan0 = vlanFactory({
+    id: 0,
+    fabric: 0,
+  });
+  const subnet0 = subnetFactory({ id: 0 });
+  const nic0 = networkInterfaceFactory({
+    id: 0,
+    name: "eth0",
+    type: NetworkInterfaceTypes.PHYSICAL,
+    parents: [],
+    children: [],
+    links: [],
+    vlan_id: 0,
+  });
+  const interfaces = [nic0];
+  const controller = controllerDetailsFactory({
+    system_id: systemId,
+    interfaces,
+  });
+  return {
+    fabric0,
+    vlan0,
+    subnet0,
+    nic0,
+    interfaces,
+    controller,
+  };
+};
+
+it("displays correct text when loading", function () {
+  const net = createNetwork();
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ loaded: true, items: [net.fabric0] }),
+    vlan: vlanStateFactory({ loaded: false, items: [] }),
+    subnet: subnetStateFactory({ loaded: true, items: [net.subnet0] }),
+    controller: controllerStateFactory({
+      items: [net.controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+
+  renderWithBrowserRouter(
+    <ControllerVLANsTable systemId={net.controller.system_id} />,
+    {
+      wrapperProps: { state },
+      route: controllerURLs.controller.vlans({
+        id: net.controller.system_id,
+      }),
+    }
+  );
+
+  const vlanTable = screen.getByRole("table", { name: "Controller VLANs" });
+  expect(within(vlanTable).getByText("Loading...")).toBeInTheDocument();
+});
+
+it("displays correct text for no VLANs", function () {
+  const net = createNetwork();
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ loaded: true, items: [net.fabric0] }),
+    vlan: vlanStateFactory({ loaded: true, items: [] }),
+    subnet: subnetStateFactory({ loaded: true, items: [net.subnet0] }),
+    controller: controllerStateFactory({
+      items: [net.controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+
+  renderWithBrowserRouter(
+    <ControllerVLANsTable systemId={net.controller.system_id} />,
+    {
+      wrapperProps: { state },
+      route: controllerURLs.controller.vlans({
+        id: net.controller.system_id,
+      }),
+    }
+  );
+
+  const vlanTable = screen.getByRole("table", { name: "Controller VLANs" });
+  expect(within(vlanTable).getByText("No VLANs found")).toBeInTheDocument();
+});
+
+it("displays a VLANs table with a single row", function () {
+  const net = createNetwork();
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ loaded: true, items: [net.fabric0] }),
+    vlan: vlanStateFactory({ loaded: true, items: [net.vlan0] }),
+    subnet: subnetStateFactory({ loaded: true, items: [net.subnet0] }),
+    controller: controllerStateFactory({
+      items: [net.controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+
+  renderWithBrowserRouter(
+    <ControllerVLANsTable systemId={net.controller.system_id} />,
+    {
+      wrapperProps: { state },
+      route: controllerURLs.controller.vlans({
+        id: net.controller.system_id,
+      }),
+    }
+  );
+
+  const vlanTable = screen.getByRole("table", { name: "Controller VLANs" });
+  expect(vlanTable).toBeInTheDocument();
+  const tableBody = within(vlanTable).getAllByRole("rowgroup")[1];
+  const vlanTableRows = within(tableBody).getAllByRole("row");
+  expect(vlanTableRows.length).toEqual(1);
+});
+
+it("displays no duplicate vlans", function () {
+  const net = createNetwork();
+  const nic1 = networkInterfaceFactory({
+    id: 1,
+    name: "eth1",
+    type: NetworkInterfaceTypes.PHYSICAL,
+    parents: [],
+    children: [],
+    links: [],
+    vlan_id: 0,
+  });
+  net.controller = controllerDetailsFactory({
+    system_id: net.controller.system_id,
+    interfaces: [net.nic0, nic1],
+  });
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ loaded: true, items: [net.fabric0] }),
+    vlan: vlanStateFactory({ loaded: true, items: [net.vlan0] }),
+    subnet: subnetStateFactory({ loaded: true, items: [net.subnet0] }),
+    controller: controllerStateFactory({
+      items: [net.controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+
+  renderWithBrowserRouter(
+    <ControllerVLANsTable systemId={net.controller.system_id} />,
+    {
+      wrapperProps: { state },
+      route: controllerURLs.controller.vlans({
+        id: net.controller.system_id,
+      }),
+    }
+  );
+
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+  const vlanTableRows = within(tableBody).getAllByRole("row");
+  expect(vlanTableRows.length).toEqual(1);
+});
+
+it("displays correct text within each cell", () => {
+  const net = createNetwork();
+  const state = rootStateFactory({
+    fabric: fabricStateFactory({ loaded: true, items: [net.fabric0] }),
+    vlan: vlanStateFactory({ loaded: true, items: [net.vlan0] }),
+    subnet: subnetStateFactory({ loaded: true, items: [net.subnet0] }),
+    controller: controllerStateFactory({
+      items: [net.controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+
+  renderWithBrowserRouter(
+    <ControllerVLANsTable systemId={net.controller.system_id} />,
+    {
+      wrapperProps: { state },
+      route: controllerURLs.controller.vlans({
+        id: net.controller.system_id,
+      }),
+    }
+  );
+
+  const expectedColumnContent = {
+    [ControllerVLANsColumns.FABRIC]: net.fabric0.name,
+    [ControllerVLANsColumns.VLAN]: net.vlan0.name,
+    [ControllerVLANsColumns.DHCP]: "Disabled",
+  };
+
+  const row = screen.getByRole("row", {
+    name: new RegExp(net.fabric0.name),
+  });
+
+  Object.values(expectedColumnContent).forEach((value, index) => {
+    expect(within(row).getAllByRole("cell")[index]).toHaveTextContent(
+      new RegExp(value)
+    );
+  });
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
@@ -204,7 +204,7 @@ it("displays correct text within each cell", () => {
   const expectedColumnContent = {
     [ControllerVLANsColumns.FABRIC]: net.fabric0.name,
     [ControllerVLANsColumns.VLAN]: net.vlan0.name,
-    [ControllerVLANsColumns.DHCP]: "Disabled",
+    [ControllerVLANsColumns.DHCP]: "No DHCP",
   };
 
   const row = screen.getByRole("row", {

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+
+import { ModularTable } from "@canonical/react-components";
+
+import { columnLabels, ControllerVLANsColumns } from "./constants";
+import { useControllerVLANsTable } from "./hooks";
+
+import ControllerLink from "app/base/components/ControllerLink";
+import FabricLink from "app/base/components/FabricLink";
+import SubnetLink from "app/base/components/SubnetLink";
+import VLANLink from "app/base/components/VLANLink";
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { Fabric } from "app/store/fabric/types";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
+
+type Props = {
+  systemId: Controller[ControllerMeta.PK];
+};
+
+const getVlanDhcpStatus = ({ vlan }: { vlan: VLAN }): string =>
+  vlan.dhcp_on === true || vlan.relay_vlan !== null || !!vlan.external_dhcp
+    ? "Enabled"
+    : "Disabled";
+
+const ControllerVLANsTable = ({ systemId }: Props): JSX.Element => {
+  const { data, loaded } = useControllerVLANsTable({ systemId });
+
+  return (
+    <ModularTable
+      emptyMsg={loaded ? "No VLANs found" : "Loading..."}
+      className="controller-vlans-table"
+      aria-label="Controller VLANs"
+      columns={useMemo(
+        () => [
+          {
+            Header: columnLabels[ControllerVLANsColumns.FABRIC],
+            accessor: ControllerVLANsColumns.FABRIC,
+            Cell: ({ value }: { value: Fabric }) => <FabricLink {...value} />,
+          },
+          {
+            Header: columnLabels[ControllerVLANsColumns.VLAN],
+            accessor: ControllerVLANsColumns.VLAN,
+            Cell: ({ value }: { value: VLAN }) => <VLANLink {...value} />,
+          },
+          {
+            id: ControllerVLANsColumns.DHCP,
+            Header: columnLabels[ControllerVLANsColumns.DHCP],
+            accessor: ControllerVLANsColumns.VLAN,
+            Cell: ({ value }: { value: VLAN }) =>
+              getVlanDhcpStatus({ vlan: value }),
+          },
+          {
+            Header: columnLabels[ControllerVLANsColumns.SUBNET],
+            accessor: ControllerVLANsColumns.SUBNET,
+            Cell: ({ value }: { value: Subnet[] }) => (
+              <>
+                {value?.map((subnet: Subnet) => (
+                  <div key={subnet.id}>
+                    <SubnetLink {...subnet} />
+                  </div>
+                ))}
+              </>
+            ),
+          },
+          {
+            Header: columnLabels[ControllerVLANsColumns.PRIMARY_RACK],
+            accessor: ControllerVLANsColumns.PRIMARY_RACK,
+            Cell: ({ value }: { value: string }) => (
+              <ControllerLink systemId={value} />
+            ),
+          },
+          {
+            Header: columnLabels[ControllerVLANsColumns.SECONDARY_RACK],
+            accessor: ControllerVLANsColumns.SECONDARY_RACK,
+            Cell: ({ value }: { value: string }) => (
+              <ControllerLink systemId={value} />
+            ),
+          },
+        ],
+        []
+      )}
+      data={data}
+    />
+  );
+};
+
+export default ControllerVLANsTable;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
@@ -4,24 +4,18 @@ import { ModularTable } from "@canonical/react-components";
 
 import { columnLabels, ControllerVLANsColumns } from "./constants";
 import { useControllerVLANsTable } from "./hooks";
+import type { ControllerTableData } from "./types";
 
 import ControllerLink from "app/base/components/ControllerLink";
 import FabricLink from "app/base/components/FabricLink";
 import SubnetLink from "app/base/components/SubnetLink";
 import VLANLink from "app/base/components/VLANLink";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
-import type { Fabric } from "app/store/fabric/types";
 import type { Subnet } from "app/store/subnet/types";
-import type { VLAN } from "app/store/vlan/types";
 
 type Props = {
   systemId: Controller[ControllerMeta.PK];
 };
-
-const getVlanDhcpStatus = ({ vlan }: { vlan: VLAN }): string =>
-  vlan.dhcp_on === true || vlan.relay_vlan !== null || !!vlan.external_dhcp
-    ? "Enabled"
-    : "Disabled";
 
 const ControllerVLANsTable = ({ systemId }: Props): JSX.Element => {
   const { data, loaded } = useControllerVLANsTable({ systemId });
@@ -36,28 +30,37 @@ const ControllerVLANsTable = ({ systemId }: Props): JSX.Element => {
           {
             Header: columnLabels[ControllerVLANsColumns.FABRIC],
             accessor: ControllerVLANsColumns.FABRIC,
-            Cell: ({ value }: { value: Fabric }) => <FabricLink {...value} />,
+            Cell: ({
+              value,
+            }: {
+              value: ControllerTableData[ControllerVLANsColumns.FABRIC];
+            }) => <FabricLink id={value?.id} />,
           },
           {
             Header: columnLabels[ControllerVLANsColumns.VLAN],
             accessor: ControllerVLANsColumns.VLAN,
-            Cell: ({ value }: { value: VLAN }) => <VLANLink {...value} />,
+            Cell: ({
+              value,
+            }: {
+              value: ControllerTableData[ControllerVLANsColumns.VLAN];
+            }) => <VLANLink id={value?.id} />,
           },
           {
-            id: ControllerVLANsColumns.DHCP,
             Header: columnLabels[ControllerVLANsColumns.DHCP],
-            accessor: ControllerVLANsColumns.VLAN,
-            Cell: ({ value }: { value: VLAN }) =>
-              getVlanDhcpStatus({ vlan: value }),
+            accessor: ControllerVLANsColumns.DHCP,
           },
           {
             Header: columnLabels[ControllerVLANsColumns.SUBNET],
             accessor: ControllerVLANsColumns.SUBNET,
-            Cell: ({ value }: { value: Subnet[] }) => (
+            Cell: ({
+              value,
+            }: {
+              value: ControllerTableData[ControllerVLANsColumns.SUBNET];
+            }) => (
               <>
-                {value?.map((subnet: Subnet) => (
-                  <div key={subnet.id}>
-                    <SubnetLink {...subnet} />
+                {value?.map(({ id }: Subnet) => (
+                  <div key={id}>
+                    <SubnetLink id={id} />
                   </div>
                 ))}
               </>
@@ -66,16 +69,20 @@ const ControllerVLANsTable = ({ systemId }: Props): JSX.Element => {
           {
             Header: columnLabels[ControllerVLANsColumns.PRIMARY_RACK],
             accessor: ControllerVLANsColumns.PRIMARY_RACK,
-            Cell: ({ value }: { value: string }) => (
-              <ControllerLink systemId={value} />
-            ),
+            Cell: ({
+              value,
+            }: {
+              value: ControllerTableData[ControllerVLANsColumns.PRIMARY_RACK];
+            }) => <ControllerLink systemId={value} />,
           },
           {
             Header: columnLabels[ControllerVLANsColumns.SECONDARY_RACK],
             accessor: ControllerVLANsColumns.SECONDARY_RACK,
-            Cell: ({ value }: { value: string }) => (
-              <ControllerLink systemId={value} />
-            ),
+            Cell: ({
+              value,
+            }: {
+              value: ControllerTableData[ControllerVLANsColumns.SECONDARY_RACK];
+            }) => <ControllerLink systemId={value} />,
           },
         ],
         []

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/_index.scss
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/_index.scss
@@ -1,0 +1,27 @@
+@mixin ControllerVLANsTable {
+    .controller-vlans-table {
+        @media (min-width: $breakpoint-small) {
+            th,
+            td {
+                &:nth-child(1) {
+                    width: 15%;
+                }
+                &:nth-child(2) {
+                    width: 15%;
+                }
+                &:nth-child(3) {
+                    width: 10%;
+                }
+                &:nth-child(4) {
+                    width: 20%;
+                }
+                &:nth-child(5) {
+                    width: 20%;
+                }
+                &:nth-child(6) {
+                    width: 20%;
+                }
+            }
+        }
+    }
+}

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/constants.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/constants.ts
@@ -1,0 +1,17 @@
+export enum ControllerVLANsColumns {
+  FABRIC = "fabric",
+  VLAN = "vlan",
+  DHCP = "dhcp",
+  SUBNET = "subnet",
+  PRIMARY_RACK = "primary_rack",
+  SECONDARY_RACK = "secondary_rack",
+}
+
+export const columnLabels = {
+  [ControllerVLANsColumns.FABRIC]: "Fabric",
+  [ControllerVLANsColumns.VLAN]: "VLAN",
+  [ControllerVLANsColumns.DHCP]: "DHCP",
+  [ControllerVLANsColumns.SUBNET]: "Subnets",
+  [ControllerVLANsColumns.PRIMARY_RACK]: "Primary rack",
+  [ControllerVLANsColumns.SECONDARY_RACK]: "Secondary rack",
+} as const;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/hooks.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/hooks.ts
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import controllerSelectors from "app/store/controller/selectors";
+import type {
+  Controller,
+  ControllerDetails,
+  ControllerMeta,
+} from "app/store/controller/types";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric } from "app/store/fabric/types";
+import { getFabricById } from "app/store/fabric/utils";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
+import { getSubnetsInVLAN } from "app/store/subnet/utils";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import type { NetworkInterface } from "app/store/types/node";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN } from "app/store/vlan/types";
+import { getVlanById, getVLANDisplay } from "app/store/vlan/utils";
+import { simpleSortByKey } from "app/utils";
+
+type ControllerTableData = {
+  fabric?: Fabric | null;
+  vlan?: VLAN | null;
+  subnet?: Subnet[];
+  primary_rack?: Controller[ControllerMeta.PK] | null;
+  secondary_rack?: Controller[ControllerMeta.PK] | null;
+  sortKey?: string;
+};
+
+const getTableData = (
+  data: {
+    fabrics: Fabric[];
+    vlans: VLAN[];
+    subnets: Subnet[];
+  },
+  controller: ControllerDetails
+): ControllerTableData[] => {
+  const rows: ControllerTableData[] = [];
+  // Keep track of VLAN IDs we've processed
+  const addedVlans: Record<number, boolean> = {};
+
+  const originalInterfaces: Record<number, NetworkInterface> = {};
+  controller.interfaces.forEach((nic) => {
+    originalInterfaces[nic.id] = nic;
+  });
+
+  controller.interfaces.forEach((nic) => {
+    // When a interface has a child that is a bond or bridge.
+    // Then that interface is not included in the interface list.
+    // Parent interface with a bond or bridge child can only have
+    // one child.
+    if (nic.children.length === 1) {
+      const child = originalInterfaces[nic.children[0]];
+      if (
+        child.type === NetworkInterfaceTypes.BOND ||
+        child.type === NetworkInterfaceTypes.BRIDGE
+      ) {
+        return;
+      }
+    }
+
+    const controllerVlan = getVlanById(data.vlans, nic.vlan_id);
+    const controllerFabric = controllerVlan
+      ? getFabricById(data.fabrics, controllerVlan.fabric)
+      : undefined;
+
+    // Skip duplicate VLANs (by id, they can share names).
+    if (!addedVlans[nic.vlan_id] && controllerFabric) {
+      addedVlans[nic.vlan_id] = true;
+      rows.push({
+        fabric: controllerFabric,
+        vlan: controllerVlan,
+        subnet: getSubnetsInVLAN(data.subnets, nic.vlan_id),
+        sortKey: controllerFabric
+          ? controllerFabric.name + "|" + getVLANDisplay(controllerVlan)
+          : undefined,
+        primary_rack: controllerVlan?.primary_rack
+          ? controllerVlan.primary_rack
+          : null,
+        secondary_rack: controllerVlan?.secondary_rack
+          ? controllerVlan.secondary_rack
+          : null,
+      });
+    }
+  });
+
+  return rows.sort(
+    simpleSortByKey("sortKey", {
+      alphanumeric: true,
+    })
+  );
+};
+
+export const useControllerVLANsTable = ({
+  systemId,
+}: {
+  systemId: Controller[ControllerMeta.PK];
+}): { data: ControllerTableData[]; loaded: boolean } => {
+  const dispatch = useDispatch();
+  const controller = useSelector((state: RootState) =>
+    controllerSelectors.getById(state, systemId)
+  ) as ControllerDetails;
+  const fabrics = useSelector(fabricSelectors.all);
+  const fabricsLoaded = useSelector(fabricSelectors.loaded);
+  const vlans = useSelector(vlanSelectors.all);
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+  const subnets = useSelector(subnetSelectors.all);
+  const loaded = fabricsLoaded && vlansLoaded && subnetsLoaded;
+
+  const [state, setState] = useState<{
+    data: ControllerTableData[];
+    loaded: boolean;
+  }>({
+    data: [],
+    loaded: false,
+  });
+
+  useEffect(() => {
+    if (!fabricsLoaded) dispatch(fabricActions.fetch());
+    if (!vlansLoaded) dispatch(vlanActions.fetch());
+    if (!subnetsLoaded) dispatch(subnetActions.fetch());
+  }, [dispatch, fabricsLoaded, vlansLoaded, subnetsLoaded]);
+
+  useEffect(() => {
+    if (controller && loaded) {
+      setState({
+        data: getTableData({ fabrics, vlans, subnets }, controller),
+        loaded: true,
+      });
+    }
+  }, [loaded, fabrics, vlans, subnets, controller]);
+
+  return state;
+};

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControllerVLANsTable";

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/types.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/types.ts
@@ -1,0 +1,14 @@
+import type { Controller, ControllerMeta } from "app/store/controller/types";
+import type { Fabric } from "app/store/fabric/types";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
+
+export type ControllerTableData = {
+  fabric?: Fabric | null;
+  vlan?: VLAN | null;
+  dhcp: string;
+  subnet?: Subnet[];
+  primary_rack?: Controller[ControllerMeta.PK] | null;
+  secondary_rack?: Controller[ControllerMeta.PK] | null;
+  sortKey?: string;
+};

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -171,6 +171,8 @@
 @import "~app/kvm/views/KVMList/VirshTable";
 @import "~app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable";
 @import "~app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard";
+@import "~app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable";
+@include ControllerVLANsTable;
 @include CoreResources;
 @include CPUPopover;
 @include KVMComposeInterfacesTable;


### PR DESCRIPTION
## Done

- migrate VLANs tab to React

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Controller VLANs tab (e.g. `MAAS/r/controller/knpge8/vlans`)
- Make sure everything works as expected

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/936

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/171022218-e49e6f4d-e40c-43e8-8917-48363357df14.png)
