### PR TITLE
refactor(ui): refactor used storage table to work with controllers

### DIFF
--- a/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
+++ b/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
@@ -66,7 +66,7 @@ const StorageTables = ({ canEditStorage, node }: Props): JSX.Element => {
       </Strip>
       <Strip shallow>
         <h4 className="u-sv-1">{Labels.UsedStorage}</h4>
-        <UsedStorageTable systemId={node.system_id} />
+        <UsedStorageTable node={node} />
       </Strip>
     </>
   );

--- a/ui/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,79 +1,129 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import UsedStorageTable from "./UsedStorageTable";
 
+import controllerURLs from "app/controllers/urls";
+import machineURLs from "app/machines/urls";
+import { FilterControllers } from "app/store/controller/utils";
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { FilterMachines } from "app/store/machine/utils";
 import { DiskTypes } from "app/store/types/enum";
 import {
+  controllerDetails as controllerDetailsFactory,
   machineDetails as machineDetailsFactory,
-  machineState as machineStateFactory,
   nodeDisk as diskFactory,
-  rootState as rootStateFactory,
 } from "testing/factories";
 
-const mockStore = configureStore();
+it("can show an empty message", () => {
+  const node = machineDetailsFactory({
+    disks: [],
+    system_id: "abc123",
+  });
+  render(
+    <MemoryRouter>
+      <CompatRouter>
+        <UsedStorageTable node={node} />
+      </CompatRouter>
+    </MemoryRouter>
+  );
 
-describe("UsedStorageTable", () => {
-  it("can show an empty message", () => {
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [
-          machineDetailsFactory({
-            disks: [],
-            system_id: "abc123",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <UsedStorageTable systemId="abc123" />
-      </Provider>
-    );
+  expect(
+    screen.getByText("No disk or partition has been fully utilised.")
+  ).toBeInTheDocument();
+});
 
-    expect(wrapper.find("[data-testid='no-used']").text()).toBe(
-      "No disk or partition has been fully utilised."
-    );
+it("only shows disks that are being used", () => {
+  const [availableDisk, usedDisk] = [
+    diskFactory({
+      available_size: MIN_PARTITION_SIZE + 1,
+      name: "available-disk",
+      filesystem: null,
+      type: DiskTypes.PHYSICAL,
+    }),
+    diskFactory({
+      available_size: MIN_PARTITION_SIZE - 1,
+      filesystem: null,
+      name: "used-disk",
+      type: DiskTypes.PHYSICAL,
+    }),
+  ];
+  const node = machineDetailsFactory({
+    disks: [availableDisk, usedDisk],
+    system_id: "abc123",
   });
 
-  it("only shows disks that are being used", () => {
-    const [availableDisk, usedDisk] = [
-      diskFactory({
-        available_size: MIN_PARTITION_SIZE + 1,
-        name: "available-disk",
-        filesystem: null,
-        type: DiskTypes.PHYSICAL,
-      }),
+  render(
+    <MemoryRouter>
+      <CompatRouter>
+        <UsedStorageTable node={node} />
+      </CompatRouter>
+    </MemoryRouter>
+  );
+
+  expect(
+    screen.getAllByRole("gridcell", { name: "Name & serial" })
+  ).toHaveLength(1);
+  expect(
+    screen.getByRole("gridcell", { name: "Name & serial" })
+  ).toHaveTextContent(usedDisk.name);
+});
+
+it("can render storage tag links for a controller", () => {
+  const node = controllerDetailsFactory({
+    disks: [
       diskFactory({
         available_size: MIN_PARTITION_SIZE - 1,
-        filesystem: null,
-        name: "used-disk",
         type: DiskTypes.PHYSICAL,
+        tags: ["abc"],
       }),
-    ];
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [
-          machineDetailsFactory({
-            disks: [availableDisk, usedDisk],
-            system_id: "abc123",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <UsedStorageTable systemId="abc123" />
-      </Provider>
-    );
-
-    expect(wrapper.find("tbody TableRow").length).toBe(1);
-    expect(wrapper.find("TableCell DoubleRow").at(0).prop("primary")).toBe(
-      usedDisk.name
-    );
+    ],
   });
+  const filter = FilterControllers.filtersToQueryString({
+    storage_tags: ["=abc"],
+  });
+  const href = `${controllerURLs.controllers.index}${filter}`;
+
+  render(
+    <MemoryRouter>
+      <CompatRouter>
+        <UsedStorageTable node={node} />
+      </CompatRouter>
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole("link", { name: "abc" })).toHaveAttribute(
+    "href",
+    href
+  );
+});
+
+it("can render storage tag links for a machine", () => {
+  const node = machineDetailsFactory({
+    disks: [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE - 1,
+        type: DiskTypes.PHYSICAL,
+        tags: ["abc"],
+      }),
+    ],
+  });
+  const filter = FilterMachines.filtersToQueryString({
+    storage_tags: ["=abc"],
+  });
+  const href = `${machineURLs.machines.index}${filter}`;
+
+  render(
+    <MemoryRouter>
+      <CompatRouter>
+        <UsedStorageTable node={node} />
+      </CompatRouter>
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole("link", { name: "abc" })).toHaveAttribute(
+    "href",
+    href
+  );
 });

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
+import configureStore from "redux-mock-store";
+
+import ControllerStorage from "./ControllerStorage";
+
+import {
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("displays a spinner if controller is loading", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <ControllerStorage systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("alert", { name: "Loading controller" })
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
@@ -1,8 +1,11 @@
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import StorageTables from "app/base/components/node/StorageTables";
 import { useWindowTitle } from "app/base/hooks";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
+import { isControllerDetails } from "app/store/controller/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -15,7 +18,10 @@ const ControllerStorage = ({ systemId }: Props): JSX.Element => {
   );
   useWindowTitle(`${`${controller?.hostname}` || "Controller"} storage`);
 
-  return <h4>Controller storage</h4>;
+  if (isControllerDetails(controller)) {
+    return <StorageTables canEditStorage={false} node={controller} />;
+  }
+  return <Spinner aria-label="Loading controller" text="Loading..." />;
 };
 
 export default ControllerStorage;


### PR DESCRIPTION
## Done

- Refactored machine used storage table to work with controllers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React storage tab for a controller
- Check that the used storage tables shows the same data as the AngularJS version
- Check that clicking a storage tag link filters the controller list appropriately

## Fixes

Fixes canonical-web-and-design/app-tribe#995

## Screenshot

![Screenshot 2022-05-31 at 15-21-45 bolla storage bolla MAAS](https://user-images.githubusercontent.com/25733845/171098642-6459d757-47cf-4dd8-b037-4af5716253ce.png)
