### PR TITLE
refactor(ui): refactor filesystems table to work with controllers

### DIFF
--- a/ui/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
+++ b/ui/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
@@ -1,5 +1,5 @@
 import { Col, Row, Select } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 
 import FormCard from "app/base/components/FormCard";
@@ -7,11 +7,8 @@ import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
+import type { MachineDetails } from "app/store/machine/types";
 import type { MachineEventErrors } from "app/store/machine/types/base";
-import { isMachineDetails } from "app/store/machine/utils";
-import type { RootState } from "app/store/root/types";
 import { usesStorage } from "app/store/utils";
 
 const AddSpecialFilesystemSchema = Yup.object().shape({
@@ -30,101 +27,95 @@ type AddSpecialFilesystemValues = {
 
 type Props = {
   closeForm: () => void;
-  systemId: Machine["system_id"];
+  machine: MachineDetails;
 };
 
 export const AddSpecialFilesystem = ({
   closeForm,
-  systemId,
+  machine,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, systemId)
-  );
   const { errors, saved, saving } = useMachineDetailsForm(
-    systemId,
+    machine.system_id,
     "mountingSpecial",
     "mountSpecial",
     () => closeForm()
   );
 
-  if (isMachineDetails(machine)) {
-    const fsOptions = machine.supported_filesystems
-      .filter((fs) => !usesStorage(fs.key))
-      .map((fs) => ({
-        label: fs.ui,
-        value: fs.key,
-      }));
+  const fsOptions = machine.supported_filesystems
+    .filter((fs) => !usesStorage(fs.key))
+    .map((fs) => ({
+      label: fs.ui,
+      value: fs.key,
+    }));
 
-    return (
-      <FormCard data-testid="confirmation-form" sidebar={false}>
-        <FormikForm<AddSpecialFilesystemValues, MachineEventErrors>
-          aria-label="Add special filesystem"
-          cleanup={machineActions.cleanup}
-          errors={errors}
-          initialValues={{
-            fstype: "",
-            mountOptions: "",
-            mountPoint: "",
-          }}
-          onCancel={closeForm}
-          onSaveAnalytics={{
-            action: "Add special filesystem",
-            category: "Machine storage",
-            label: "Mount",
-          }}
-          onSubmit={(values) => {
-            dispatch(machineActions.cleanup());
-            const params = {
-              fstype: values.fstype,
-              mountOptions: values.mountOptions,
-              mountPoint: values.mountPoint,
-              systemId,
-            };
-            dispatch(machineActions.mountSpecial(params));
-          }}
-          saved={saved}
-          saving={saving}
-          submitLabel="Mount"
-          validationSchema={AddSpecialFilesystemSchema}
-        >
-          <Row>
-            <Col size={6}>
-              <FormikField
-                component={Select}
-                label="Type"
-                name="fstype"
-                options={[
-                  {
-                    label: "Select filesystem type",
-                    value: "",
-                    disabled: true,
-                  },
-                  ...fsOptions,
-                ]}
-                required
-              />
-              <FormikField
-                help="Absolute path to filesystem"
-                label="Mount point"
-                name="mountPoint"
-                placeholder="/path/to/filesystem"
-                required
-                type="text"
-              />
-              <FormikField
-                help='Comma-separated list without spaces, e.g. "noexec,size=1024k"'
-                label="Mount options"
-                name="mountOptions"
-                type="text"
-              />
-            </Col>
-          </Row>
-        </FormikForm>
-      </FormCard>
-    );
-  }
-  return null;
+  return (
+    <FormCard data-testid="confirmation-form" sidebar={false}>
+      <FormikForm<AddSpecialFilesystemValues, MachineEventErrors>
+        aria-label="Add special filesystem"
+        cleanup={machineActions.cleanup}
+        errors={errors}
+        initialValues={{
+          fstype: "",
+          mountOptions: "",
+          mountPoint: "",
+        }}
+        onCancel={closeForm}
+        onSaveAnalytics={{
+          action: "Add special filesystem",
+          category: "Machine storage",
+          label: "Mount",
+        }}
+        onSubmit={(values) => {
+          dispatch(machineActions.cleanup());
+          const params = {
+            fstype: values.fstype,
+            mountOptions: values.mountOptions,
+            mountPoint: values.mountPoint,
+            systemId: machine.system_id,
+          };
+          dispatch(machineActions.mountSpecial(params));
+        }}
+        saved={saved}
+        saving={saving}
+        submitLabel="Mount"
+        validationSchema={AddSpecialFilesystemSchema}
+      >
+        <Row>
+          <Col size={6}>
+            <FormikField
+              component={Select}
+              label="Type"
+              name="fstype"
+              options={[
+                {
+                  label: "Select filesystem type",
+                  value: "",
+                  disabled: true,
+                },
+                ...fsOptions,
+              ]}
+              required
+            />
+            <FormikField
+              help="Absolute path to filesystem"
+              label="Mount point"
+              name="mountPoint"
+              placeholder="/path/to/filesystem"
+              required
+              type="text"
+            />
+            <FormikField
+              help='Comma-separated list without spaces, e.g. "noexec,size=1024k"'
+              label="Mount options"
+              name="mountOptions"
+              type="text"
+            />
+          </Col>
+        </Row>
+      </FormikForm>
+    </FormCard>
+  );
 };
 
 export default AddSpecialFilesystem;

--- a/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
+++ b/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
@@ -41,10 +41,7 @@ const StorageTables = ({ canEditStorage, node }: Props): JSX.Element => {
         ) : (
           <>
             <h4 className="u-sv-1">{Labels.Filesystems}</h4>
-            <FilesystemsTable
-              canEditStorage={canEditStorage}
-              systemId={node.system_id}
-            />
+            <FilesystemsTable canEditStorage={canEditStorage} node={node} />
           </>
         )}
       </Strip>

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
+import configureStore from "redux-mock-store";
+
+import ControllerStorage from "./ControllerStorage";
+
+import {
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("displays a spinner if controller is loading", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <ControllerStorage systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("alert", { name: "Loading controller" })
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
@@ -1,8 +1,11 @@
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import StorageTables from "app/base/components/node/StorageTables";
 import { useWindowTitle } from "app/base/hooks";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
+import { isControllerDetails } from "app/store/controller/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -15,7 +18,10 @@ const ControllerStorage = ({ systemId }: Props): JSX.Element => {
   );
   useWindowTitle(`${`${controller?.hostname}` || "Controller"} storage`);
 
-  return <h4>Controller storage</h4>;
+  if (isControllerDetails(controller)) {
+    return <StorageTables canEditStorage={false} node={controller} />;
+  }
+  return <Spinner aria-label="Loading controller" text="Loading..." />;
 };
 
 export default ControllerStorage;


### PR DESCRIPTION
## Done

- Refactored filesystems table to work with controllers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the filesystems table is unchanged for machine
  - Test out running a few actions on a machine that is in Ready or Allocated state
- Go to the React storage tab of a controller and check that the filesystems table data matches the AngularJS version 

## Fixes

Fixes canonical-web-and-design/app-tribe#996

## Screenshot

![Screenshot 2022-05-31 at 17-23-27 karura storage karura MAAS](https://user-images.githubusercontent.com/25733845/171116017-7a0f1929-0062-4c58-86fb-7f066a33293d.png)

