### PR TITLE
refactor(ui): refactor cache sets table to work with controllers

### DIFF
--- a/ui/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.tsx
@@ -2,16 +2,14 @@ import { useState } from "react";
 
 import { MainTable } from "@canonical/react-components";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import TableActionsDropdown from "app/base/components/TableActionsDropdown";
 import ActionConfirm from "app/base/components/node/ActionConfirm";
+import type { ControllerDetails } from "app/store/controller/types";
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
-import { isMachineDetails } from "app/store/machine/utils";
-import type { RootState } from "app/store/root/types";
-import { formatSize, isCacheSet } from "app/store/utils";
+import type { MachineDetails } from "app/store/machine/types";
+import { formatSize, isCacheSet, nodeIsMachine } from "app/store/utils";
 
 export enum CacheSetAction {
   DELETE = "deleteCacheSet",
@@ -24,19 +22,14 @@ type Expanded = {
 
 type Props = {
   canEditStorage: boolean;
-  systemId: Machine["system_id"];
+  node: ControllerDetails | MachineDetails;
 };
 
-const CacheSetsTable = ({
-  canEditStorage,
-  systemId,
-}: Props): JSX.Element | null => {
+const CacheSetsTable = ({ canEditStorage, node }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, systemId)
-  );
   const [expanded, setExpanded] = useState<Expanded | null>(null);
   const closeExpanded = () => setExpanded(null);
+  const isMachine = nodeIsMachine(node);
 
   const headers = [
     { content: "Name" },
@@ -48,85 +41,86 @@ const CacheSetsTable = ({
     },
   ];
 
-  if (isMachineDetails(machine)) {
-    const rows = machine.disks.reduce<MainTableRow[]>((rows, disk) => {
-      if (isCacheSet(disk)) {
-        const rowId = `${disk.type}-${disk.id}`;
-        const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+  const rows = node.disks.reduce<MainTableRow[]>((rows, disk) => {
+    if (isCacheSet(disk)) {
+      const rowId = `${disk.type}-${disk.id}`;
+      const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
 
-        rows.push({
-          className: isExpanded ? "p-table__row is-active" : null,
-          columns: [
-            { content: disk.name },
-            { content: formatSize(disk.size) },
-            { className: "u-break-spaces", content: disk.used_for },
-            {
-              className: "u-align--right",
-              content: (
-                <TableActionsDropdown
-                  actions={[
-                    {
-                      label: "Remove cache set...",
-                      type: CacheSetAction.DELETE,
-                    },
-                  ]}
-                  disabled={!canEditStorage}
-                  onActionClick={(action: CacheSetAction) =>
-                    setExpanded({ content: action, id: rowId })
-                  }
-                />
-              ),
-            },
-          ].map((column, i) => ({
-            ...column,
-            "aria-label": headers[i].content,
-          })),
-          expanded: isExpanded,
-          expandedContent: (
-            <div className="u-flex--grow">
-              {expanded?.content === CacheSetAction.DELETE && (
-                <ActionConfirm
-                  closeExpanded={closeExpanded}
-                  confirmLabel="Remove cache set"
-                  eventName="deleteCacheSet"
-                  message="Are you sure you want to remove this cache set?"
-                  onConfirm={() => {
-                    dispatch(machineActions.cleanup());
-                    dispatch(
-                      machineActions.deleteCacheSet({
-                        cacheSetId: disk.id,
-                        systemId,
-                      })
-                    );
-                  }}
-                  onSaveAnalytics={{
-                    action: "Delete cache set",
-                    category: "Machine storage",
-                    label: "Remove cache set",
-                  }}
-                  statusKey="deletingCacheSet"
-                  systemId={systemId}
-                />
-              )}
-            </div>
-          ),
-          key: rowId,
-        });
-      }
-      return rows;
-    }, []);
+      rows.push({
+        className: isExpanded ? "p-table__row is-active" : null,
+        columns: [
+          { content: disk.name },
+          { content: formatSize(disk.size) },
+          { className: "u-break-spaces", content: disk.used_for },
+          ...(isMachine
+            ? [
+                {
+                  className: "u-align--right",
+                  content: (
+                    <TableActionsDropdown
+                      actions={[
+                        {
+                          label: "Remove cache set...",
+                          type: CacheSetAction.DELETE,
+                        },
+                      ]}
+                      disabled={!canEditStorage}
+                      onActionClick={(action: CacheSetAction) =>
+                        setExpanded({ content: action, id: rowId })
+                      }
+                    />
+                  ),
+                },
+              ]
+            : []),
+        ].map((column, i) => ({
+          ...column,
+          "aria-label": headers[i].content,
+        })),
+        expanded: isExpanded,
+        expandedContent: isMachine ? (
+          <div className="u-flex--grow">
+            {expanded?.content === CacheSetAction.DELETE && (
+              <ActionConfirm
+                closeExpanded={closeExpanded}
+                confirmLabel="Remove cache set"
+                eventName="deleteCacheSet"
+                message="Are you sure you want to remove this cache set?"
+                onConfirm={() => {
+                  dispatch(machineActions.cleanup());
+                  dispatch(
+                    machineActions.deleteCacheSet({
+                      cacheSetId: disk.id,
+                      systemId: node.system_id,
+                    })
+                  );
+                }}
+                onSaveAnalytics={{
+                  action: "Delete cache set",
+                  category: "Machine storage",
+                  label: "Remove cache set",
+                }}
+                statusKey="deletingCacheSet"
+                systemId={node.system_id}
+              />
+            )}
+          </div>
+        ) : null,
+        key: rowId,
+      });
+    }
+    return rows;
+  }, []);
 
-    return (
-      <MainTable
-        className="p-table-expanding--light"
-        expanding
-        responsive
-        headers={headers}
-        rows={rows}
-      />
-    );
-  }
-  return null;
+  return (
+    <MainTable
+      className="p-table-expanding--light"
+      expanding
+      responsive
+      headers={isMachine ? headers : headers.slice(0, -1)}
+      rows={rows}
+    />
+  );
 };
 
 export default CacheSetsTable;

--- a/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
+++ b/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
@@ -51,10 +51,7 @@ const StorageTables = ({ canEditStorage, node }: Props): JSX.Element => {
       {showCacheSets && (
         <Strip shallow>
           <h4 className="u-sv-1">{Labels.CacheSets}</h4>
-          <CacheSetsTable
-            canEditStorage={canEditStorage}
-            systemId={node.system_id}
-          />
+          <CacheSetsTable canEditStorage={canEditStorage} node={node} />
         </Strip>
       )}
       <Strip shallow>

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
+import configureStore from "redux-mock-store";
+
+import ControllerStorage from "./ControllerStorage";
+
+import {
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("displays a spinner if controller is loading", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <ControllerStorage systemId="abc123" />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("alert", { name: "Loading controller" })
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.tsx
@@ -1,8 +1,11 @@
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import StorageTables from "app/base/components/node/StorageTables";
 import { useWindowTitle } from "app/base/hooks";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "app/store/controller/types";
+import { isControllerDetails } from "app/store/controller/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -15,7 +18,10 @@ const ControllerStorage = ({ systemId }: Props): JSX.Element => {
   );
   useWindowTitle(`${`${controller?.hostname}` || "Controller"} storage`);
 
-  return <h4>Controller storage</h4>;
+  if (isControllerDetails(controller)) {
+    return <StorageTables canEditStorage={false} node={controller} />;
+  }
+  return <Spinner aria-label="Loading controller" text="Loading..." />;
 };
 
 export default ControllerStorage;


### PR DESCRIPTION
## Done

- Refactored machine cache sets table to work with controllers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React storage tab for a controller with cache sets
- Check that the cache sets tables shows the same data as the AngularJS version

## Fixes

Fixes canonical-web-and-design/app-tribe#998
