### PR TITLE
refactor: add controller take action menu

### DIFF
--- a/integration/cypress/integration/with-users/controllers/list.spec.ts
+++ b/integration/cypress/integration/with-users/controllers/list.spec.ts
@@ -22,9 +22,11 @@ context("Controller listing", () => {
     const tagName = "new-tag";
 
     // displays the controller details page on click of the controller name
-    cy.findByRole("gridcell", { name: "Name" }).within(() => {
-      cy.findByRole("link").click();
-    });
+    cy.findAllByRole("gridcell", { name: "Name" })
+      .first()
+      .within(() => {
+        cy.findByRole("link").click();
+      });
 
     cy.findByText(/Controller summary/).should("exist");
 
@@ -57,5 +59,30 @@ context("Controller listing", () => {
     cy.findByRole("grid", { name: "controllers list" }).within(() => {
       cy.get("tbody tr").should("have.length", 1);
     });
+  });
+
+  it("lists valid actions on the controller details page", () => {
+    cy.findAllByRole("gridcell", { name: "Name" })
+      .first()
+      .within(() => {
+        cy.findByRole("link").click();
+      });
+
+    cy.findByText(/Take action/).click();
+
+    [/Import images/i, /Delete/i].forEach((name) =>
+      cy
+        .findByRole("button", {
+          name,
+        })
+        .should("exist")
+    );
+    [/Set zone/i].forEach((name) =>
+      cy
+        .findByRole("button", {
+          name,
+        })
+        .should("not.exist")
+    );
   });
 });

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect, Route, Switch } from "react-router-dom";
@@ -17,6 +17,7 @@ import ControllerVLANs from "./ControllerVLANs";
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import { useGetURLId } from "app/base/hooks/urls";
+import type { ControllerHeaderContent } from "app/controllers/types";
 import controllerURLs from "app/controllers/urls";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
@@ -31,6 +32,8 @@ const ControllerDetails = (): JSX.Element => {
     controllerSelectors.getById(state, id)
   );
   const controllersLoading = useSelector(controllerSelectors.loading);
+  const [headerContent, setHeaderContent] =
+    useState<ControllerHeaderContent | null>(null);
 
   useEffect(() => {
     if (isId(id)) {
@@ -57,7 +60,15 @@ const ControllerDetails = (): JSX.Element => {
   }
 
   return (
-    <Section header={<ControllerDetailsHeader systemId={id} />}>
+    <Section
+      header={
+        <ControllerDetailsHeader
+          systemId={id}
+          headerContent={headerContent}
+          setHeaderContent={setHeaderContent}
+        />
+      }
+    >
       {controller && (
         <Switch>
           <Route

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
@@ -2,8 +2,16 @@ import { useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom-v5-compat";
 
+import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
+import ControllerHeaderForms from "app/controllers/components/ControllerHeaderForms";
+import { ControllerHeaderViews } from "app/controllers/constants";
+import type {
+  ControllerHeaderContent,
+  ControllerSetHeaderContent,
+} from "app/controllers/types";
 import controllerURLs from "app/controllers/urls";
+import { getHeaderTitle } from "app/controllers/utils";
 import controllerSelectors from "app/store/controller/selectors";
 import type { Controller } from "app/store/controller/types";
 import { isControllerDetails } from "app/store/controller/utils";
@@ -11,9 +19,15 @@ import type { RootState } from "app/store/root/types";
 
 type Props = {
   systemId: Controller["system_id"];
+  headerContent: ControllerHeaderContent | null;
+  setHeaderContent: ControllerSetHeaderContent;
 };
 
-const ControllerDetailsHeader = ({ systemId }: Props): JSX.Element => {
+const ControllerDetailsHeader = ({
+  systemId,
+  headerContent,
+  setHeaderContent,
+}: Props): JSX.Element => {
   const controller = useSelector((state: RootState) =>
     controllerSelectors.getById(state, systemId)
   );
@@ -26,6 +40,21 @@ const ControllerDetailsHeader = ({ systemId }: Props): JSX.Element => {
   return (
     <SectionHeader
       subtitleLoading={!isControllerDetails(controller)}
+      buttons={[
+        <NodeActionMenu
+          key="action-dropdown"
+          nodeDisplay="controller"
+          nodes={[controller]}
+          onActionClick={(action) => {
+            const view = Object.values(ControllerHeaderViews).find(
+              ([, actionName]) => actionName === action
+            );
+            if (view) {
+              setHeaderContent({ view });
+            }
+          }}
+        />,
+      ]}
       tabLinks={[
         {
           label: "Summary",
@@ -69,7 +98,17 @@ const ControllerDetailsHeader = ({ systemId }: Props): JSX.Element => {
         label: link.label,
         to: link.url,
       }))}
-      title={controller.fqdn}
+      title={getHeaderTitle(controller.fqdn, headerContent)}
+      headerContent={
+        headerContent ? (
+          <ControllerHeaderForms
+            controllers={[controller]}
+            headerContent={headerContent}
+            setHeaderContent={setHeaderContent}
+            viewingDetails
+          />
+        ) : null
+      }
     />
   );
 };


### PR DESCRIPTION
## Done

- add controller take action menu

I wasn't able to actually perform any of the actions (neither in legacy nor react version). This _may_ require extra work.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Controller Details page, e.g. `/MAAS/r/controller/knpge8` on bolla
- Verify correct actions are displayed under the "Take action" menu

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/934

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

![image](https://user-images.githubusercontent.com/7452681/171189429-79d94eb4-9615-4daa-863e-7950ed17a7b3.png)

![image](https://user-images.githubusercontent.com/7452681/171200211-72e76f4c-4931-451f-b187-09988848007e.png)
