### PR TITLE
feat(ui): set up controller network tab and DCHP snippets

### DIFF
--- a/ui/src/app/base/components/NodeNetworkTab/NodeNetworkTab.tsx
+++ b/ui/src/app/base/components/NodeNetworkTab/NodeNetworkTab.tsx
@@ -32,10 +32,10 @@ type GetComponent = (
 ) => ReactNode;
 
 type Props = {
-  actions: GetComponent;
+  actions?: GetComponent;
   addInterface?: GetComponent;
   dhcpTable: GetComponent;
-  expandedForm: GetComponent;
+  expandedForm?: GetComponent;
   interfaceTable: GetComponent;
 };
 
@@ -45,17 +45,18 @@ const NodeNetworkTab = ({
   dhcpTable,
   expandedForm,
   interfaceTable,
+  ...props
 }: Props): JSX.Element => {
   const [expanded, setExpanded] = useState<Expanded | null>(null);
-  if (expanded) {
+  if (expanded && expandedForm) {
     const form = expandedForm(expanded, setExpanded);
     if (form) {
       return <>{form}</>;
     }
   }
   return (
-    <>
-      {actions(expanded, setExpanded)}
+    <div {...props}>
+      {actions?.(expanded, setExpanded)}
       <Strip shallow>
         {interfaceTable(expanded, setExpanded)}
         {addInterface && expanded?.content === ExpandedState.ADD_PHYSICAL
@@ -63,7 +64,7 @@ const NodeNetworkTab = ({
           : null}
       </Strip>
       {dhcpTable(expanded, setExpanded)}
-    </>
+    </div>
   );
 };
 

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+
+import ControllerNetwork from "./ControllerNetwork";
+
+import {
+  controllerDetails as controllerDetailsFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
+
+it("displays a spinner if controller is loading", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [],
+    }),
+  });
+  renderWithBrowserRouter(<ControllerNetwork systemId="abc123" />, {
+    wrapperProps: { state },
+  });
+  expect(screen.getByLabelText("Loading controller")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Controller network")).not.toBeInTheDocument();
+});
+
+it("displays the network tab when loaded", () => {
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controllerDetailsFactory({ system_id: "abc123" })],
+    }),
+  });
+  renderWithBrowserRouter(<ControllerNetwork systemId="abc123" />, {
+    wrapperProps: { state },
+  });
+  expect(screen.queryByLabelText("Loading controller")).not.toBeInTheDocument();
+  expect(screen.getByLabelText("Controller network")).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.tsx
@@ -1,8 +1,12 @@
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import DHCPTable from "app/base/components/DHCPTable";
+import NodeNetworkTab from "app/base/components/NodeNetworkTab";
 import { useWindowTitle } from "app/base/hooks";
 import controllerSelectors from "app/store/controller/selectors";
-import type { Controller, ControllerMeta } from "app/store/controller/types";
+import { ControllerMeta } from "app/store/controller/types";
+import type { Controller } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -15,7 +19,26 @@ const ControllerNetwork = ({ systemId }: Props): JSX.Element => {
   );
   useWindowTitle(`${`${controller?.hostname}` || "Controller"} network`);
 
-  return <h4>Controller network</h4>;
+  if (!controller) {
+    return <Spinner aria-label="Loading controller" text="Loading..." />;
+  }
+
+  return (
+    <NodeNetworkTab
+      aria-label="Controller network"
+      dhcpTable={() => (
+        <DHCPTable
+          className="u-no-padding--top"
+          node={controller}
+          modelName={ControllerMeta.MODEL}
+        />
+      )}
+      interfaceTable={
+        // TODO: implement the interfaces table.
+        () => <></>
+      }
+    />
+  );
 };
 
 export default ControllerNetwork;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -1,8 +1,4 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
+import { screen } from "@testing-library/react";
 
 import MachineNetwork from "./MachineNetwork";
 
@@ -11,51 +7,32 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
-const mockStore = configureStore();
-
-describe("MachineNetwork", () => {
-  it("displays a spinner if machine is loading", () => {
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
-    expect(wrapper.find("NodeNetworkTab").exists()).toBe(false);
+it("displays a spinner if machine is loading", () => {
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [],
+    }),
   });
+  renderWithBrowserRouter(
+    <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />,
+    { wrapperProps: { state } }
+  );
+  expect(screen.getByLabelText("Loading machine")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Machine network")).not.toBeInTheDocument();
+});
 
-  it("displays the network tab when loaded", () => {
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machineDetailsFactory({ system_id: "abc123" })],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("NodeNetworkTab").exists()).toBe(true);
-    expect(wrapper.find("Spinner").exists()).toBe(false);
+it("displays the network tab when loaded", () => {
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machineDetailsFactory({ system_id: "abc123" })],
+    }),
   });
+  renderWithBrowserRouter(
+    <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />,
+    { wrapperProps: { state } }
+  );
+  expect(screen.queryByLabelText("Loading machine")).not.toBeInTheDocument();
+  expect(screen.getByLabelText("Machine network")).toBeInTheDocument();
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -35,80 +35,79 @@ const MachineNetwork = ({ id, setHeaderContent }: Props): JSX.Element => {
   useWindowTitle(`${machine?.fqdn ? `${machine?.fqdn} ` : "Machine"} network`);
 
   if (!machine) {
-    return <Spinner text="Loading..." />;
+    return <Spinner aria-label="Loading machine" text="Loading..." />;
   }
 
   return (
-    <>
-      <NodeNetworkTab
-        actions={(expanded, setExpanded) => (
-          <MachineNetworkActions
-            expanded={expanded}
-            selected={selected}
-            setExpanded={setExpanded}
-            setHeaderContent={setHeaderContent}
-            systemId={id}
-          />
-        )}
-        addInterface={(_, setExpanded) => (
-          <AddInterface close={() => setExpanded(null)} systemId={id} />
-        )}
-        dhcpTable={() => (
-          <DHCPTable
-            className="u-no-padding--top"
-            node={machine}
-            modelName={MachineMeta.MODEL}
-          />
-        )}
-        expandedForm={(expanded, setExpanded) => {
-          if (expanded?.content === ExpandedState.EDIT) {
-            return (
-              <EditInterface
-                close={() => setExpanded(null)}
-                linkId={expanded?.linkId}
-                nicId={expanded?.nicId}
-                selected={selected}
-                setSelected={setSelected}
-                systemId={id}
-              />
-            );
-          } else if (expanded?.content === ExpandedState.ADD_BOND) {
-            return (
-              <AddBondForm
-                close={() => {
-                  setExpanded(null);
-                  setSelected([]);
-                }}
-                selected={selected}
-                setSelected={setSelected}
-                systemId={id}
-              />
-            );
-          } else if (expanded?.content === ExpandedState.ADD_BRIDGE) {
-            return (
-              <AddBridgeForm
-                close={() => {
-                  setExpanded(null);
-                  setSelected([]);
-                }}
-                selected={selected}
-                systemId={id}
-              />
-            );
-          }
-          return null;
-        }}
-        interfaceTable={(expanded, setExpanded) => (
-          <NetworkTable
-            expanded={expanded}
-            selected={selected}
-            setExpanded={setExpanded}
-            setSelected={setSelected}
-            systemId={id}
-          />
-        )}
-      />
-    </>
+    <NodeNetworkTab
+      aria-label="Machine network"
+      actions={(expanded, setExpanded) => (
+        <MachineNetworkActions
+          expanded={expanded}
+          selected={selected}
+          setExpanded={setExpanded}
+          setHeaderContent={setHeaderContent}
+          systemId={id}
+        />
+      )}
+      addInterface={(_, setExpanded) => (
+        <AddInterface close={() => setExpanded(null)} systemId={id} />
+      )}
+      dhcpTable={() => (
+        <DHCPTable
+          className="u-no-padding--top"
+          node={machine}
+          modelName={MachineMeta.MODEL}
+        />
+      )}
+      expandedForm={(expanded, setExpanded) => {
+        if (expanded?.content === ExpandedState.EDIT) {
+          return (
+            <EditInterface
+              close={() => setExpanded(null)}
+              linkId={expanded?.linkId}
+              nicId={expanded?.nicId}
+              selected={selected}
+              setSelected={setSelected}
+              systemId={id}
+            />
+          );
+        } else if (expanded?.content === ExpandedState.ADD_BOND) {
+          return (
+            <AddBondForm
+              close={() => {
+                setExpanded(null);
+                setSelected([]);
+              }}
+              selected={selected}
+              setSelected={setSelected}
+              systemId={id}
+            />
+          );
+        } else if (expanded?.content === ExpandedState.ADD_BRIDGE) {
+          return (
+            <AddBridgeForm
+              close={() => {
+                setExpanded(null);
+                setSelected([]);
+              }}
+              selected={selected}
+              systemId={id}
+            />
+          );
+        }
+        return null;
+      }}
+      interfaceTable={(expanded, setExpanded) => (
+        <NetworkTable
+          expanded={expanded}
+          selected={selected}
+          setExpanded={setExpanded}
+          setSelected={setSelected}
+          systemId={id}
+        />
+      )}
+    />
   );
 };
 


### PR DESCRIPTION
## Done

- Add the controller network tab component and DHCP snippets table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Either add a DHCP snippet to a controller or use "fake-controller" on Bolla.
- Go to the React network tab for the controller.
- You should see the DHCP snippet table.

## Fixes

Fixes: canonical-web-and-design/app-tribe#987.
Fixes: canonical-web-and-design/app-tribe#993.