### PR TITLE
refactor(ui): refactor datastores table to work with controllers

### DIFF
--- a/ui/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
@@ -1,10 +1,14 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import DatastoresTable from "./DatastoresTable";
 
+import { actions as machineActions } from "app/store/machine";
 import {
+  controllerDetails as controllerDetailsFactory,
+  controllerState as controllerStateFactory,
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
@@ -16,105 +20,150 @@ import {
 
 const mockStore = configureStore();
 
-describe("DatastoresTable", () => {
-  it("shows a message if no datastores are detected", () => {
-    const notDatastore = fsFactory({ fstype: "fat32" });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [
-          machineDetailsFactory({
-            disks: [
-              diskFactory({ name: "not-datastore", filesystem: notDatastore }),
-            ],
-            system_id: "abc123",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <DatastoresTable canEditStorage systemId="abc123" />
-      </Provider>
-    );
-    expect(wrapper.find("[data-testid='no-datastores']").text()).toBe(
-      "No datastores detected."
-    );
+it("shows a message if no datastores are detected", () => {
+  const notDatastore = fsFactory({ fstype: "fat32" });
+  const machine = machineDetailsFactory({
+    disks: [diskFactory({ name: "not-datastore", filesystem: notDatastore })],
+    system_id: "abc123",
   });
-
-  it("only shows filesystems that are VMFS6 datastores", () => {
-    const [datastore, notDatastore] = [
-      fsFactory({ fstype: "vmfs6" }),
-      fsFactory({ fstype: "fat32" }),
-    ];
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [
-          machineDetailsFactory({
-            disks: [
-              diskFactory({ name: "datastore", filesystem: datastore }),
-              diskFactory({ name: "not-datastore", filesystem: notDatastore }),
-            ],
-            system_id: "abc123",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <DatastoresTable canEditStorage systemId="abc123" />
-      </Provider>
-    );
-
-    expect(wrapper.find("tbody TableRow").length).toBe(1);
-    expect(wrapper.find("TableCell").at(0).text()).toBe("datastore");
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machine],
+    }),
   });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DatastoresTable canEditStorage node={machine} />
+    </Provider>
+  );
+  expect(screen.getByTestId("no-datastores")).toHaveTextContent(
+    "No datastores detected."
+  );
+});
 
-  it("can remove a datastore", () => {
-    const datastore = fsFactory({ fstype: "vmfs6" });
-    const disk = diskFactory({ filesystem: datastore });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
-        statuses: machineStatusesFactory({
-          abc123: machineStatusFactory(),
-        }),
+it("only shows filesystems that are VMFS6 datastores", () => {
+  const [datastore, notDatastore] = [
+    fsFactory({ fstype: "vmfs6" }),
+    fsFactory({ fstype: "fat32" }),
+  ];
+  const [dsDisk, notDsDisk] = [
+    diskFactory({ name: "datastore", filesystem: datastore }),
+    diskFactory({ name: "not-datastore", filesystem: notDatastore }),
+  ];
+  const machine = machineDetailsFactory({
+    disks: [dsDisk, notDsDisk],
+    system_id: "abc123",
+  });
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machine],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DatastoresTable canEditStorage node={machine} />
+    </Provider>
+  );
+
+  expect(screen.getAllByRole("gridcell", { name: "Name" })).toHaveLength(1);
+  expect(screen.getByRole("gridcell", { name: "Name" })).toHaveTextContent(
+    dsDisk.name
+  );
+});
+
+it("does not show an action column if node is a controller", () => {
+  const controller = controllerDetailsFactory({
+    disks: [
+      diskFactory({
+        name: "datastore",
+        filesystem: fsFactory({ fstype: "vmfs6" }),
       }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <DatastoresTable canEditStorage systemId="abc123" />
-      </Provider>
-    );
+    ],
+    system_id: "abc123",
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DatastoresTable canEditStorage node={controller} />
+    </Provider>
+  );
 
-    wrapper.find("TableMenu button").at(0).simulate("click");
-    wrapper
-      .findWhere(
-        (button) =>
-          button.name() === "button" && button.text().includes("Remove")
-      )
-      .simulate("click");
-    wrapper.find("ActionButton").simulate("click");
+  expect(
+    screen.queryByRole("columnheader", { name: "Actions" })
+  ).not.toBeInTheDocument();
+});
 
-    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+it("shows an action column if node is a machine", () => {
+  const machine = machineDetailsFactory({
+    disks: [
+      diskFactory({
+        name: "datastore",
+        filesystem: fsFactory({ fstype: "vmfs6" }),
+      }),
+    ],
+    system_id: "abc123",
+  });
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machine],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DatastoresTable canEditStorage node={machine} />
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("columnheader", { name: "Actions" })
+  ).toBeInTheDocument();
+});
+
+it("can remove a datastore if node is a machine", async () => {
+  const datastore = fsFactory({ fstype: "vmfs6" });
+  const disk = diskFactory({ filesystem: datastore });
+  const machine = machineDetailsFactory({ disks: [disk], system_id: "abc123" });
+  const state = rootStateFactory({
+    machine: machineStateFactory({
+      items: [machine],
+      statuses: machineStatusesFactory({
+        abc123: machineStatusFactory(),
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <DatastoresTable canEditStorage node={machine} />
+    </Provider>
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
+  await userEvent.click(
+    screen.getByRole("button", { name: "Remove datastore..." })
+  );
+  expect(
+    screen.getByText(
       "Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
-    );
-    expect(
-      store.getActions().find((action) => action.type === "machine/deleteDisk")
-    ).toStrictEqual({
-      meta: {
-        method: "delete_disk",
-        model: "machine",
-      },
-      payload: {
-        params: {
-          block_id: disk.id,
-          system_id: "abc123",
-        },
-      },
-      type: "machine/deleteDisk",
-    });
+    )
+  ).toBeInTheDocument();
+  await userEvent.click(
+    screen.getByRole("button", { name: "Remove datastore" })
+  );
+
+  const expectedAction = machineActions.deleteDisk({
+    blockId: disk.id,
+    systemId: machine.system_id,
   });
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
 });

--- a/ui/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.tsx
@@ -2,16 +2,14 @@ import { useState } from "react";
 
 import { MainTable } from "@canonical/react-components";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import TableActionsDropdown from "app/base/components/TableActionsDropdown";
 import ActionConfirm from "app/base/components/node/ActionConfirm";
+import type { ControllerDetails } from "app/store/controller/types";
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
-import { isMachineDetails } from "app/store/machine/utils";
-import type { RootState } from "app/store/root/types";
-import { formatSize, isDatastore } from "app/store/utils";
+import type { MachineDetails } from "app/store/machine/types";
+import { formatSize, isDatastore, nodeIsMachine } from "app/store/utils";
 
 export enum DatastoreAction {
   DELETE = "deleteDisk",
@@ -24,19 +22,13 @@ type Expanded = {
 
 type Props = {
   canEditStorage: boolean;
-  systemId: Machine["system_id"];
+  node: ControllerDetails | MachineDetails;
 };
 
-const DatastoresTable = ({
-  canEditStorage,
-  systemId,
-}: Props): JSX.Element | null => {
+const DatastoresTable = ({ canEditStorage, node }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, systemId)
-  );
   const [expanded, setExpanded] = useState<Expanded | null>(null);
-
+  const isMachine = nodeIsMachine(node);
   const closeExpanded = () => setExpanded(null);
 
   const headers = [
@@ -50,93 +42,94 @@ const DatastoresTable = ({
     },
   ];
 
-  if (isMachineDetails(machine)) {
-    const rows = machine.disks.reduce<MainTableRow[]>((rows, disk) => {
-      if (disk.filesystem && isDatastore(disk.filesystem)) {
-        const fs = disk.filesystem;
-        const rowId = `${fs.fstype}-${fs.id}`;
-        const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
-        rows.push({
-          className: isExpanded ? "p-table__row is-active" : null,
-          columns: [
-            { content: disk.name },
-            { content: fs.fstype },
-            { content: formatSize(disk.size) },
-            { content: fs.mount_point },
-            {
-              content: (
-                <TableActionsDropdown
-                  actions={[
-                    {
-                      label: "Remove datastore...",
-                      type: DatastoreAction.DELETE,
-                    },
-                  ]}
-                  disabled={!canEditStorage}
-                  onActionClick={(action: DatastoreAction) =>
-                    setExpanded({ content: action, id: rowId })
-                  }
-                />
-              ),
-              className: "u-align--right",
-            },
-          ].map((column, i) => ({
-            ...column,
-            "aria-label": headers[i].content,
-          })),
-          expanded: isExpanded,
-          expandedContent: (
-            <div className="u-flex--grow">
-              {expanded?.content === "deleteDisk" && (
-                <ActionConfirm
-                  closeExpanded={closeExpanded}
-                  confirmLabel="Remove datastore"
-                  eventName="deleteDisk"
-                  message="Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
-                  onConfirm={() => {
-                    dispatch(machineActions.cleanup());
-                    dispatch(
-                      machineActions.deleteDisk({
-                        blockId: disk.id,
-                        systemId,
-                      })
-                    );
-                  }}
-                  onSaveAnalytics={{
-                    action: "Delete datastore",
-                    category: "Machine storage",
-                    label: "Remove datastore",
-                  }}
-                  statusKey="deletingDisk"
-                  systemId={systemId}
-                />
-              )}
-            </div>
-          ),
-          key: rowId,
-        });
-      }
-      return rows;
-    }, []);
-
-    return (
-      <>
-        <MainTable
-          className="p-table-expanding--light"
-          expanding
-          responsive
-          headers={headers}
-          rows={rows}
-        />
-        {rows.length === 0 && (
-          <div className="u-nudge-right--small" data-testid="no-datastores">
-            No datastores detected.
+  const rows = node.disks.reduce<MainTableRow[]>((rows, disk) => {
+    if (disk.filesystem && isDatastore(disk.filesystem)) {
+      const fs = disk.filesystem;
+      const rowId = `${fs.fstype}-${fs.id}`;
+      const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+      rows.push({
+        className: isExpanded ? "p-table__row is-active" : null,
+        columns: [
+          { content: disk.name },
+          { content: fs.fstype },
+          { content: formatSize(disk.size) },
+          { content: fs.mount_point },
+          ...(isMachine
+            ? [
+                {
+                  content: (
+                    <TableActionsDropdown
+                      actions={[
+                        {
+                          label: "Remove datastore...",
+                          type: DatastoreAction.DELETE,
+                        },
+                      ]}
+                      disabled={!canEditStorage}
+                      onActionClick={(action: DatastoreAction) =>
+                        setExpanded({ content: action, id: rowId })
+                      }
+                    />
+                  ),
+                  className: "u-align--right",
+                },
+              ]
+            : []),
+        ].map((column, i) => ({
+          ...column,
+          "aria-label": headers[i].content,
+        })),
+        expanded: isExpanded,
+        expandedContent: isMachine ? (
+          <div className="u-flex--grow">
+            {expanded?.content === "deleteDisk" && (
+              <ActionConfirm
+                closeExpanded={closeExpanded}
+                confirmLabel="Remove datastore"
+                eventName="deleteDisk"
+                message="Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
+                onConfirm={() => {
+                  dispatch(machineActions.cleanup());
+                  dispatch(
+                    machineActions.deleteDisk({
+                      blockId: disk.id,
+                      systemId: node.system_id,
+                    })
+                  );
+                }}
+                onSaveAnalytics={{
+                  action: "Delete datastore",
+                  category: "Machine storage",
+                  label: "Remove datastore",
+                }}
+                statusKey="deletingDisk"
+                systemId={node.system_id}
+              />
+            )}
           </div>
-        )}
-      </>
-    );
-  }
-  return null;
+        ) : null,
+        key: rowId,
+      });
+    }
+    return rows;
+  }, []);
+
+  return (
+    <>
+      <MainTable
+        className="p-table-expanding--light"
+        expanding
+        responsive
+        headers={isMachine ? headers : headers.slice(0, -1)}
+        rows={rows}
+      />
+      {rows.length === 0 && (
+        <div className="u-nudge-right--small" data-testid="no-datastores">
+          No datastores detected.
+        </div>
+      )}
+    </>
+  );
 };
 
 export default DatastoresTable;

--- a/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
+++ b/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
@@ -33,10 +33,7 @@ const StorageTables = ({ canEditStorage, node }: Props): JSX.Element => {
         {showDatastores ? (
           <>
             <h4 className="u-sv-1">{Labels.Datastores}</h4>
-            <DatastoresTable
-              canEditStorage={canEditStorage}
-              systemId={node.system_id}
-            />
+            <DatastoresTable canEditStorage={canEditStorage} node={node} />
           </>
         ) : (
           <>


### PR DESCRIPTION
## Done

- Refactored machine datastores table to work with controllers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- This is hard to QA with controllers, but for now just check that the machine datastores table works as before
  - Go to the storage tab of a Ready or Allocated machine and change the storage layout to VMFS6 if it isn't already
  - Check that the data is unchanged and that you can still remove datastores

## Fixes

Fixes canonical-web-and-design/app-tribe#997
