### PR TITLE
refactor(ui): refactor available storage table to work with controllers

### DIFF
--- a/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
+++ b/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
@@ -106,6 +106,7 @@ export const AddLogicalVolume = ({
     return (
       <FormikForm<AddLogicalVolumeValues, MachineEventErrors>
         allowUnchanged
+        aria-label="Add logical volume form"
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{

--- a/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -100,6 +100,7 @@ export const AddPartition = ({
     return (
       <FormikForm<AddPartitionValues, MachineEventErrors>
         allowUnchanged
+        aria-label="Add partition form"
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{

--- a/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateBcache/CreateBcache.tsx
+++ b/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateBcache/CreateBcache.tsx
@@ -84,6 +84,7 @@ export const CreateBcache = ({
     return (
       <FormikForm<CreateBcacheValues, MachineEventErrors>
         allowUnchanged
+        aria-label="Create bcache form"
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{

--- a/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/EditDisk/EditDisk.tsx
+++ b/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/EditDisk/EditDisk.tsx
@@ -49,6 +49,7 @@ export const EditDisk = ({
 
   return (
     <FormikForm<EditDiskValues, MachineEventErrors>
+      aria-label="Edit disk form"
       cleanup={machineActions.cleanup}
       errors={errors}
       initialValues={{

--- a/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/EditPartition/EditPartition.tsx
+++ b/ui/src/app/base/components/node/StorageTables/AvailableStorageTable/EditPartition/EditPartition.tsx
@@ -57,6 +57,7 @@ export const EditPartition = ({
 
     return (
       <FormikForm<EditPartitionValues, MachineEventErrors>
+        aria-label="Edit partition form"
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{

--- a/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
+++ b/ui/src/app/base/components/node/StorageTables/StorageTables.tsx
@@ -53,10 +53,7 @@ const StorageTables = ({ canEditStorage, node }: Props): JSX.Element => {
       )}
       <Strip shallow>
         <h4 className="u-sv-1">{Labels.AvailableStorage}</h4>
-        <AvailableStorageTable
-          canEditStorage={canEditStorage}
-          systemId={node.system_id}
-        />
+        <AvailableStorageTable canEditStorage={canEditStorage} node={node} />
       </Strip>
       <Strip shallow>
         <h4 className="u-sv-1">{Labels.UsedStorage}</h4>


### PR DESCRIPTION
## Done

- Refactored machine available storage table to work with controllers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React storage tab of a controller and check that the data matches what you see in the AngularJS version
- Check that you can still edit the storage of a Ready or Allocated machine

## Fixes

Fixes canonical-web-and-design/app-tribe#999

## Screenshot

![Screenshot 2022-06-01 at 14-29-13 bolla storage bolla MAAS](https://user-images.githubusercontent.com/25733845/171328301-9b6cf942-32c4-4cbb-b090-e04214c23f43.png)

