### PR TITLE
test: increment test entity names by default

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`NameColumn renders 1`] = `
         handleRowCheckbox={[MockFunction]}
         inputLabel={
           <Link
-            title="test.maas"
+            title="test-machine-1.maas"
             to="/machine/abc123"
           >
             <strong
@@ -50,7 +50,7 @@ exports[`NameColumn renders 1`] = `
               handleRowCheckbox={[MockFunction]}
               inputLabel={
                 <Link
-                  title="test.maas"
+                  title="test-machine-1.maas"
                   to="/machine/abc123"
                 >
                   <strong
@@ -73,7 +73,7 @@ exports[`NameColumn renders 1`] = `
                 id="mock-redux-js-nanoid-1"
                 label={
                   <Link
-                    title="test.maas"
+                    title="test-machine-1.maas"
                     to="/machine/abc123"
                   >
                     <strong
@@ -115,7 +115,7 @@ exports[`NameColumn renders 1`] = `
                         id="mock-redux-js-nanoid-1"
                         label={
                           <Link
-                            title="test.maas"
+                            title="test-machine-1.maas"
                             to="/machine/abc123"
                           >
                             <strong
@@ -142,7 +142,7 @@ exports[`NameColumn renders 1`] = `
                           inputType="checkbox"
                           label={
                             <Link
-                              title="test.maas"
+                              title="test-machine-1.maas"
                               to="/machine/abc123"
                             >
                               <strong
@@ -178,13 +178,13 @@ exports[`NameColumn renders 1`] = `
                               id="mock-nanoid-3"
                             >
                               <Link
-                                title="test.maas"
+                                title="test-machine-1.maas"
                                 to="/machine/abc123"
                               >
                                 <a
                                   href="/machine/abc123"
                                   onClick={[Function]}
-                                  title="test.maas"
+                                  title="test-machine-1.maas"
                                 >
                                   <strong
                                     data-testid="hostname"

--- a/ui/src/app/store/vlan/utils.test.ts
+++ b/ui/src/app/store/vlan/utils.test.ts
@@ -90,7 +90,7 @@ describe("vlan utils", () => {
       const fabrics = [fabricFactory({ id: 1, name: "fabric-1" })];
       const vlans = [
         vlanFactory({ id: 2, relay_vlan: 3, vid: 99 }),
-        vlanFactory({ fabric: 1, id: 3, vid: 101 }),
+        vlanFactory({ fabric: 1, id: 3, vid: 101, name: "test-vlan" }),
       ];
       expect(getDHCPStatus(vlans[0], vlans, fabrics, true)).toEqual(
         "Relayed via fabric-1.101 (test-vlan)"

--- a/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/ui/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -37,7 +37,7 @@ it("renders correct details", () => {
     }),
   });
   const store = mockStore(state);
-  const fabric = fabricFactory({ id: 1 });
+  const fabric = fabricFactory({ id: 1, name: "test-fabric" });
 
   render(
     <Provider store={store}>

--- a/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
+++ b/ui/src/app/subnets/views/SubnetsList/SubnetsTable/utils.test.tsx
@@ -22,7 +22,7 @@ test("getTableData generates correct sortData for fabric", () => {
   ).toEqual({
     cidr: "172.16.1.0/24",
     fabricId: 1,
-    fabricName: "test-fabric",
+    fabricName: fabrics[0].name,
     spaceName: "no space",
     vlanId: 1,
   });
@@ -75,19 +75,19 @@ test("groupRowsByFabricAndVlan returns grouped fabrics in a correct format", () 
   expect(groupRowsByFabricAndVlan(tableData)[0].fabric).toStrictEqual({
     href: "/fabric/1",
     isVisuallyHidden: false,
-    label: "test-fabric",
+    label: fabrics[0].name,
   });
 
   expect(groupRowsByFabricAndVlan(tableData)[1].fabric).toStrictEqual({
     href: "/fabric/1",
     isVisuallyHidden: true,
-    label: "test-fabric",
+    label: fabrics[0].name,
   });
 
   expect(groupRowsByFabricAndVlan(tableData)[2].fabric).toStrictEqual({
     href: "/fabric/2",
     isVisuallyHidden: false,
-    label: "test-fabric",
+    label: fabrics[1].name,
   });
 });
 

--- a/ui/src/testing/factories/domain.ts
+++ b/ui/src/testing/factories/domain.ts
@@ -11,12 +11,12 @@ import { RecordType } from "app/store/domain/types";
 import type { TimestampedModel } from "app/store/types/model";
 
 export const domain = extend<TimestampedModel, Domain>(timestampedModel, {
-  name: "test name",
+  name: (i: number) => `test name ${i}`,
   authoritative: false,
   ttl: null,
   hosts: random,
   resource_count: random,
-  displayname: "test display",
+  displayname: (i: number) => `test display ${i}`,
   is_default: false,
 });
 
@@ -27,7 +27,7 @@ export const domainDetails = extend<Domain, DomainDetails>(domain, {
 export const domainResource = define<DomainResource>({
   dnsdata_id: null,
   dnsresource_id: null,
-  name: "test-resource",
+  name: (i: number) => `test-resource-${i}`,
   node_type: null,
   rrdata: "test-data",
   rrtype: RecordType.TXT,

--- a/ui/src/testing/factories/fabric.ts
+++ b/ui/src/testing/factories/fabric.ts
@@ -9,6 +9,6 @@ export const fabric = extend<TimestampedModel, Fabric>(timestampedModel, {
   class_type: "10g",
   default_vlan_id: random,
   description: "a fabric",
-  name: "test-fabric",
+  name: (i: number) => `test-fabric-${i}`,
   vlan_ids: () => [],
 });

--- a/ui/src/testing/factories/general.ts
+++ b/ui/src/testing/factories/general.ts
@@ -103,8 +103,8 @@ export const powerField = define<PowerField>({
   choices: () => [],
   default: "auto",
   field_type: PowerFieldType.STRING,
-  label: "test label",
-  name: "test name",
+  label: (i: number) => `test-powerfield-label-${i}`,
+  name: (i: number) => `test-powerfield-name-${i}`,
   required: false,
   scope: PowerFieldScope.BMC,
 });

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -97,7 +97,7 @@ const tags = () => [];
 const simpleNode = extend<Model, SimpleNode>(model, {
   domain: modelRef,
   hostname: (i: number) => `test-machine-${i}`,
-  fqdn: "test.maas",
+  fqdn: (i: number) => `test-machine-${i}.maas`,
   permissions,
   system_id: () => random().toString(),
   tags,

--- a/ui/src/testing/factories/packagerepository.ts
+++ b/ui/src/testing/factories/packagerepository.ts
@@ -8,7 +8,7 @@ import type { TimestampedModel } from "app/store/types/model";
 export const packageRepository = extend<TimestampedModel, PackageRepository>(
   timestampedModel,
   {
-    name: "test repo",
+    name: (i: number) => `test-repo-${i}`,
     url: "test url",
     distributions: () => [],
     disabled_pockets: () => [],

--- a/ui/src/testing/factories/resourcepool.ts
+++ b/ui/src/testing/factories/resourcepool.ts
@@ -12,7 +12,7 @@ export const resourcePool = extend<TimestampedModel, ResourcePool>(
     is_default: false,
     machine_ready_count: random,
     machine_total_count: random,
-    name: "test name",
+    name: (i: number) => `test name ${i}`,
     permissions: () => [],
   }
 );

--- a/ui/src/testing/factories/script.ts
+++ b/ui/src/testing/factories/script.ts
@@ -14,7 +14,7 @@ export const script = extend<TimestampedModel, Script>(timestampedModel, {
   for_hardware: () => [],
   hardware_type: random,
   may_reboot: false,
-  name: "test name",
+  name: (i: number) => `test name ${i}`,
   packages: () => ({}),
   parallel: random,
   parameters: () => ({}),

--- a/ui/src/testing/factories/scriptResult.ts
+++ b/ui/src/testing/factories/scriptResult.ts
@@ -36,7 +36,7 @@ export const scriptResult = extend<Model, ScriptResult>(model, {
   exit_status: 0,
   hardware_type: 3,
   interface: null,
-  name: "test name",
+  name: (i: number) => `test scriptResult ${i}`,
   parameters: () => ({}),
   physical_blockdevice: 2451,
   result_type: 1,

--- a/ui/src/testing/factories/service.ts
+++ b/ui/src/testing/factories/service.ts
@@ -7,7 +7,7 @@ import type { Service } from "app/store/service/types";
 import type { Model } from "app/store/types/model";
 
 export const service = extend<Model, Service>(model, {
-  name: "test name",
+  name: (i: number) => `test service ${i}`,
   status: ServiceStatus.RUNNING,
   status_info: "test info",
 });

--- a/ui/src/testing/factories/space.ts
+++ b/ui/src/testing/factories/space.ts
@@ -7,7 +7,7 @@ import type { TimestampedModel } from "app/store/types/model";
 
 export const space = extend<TimestampedModel, Space>(timestampedModel, {
   description: "a space",
-  name: "test-space",
+  name: (i: number) => `test space ${i}`,
   subnet_ids: () => [],
   vlan_ids: () => [],
 });

--- a/ui/src/testing/factories/sshkey.ts
+++ b/ui/src/testing/factories/sshkey.ts
@@ -11,7 +11,7 @@ export const keySource = define<KeySource>({
 });
 
 export const sshKey = extend<TimestampedModel, SSHKey>(timestampedModel, {
-  display: "display key",
+  display: (i: number) => `display key ${i}`,
   key: "test key",
   user: random,
 });

--- a/ui/src/testing/factories/sslkey.ts
+++ b/ui/src/testing/factories/sslkey.ts
@@ -6,7 +6,7 @@ import type { SSLKey } from "app/store/sslkey/types";
 import type { TimestampedModel } from "app/store/types/model";
 
 export const sslKey = extend<TimestampedModel, SSLKey>(timestampedModel, {
-  display: "test key display",
-  key: "test key",
+  display: (i: number) => `test key display ${i}`,
+  key: (i: number) => `test key ${i}`,
   user: random,
 });

--- a/ui/src/testing/factories/subnet.ts
+++ b/ui/src/testing/factories/subnet.ts
@@ -98,7 +98,7 @@ export const subnet = extend<TimestampedModel, BaseSubnet>(timestampedModel, {
   dns_servers: "fd89:8724:81f1:5512:557f:99c3:6967:8d63",
   gateway_ip: null,
   managed: false,
-  name: "test-name",
+  name: (i: number) => `test subnet ${i}`,
   rdns_mode: random,
   space: null,
   statistics: subnetStatistics,

--- a/ui/src/testing/factories/tag.ts
+++ b/ui/src/testing/factories/tag.ts
@@ -12,5 +12,5 @@ export const tag = extend<TimestampedModel, Tag>(timestampedModel, {
   device_count: 0,
   kernel_opts: null,
   machine_count: 0,
-  name: "test name",
+  name: (i: number) => `test tag ${i}`,
 });

--- a/ui/src/testing/factories/token.ts
+++ b/ui/src/testing/factories/token.ts
@@ -6,12 +6,12 @@ import type { Token, TokenConsumer } from "app/store/token/types";
 import type { Model } from "app/store/types/model";
 
 export const tokenConsumer = define<TokenConsumer>({
-  key: "consumer key",
-  name: "consumer name",
+  key: (i: number) => `consumer key ${i}`,
+  name: (i: number) => `consumer name ${i}`,
 });
 
 export const token = extend<Model, Token>(model, {
   consumer: tokenConsumer,
-  key: "token key",
-  secret: "secret key",
+  key: (i: number) => `token key ${i}`,
+  secret: (i: number) => `secret key ${i}`,
 });

--- a/ui/src/testing/factories/vlan.ts
+++ b/ui/src/testing/factories/vlan.ts
@@ -11,7 +11,7 @@ export const vlan = extend<TimestampedModel, BaseVLAN>(timestampedModel, {
   external_dhcp: null,
   fabric: random,
   mtu: random,
-  name: "test-vlan",
+  name: (i: number) => `test-vlan-${i}`,
   primary_rack: null,
   rack_sids: () => [],
   relay_vlan: null,

--- a/ui/src/testing/factories/vmcluster.ts
+++ b/ui/src/testing/factories/vmcluster.ts
@@ -15,7 +15,7 @@ import type {
 } from "app/store/vmcluster/types";
 
 export const vmHost = extend<Model, VMHost>(model, {
-  name: "podA",
+  name: (i: number) => `vmHost-${i}`,
   project: "my-project",
   tags: () => [],
   resource_pool: "default",

--- a/ui/src/testing/factories/zone.ts
+++ b/ui/src/testing/factories/zone.ts
@@ -10,5 +10,5 @@ export const zone = extend<TimestampedModel, Zone>(timestampedModel, {
   description: "test description",
   devices_count: random,
   machines_count: random,
-  name: "test name",
+  name: (i: number) => `zone-${i}`,
 });


### PR DESCRIPTION
## Done

- increment test entity names by default
  - we already do this in some cases, this brings more consistency

## Why is this needed / background
I wasted too much time than I'd like to admit today because I assumed the names of my test domains would be auto incremented (and they weren't).

In the real world you wouldn't usually have the same names for different items (and it makes things more difficult to test). When interacting with real UI in integration tests you need a way of differentiating between different options. This should be the default behaviour.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
