### PR TITLE
feat(ui): show last image sync timestamp in controller status bar

### DIFF
--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -5,10 +5,12 @@ import StatusBar from "./StatusBar";
 import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
 import {
-  machineDetails as machineDetailsFactory,
   config as configFactory,
   configState as configStateFactory,
+  controllerDetails as controllerDetailsFactory,
+  controllerState as controllerStateFactory,
   generalState as generalStateFactory,
+  machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   versionState as versionStateFactory,
@@ -23,6 +25,9 @@ beforeEach(() => {
   state = rootStateFactory({
     config: configStateFactory({
       items: [configFactory({ name: "maas_name", value: "bolla" })],
+    }),
+    controller: controllerStateFactory({
+      items: [],
     }),
     general: generalStateFactory({
       version: versionStateFactory({ data: "2.10.0" }),
@@ -187,5 +192,19 @@ it("displays correct text for machines with hardware sync enabled and no last_sy
   );
   expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
     /Next sync: Never/
+  );
+});
+
+it("displays last image sync timestamp for a controller", () => {
+  const controller = controllerDetailsFactory({
+    last_image_sync: "Thu, 02 Jun. 2022 00:48:41",
+  });
+  state.controller.active = controller.system_id;
+  state.controller.items = [controller];
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+    `Last image sync: ${controller.last_image_sync}`
   );
 });

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -5,6 +5,8 @@ import { formatDistance, parse } from "date-fns";
 import { useSelector } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
+import controllerSelectors from "app/store/controller/selectors";
+import { isControllerDetails } from "app/store/controller/utils";
 import { version as versionSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
@@ -55,6 +57,7 @@ const getSyncStatusString = (syncStatus: string) => {
 };
 
 export const StatusBar = (): JSX.Element | null => {
+  const activeController = useSelector(controllerSelectors.active);
   const activeMachine = useSelector(machineSelectors.active);
   const version = useSelector(versionSelectors.get);
   const maasName = useSelector(configSelectors.maasName);
@@ -85,6 +88,8 @@ export const StatusBar = (): JSX.Element | null => {
         ))}
       </ul>
     );
+  } else if (isControllerDetails(activeController)) {
+    status = `Last image sync: ${activeController.last_image_sync}`;
   }
 
   return (


### PR DESCRIPTION
## Done

- Show last image sync timestamp in controller status bar

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React details page of a controller
- Check that the last image sync timestamp is shown in the status bar

## Fixes

Fixes canonical-web-and-design/app-tribe#983
