### PR TITLE
feat(ui): display controller interfaces

### DIFF
--- a/ui/src/app/base/components/node/networking/NetworkTable/_index.scss
+++ b/ui/src/app/base/components/node/networking/NetworkTable/_index.scss
@@ -7,6 +7,36 @@
     th,
     td {
       &:nth-child(1) {
+        @include breakpoint-widths(0.5, 0.5, 0.26, 0.23, 0.17, true);
+      }
+      &:nth-child(2) {
+        @include breakpoint-widths(0, 0.06, 0.05, 0.05, 0.05, true);
+      }
+      &:nth-child(3) {
+        @include breakpoint-widths(0, 0, 0, 0.16, 0.14, true);
+      }
+      &:nth-child(4) {
+        @include breakpoint-widths(0.5, 0.5, 0.2, 0.15, 0.14, true);
+      }
+      &:nth-child(5) {
+        @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
+      }
+      &:nth-child(6) {
+        @include breakpoint-widths(0, 0, 0.17, 0.13, 0.12, true);
+      }
+      &:nth-child(7) {
+        @include breakpoint-widths(0, 0, 0, 0.13, 0.13, true);
+      }
+      &:nth-child(8) {
+        @include breakpoint-widths(0, 0, 0, 0, 0.14, true);
+      }
+    }
+  }
+
+  .network-table--has-actions {
+    th,
+    td {
+      &:nth-child(1) {
         @include breakpoint-widths(0.45, 0.45, 0.26, 0.2, 0.16, true);
       }
       &:nth-child(2) {

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.tsx
@@ -3,10 +3,12 @@ import { useSelector } from "react-redux";
 
 import DHCPTable from "app/base/components/DHCPTable";
 import NodeNetworkTab from "app/base/components/NodeNetworkTab";
+import NetworkTable from "app/base/components/node/networking/NetworkTable";
 import { useWindowTitle } from "app/base/hooks";
 import controllerSelectors from "app/store/controller/selectors";
 import { ControllerMeta } from "app/store/controller/types";
 import type { Controller } from "app/store/controller/types";
+import { isControllerDetails } from "app/store/controller/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -19,7 +21,7 @@ const ControllerNetwork = ({ systemId }: Props): JSX.Element => {
   );
   useWindowTitle(`${`${controller?.hostname}` || "Controller"} network`);
 
-  if (!controller) {
+  if (!controller || !isControllerDetails(controller)) {
     return <Spinner aria-label="Loading controller" text="Loading..." />;
   }
 
@@ -33,10 +35,7 @@ const ControllerNetwork = ({ systemId }: Props): JSX.Element => {
           modelName={ControllerMeta.MODEL}
         />
       )}
-      interfaceTable={
-        // TODO: implement the interfaces table.
-        () => <></>
-      }
+      interfaceTable={() => <NetworkTable node={controller} />}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -30,6 +30,10 @@ type Props = {
   systemId: Machine["system_id"];
 };
 
+export enum Label {
+  Title = "Take action:",
+}
+
 const NetworkTableActions = ({
   link,
   nic,
@@ -144,7 +148,7 @@ const NetworkTableActions = ({
       disabled={isAllNetworkingDisabled && !isLimitedEditingAllowed}
       links={actions}
       position="right"
-      title="Take action:"
+      title={Label.Title}
     />
   );
 };


### PR DESCRIPTION
## Done

- Add the network interfaces table to controllers.
- Hide actions in the network table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a react controllers network tab (fake-controller on bolla has a good set of interfaces).
- Check that the interfaces list has the same info as the legacy table.
- Go to a machine and check that the actions are still visible.

## Fixes

Fixes: canonical-web-and-design/app-tribe#941.

## Screenshots

<img width="1432" alt="Screen Shot 2022-06-02 at 11 04 45 am" src="https://user-images.githubusercontent.com/361637/171545294-8ed22936-31bc-47ab-aade-df772b7357d9.png">

