### PR TITLE
feat(ui): fetch controller services in summary page

### DIFF
--- a/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ControllerSummary.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ControllerSummary.tsx
@@ -1,6 +1,8 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import ServicesCard from "./ServicesCard";
+
 import HardwareCard from "app/base/components/node/HardwareCard";
 import OverviewCard from "app/base/components/node/OverviewCard";
 import { useWindowTitle } from "app/base/hooks";
@@ -26,6 +28,9 @@ const ControllerSummary = ({ systemId }: Props): JSX.Element => {
     <div className="controller-summary">
       <div className="controller-summary__overview-card">
         <OverviewCard node={controller} />
+      </div>
+      <div className="controller-summary__services-card">
+        <ServicesCard controller={controller} />
       </div>
       <div className="controller-summary__hardware-card">
         <HardwareCard node={controller} />

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.test.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ServicesCard from "./ServicesCard";
+
+import { actions as serviceActions } from "app/store/service";
+import {
+  controllerDetails as controllerDetailsFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+  serviceState as serviceStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("fetches services on load", () => {
+  const controller = controllerDetailsFactory();
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+    }),
+  });
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <ServicesCard controller={controller} />
+    </Provider>
+  );
+
+  const expectedAction = serviceActions.fetch();
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});
+
+it("shows a spinner if services are loading", () => {
+  const controller = controllerDetailsFactory();
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+    }),
+    service: serviceStateFactory({
+      loading: true,
+    }),
+  });
+  const store = mockStore(state);
+
+  render(
+    <Provider store={store}>
+      <ServicesCard controller={controller} />
+    </Provider>
+  );
+
+  expect(
+    screen.getByRole("alert", { name: "Loading services" })
+  ).toBeInTheDocument();
+});

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+import { Card, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import type { ControllerDetails } from "app/store/controller/types";
+import type { RootState } from "app/store/root/types";
+import { actions as serviceActions } from "app/store/service";
+import serviceSelectors from "app/store/service/selectors";
+
+type Props = {
+  controller: ControllerDetails;
+};
+
+const ServicesCard = ({ controller }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const services = useSelector((state: RootState) =>
+    serviceSelectors.getByIDs(state, controller.service_ids)
+  );
+  const servicesLoading = useSelector(serviceSelectors.loading);
+
+  useEffect(() => {
+    dispatch(serviceActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Card>
+      <strong className="p-muted-heading u-sv1">Services</strong>
+      <hr />
+      {servicesLoading ? (
+        <Spinner aria-label="Loading services" text="Loading..." />
+      ) : (
+        <ul>
+          {services.map((service) => (
+            <li key={service.id}>{service.name}</li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+};
+
+export default ServicesCard;

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/index.ts
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ServicesCard";

--- a/ui/src/app/store/service/selectors.test.ts
+++ b/ui/src/app/store/service/selectors.test.ts
@@ -6,41 +6,56 @@ import {
   serviceState as serviceStateFactory,
 } from "testing/factories";
 
-describe("service selectors", () => {
-  it("can get all items", () => {
-    const items = [serviceFactory(), serviceFactory()];
-    const state = rootStateFactory({
-      service: serviceStateFactory({
-        items,
-      }),
-    });
-    expect(service.all(state)).toEqual(items);
+it("can get all items", () => {
+  const items = [serviceFactory(), serviceFactory()];
+  const state = rootStateFactory({
+    service: serviceStateFactory({
+      items,
+    }),
   });
+  expect(service.all(state)).toEqual(items);
+});
 
-  it("can get the loading state", () => {
-    const state = rootStateFactory({
-      service: serviceStateFactory({
-        loading: true,
-      }),
-    });
-    expect(service.loading(state)).toEqual(true);
+it("can get the loading state", () => {
+  const state = rootStateFactory({
+    service: serviceStateFactory({
+      loading: true,
+    }),
   });
+  expect(service.loading(state)).toEqual(true);
+});
 
-  it("can get the loaded state", () => {
-    const state = rootStateFactory({
-      service: serviceStateFactory({
-        loaded: true,
-      }),
-    });
-    expect(service.loaded(state)).toEqual(true);
+it("can get the loaded state", () => {
+  const state = rootStateFactory({
+    service: serviceStateFactory({
+      loaded: true,
+    }),
   });
+  expect(service.loaded(state)).toEqual(true);
+});
 
-  it("can get the errors state", () => {
-    const state = rootStateFactory({
-      service: serviceStateFactory({
-        errors: "Data is incorrect",
-      }),
-    });
-    expect(service.errors(state)).toStrictEqual("Data is incorrect");
+it("can get the errors state", () => {
+  const state = rootStateFactory({
+    service: serviceStateFactory({
+      errors: "Data is incorrect",
+    }),
   });
+  expect(service.errors(state)).toStrictEqual("Data is incorrect");
+});
+
+it("can get a list of services by their IDs", () => {
+  const services = [
+    serviceFactory({ id: 0 }),
+    serviceFactory({ id: 1 }),
+    serviceFactory({ id: 2 }),
+  ];
+  const state = rootStateFactory({
+    service: serviceStateFactory({
+      items: services,
+    }),
+  });
+  expect(service.getByIDs(state, [0, 2])).toStrictEqual([
+    services[0],
+    services[2],
+  ]);
 });

--- a/ui/src/app/store/service/selectors.ts
+++ b/ui/src/app/store/service/selectors.ts
@@ -1,3 +1,6 @@
+import { createSelector } from "reselect";
+
+import type { RootState } from "app/store/root/types";
 import { ServiceMeta } from "app/store/service/types";
 import type { Service, ServiceState } from "app/store/service/types";
 import { generateBaseSelectors } from "app/store/utils";
@@ -5,10 +8,36 @@ import { generateBaseSelectors } from "app/store/utils";
 const searchFunction = (service: Service, term: string) =>
   service.name.includes(term);
 
-const selectors = generateBaseSelectors<ServiceState, Service, ServiceMeta.PK>(
-  ServiceMeta.MODEL,
-  ServiceMeta.PK,
-  searchFunction
+const defaultSelectors = generateBaseSelectors<
+  ServiceState,
+  Service,
+  ServiceMeta.PK
+>(ServiceMeta.MODEL, ServiceMeta.PK, searchFunction);
+
+/**
+ * Get a list of services from a list of their IDs.
+ * @param state - The redux state.
+ * @param serviceIDs - A list of service IDs.
+ * @returns A list of services.
+ */
+const getByIDs = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, serviceIDs: Service[ServiceMeta.PK][]) => serviceIDs,
+  ],
+  (services, serviceIDs) =>
+    serviceIDs.reduce<Service[]>((acc, serviceID) => {
+      const service = services.find((service) => service.id === serviceID);
+      if (service) {
+        acc.push(service);
+      }
+      return acc;
+    }, [])
 );
+
+const selectors = {
+  ...defaultSelectors,
+  getByIDs,
+};
 
 export default selectors;


### PR DESCRIPTION
## Done

- Added selector for getting services by IDs
- Created scaffolding for controller services card

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the summary tab of a controller
- Check that services are fetched and displayed in the services card in a simple list (styling to come as a follow up)

## Fixes

Fixes canonical-web-and-design/app-tribe#1002

