### PR TITLE
fix(ui): controller details calling setActive on every route change

### DIFF
--- a/ui/src/app/controllers/constants.ts
+++ b/ui/src/app/controllers/constants.ts
@@ -1,3 +1,5 @@
+import type urls from "./urls";
+
 import { NodeActions } from "app/store/types/node";
 
 export const ControllerActionHeaderViews = {
@@ -21,3 +23,18 @@ export const ControllerHeaderViews = {
   ...ControllerActionHeaderViews,
   ...ControllerNonActionHeaderViews,
 } as const;
+
+export const ControllerDetailsTabLabels: Record<
+  Exclude<keyof typeof urls.controller, "index">,
+  string
+> = {
+  summary: "Summary",
+  vlans: "VLANs",
+  network: "Network",
+  storage: "Storage",
+  pciDevices: "PCI devices",
+  usbDevices: "USB",
+  commissioning: "Commissioning",
+  logs: "Logs",
+  configuration: "Configuration",
+};

--- a/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
+++ b/ui/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
@@ -9,7 +9,10 @@ import ControllerName from "./ControllerName";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
 import ControllerHeaderForms from "app/controllers/components/ControllerHeaderForms";
-import { ControllerHeaderViews } from "app/controllers/constants";
+import {
+  ControllerDetailsTabLabels,
+  ControllerHeaderViews,
+} from "app/controllers/constants";
 import type {
   ControllerHeaderContent,
   ControllerSetHeaderContent,
@@ -61,39 +64,39 @@ const ControllerDetailsHeader = ({
       ]}
       tabLinks={[
         {
-          label: "Summary",
+          label: ControllerDetailsTabLabels.summary,
           url: controllerURLs.controller.summary({ id: systemId }),
         },
         {
-          label: "VLANs",
+          label: ControllerDetailsTabLabels.vlans,
           url: controllerURLs.controller.vlans({ id: systemId }),
         },
         {
-          label: "Network",
+          label: ControllerDetailsTabLabels.network,
           url: controllerURLs.controller.network({ id: systemId }),
         },
         {
-          label: "Storage",
+          label: ControllerDetailsTabLabels.storage,
           url: controllerURLs.controller.storage({ id: systemId }),
         },
         {
-          label: "PCI devices",
+          label: ControllerDetailsTabLabels.pciDevices,
           url: controllerURLs.controller.pciDevices({ id: systemId }),
         },
         {
-          label: "USB",
+          label: ControllerDetailsTabLabels.usbDevices,
           url: controllerURLs.controller.usbDevices({ id: systemId }),
         },
         {
-          label: "Commissioning",
+          label: ControllerDetailsTabLabels.commissioning,
           url: controllerURLs.controller.commissioning({ id: systemId }),
         },
         {
-          label: "Logs",
+          label: ControllerDetailsTabLabels.logs,
           url: controllerURLs.controller.logs.index({ id: systemId }),
         },
         {
-          label: "Configuration",
+          label: ControllerDetailsTabLabels.configuration,
           url: controllerURLs.controller.configuration({ id: systemId }),
         },
       ].map((link) => ({

--- a/ui/src/app/controllers/views/Controllers.test.tsx
+++ b/ui/src/app/controllers/views/Controllers.test.tsx
@@ -1,13 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
+import { ControllerDetailsTabLabels } from "../constants";
+import controllerURLs from "../urls";
+
 import Controllers from "./Controllers";
 
 import controllersURLs from "app/controllers/urls";
-import { rootState as rootStateFactory } from "testing/factories";
+import { actions as controllerActions } from "app/store/controller";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -36,4 +46,51 @@ describe("Controllers", () => {
       expect(wrapper.find(component).exists()).toBe(true);
     });
   });
+});
+
+it("gets and sets the controller as active only once when navigating within the same controller", async () => {
+  const controller = controllerFactory({ system_id: "abc123" });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [controller],
+      loaded: true,
+      loading: false,
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: controllerURLs.controller.index({
+              id: controller.system_id,
+            }),
+          },
+        ]}
+      >
+        <CompatRouter>
+          <Controllers />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  await userEvent.click(
+    screen.getByRole("link", { name: ControllerDetailsTabLabels.vlans })
+  );
+
+  const actualActions = store.getActions();
+  const getControllerActions = actualActions.filter(
+    (actualAction) =>
+      actualAction.type === controllerActions.get(controller.system_id).type
+  );
+  const setActiveControllerActions = actualActions.filter(
+    (actualAction) =>
+      actualAction.type ===
+      controllerActions.setActive(controller.system_id).type
+  );
+
+  expect(getControllerActions).toHaveLength(1);
+  expect(setActiveControllerActions).toHaveLength(1);
 });

--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -28,12 +28,7 @@ const Controllers = (): JSX.Element => {
         controllersURLs.controller.usbDevices(null, true),
         controllersURLs.controller.vlans(null, true),
       ].map((path) => (
-        <Route
-          exact
-          key={path}
-          path={path}
-          render={() => <ControllerDetails />}
-        />
+        <Route exact path={path} render={() => <ControllerDetails />} />
       ))}
       <Route path="*" render={() => <NotFound />} />
     </Switch>

--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -28,7 +28,14 @@ const Controllers = (): JSX.Element => {
         controllersURLs.controller.usbDevices(null, true),
         controllersURLs.controller.vlans(null, true),
       ].map((path) => (
-        <Route exact path={path} render={() => <ControllerDetails />} />
+        <Route
+          // using a single key as a workaround for Controller details pages
+          // calling "get" and "setActive" on every route change
+          key="controller-details"
+          exact
+          path={path}
+          render={() => <ControllerDetails />}
+        />
       ))}
       <Route path="*" render={() => <NotFound />} />
     </Switch>


### PR DESCRIPTION
## Done

- fix controller details calling setActive on every route change
  - add integration test to `Controllers.test.tsx` verifying it gets and sets the controller as active only once when navigating within the same controller

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/3994

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
