### PR TITLE
feat(ui): scroll to top on controller route changes

### DIFF
--- a/ui/src/app/controllers/views/Controllers.tsx
+++ b/ui/src/app/controllers/views/Controllers.tsx
@@ -3,10 +3,13 @@ import { Route, Switch } from "react-router-dom";
 import ControllerDetails from "./ControllerDetails";
 import ControllerList from "./ControllerList";
 
+import { useScrollToTop } from "app/base/hooks";
 import NotFound from "app/base/views/NotFound";
 import controllersURLs from "app/controllers/urls";
 
 const Controllers = (): JSX.Element => {
+  useScrollToTop();
+
   return (
     <Switch>
       <Route


### PR DESCRIPTION
## Done

- scroll to top on controller route changes with useScrollToTop hook

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to controller details page, scroll down and click a link to storage from the summary page.
- Verify the page scrolled to the top after navigating to the new route.

## Fixes

Fixes: 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
![Kapture 2022-06-07 at 12 22 31](https://user-images.githubusercontent.com/7452681/172357589-ec808b57-9982-43a4-8f69-6b33856f72a4.gif)
