### PR TITLE
feat(ui): add status section to controller summary

### DIFF
--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import StatusBar from "./StatusBar";
 
 import type { RootState } from "app/store/root/types";
-import { NodeStatus } from "app/store/types/node";
+import { NodeStatus, NodeType } from "app/store/types/node";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -195,9 +195,10 @@ it("displays correct text for machines with hardware sync enabled and no last_sy
   );
 });
 
-it("displays last image sync timestamp for a controller", () => {
+it("displays last image sync timestamp for a rack or region+rack controller", () => {
   const controller = controllerDetailsFactory({
     last_image_sync: "Thu, 02 Jun. 2022 00:48:41",
+    node_type: NodeType.RACK_CONTROLLER,
   });
   state.controller.active = controller.system_id;
   state.controller.items = [controller];

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -5,7 +5,11 @@ import { useSelector } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
 import controllerSelectors from "app/store/controller/selectors";
-import { isControllerDetails } from "app/store/controller/utils";
+import {
+  isControllerDetails,
+  isRack,
+  isRegionAndRack,
+} from "app/store/controller/utils";
 import { version as versionSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
@@ -87,7 +91,10 @@ export const StatusBar = (): JSX.Element | null => {
         ))}
       </ul>
     );
-  } else if (isControllerDetails(activeController)) {
+  } else if (
+    isControllerDetails(activeController) &&
+    (isRack(activeController) || isRegionAndRack(activeController))
+  ) {
     status = `Last image sync: ${activeController.last_image_sync}`;
   }
 

--- a/ui/src/app/base/components/node/OverviewCard/ControllerStatusCard/ControllerStatusCard.test.tsx
+++ b/ui/src/app/base/components/node/OverviewCard/ControllerStatusCard/ControllerStatusCard.test.tsx
@@ -1,0 +1,311 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ControllerStatusCard, { Labels } from "./ControllerStatusCard";
+
+import { actions as controllerActions } from "app/store/controller";
+import {
+  ControllerInstallType,
+  ImageSyncStatus,
+} from "app/store/controller/types";
+import { NodeType } from "app/store/types/node";
+import {
+  controllerDetails as controllerDetailsFactory,
+  controllerImageSyncStatuses as controllerImageSyncStatusesFactory,
+  controllerState as controllerStateFactory,
+  controllerStatus as controllerStatusFactory,
+  controllerStatuses as controllerStatusesFactory,
+  controllerVersionInfo as controllerVersionInfoFactory,
+  controllerVersions as controllerVersionsFactory,
+  generalState as generalStateFactory,
+  osInfo as osInfoFactory,
+  osInfoState as osInfoStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+it("dispatches an action to poll images if controller is a rack or region+rack", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.RACK_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(
+    store
+      .getActions()
+      .some(
+        (action) =>
+          action.type ===
+          controllerActions.pollCheckImages([controller.system_id], "").type
+      )
+  );
+});
+
+it("does not dispatch an action to poll images if controller is a region controller", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.REGION_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(
+    store
+      .getActions()
+      .every(
+        (action) =>
+          action.type !==
+          controllerActions.pollCheckImages([controller.system_id], "").type
+      )
+  );
+});
+
+it("dispatches an action to stop polling images on unmount", () => {
+  const controller = controllerDetailsFactory();
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  const { unmount } = render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  unmount();
+
+  expect(
+    store
+      .getActions()
+      .some(
+        (action) =>
+          action.type === controllerActions.pollCheckImagesStop("").type
+      )
+  );
+});
+
+it("renders correct version info for a deb install", () => {
+  const controller = controllerDetailsFactory({
+    versions: controllerVersionsFactory({
+      current: controllerVersionInfoFactory({ version: "1.2.3" }),
+      install_type: ControllerInstallType.DEB,
+      origin: "ppa:some/ppa",
+    }),
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.Version).textContent).toBe(
+    "Version: 1.2.3"
+  );
+  expect(screen.getByLabelText(Labels.Origin).textContent).toBe(
+    "Deb: ppa:some/ppa"
+  );
+});
+
+it("renders correct version info for a snap install", () => {
+  const controller = controllerDetailsFactory({
+    versions: controllerVersionsFactory({
+      current: controllerVersionInfoFactory({ version: "1.2.3" }),
+      install_type: ControllerInstallType.SNAP,
+      origin: "1.2/edge",
+    }),
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.Version).textContent).toBe(
+    "Version: 1.2.3"
+  );
+  expect(screen.getByLabelText(Labels.Origin).textContent).toBe(
+    "Channel: 1.2/edge"
+  );
+});
+
+it("renders correct version info for an unknown install type", () => {
+  const controller = controllerDetailsFactory({
+    versions: controllerVersionsFactory({
+      current: controllerVersionInfoFactory({ version: "" }),
+      install_type: ControllerInstallType.UNKNOWN,
+      origin: "nowhere",
+    }),
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.Version).textContent).toBe(
+    "Version: Unknown (less than 2.3.0)"
+  );
+  expect(screen.getByLabelText(Labels.Origin).textContent).toBe(
+    "Origin: nowhere"
+  );
+});
+
+it("renders OS info", () => {
+  const controller = controllerDetailsFactory({
+    distro_series: "focal",
+    osystem: "ubuntu",
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+    general: generalStateFactory({
+      osInfo: osInfoStateFactory({
+        data: osInfoFactory({
+          releases: [["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"']],
+        }),
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.OSInfo).textContent).toBe(
+    'Ubuntu 20.04 LTS "Focal Fossa"'
+  );
+});
+
+it("shows image sync status for rack or region+rack controllers", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.RACK_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.ImageSyncStatus)).toBeInTheDocument();
+});
+
+it("can render when no image sync status exists", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.RACK_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      imageSyncStatuses: controllerImageSyncStatusesFactory(),
+      items: [controller],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByText(Labels.NoStatus)).toBeInTheDocument();
+});
+
+it("can render when image status is synced", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.RACK_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      imageSyncStatuses: controllerImageSyncStatusesFactory({
+        [controller.system_id]: ImageSyncStatus.Synced,
+      }),
+      items: [controller],
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByLabelText(Labels.ImagesSynced)).toBeInTheDocument();
+});
+
+it("can render when checking image status", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.RACK_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({
+      imageSyncStatuses: controllerImageSyncStatusesFactory({
+        [controller.system_id]: ImageSyncStatus.Synced,
+      }),
+      items: [controller],
+      statuses: controllerStatusesFactory({
+        [controller.system_id]: controllerStatusFactory({
+          checkingImages: true,
+        }),
+      }),
+    }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(screen.getByText(Labels.CheckingImages)).toBeInTheDocument();
+});
+
+it("does not show image sync status for region controllers", () => {
+  const controller = controllerDetailsFactory({
+    node_type: NodeType.REGION_CONTROLLER,
+  });
+  const state = rootStateFactory({
+    controller: controllerStateFactory({ items: [controller] }),
+  });
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <ControllerStatusCard controller={controller} />
+    </Provider>
+  );
+
+  expect(
+    screen.queryByLabelText(Labels.ImageSyncStatus)
+  ).not.toBeInTheDocument();
+});

--- a/ui/src/app/base/components/node/OverviewCard/ControllerStatusCard/ControllerStatusCard.tsx
+++ b/ui/src/app/base/components/node/OverviewCard/ControllerStatusCard/ControllerStatusCard.tsx
@@ -1,16 +1,149 @@
-import type { ControllerDetails } from "app/store/controller/types";
+import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
+
+import { Icon, Spinner } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+import { useDispatch, useSelector } from "react-redux";
+
+import TooltipButton from "app/base/components/TooltipButton";
+import { actions as controllerActions } from "app/store/controller";
+import controllerSelectors from "app/store/controller/selectors";
+import {
+  ControllerInstallType,
+  ImageSyncStatus,
+} from "app/store/controller/types";
+import type {
+  ControllerVersions,
+  ControllerDetails,
+} from "app/store/controller/types";
+import { isRack, isRegionAndRack } from "app/store/controller/utils";
+import { useFormattedOS } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
 
 type Props = {
   controller: ControllerDetails;
 };
 
+export enum Labels {
+  CheckingImages = "Checking images...",
+  ImagesSynced = "Images synced",
+  ImageSyncStatus = "Image sync status",
+  NoStatus = "Asking for status...",
+  Origin = "Origin",
+  OSInfo = "OS info",
+  RackTitle = "rackd",
+  RegionRackTitle = "regiond + rackd",
+  RegionTitle = "regiond",
+  UnknownTitle = "Unknown node type",
+  Version = "Version",
+  VersionDetails = "Version details",
+}
+
+const getImageSyncStatus = (
+  status: ImageSyncStatus | null,
+  checkingImages: boolean
+) => {
+  let content: ReactNode;
+  const showSpinner =
+    checkingImages ||
+    !status ||
+    status === ImageSyncStatus.RegionImporting ||
+    status === ImageSyncStatus.Syncing;
+  if (showSpinner) {
+    content = (
+      <Spinner
+        text={
+          !status
+            ? Labels.NoStatus
+            : checkingImages
+            ? Labels.CheckingImages
+            : status
+        }
+      />
+    );
+  } else {
+    content =
+      status === ImageSyncStatus.Synced ? (
+        <>
+          <span className="u-nudge-left--small">{Labels.ImagesSynced}</span>
+          <Icon aria-label={Labels.ImagesSynced} name="success" />
+        </>
+      ) : (
+        status
+      );
+  }
+
+  return (
+    <p aria-label={Labels.ImageSyncStatus} className="u-sv-1">
+      {content}
+    </p>
+  );
+};
+
+const getVersionDisplay = (versions: ControllerVersions) => {
+  const { current, install_type, origin } = versions;
+  const isDeb = install_type === ControllerInstallType.DEB;
+  const isSnap = install_type === ControllerInstallType.SNAP;
+  return (
+    <>
+      <span aria-label={Labels.Version}>
+        Version: {current.version || "Unknown (less than 2.3.0)"}
+      </span>
+      <br />
+      <span aria-label={Labels.Origin}>
+        {isDeb ? "Deb" : isSnap ? "Channel" : "Origin"}: {origin || "Unknown"}
+      </span>
+    </>
+  );
+};
+
 const ControllerStatusCard = ({ controller }: Props): JSX.Element => {
-  // TODO: Build controller status card
+  const dispatch = useDispatch();
+  const pollId = useRef(nanoid());
+  const status = useSelector((state: RootState) =>
+    controllerSelectors.imageSyncStatusesForController(
+      state,
+      controller.system_id
+    )
+  );
+  const checkingImages = useSelector((state: RootState) =>
+    controllerSelectors.getStatusForController(
+      state,
+      controller.system_id,
+      "checkingImages"
+    )
+  );
+  const formattedOS = useFormattedOS(controller);
+
+  useEffect(() => {
+    const id = pollId.current;
+    if (isRack(controller) || isRegionAndRack(controller)) {
+      dispatch(controllerActions.pollCheckImages([controller.system_id], id));
+    }
+    return () => {
+      dispatch(controllerActions.pollCheckImagesStop(id));
+    };
+  }, [dispatch, controller]);
+
   return (
     <>
       <div className="overview-card__status" data-testid="controller-status">
-        <strong className="p-muted-heading">regiond + rackd status</strong>
-        <h4 className="u-no-margin--bottom">{controller.hostname}</h4>
+        <strong className="p-muted-heading">Overview</strong>
+        <h4 className="u-no-margin--bottom">
+          {controller.node_type_display}&nbsp;
+          {controller.versions && (
+            <TooltipButton
+              aria-label={Labels.VersionDetails}
+              message={getVersionDisplay(controller.versions)}
+            />
+          )}
+        </h4>
+        {isRack(controller) || isRegionAndRack(controller)
+          ? getImageSyncStatus(status, checkingImages)
+          : null}
+        <p aria-label={Labels.OSInfo} className="u-text--muted">
+          {formattedOS}
+        </p>
       </div>
       <div className="overview-card__test-warning" />
     </>

--- a/ui/src/app/base/components/node/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/base/components/node/OverviewCard/CpuCard/CpuCard.tsx
@@ -34,7 +34,7 @@ const CpuCard = ({ node, setHeaderContent }: Props): JSX.Element => (
   <>
     <div className="overview-card__cpu">
       <div className="u-flex--between">
-        <strong className="p-muted-heading">CPU</strong>
+        <strong className="p-muted-heading u-no-margin--bottom">CPU</strong>
         <span>{node.architecture}</span>
       </div>
       <h4 className="u-no-margin--bottom" data-testid="cpu-subtext">

--- a/ui/src/app/store/controller/utils/common.test.ts
+++ b/ui/src/app/store/controller/utils/common.test.ts
@@ -1,28 +1,98 @@
-import { isControllerDetails } from "./common";
+import {
+  isControllerDetails,
+  isRack,
+  isRegionAndRack,
+  isRegion,
+} from "./common";
 
+import { NodeType } from "app/store/types/node";
 import {
   controller as controllerFactory,
   controllerDetails as controllerDetailsFactory,
 } from "testing/factories";
 
-describe("controller utils", () => {
-  describe("isControllerDetails", () => {
-    it("identifies controller details", () => {
-      const controllerDetails = controllerDetailsFactory();
-      expect(isControllerDetails(controllerDetails)).toBe(true);
-    });
+describe("isControllerDetails", () => {
+  it("identifies controller details", () => {
+    const controllerDetails = controllerDetailsFactory();
+    expect(isControllerDetails(controllerDetails)).toBe(true);
+  });
 
-    it("handles base controller", () => {
-      const baseController = controllerFactory();
-      expect(isControllerDetails(baseController)).toBe(false);
-    });
+  it("handles base controller", () => {
+    const baseController = controllerFactory();
+    expect(isControllerDetails(baseController)).toBe(false);
+  });
 
-    it("handles no controller", () => {
-      expect(isControllerDetails()).toBe(false);
-    });
+  it("handles no controller", () => {
+    expect(isControllerDetails()).toBe(false);
+  });
 
-    it("handles null", () => {
-      expect(isControllerDetails(null)).toBe(false);
+  it("handles null", () => {
+    expect(isControllerDetails(null)).toBe(false);
+  });
+});
+
+describe("isRack", () => {
+  it("identifies rack controller", () => {
+    const rackController = controllerFactory({
+      node_type: NodeType.RACK_CONTROLLER,
     });
+    const regionController = controllerFactory({
+      node_type: NodeType.REGION_CONTROLLER,
+    });
+    const regionAndRackController = controllerFactory({
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    });
+    expect(isRack(rackController)).toBe(true);
+    expect(isRack(regionController)).toBe(false);
+    expect(isRack(regionAndRackController)).toBe(false);
+  });
+
+  it("handles null and undefined cases", () => {
+    expect(isRack(null)).toBe(false);
+    expect(isRack()).toBe(false);
+  });
+});
+
+describe("isRegion", () => {
+  it("identifies region controller", () => {
+    const rackController = controllerFactory({
+      node_type: NodeType.RACK_CONTROLLER,
+    });
+    const regionController = controllerFactory({
+      node_type: NodeType.REGION_CONTROLLER,
+    });
+    const regionAndRackController = controllerFactory({
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    });
+    expect(isRegion(rackController)).toBe(false);
+    expect(isRegion(regionController)).toBe(true);
+    expect(isRegion(regionAndRackController)).toBe(false);
+  });
+
+  it("handles null and undefined cases", () => {
+    expect(isRegion(null)).toBe(false);
+    expect(isRegion()).toBe(false);
+  });
+});
+
+describe("isRegionAndRack", () => {
+  it("identifies region+rack controller", () => {
+    const rackController = controllerFactory({
+      node_type: NodeType.RACK_CONTROLLER,
+    });
+    const regionController = controllerFactory({
+      node_type: NodeType.REGION_CONTROLLER,
+    });
+    const regionAndRackController = controllerFactory({
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    });
+    expect(isRegionAndRack(rackController)).toBe(false);
+    expect(isRegionAndRack(regionController)).toBe(false);
+    expect(isRegionAndRack(regionAndRackController)).toBe(true);
+  });
+
+  it("handles null and undefined cases", () => {
+    expect(isRegionAndRack(null)).toBe(false);
+    expect(isRegionAndRack()).toBe(false);
   });
 });

--- a/ui/src/app/store/controller/utils/common.ts
+++ b/ui/src/app/store/controller/utils/common.ts
@@ -1,4 +1,5 @@
 import type { Controller, ControllerDetails } from "app/store/controller/types";
+import { NodeType } from "app/store/types/node";
 
 /**
  * Returns whether a controller is of type ControllerDetails.
@@ -10,3 +11,27 @@ export const isControllerDetails = (
   // Use "interfaces" as the canary as it only exists for ControllerDetails.
 ): controller is ControllerDetails =>
   !!controller && "interfaces" in controller;
+
+/**
+ * Returns whether a controller is a rack controller.
+ * @param controller - The controller to check
+ * @returns Whether the controller is a rack controller
+ */
+export const isRack = (controller?: Controller | null): boolean =>
+  controller?.node_type === NodeType.RACK_CONTROLLER;
+
+/**
+ * Returns whether a controller is a region controller.
+ * @param controller - The controller to check
+ * @returns Whether the controller is a region controller
+ */
+export const isRegion = (controller?: Controller | null): boolean =>
+  controller?.node_type === NodeType.REGION_CONTROLLER;
+
+/**
+ * Returns whether a controller is a region+rack controller.
+ * @param controller - The controller to check
+ * @returns Whether the controller is a region+rack controller
+ */
+export const isRegionAndRack = (controller?: Controller | null): boolean =>
+  controller?.node_type === NodeType.REGION_AND_RACK_CONTROLLER;

--- a/ui/src/app/store/controller/utils/index.ts
+++ b/ui/src/app/store/controller/utils/index.ts
@@ -1,2 +1,7 @@
-export { isControllerDetails } from "./common";
+export {
+  isControllerDetails,
+  isRack,
+  isRegionAndRack,
+  isRegion,
+} from "./common";
 export { FilterControllers, getControllerValue } from "./search";


### PR DESCRIPTION
## Done

- Built status section in controller summary

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React summary tab of a controller and check that it matches the [design in the spec](https://docs.google.com/document/d/1H-GWCLx3aSRiJRo9h5Fz-6IFLQ3adsa63pRFGlBFuq0/edit#heading=h.gczn4qs17xmf).

## Fixes

Fixes canonical-web-and-design/app-tribe#1007

## Screenshot

![Screenshot 2022-06-09 at 10-26-05 bolla summary bolla MAAS](https://user-images.githubusercontent.com/25733845/172740073-9e0d8729-7d50-4e37-9f23-d6d24eadc6be.png)

