### PR TITLE
fix: cannot save controller or device configuration with automatic tags

### DIFF
--- a/ui/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
+++ b/ui/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
@@ -76,6 +76,39 @@ it("can open a create tag form", async () => {
   );
 });
 
+it("does not display automatic tags on the list", async () => {
+  const manualTag = tagFactory({ id: 1, name: "tag1" });
+  const automaticTag = tagFactory({
+    id: 4,
+    name: "automatic-tag",
+    definition: `//node[@class="system"]/vendor = "QEMU"`,
+  });
+  state.tag.items = [manualTag, automaticTag];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CompatRouter>
+          <Formik initialValues={{ tags: [] }} onSubmit={jest.fn()}>
+            <NodeConfigurationFields />
+          </Formik>
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+  await userEvent.click(
+    screen.getByRole("textbox", { name: TagFieldLabel.Input })
+  );
+  expect(
+    screen.getByRole("option", { name: manualTag.name })
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("option", {
+      name: automaticTag.name,
+    })
+  ).not.toBeInTheDocument();
+});
+
 it("updates the new tags after creating a tag", async () => {
   const store = mockStore(state);
   const Form = ({ tags }: { tags: Tag[TagMeta.PK][] }) => (

--- a/ui/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.tsx
+++ b/ui/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.tsx
@@ -38,7 +38,7 @@ const NodeConfigurationFields = (): JSX.Element => {
   );
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const [newTagName, setNewTagName] = useState<string | null>(null);
-  const allTags = useSelector(tagSelectors.all);
+  const manualTags = useSelector(tagSelectors.getManual);
 
   return (
     <>
@@ -54,7 +54,7 @@ const NodeConfigurationFields = (): JSX.Element => {
             externalSelectedTags={selectedTags}
             name="tags"
             placeholder="Create or remove tags"
-            tagList={allTags}
+            tagList={manualTags}
             onAddNewTag={(name) => {
               setNewTagName(name);
               openPortal(NULL_EVENT);

--- a/ui/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.tsx
+++ b/ui/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.tsx
@@ -59,6 +59,9 @@ const NodeConfigurationFields = (): JSX.Element => {
               setNewTagName(name);
               openPortal(NULL_EVENT);
             }}
+            disabledTags={selectedTags.filter(
+              (tag) => tag.definition.length > 0
+            )}
           />
         </Col>
       </Row>


### PR DESCRIPTION
## Done

- fix: cannot save controller or device configuration with automatic tags

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- Go to tags and add a new automatic tag (with a description)
- Go to device or controller configuration and verify that this tag does not show on the list of possible choices

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4027

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
