### PR TITLE
fix: tag edit button icon contrast

### DIFF
--- a/ui/src/app/tags/views/TagDetails/TagDetails.tsx
+++ b/ui/src/app/tags/views/TagDetails/TagDetails.tsx
@@ -89,8 +89,7 @@ const TagDetails = ({ onDelete, tagViewState }: Props): JSX.Element => {
                   pathname: tagURLs.tag.update({ id: tag.id }),
                 }}
               >
-                <Icon className="is-light" name="edit" />{" "}
-                <span>{Label.EditButton}</span>
+                <Icon name="edit" /> <span>{Label.EditButton}</span>
               </Button>
               <Button
                 appearance="negative"


### PR DESCRIPTION
## Done

- fix: tag edit button icon contrast

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machines tags and edit a tag
- verify the edit button icon is using the dark variant for sufficient colour contrast

## Fixes


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### before
<img src="https://user-images.githubusercontent.com/7452681/172640458-042c82c3-609b-43dc-ae53-0a33ff109ca6.png" width="240" />

### after
<img src="https://user-images.githubusercontent.com/7452681/172640395-5239dcb5-f6ec-42ce-90ea-147366056db2.png" width="240" />
