### PR TITLE
test: add default state to test utils

### DIFF
--- a/ui/src/app/base/components/Header/Header.test.tsx
+++ b/ui/src/app/base/components/Header/Header.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 
 import { Header } from "./Header";
 
-import { rootState as rootStateFactory } from "testing/factories";
 import { renderWithBrowserRouter } from "testing/utils";
 
 describe("Header", () => {
@@ -27,7 +26,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/", wrapperProps: { state: rootStateFactory() } }
+      { route: "/" }
     );
 
     // header has a role of banner in this context
@@ -60,7 +59,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/", wrapperProps: { state: rootStateFactory() } }
+      { route: "/" }
     );
     expect(screen.getByRole("banner")).toBeInTheDocument();
     const primaryNavigation = screen.getByRole("navigation", {
@@ -93,7 +92,7 @@ describe("Header", () => {
         }
         logout={logout}
       />,
-      { route: "/", wrapperProps: { state: rootStateFactory() } }
+      { route: "/" }
     );
     await userEvent.click(screen.getByRole("button", { name: "Log out" }));
     expect(logout).toHaveBeenCalled();
@@ -115,7 +114,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/", wrapperProps: { state: rootStateFactory() } }
+      { route: "/" }
     );
     const mainNav = screen.getByRole("list", { name: "main" });
     expect(within(mainNav).queryByRole("link")).not.toBeInTheDocument();
@@ -142,7 +141,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/settings", wrapperProps: { state: rootStateFactory() } }
+      { route: "/settings" }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
     expect(currentMenuItem).toBeInTheDocument();
@@ -165,7 +164,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/machines", wrapperProps: { state: rootStateFactory() } }
+      { route: "/machines" }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
     expect(currentMenuItem).toBeInTheDocument();
@@ -188,7 +187,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/pools", wrapperProps: { state: rootStateFactory() } }
+      { route: "/pools" }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
     expect(currentMenuItem).toBeInTheDocument();
@@ -211,7 +210,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/tags", wrapperProps: { state: rootStateFactory() } }
+      { route: "/tags" }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
     expect(currentMenuItem).toBeInTheDocument();
@@ -234,7 +233,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/tag/1", wrapperProps: { state: rootStateFactory() } }
+      { route: "/tag/1" }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
     expect(currentMenuItem).toBeInTheDocument();
@@ -260,7 +259,6 @@ describe("Header", () => {
       />,
       {
         route: "/networks?by=fabric",
-        wrapperProps: { state: rootStateFactory() },
       }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -286,7 +284,6 @@ describe("Header", () => {
       />,
       {
         route: "/machine/abc123",
-        wrapperProps: { state: rootStateFactory() },
       }
     );
     const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -310,7 +307,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/dashboard", wrapperProps: { state: rootStateFactory() } }
+      { route: "/dashboard" }
     );
     expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute(
       "href",
@@ -334,7 +331,7 @@ describe("Header", () => {
         }
         logout={jest.fn()}
       />,
-      { route: "/", wrapperProps: { state: rootStateFactory() } }
+      { route: "/" }
     );
     expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute(
       "href",

--- a/ui/src/testing/utils.tsx
+++ b/ui/src/testing/utils.tsx
@@ -13,6 +13,7 @@ import configureStore from "redux-mock-store";
 import FormikForm from "app/base/components/FormikForm";
 import type { AnyObject } from "app/base/types";
 import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
 
 /**
  * Assert that some JSX from Enzyme is equal to some provided JSX.
@@ -101,7 +102,7 @@ export const submitFormikForm = (
   }
 };
 
-type WrapperProps = { state: RootState };
+type WrapperProps = { state?: RootState };
 
 const BrowserRouterWithProvider = ({
   children,
@@ -113,7 +114,7 @@ const BrowserRouterWithProvider = ({
   };
 
   return (
-    <Provider store={getMockStore(state)}>
+    <Provider store={getMockStore(state || rootStateFactory())}>
       <BrowserRouter>
         <CompatRouter>{children}</CompatRouter>
       </BrowserRouter>
@@ -129,13 +130,17 @@ const WithMockStoreProvider = ({
     const mockStore = configureStore();
     return mockStore(state);
   };
-  return <Provider store={getMockStore(state)}>{children}</Provider>;
+  return (
+    <Provider store={getMockStore(state || rootStateFactory())}>
+      {children}
+    </Provider>
+  );
 };
 
 export const renderWithBrowserRouter = (
   ui: React.ReactElement,
   options: RenderOptions & {
-    wrapperProps: WrapperProps;
+    wrapperProps?: WrapperProps;
     route?: string;
   }
 ): RenderResult => {
@@ -152,7 +157,7 @@ export const renderWithBrowserRouter = (
 export const renderWithMockStore = (
   ui: React.ReactElement,
   options: RenderOptions & {
-    state: RootState;
+    state?: RootState;
   }
 ): RenderResult => {
   const rendered = render(ui, {


### PR DESCRIPTION
## Done

- add default rootState to test utils

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
