### PR TITLE
Fix eslint on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "cSpell.words": ["lifecycles", "unmount"]
+  "cSpell.words": ["lifecycles", "unmount"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
## Done

- Fix eslint on save.

## QA

### QA steps

- Open vscode. Make a change that the linter complains about.
- Save the file.
- The eslint error should get fixed (if it knows how to).
