### PR TITLE
refactor: update zone state shape in Redux

### DIFF
--- a/src/__snapshots__/root-reducer.test.ts.snap
+++ b/src/__snapshots__/root-reducer.test.ts.snap
@@ -406,12 +406,24 @@ Object {
     },
   },
   "zone": Object {
-    "errors": null,
+    "errors": Array [],
+    "genericActions": Object {
+      "create": "idle",
+      "fetch": "idle",
+    },
     "items": Array [],
-    "loaded": false,
-    "loading": false,
-    "saved": false,
-    "saving": false,
+    "modelActions": Object {
+      "delete": Object {
+        "error": Array [],
+        "loading": Array [],
+        "success": Array [],
+      },
+      "update": Object {
+        "error": Array [],
+        "loading": Array [],
+        "success": Array [],
+      },
+    },
   },
 }
 `;

--- a/src/app/base/components/ZoneSelect/ZoneSelect.test.tsx
+++ b/src/app/base/components/ZoneSelect/ZoneSelect.test.tsx
@@ -8,6 +8,7 @@ import ZoneSelect from "./ZoneSelect";
 import {
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -17,11 +18,11 @@ describe("ZoneSelect", () => {
   it("renders a list of all zones in state", () => {
     const state = rootStateFactory({
       zone: zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
         items: [
           zoneFactory({ id: 101, name: "Pool 1" }),
           zoneFactory({ id: 202, name: "Pool 2" }),
         ],
-        loaded: true,
       }),
     });
     const store = mockStore(state);
@@ -55,7 +56,7 @@ describe("ZoneSelect", () => {
   it("disables select if zones have not loaded", () => {
     const state = rootStateFactory({
       zone: zoneStateFactory({
-        loaded: false,
+        genericActions: zoneGenericActionsFactory({ fetch: "idle" }),
       }),
     });
     const store = mockStore(state);

--- a/src/app/base/components/ZoneSelect/ZoneSelect.tsx
+++ b/src/app/base/components/ZoneSelect/ZoneSelect.tsx
@@ -20,7 +20,7 @@ export enum Label {
   Zone = "Zone",
 }
 
-export const DomainSelect = ({
+export const ZoneSelect = ({
   disabled = false,
   label = Label.Zone,
   name,
@@ -54,4 +54,4 @@ export const DomainSelect = ({
   );
 };
 
-export default DomainSelect;
+export default ZoneSelect;

--- a/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
+++ b/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
@@ -13,6 +13,7 @@ import {
   modelRef as modelRefFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -22,11 +23,11 @@ let state: RootState;
 beforeEach(() => {
   state = rootStateFactory({
     zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       items: [
         zoneFactory({ id: 0, name: "default" }),
         zoneFactory({ id: 1, name: "zone-1" }),
       ],
-      loaded: true,
     }),
   });
 });

--- a/src/app/base/constants.ts
+++ b/src/app/base/constants.ts
@@ -1,3 +1,25 @@
+export const ACTION_STATUS = {
+  error: "error",
+  idle: "idle",
+  loading: "loading",
+  success: "success",
+} as const;
+
+export const COMMON_ACTIONS = {
+  cleanup: "cleanup",
+  create: "create",
+  delete: "delete",
+  fetch: "fetch",
+  update: "update",
+} as const;
+
+export const COMMON_WEBSOCKET_METHODS = {
+  create: "create",
+  delete: "delete",
+  list: "list",
+  update: "update",
+} as const;
+
 /**
  * Common column sizes used in <Col> components
  */

--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -323,10 +323,14 @@ describe("websocket sagas", () => {
         data: JSON.stringify({ request_id: 99, result: { response: "here" } }),
       }).value
     ).toStrictEqual(call([socketClient, socketClient.getRequest], 99));
-    saga.next({ type: "test/action", payload: { id: 808 } });
+    saga.next({
+      type: "test/action",
+      payload: { id: 808 },
+      meta: { identifier: 123 },
+    });
     expect(saga.next(false).value).toEqual(
       put({
-        meta: { item: { id: 808 } },
+        meta: { item: { id: 808 }, identifier: 123 },
         type: "test/actionSuccess",
         payload: { response: "here" },
       })

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -481,14 +481,14 @@ export function* handleMessage(
         // can be 0 when requesting a model with an id of 0.
         if (error || error === 0) {
           yield* put({
-            meta: { item },
+            meta: { item, identifier: action.meta?.identifier },
             type: `${action.type}Error`,
             error: true,
             payload: error,
           });
         } else {
           yield* put({
-            meta: { item },
+            meta: { item, identifier: action.meta?.identifier },
             type: `${action.type}Success`,
             payload: result,
           });
@@ -569,7 +569,7 @@ export function* sendMessage(
 ): SagaGenerator<void> {
   const { meta, payload, type } = action;
   const params = payload ? payload.params : null;
-  const { cache, method, model, nocache } = meta;
+  const { cache, identifier, method, model, nocache } = meta;
   const endpoint = `${model}.${method}`;
   const hasMultipleDispatches = meta.dispatchMultiple && Array.isArray(params);
   // If method is 'list' and data has loaded/is loading, do not fetch again
@@ -587,7 +587,10 @@ export function* sendMessage(
     }
     setLoaded(endpoint);
   }
-  yield* put({ meta: { item: params || payload }, type: `${type}Start` });
+  yield* put({
+    meta: { item: params || payload, identifier },
+    type: `${type}Start`,
+  });
   const requestIDs = [];
   try {
     if (params && hasMultipleDispatches) {

--- a/src/app/base/types.ts
+++ b/src/app/base/types.ts
@@ -1,4 +1,7 @@
 import type { ValueOf } from "@canonical/react-components";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+import type { ACTION_STATUS } from "./constants";
 
 export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -76,3 +79,23 @@ type UsabillaConfig =
     };
 
 export type UsabillaLive = (type: string, config?: UsabillaConfig) => void;
+
+export type ActionStatuses = ValueOf<typeof ACTION_STATUS>;
+
+export type ModelAction<PK> = {
+  [ACTION_STATUS.error]: PK[];
+  [ACTION_STATUS.loading]: PK[];
+  [ACTION_STATUS.success]: PK[];
+};
+
+export type PayloadActionWithIdentifier<I, P = null> = PayloadAction<
+  P,
+  string,
+  { identifier: I }
+>;
+
+export type StateError<A extends string, I> = {
+  action: A;
+  error: APIError;
+  identifier: I | null;
+};

--- a/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
@@ -28,6 +28,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -67,7 +68,7 @@ beforeEach(() => {
       ],
     }),
     zone: zoneStateFactory({
-      loaded: true,
+      genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       items: [zoneFactory({ name: "twilight" })],
     }),
   });

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -19,6 +19,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { submitFormikForm } from "testing/utils";
@@ -39,8 +40,8 @@ describe("AddDeviceForm", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
         items: [zoneFactory({ id: 0, name: "default" })],
-        loaded: true,
       }),
     });
   });
@@ -73,7 +74,7 @@ describe("AddDeviceForm", () => {
   });
 
   it("displays a spinner if data has not loaded", () => {
-    state.zone.loaded = false;
+    state.zone.genericActions.fetch = "idle";
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -20,6 +20,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -41,7 +42,7 @@ describe("DeviceConfiguration", () => {
         ],
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
         items: [zoneFactory({ name: "twilight" })],
       }),
     });

--- a/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -17,6 +17,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -34,8 +35,8 @@ beforeEach(() => {
       loaded: true,
     }),
     zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       items: [zoneFactory({ id: 3 })],
-      loaded: true,
     }),
   });
 });

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
@@ -65,7 +65,6 @@ describe("AddLxd", () => {
       }),
       zone: zoneStateFactory({
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.test.tsx
@@ -50,7 +50,6 @@ describe("AuthenticationForm", () => {
       }),
       zone: zoneStateFactory({
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
     newPodValues = {

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/CredentialsForm/CredentialsForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/CredentialsForm/CredentialsForm.test.tsx
@@ -50,7 +50,6 @@ describe("CredentialsForm", () => {
       }),
       zone: zoneStateFactory({
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
     newPodValues = {

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
@@ -40,7 +40,6 @@ describe("SelectProjectForm", () => {
       }),
       zone: zoneStateFactory({
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
     newPodValues = {

--- a/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
@@ -24,6 +24,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { submitFormikForm } from "testing/utils";
@@ -60,8 +61,8 @@ describe("AddVirsh", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirshFields/AddVirshFields.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirshFields/AddVirshFields.test.tsx
@@ -21,6 +21,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -52,8 +53,8 @@ describe("AddVirshFields", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.test.tsx
@@ -29,6 +29,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { submitFormikForm } from "testing/utils";
@@ -67,7 +68,7 @@ describe("ComposeForm", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });
@@ -101,7 +102,7 @@ describe("ComposeForm", () => {
   });
 
   it("displays a spinner if data has not loaded", () => {
-    state.zone.loaded = false;
+    state.zone.genericActions.fetch = "idle";
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -31,6 +31,7 @@ import {
   spaceState as spaceStateFactory,
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
@@ -72,7 +73,7 @@ describe("ComposeFormFields", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -27,6 +27,7 @@ import {
   subnetState as subnetStateFactory,
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
@@ -83,7 +84,7 @@ describe("InterfacesTable", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -30,6 +30,7 @@ import {
   subnetState as subnetStateFactory,
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
@@ -86,7 +87,7 @@ describe("SubnetSelect", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -27,6 +27,7 @@ import {
   spaceState as spaceStateFactory,
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
@@ -83,7 +84,7 @@ describe("PoolSelect", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -26,6 +26,7 @@ import {
   spaceState as spaceStateFactory,
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
@@ -82,7 +83,7 @@ describe("StorageTable", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
+++ b/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
@@ -38,7 +38,6 @@ describe("VirshTable", () => {
         ],
       }),
       zone: zoneStateFactory({
-        loaded: true,
         items: [
           zoneFactory({ id: pods[0].zone }),
           zoneFactory({ id: pods[1].zone }),

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -14,6 +14,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   tagState as tagStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { renderWithBrowserRouter } from "testing/utils";
@@ -34,7 +35,7 @@ describe("LXDSingleDetails", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.test.tsx
@@ -33,9 +33,7 @@ describe("LXDSingleSettings", () => {
       tag: tagStateFactory({
         loaded: true,
       }),
-      zone: zoneStateFactory({
-        loaded: true,
-      }),
+      zone: zoneStateFactory({}),
     });
   });
 

--- a/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
@@ -13,6 +13,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   tagState as tagStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { renderWithBrowserRouter } from "testing/utils";
@@ -33,7 +34,7 @@ describe("VirshDetails", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
-        loaded: true,
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       }),
     });
   });

--- a/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
@@ -33,9 +33,7 @@ describe("VirshSettings", () => {
       tag: tagStateFactory({
         loaded: true,
       }),
-      zone: zoneStateFactory({
-        loaded: true,
-      }),
+      zone: zoneStateFactory({}),
     });
   });
 

--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -24,6 +24,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -88,12 +89,12 @@ beforeEach(() => {
       loaded: true,
     }),
     zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({ fetch: "success" }),
       items: [
         zoneFactory({
           name: "twilight",
         }),
       ],
-      loaded: true,
     }),
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
@@ -21,6 +21,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
@@ -67,8 +68,8 @@ describe("AddMachineFormFields", () => {
         loaded: true,
       }),
       zone: zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({ fetch: "success" }),
         items: [zoneFactory()],
-        loaded: true,
       }),
     });
   });

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -195,7 +195,6 @@ describe("MachineListTable", () => {
         ],
       }),
       zone: zoneStateFactory({
-        loaded: true,
         items: [
           zoneFactory({
             id: 0,

--- a/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.tsx
@@ -36,7 +36,6 @@ describe("ZoneColumn", () => {
         ],
       }),
       zone: zoneStateFactory({
-        loaded: true,
         items: [
           zoneFactory({
             id: 0,

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -22,6 +22,7 @@ import type { RootState } from "app/store/root/types";
 import type { StatusMeta } from "app/store/status/types";
 import type { SubnetMeta, SubnetStatus } from "app/store/subnet/types";
 import type { VLANMeta, VLANStatus } from "app/store/vlan/types";
+import type { ZoneMeta } from "app/store/zone/types";
 import { objectHasKey } from "app/utils";
 
 export type GenericItemMeta<I> = {
@@ -45,6 +46,7 @@ export type CommonStates = Omit<
   | MessageMeta.MODEL
   | NodeScriptResultMeta.MODEL
   | StatusMeta.MODEL
+  | ZoneMeta.MODEL
 >;
 
 // Get the types of the common models. e.g. "DHCPSnippetState".

--- a/src/app/store/zone/actions.test.ts
+++ b/src/app/store/zone/actions.test.ts
@@ -1,46 +1,82 @@
-import { actions } from "./slice";
+import { ZONE_ACTIONS, ZONE_WEBSOCKET_METHODS } from "./constants";
+import { actions as zoneActions } from "./slice";
+import { ZoneMeta } from "./types";
 
-describe("base actions", () => {
-  it("creates an action for fetching zones", () => {
-    expect(actions.fetch()).toEqual({
-      type: "zone/fetch",
-      meta: {
-        model: "zone",
-        method: "list",
+it("can create an action for creating a zone", () => {
+  expect(
+    zoneActions[ZONE_ACTIONS.create]({
+      description: "Welcome to the",
+      name: "danger",
+    })
+  ).toEqual({
+    type: `${ZoneMeta.MODEL}/${ZONE_ACTIONS.create}`,
+    meta: {
+      model: ZoneMeta.MODEL,
+      method: ZONE_WEBSOCKET_METHODS.create,
+    },
+    payload: {
+      params: {
+        description: "Welcome to the",
+        name: "danger",
       },
-      payload: null,
-    });
+    },
   });
+});
 
-  it("creates an action for fetching zones", () => {
-    expect(
-      actions.create({ name: "zone1", description: "It's the best zone" })
-    ).toEqual({
-      type: "zone/create",
-      meta: {
-        model: "zone",
-        method: "create",
-      },
-      payload: { params: { name: "zone1", description: "It's the best zone" } },
-    });
+it("can create an action for fetching zones", () => {
+  expect(zoneActions[ZONE_ACTIONS.fetch]()).toEqual({
+    type: `${ZoneMeta.MODEL}/${ZONE_ACTIONS.fetch}`,
+    meta: {
+      model: ZoneMeta.MODEL,
+      method: ZONE_WEBSOCKET_METHODS.list,
+    },
+    payload: null,
   });
+});
 
-  it("creates an action for fetching zones", () => {
-    expect(
-      actions.update({
-        id: 1,
-        name: "zone1",
-        description: "It's the best zone",
-      })
-    ).toEqual({
-      type: "zone/update",
-      meta: {
-        model: "zone",
-        method: "update",
+it("can create an action for deleting a zone", () => {
+  expect(zoneActions[ZONE_ACTIONS.delete]({ [ZoneMeta.PK]: 123 })).toEqual({
+    type: `${ZoneMeta.MODEL}/${ZONE_ACTIONS.delete}`,
+    meta: {
+      model: ZoneMeta.MODEL,
+      method: ZONE_WEBSOCKET_METHODS.delete,
+      identifier: 123,
+    },
+    payload: {
+      params: {
+        [ZoneMeta.PK]: 123,
       },
-      payload: {
-        params: { id: 1, name: "zone1", description: "It's the best zone" },
+    },
+  });
+});
+
+it("can create an action for updating a zone", () => {
+  expect(
+    zoneActions[ZONE_ACTIONS.update]({
+      [ZoneMeta.PK]: 321,
+      description: "Goodbye to the",
+      name: "danger",
+    })
+  ).toEqual({
+    type: `${ZoneMeta.MODEL}/${ZONE_ACTIONS.update}`,
+    meta: {
+      model: ZoneMeta.MODEL,
+      method: ZONE_WEBSOCKET_METHODS.update,
+      identifier: 321,
+    },
+    payload: {
+      params: {
+        [ZoneMeta.PK]: 321,
+        description: "Goodbye to the",
+        name: "danger",
       },
-    });
+    },
+  });
+});
+
+it("can create an action for cleaning up zone state", () => {
+  expect(zoneActions[ZONE_ACTIONS.cleanup]([ZONE_ACTIONS.delete])).toEqual({
+    type: `${ZoneMeta.MODEL}/${ZONE_ACTIONS.cleanup}`,
+    payload: [ZONE_ACTIONS.delete],
   });
 });

--- a/src/app/store/zone/constants.ts
+++ b/src/app/store/zone/constants.ts
@@ -1,0 +1,9 @@
+import { COMMON_ACTIONS, COMMON_WEBSOCKET_METHODS } from "app/base/constants";
+
+export const ZONE_ACTIONS = {
+  ...COMMON_ACTIONS,
+} as const;
+
+export const ZONE_WEBSOCKET_METHODS = {
+  ...COMMON_WEBSOCKET_METHODS,
+} as const;

--- a/src/app/store/zone/index.ts
+++ b/src/app/store/zone/index.ts
@@ -1,1 +1,6 @@
-export { default, actions } from "./slice";
+export {
+  default,
+  actions,
+  initialGenericActions,
+  initialModelActions,
+} from "./slice";

--- a/src/app/store/zone/reducers.test.ts
+++ b/src/app/store/zone/reducers.test.ts
@@ -1,59 +1,430 @@
-import reducers, { actions } from "./slice";
+import { ZONE_ACTIONS } from "./constants";
+import reducers, {
+  actions,
+  initialGenericActions,
+  initialModelActions,
+} from "./slice";
+import { ZoneMeta } from "./types";
 
+import { ACTION_STATUS } from "app/base/constants";
 import {
   zone as zoneFactory,
+  zoneError as zoneErrorFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
+  zoneModelAction as zoneModelActionFactory,
+  zoneModelActions as zoneModelActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
-describe("zone reducer", () => {
-  it("returns the initial state", () => {
-    expect(reducers(undefined, { type: "" })).toEqual({
-      errors: null,
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
+it("returns the initial state", () => {
+  expect(reducers(undefined, { type: "" })).toEqual({
+    errors: [],
+    genericActions: initialGenericActions,
+    items: [],
+    modelActions: initialModelActions,
+  });
+});
+
+describe("cleanup", () => {
+  it("clears errors and statuses for given action names", () => {
+    const [deleteError, fetchError] = [
+      zoneErrorFactory({ action: ZONE_ACTIONS.delete }),
+      zoneErrorFactory({ action: ZONE_ACTIONS.fetch }),
+    ];
+    const initialState = zoneStateFactory({
+      errors: [deleteError, fetchError],
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.fetch]: ACTION_STATUS.success,
+      }),
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+          [ACTION_STATUS.error]: [1],
+          [ACTION_STATUS.loading]: [2],
+          [ACTION_STATUS.success]: [3],
+        }),
+      }),
     });
+
+    expect(
+      // Only clear delete errors and statuses
+      reducers(initialState, actions.cleanup([ZONE_ACTIONS.delete]))
+    ).toEqual(
+      zoneStateFactory({
+        errors: [fetchError],
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.fetch]: ACTION_STATUS.success,
+        }),
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+            [ACTION_STATUS.error]: [],
+            [ACTION_STATUS.loading]: [],
+            [ACTION_STATUS.success]: [],
+          }),
+        }),
+      })
+    );
+  });
+});
+
+describe("create", () => {
+  it("reduces createStart", () => {
+    const initialState = zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.create]: ACTION_STATUS.idle,
+      }),
+    });
+
+    expect(reducers(initialState, actions.createStart())).toEqual(
+      zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.create]: ACTION_STATUS.loading,
+        }),
+      })
+    );
   });
 
-  it("reduces fetchStart", () => {
-    expect(reducers(undefined, actions.fetchStart())).toEqual({
-      errors: null,
-      items: [],
-      loaded: false,
-      loading: true,
-      saved: false,
-      saving: false,
+  it("reduces createSuccess", () => {
+    const initialState = zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.create]: ACTION_STATUS.loading,
+      }),
     });
+
+    expect(reducers(initialState, actions.createSuccess())).toEqual(
+      zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.create]: ACTION_STATUS.success,
+        }),
+      })
+    );
+  });
+
+  it("reduces createError", () => {
+    const initialState = zoneStateFactory({
+      errors: [],
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.create]: ACTION_STATUS.loading,
+      }),
+    });
+    const errorMessage = "Unable to create zone";
+
+    expect(reducers(initialState, actions.createError(errorMessage))).toEqual(
+      zoneStateFactory({
+        errors: [
+          zoneErrorFactory({
+            action: ZONE_ACTIONS.create,
+            error: errorMessage,
+          }),
+        ],
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.create]: ACTION_STATUS.error,
+        }),
+      })
+    );
+  });
+
+  it("reduces createNotify", () => {
+    const initialState = zoneStateFactory({
+      items: [zoneFactory()],
+    });
+    const createdZone = zoneFactory();
+
+    expect(reducers(initialState, actions.createNotify(createdZone))).toEqual(
+      zoneStateFactory({
+        items: [...initialState.items, createdZone],
+      })
+    );
+  });
+});
+
+describe("fetch", () => {
+  it("reduces fetchStart", () => {
+    const initialState = zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.fetch]: ACTION_STATUS.idle,
+      }),
+    });
+
+    expect(reducers(initialState, actions.fetchStart())).toEqual(
+      zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.fetch]: ACTION_STATUS.loading,
+        }),
+      })
+    );
   });
 
   it("reduces fetchSuccess", () => {
-    const state = zoneStateFactory();
-    const zones = [zoneFactory()];
-
-    expect(reducers(state, actions.fetchSuccess(zones))).toEqual({
-      errors: {},
-      items: zones,
-      loading: false,
-      loaded: true,
-      saved: false,
-      saving: false,
+    const initialState = zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.fetch]: ACTION_STATUS.loading,
+      }),
+      items: [],
     });
+    const fetchedZones = [zoneFactory(), zoneFactory()];
+
+    expect(reducers(initialState, actions.fetchSuccess(fetchedZones))).toEqual(
+      zoneStateFactory({
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.fetch]: ACTION_STATUS.success,
+        }),
+        items: fetchedZones,
+      })
+    );
   });
 
-  it("should correctly reduce FETCH_ZONE_ERROR", () => {
-    const state = zoneStateFactory();
+  it("reduces fetchError", () => {
+    const initialState = zoneStateFactory({
+      errors: [],
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.fetch]: ACTION_STATUS.loading,
+      }),
+    });
+    const errorMessage = "Unable to fetch zones";
+
+    expect(reducers(initialState, actions.fetchError(errorMessage))).toEqual(
+      zoneStateFactory({
+        errors: [
+          zoneErrorFactory({
+            action: ZONE_ACTIONS.fetch,
+            error: errorMessage,
+          }),
+        ],
+        genericActions: zoneGenericActionsFactory({
+          [ZONE_ACTIONS.fetch]: ACTION_STATUS.error,
+        }),
+      })
+    );
+  });
+});
+
+describe("update", () => {
+  it("reduces updateStart", () => {
+    const initialState = zoneStateFactory({
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.update]: zoneModelActionFactory({
+          [ACTION_STATUS.loading]: [],
+        }),
+      }),
+    });
 
     expect(
-      reducers(state, actions.fetchError("Could not fetch zones"))
-    ).toEqual({
-      errors: "Could not fetch zones",
+      reducers(
+        initialState,
+        actions.updateStart({
+          meta: { identifier: 123 },
+          payload: null,
+          type: "updateStart",
+        })
+      )
+    ).toEqual(
+      zoneStateFactory({
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.update]: zoneModelActionFactory({
+            [ACTION_STATUS.loading]: [123],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("reduces updateSuccess", () => {
+    const zone = zoneFactory({ id: 123 });
+    const initialState = zoneStateFactory({
       items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.update]: zoneModelActionFactory({
+          [ACTION_STATUS.loading]: [123],
+          [ACTION_STATUS.success]: [],
+        }),
+      }),
     });
+
+    expect(
+      reducers(
+        initialState,
+        actions.updateSuccess({
+          meta: { identifier: 123 },
+          payload: zone,
+          type: "updateSuccess",
+        })
+      )
+    ).toEqual(
+      zoneStateFactory({
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.update]: zoneModelActionFactory({
+            [ACTION_STATUS.loading]: [],
+            [ACTION_STATUS.success]: [123],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("reduces updateError", () => {
+    const initialState = zoneStateFactory({
+      errors: [],
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.update]: zoneModelActionFactory({
+          [ACTION_STATUS.error]: [],
+          [ACTION_STATUS.loading]: [123],
+        }),
+      }),
+    });
+    const errorMessage = "Unable to update zone";
+
+    expect(
+      reducers(
+        initialState,
+        actions.updateError({
+          meta: { identifier: 123 },
+          payload: errorMessage,
+          type: "updateError",
+        })
+      )
+    ).toEqual(
+      zoneStateFactory({
+        errors: [
+          zoneErrorFactory({
+            action: ZONE_ACTIONS.update,
+            error: errorMessage,
+            identifier: 123,
+          }),
+        ],
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.update]: zoneModelActionFactory({
+            [ACTION_STATUS.error]: [123],
+            [ACTION_STATUS.loading]: [],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("reduces updateNotify", () => {
+    const initialState = zoneStateFactory({
+      items: [zoneFactory({ [ZoneMeta.PK]: 123, name: "danger" })],
+    });
+    const updatedZone = zoneFactory({ [ZoneMeta.PK]: 123, name: "twilight" });
+
+    expect(reducers(initialState, actions.updateNotify(updatedZone))).toEqual(
+      zoneStateFactory({
+        items: [updatedZone],
+      })
+    );
+  });
+});
+
+describe("delete", () => {
+  it("reduces deleteStart", () => {
+    const initialState = zoneStateFactory({
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+          [ACTION_STATUS.loading]: [],
+        }),
+      }),
+    });
+
+    expect(
+      reducers(
+        initialState,
+        actions.deleteStart({
+          meta: { identifier: 123 },
+          payload: null,
+          type: "deleteStart",
+        })
+      )
+    ).toEqual(
+      zoneStateFactory({
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+            [ACTION_STATUS.loading]: [123],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("reduces deleteSuccess", () => {
+    const initialState = zoneStateFactory({
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+          [ACTION_STATUS.loading]: [123],
+          [ACTION_STATUS.success]: [],
+        }),
+      }),
+    });
+
+    expect(
+      reducers(
+        initialState,
+        actions.deleteSuccess({
+          meta: { identifier: 123 },
+          payload: 123,
+          type: "deleteSuccess",
+        })
+      )
+    ).toEqual(
+      zoneStateFactory({
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+            [ACTION_STATUS.loading]: [],
+            [ACTION_STATUS.success]: [123],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("reduces deleteError", () => {
+    const initialState = zoneStateFactory({
+      errors: [],
+      modelActions: zoneModelActionsFactory({
+        [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+          [ACTION_STATUS.error]: [],
+          [ACTION_STATUS.loading]: [123],
+        }),
+      }),
+    });
+    const errorMessage = "Unable to delete zone";
+
+    expect(
+      reducers(
+        initialState,
+        actions.deleteError({
+          meta: { identifier: 123 },
+          payload: errorMessage,
+          type: "deleteError",
+        })
+      )
+    ).toEqual(
+      zoneStateFactory({
+        errors: [
+          zoneErrorFactory({
+            action: ZONE_ACTIONS.delete,
+            error: errorMessage,
+            identifier: 123,
+          }),
+        ],
+        modelActions: zoneModelActionsFactory({
+          [ZONE_ACTIONS.delete]: zoneModelActionFactory({
+            [ACTION_STATUS.error]: [123],
+            [ACTION_STATUS.loading]: [],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("reduces deleteNotify", () => {
+    const initialState = zoneStateFactory({
+      items: [zoneFactory({ [ZoneMeta.PK]: 123 })],
+    });
+
+    expect(reducers(initialState, actions.deleteNotify(123))).toEqual(
+      zoneStateFactory({
+        items: [],
+      })
+    );
   });
 });

--- a/src/app/store/zone/selectors.test.ts
+++ b/src/app/store/zone/selectors.test.ts
@@ -1,56 +1,195 @@
+import { ZONE_ACTIONS } from "./constants";
 import zone from "./selectors";
 
+import { ACTION_STATUS } from "app/base/constants";
 import {
   rootState as rootStateFactory,
   zone as zoneFactory,
+  zoneError as zoneErrorFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
+  zoneModelAction as zoneModelActionFactory,
+  zoneModelActions as zoneModelActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
-describe("zone selectors", () => {
-  it("can get all items", () => {
-    const items = [zoneFactory(), zoneFactory()];
-    const state = rootStateFactory({
-      zone: zoneStateFactory({
-        items,
-      }),
-    });
-    expect(zone.all(state)).toEqual(items);
+it("can get all zones", () => {
+  const items = [zoneFactory(), zoneFactory()];
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      items,
+    }),
   });
 
-  it("can get the loading state", () => {
-    const state = rootStateFactory({
-      zone: zoneStateFactory({
-        loading: true,
-      }),
-    });
-    expect(zone.loading(state)).toEqual(true);
+  expect(zone.all(state)).toEqual(items);
+});
+
+it("can get zone errors", () => {
+  const errors = [zoneErrorFactory(), zoneErrorFactory()];
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      errors,
+    }),
   });
 
-  it("can get the loaded state", () => {
-    const state = rootStateFactory({
-      zone: zoneStateFactory({
-        loaded: true,
-      }),
-    });
-    expect(zone.loaded(state)).toEqual(true);
+  expect(zone.errors(state)).toEqual(errors);
+});
+
+it("can get zone generic actions", () => {
+  const genericActions = zoneGenericActionsFactory();
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      genericActions,
+    }),
   });
 
-  it("can get the errors state", () => {
-    const state = rootStateFactory({
-      zone: zoneStateFactory({
-        errors: "Data is incorrect",
-      }),
-    });
-    expect(zone.errors(state)).toStrictEqual("Data is incorrect");
+  expect(zone.genericActions(state)).toEqual(genericActions);
+});
+
+it("can get zone model actions", () => {
+  const modelActions = zoneModelActionsFactory();
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      modelActions,
+    }),
   });
 
-  it("can get a zone by id", () => {
-    const items = [zoneFactory({ id: 1 }), zoneFactory({ id: 2 })];
-    const state = rootStateFactory({
-      zone: zoneStateFactory({
-        items,
-      }),
-    });
-    expect(zone.getById(state, 1)).toStrictEqual(items[0]);
+  expect(zone.modelActions(state)).toEqual(modelActions);
+});
+
+it("can get the zone count", () => {
+  const items = [zoneFactory(), zoneFactory()];
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      items,
+    }),
   });
+
+  expect(zone.count(state)).toEqual(items.length);
+});
+
+it("can get a zone by id", () => {
+  const [thisZone, otherZone] = [
+    zoneFactory({ id: 1 }),
+    zoneFactory({ id: 2 }),
+  ];
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      items: [thisZone, otherZone],
+    }),
+  });
+
+  expect(zone.getById(state, 1)).toStrictEqual(thisZone);
+});
+
+it("can get a zone generic action's status", () => {
+  const genericActions = zoneGenericActionsFactory({
+    [ZONE_ACTIONS.fetch]: ACTION_STATUS.error,
+  });
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      genericActions,
+    }),
+  });
+
+  expect(zone.getGenericActionStatus(state, ZONE_ACTIONS.fetch)).toBe(
+    ACTION_STATUS.error
+  );
+});
+
+it("can get a zone's model action status", () => {
+  const modelActions = zoneModelActionsFactory({
+    [ZONE_ACTIONS.update]: zoneModelActionFactory({
+      [ACTION_STATUS.loading]: [123],
+    }),
+  });
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      modelActions,
+    }),
+  });
+
+  expect(zone.getModelActionStatus(state, ZONE_ACTIONS.update, 123)).toBe(
+    ACTION_STATUS.loading
+  );
+});
+
+it("can get the zone loading state", () => {
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.fetch]: ACTION_STATUS.loading,
+      }),
+    }),
+  });
+
+  expect(zone.loading(state)).toEqual(true);
+});
+
+it("can get the zone loaded state", () => {
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.fetch]: ACTION_STATUS.success,
+      }),
+    }),
+  });
+
+  expect(zone.loaded(state)).toEqual(true);
+});
+
+it("can get the zone creating state", () => {
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.create]: ACTION_STATUS.loading,
+      }),
+    }),
+  });
+
+  expect(zone.creating(state)).toEqual(true);
+});
+
+it("can get the zone created state", () => {
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({
+        [ZONE_ACTIONS.create]: ACTION_STATUS.success,
+      }),
+    }),
+  });
+
+  expect(zone.created(state)).toEqual(true);
+});
+
+it("can get the latest error for an action", () => {
+  const latestErrorMessage = "This is the latest error.";
+  const [
+    otherActionError,
+    otherModelError,
+    latestActionError,
+    nonLatestActionError,
+  ] = [
+    zoneErrorFactory({ action: ZONE_ACTIONS.update, identifier: 123 }),
+    zoneErrorFactory({ action: ZONE_ACTIONS.delete, identifier: 321 }),
+    zoneErrorFactory({
+      action: ZONE_ACTIONS.delete,
+      identifier: 123,
+      error: latestErrorMessage,
+    }),
+    zoneErrorFactory({ action: ZONE_ACTIONS.delete, identifier: 123 }),
+  ];
+  const state = rootStateFactory({
+    zone: zoneStateFactory({
+      errors: [
+        otherActionError,
+        otherModelError,
+        latestActionError,
+        nonLatestActionError,
+      ],
+    }),
+  });
+
+  expect(zone.getLatestError(state, ZONE_ACTIONS.delete, 123)).toEqual(
+    latestErrorMessage
+  );
 });

--- a/src/app/store/zone/selectors.ts
+++ b/src/app/store/zone/selectors.ts
@@ -1,13 +1,110 @@
-import { generateBaseSelectors } from "app/store/utils";
-import { ZoneMeta } from "app/store/zone/types";
-import type { Zone, ZoneState } from "app/store/zone/types";
+import { createSelector } from "@reduxjs/toolkit";
 
-const searchFunction = (zone: Zone, term: string) => zone.name.includes(term);
+import { ZONE_ACTIONS } from "./constants";
+import type {
+  ZoneActionNames,
+  ZoneGenericActions,
+  ZoneModelActions,
+  ZonePK,
+  ZoneState,
+} from "./types";
+import { ZoneMeta } from "./types";
 
-const selectors = generateBaseSelectors<ZoneState, Zone, ZoneMeta.PK>(
-  ZoneMeta.MODEL,
-  ZoneMeta.PK,
-  searchFunction
+import { ACTION_STATUS } from "app/base/constants";
+import type { RootState } from "app/store/root/types";
+import { isId } from "app/utils";
+
+const all = (state: RootState): ZoneState["items"] =>
+  state[ZoneMeta.MODEL].items;
+
+const errors = (state: RootState): ZoneState["errors"] =>
+  state[ZoneMeta.MODEL].errors;
+
+const genericActions = (state: RootState): ZoneState["genericActions"] =>
+  state[ZoneMeta.MODEL].genericActions;
+
+const modelActions = (state: RootState): ZoneState["modelActions"] =>
+  state[ZoneMeta.MODEL].modelActions;
+
+const count = createSelector([all], (zones) => zones.length);
+
+const getById = createSelector(
+  [all, (_state: RootState, id: ZonePK | null | undefined) => id],
+  (zones, id) => {
+    if (!isId(id)) {
+      return null;
+    }
+    return zones.find((zone) => zone[ZoneMeta.PK] === id) || null;
+  }
 );
+
+const getGenericActionStatus = createSelector(
+  (state: RootState, action: keyof ZoneGenericActions) => ({
+    action,
+    genericActions: genericActions(state),
+  }),
+  ({ genericActions, action }) => genericActions[action]
+);
+
+const getModelActionStatus = createSelector(
+  (state: RootState, action: keyof ZoneModelActions, zonePK: ZonePK) => ({
+    action,
+    modelActions: modelActions(state),
+    zonePK,
+  }),
+  ({ action, modelActions, zonePK }) => {
+    const { error, loading, success } = modelActions[action];
+    if (error.includes(zonePK)) {
+      return ACTION_STATUS.error;
+    } else if (loading.includes(zonePK)) {
+      return ACTION_STATUS.loading;
+    } else if (success.includes(zonePK)) {
+      return ACTION_STATUS.success;
+    }
+    return ACTION_STATUS.idle;
+  }
+);
+
+const loaded = (state: RootState): boolean =>
+  getGenericActionStatus(state, ZONE_ACTIONS.fetch) === ACTION_STATUS.success;
+
+const loading = (state: RootState): boolean =>
+  getGenericActionStatus(state, ZONE_ACTIONS.fetch) === ACTION_STATUS.loading;
+
+const created = (state: RootState): boolean =>
+  getGenericActionStatus(state, ZONE_ACTIONS.create) === ACTION_STATUS.success;
+
+const creating = (state: RootState): boolean =>
+  getGenericActionStatus(state, ZONE_ACTIONS.create) === ACTION_STATUS.loading;
+
+const getLatestError = createSelector(
+  (
+    state: RootState,
+    action: ZoneActionNames | null = null,
+    zonePK: ZonePK | null = null
+  ) => ({ action, errors: errors(state), zonePK }),
+  ({ action, errors, zonePK }) =>
+    errors.find((error) => {
+      const matchesAction = action ? error.action === action : true;
+      const matchesIdentifier = zonePK ? error.identifier === zonePK : true;
+      return matchesAction && matchesIdentifier;
+    })?.error || null
+);
+
+const selectors = {
+  all,
+  count,
+  created,
+  creating,
+  errors,
+  genericActions,
+  getById,
+  getGenericActionStatus,
+  getLatestError,
+  getModelActionStatus,
+  loaded,
+  loading,
+  modelActions,
+};
 
 export default selectors;

--- a/src/app/store/zone/slice.ts
+++ b/src/app/store/zone/slice.ts
@@ -1,22 +1,249 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
+import { ZONE_ACTIONS, ZONE_WEBSOCKET_METHODS } from "./constants";
+import type {
+  CreateParams,
+  DeleteParams,
+  UpdateParams,
+  Zone,
+  ZoneActionNames,
+  ZonePayloadActionWithIdentifier,
+  ZoneGenericActions,
+  ZoneModelActions,
+  ZonePK,
+  ZoneState,
+} from "./types";
 import { ZoneMeta } from "./types";
-import type { CreateParams, UpdateParams, ZoneState } from "./types";
 
-import {
-  generateCommonReducers,
-  genericInitialState,
-} from "app/store/utils/slice";
+import { ACTION_STATUS } from "app/base/constants";
+import type { ActionStatuses, APIError } from "app/base/types";
+
+const { cleanup, create, delete: deleteAction, fetch, update } = ZONE_ACTIONS;
+
+const { error, idle, loading, success } = ACTION_STATUS;
+
+export const initialGenericActions: ZoneGenericActions = {
+  [create]: idle,
+  [fetch]: idle,
+};
+
+export const initialModelActions: ZoneModelActions = {
+  [deleteAction]: {
+    [error]: [],
+    [loading]: [],
+    [success]: [],
+  },
+  [update]: {
+    [error]: [],
+    [loading]: [],
+    [success]: [],
+  },
+};
+
+const addError = (
+  state: ZoneState,
+  action: ZoneActionNames,
+  error: APIError,
+  zonePK: ZonePK | null = null
+) => {
+  state.errors.unshift({ action, error, identifier: zonePK });
+};
+
+const updateGenericAction = (
+  state: ZoneState,
+  actionName: keyof ZoneGenericActions,
+  status: ActionStatuses
+) => {
+  state.genericActions[actionName] = status;
+};
+
+const updateModelAction = (
+  state: ZoneState,
+  actionName: keyof ZoneModelActions,
+  status: ActionStatuses,
+  zonePK: ZonePK
+) => {
+  const statuses = state.modelActions[actionName];
+  statuses[error] = statuses[error].filter((id) => id !== zonePK);
+  statuses[loading] = statuses[loading].filter((id) => id !== zonePK);
+  statuses[success] = statuses[success].filter((id) => id !== zonePK);
+  if (status === error) {
+    statuses[error].push(zonePK);
+  } else if (status === loading) {
+    statuses[loading].push(zonePK);
+  } else {
+    statuses[success].push(zonePK);
+  }
+};
 
 const zoneSlice = createSlice({
   name: ZoneMeta.MODEL,
-  initialState: genericInitialState as ZoneState,
-  reducers: generateCommonReducers<
-    ZoneState,
-    ZoneMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(ZoneMeta.MODEL, ZoneMeta.PK),
+  initialState: {
+    errors: [],
+    genericActions: initialGenericActions,
+    items: [],
+    modelActions: initialModelActions,
+  } as ZoneState,
+  reducers: {
+    [cleanup]: (state, action: PayloadAction<ZoneActionNames[]>) => {
+      const actions = action.payload;
+      for (const key in state.genericActions) {
+        const actionName = key as keyof ZoneGenericActions;
+        if (actions.includes(actionName)) {
+          state.genericActions[actionName] = initialGenericActions[actionName];
+        }
+      }
+      for (const key in state.modelActions) {
+        const actionName = key as keyof ZoneModelActions;
+        if (actions.includes(actionName)) {
+          state.modelActions[actionName] = initialModelActions[actionName];
+        }
+      }
+      state.errors = state.errors.filter(
+        (error) => !actions.includes(error.action)
+      );
+    },
+    [create]: {
+      prepare: (params: CreateParams) => ({
+        meta: {
+          model: ZoneMeta.MODEL,
+          method: ZONE_WEBSOCKET_METHODS.create,
+        },
+        payload: {
+          params,
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    createError: (state, action: PayloadAction<APIError>) => {
+      addError(state, create, action.payload);
+      updateGenericAction(state, create, error);
+    },
+    createNotify: (state, action: PayloadAction<Zone>) => {
+      const existingIdx = state.items.findIndex(
+        (existingItem) =>
+          existingItem[ZoneMeta.PK] === action.payload[ZoneMeta.PK]
+      );
+      if (existingIdx !== -1) {
+        state.items[existingIdx] = action.payload;
+      } else {
+        state.items.push(action.payload);
+      }
+    },
+    createStart: (state) => {
+      updateGenericAction(state, create, loading);
+    },
+    createSuccess: (state) => {
+      updateGenericAction(state, create, success);
+    },
+    [deleteAction]: {
+      prepare: (params: DeleteParams) => ({
+        meta: {
+          model: ZoneMeta.MODEL,
+          method: ZONE_WEBSOCKET_METHODS.delete,
+          identifier: params[ZoneMeta.PK],
+        },
+        payload: {
+          params,
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    deleteError: {
+      prepare: (action: ZonePayloadActionWithIdentifier<APIError>) => action,
+      reducer: (state, action: ZonePayloadActionWithIdentifier<APIError>) => {
+        addError(state, deleteAction, action.payload, action.meta.identifier);
+        updateModelAction(state, deleteAction, error, action.meta.identifier);
+      },
+    },
+    deleteNotify: (state, action: PayloadAction<ZonePK>) => {
+      const index = state.items.findIndex(
+        (item) => item[ZoneMeta.PK] === action.payload
+      );
+      state.items.splice(index, 1);
+    },
+    deleteStart: {
+      prepare: (action: ZonePayloadActionWithIdentifier) => action,
+      reducer: (state, action: ZonePayloadActionWithIdentifier) => {
+        updateModelAction(state, deleteAction, loading, action.meta.identifier);
+      },
+    },
+    deleteSuccess: {
+      prepare: (action: ZonePayloadActionWithIdentifier<ZonePK>) => action,
+      reducer: (state, action: ZonePayloadActionWithIdentifier<ZonePK>) => {
+        updateModelAction(state, deleteAction, success, action.meta.identifier);
+      },
+    },
+    [fetch]: {
+      prepare: () => ({
+        meta: {
+          model: ZoneMeta.MODEL,
+          method: ZONE_WEBSOCKET_METHODS.list,
+        },
+        payload: null,
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    fetchError: (state, action: PayloadAction<APIError>) => {
+      addError(state, fetch, action.payload);
+      updateGenericAction(state, fetch, error);
+    },
+    fetchStart: (state) => {
+      updateGenericAction(state, fetch, loading);
+    },
+    fetchSuccess: (state, action: PayloadAction<Zone[]>) => {
+      state.items = action.payload;
+      updateGenericAction(state, fetch, success);
+    },
+    [update]: {
+      prepare: (params: UpdateParams) => ({
+        meta: {
+          model: ZoneMeta.MODEL,
+          method: ZONE_WEBSOCKET_METHODS.update,
+          identifier: params[ZoneMeta.PK],
+        },
+        payload: {
+          params,
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    updateError: {
+      prepare: (action: ZonePayloadActionWithIdentifier<APIError>) => action,
+      reducer: (state, action: ZonePayloadActionWithIdentifier<APIError>) => {
+        addError(state, update, action.payload, action.meta.identifier);
+        updateModelAction(state, update, error, action.meta.identifier);
+      },
+    },
+    updateNotify: (state, action: PayloadAction<Zone>) => {
+      state.items.forEach((zone, i) => {
+        if (zone[ZoneMeta.PK] === action.payload[ZoneMeta.PK]) {
+          state.items[i] = action.payload;
+        }
+      });
+    },
+    updateStart: {
+      prepare: (action: ZonePayloadActionWithIdentifier) => action,
+      reducer: (state, action: ZonePayloadActionWithIdentifier) => {
+        updateModelAction(state, update, loading, action.meta.identifier);
+      },
+    },
+    updateSuccess: {
+      prepare: (action: ZonePayloadActionWithIdentifier<Zone>) => action,
+      reducer: (state, action: ZonePayloadActionWithIdentifier<Zone>) => {
+        updateModelAction(state, update, success, action.meta.identifier);
+      },
+    },
+  },
 });
 
 export const { actions } = zoneSlice;

--- a/src/app/store/zone/types/actions.ts
+++ b/src/app/store/zone/types/actions.ts
@@ -1,4 +1,4 @@
-import type { Zone } from "./base";
+import type { Zone, ZonePK } from "./base";
 import type { ZoneMeta } from "./enum";
 
 export type CreateParams = {
@@ -6,6 +6,10 @@ export type CreateParams = {
   name: Zone["name"];
 };
 
-export type UpdateParams = CreateParams & {
-  [ZoneMeta.PK]: Zone[ZoneMeta.PK];
+export type DeleteParams = {
+  [ZoneMeta.PK]: ZonePK;
 };
+
+export type UpdateParams = {
+  [ZoneMeta.PK]: ZonePK;
+} & Partial<CreateParams>;

--- a/src/app/store/zone/types/base.ts
+++ b/src/app/store/zone/types/base.ts
@@ -1,6 +1,20 @@
-import type { APIError } from "app/base/types";
+import type { ValueOf } from "@canonical/react-components";
+
+import type { ZONE_ACTIONS } from "../constants";
+
+import type { ZoneMeta } from "./enum";
+
+import type {
+  ActionStatuses,
+  ModelAction,
+  PayloadActionWithIdentifier,
+  StateError,
+} from "app/base/types";
 import type { TimestampedModel } from "app/store/types/model";
-import type { GenericState } from "app/store/types/state";
+
+export type ZonePK = Zone[ZoneMeta.PK];
+
+export type ZoneActionNames = ValueOf<typeof ZONE_ACTIONS>;
 
 export type Zone = TimestampedModel & {
   controllers_count: number;
@@ -10,4 +24,26 @@ export type Zone = TimestampedModel & {
   name: string;
 };
 
-export type ZoneState = GenericState<Zone, APIError>;
+export type ZoneGenericActions = {
+  [ZONE_ACTIONS.create]: ActionStatuses;
+  [ZONE_ACTIONS.fetch]: ActionStatuses;
+};
+
+export type ZoneModelAction = ModelAction<ZonePK>;
+
+export type ZoneModelActions = {
+  [ZONE_ACTIONS.delete]: ZoneModelAction;
+  [ZONE_ACTIONS.update]: ZoneModelAction;
+};
+
+export type ZonePayloadActionWithIdentifier<P = null> =
+  PayloadActionWithIdentifier<ZonePK, P>;
+
+export type ZoneStateError = StateError<ZoneActionNames, ZonePK>;
+
+export type ZoneState = {
+  errors: ZoneStateError[];
+  genericActions: ZoneGenericActions;
+  items: Zone[];
+  modelActions: ZoneModelActions;
+};

--- a/src/app/store/zone/types/index.ts
+++ b/src/app/store/zone/types/index.ts
@@ -1,5 +1,15 @@
-export type { CreateParams, UpdateParams } from "./actions";
+export type { CreateParams, DeleteParams, UpdateParams } from "./actions";
 
-export type { Zone, ZoneState } from "./base";
+export type {
+  Zone,
+  ZoneActionNames,
+  ZoneGenericActions,
+  ZoneModelAction,
+  ZoneModelActions,
+  ZonePayloadActionWithIdentifier,
+  ZonePK,
+  ZoneState,
+  ZoneStateError,
+} from "./base";
 
 export { ZoneMeta } from "./enum";

--- a/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -23,9 +23,6 @@ describe("ZoneDetails", () => {
   let initialState: RootState;
 
   const testZones = zoneStateFactory({
-    errors: {},
-    loading: false,
-    loaded: true,
     items: [
       zoneFactory({
         id: 1,

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import ZoneDetailsForm from "./ZoneDetailsForm";
 
 import type { RootState } from "app/store/root/types";
+import { actions as zoneActions } from "app/store/zone";
 import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
@@ -24,9 +25,6 @@ describe("ZoneDetailsForm", () => {
   beforeEach(() => {
     initialState = rootStateFactory({
       zone: zoneStateFactory({
-        errors: {},
-        loading: false,
-        loaded: true,
         items: [testZone],
       }),
     });
@@ -68,21 +66,13 @@ describe("ZoneDetailsForm", () => {
       })
     );
 
-    expect(
-      store.getActions().find((action) => action.type === "zone/update")
-    ).toStrictEqual({
-      type: "zone/update",
-      meta: {
-        method: "update",
-        model: "zone",
-      },
-      payload: {
-        params: {
-          id: testZone.id,
-          description: testZone.description,
-          name: testZone.name,
-        },
-      },
+    const expectedAction = zoneActions.update({
+      id: testZone.id,
+      description: testZone.description,
+      name: testZone.name,
     });
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
   });
 });

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.tsx
@@ -5,8 +5,10 @@ import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
+import { ACTION_STATUS } from "app/base/constants";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
+import { ZONE_ACTIONS } from "app/store/zone/constants";
 import zoneSelectors from "app/store/zone/selectors";
 
 type Props = {
@@ -19,14 +21,20 @@ export type CreateZoneValues = {
   name: string;
 };
 
-const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
+const ZoneDetailsForm = ({ id, closeForm }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const errors = useSelector(zoneSelectors.errors);
-  const saved = useSelector(zoneSelectors.saved);
-  const saving = useSelector(zoneSelectors.saving);
-  const cleanup = useCallback(() => zoneActions.cleanup(), []);
+  const cleanup = useCallback(
+    () => zoneActions.cleanup([ZONE_ACTIONS.update]),
+    []
+  );
   const zone = useSelector((state: RootState) =>
     zoneSelectors.getById(state, id)
+  );
+  const errors = useSelector((state: RootState) =>
+    zoneSelectors.getLatestError(state, ZONE_ACTIONS.update, id)
+  );
+  const updateStatus = useSelector((state: RootState) =>
+    zoneSelectors.getModelActionStatus(state, ZONE_ACTIONS.update, id)
   );
 
   useEffect(() => {
@@ -54,8 +62,8 @@ const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
           );
         }}
         onSuccess={closeForm}
-        saved={saved}
-        saving={saving}
+        saved={updateStatus === ACTION_STATUS.success}
+        saving={updateStatus === ACTION_STATUS.loading}
         submitLabel="Update AZ"
       >
         <Row>
@@ -79,4 +87,4 @@ const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
   return null;
 };
 
-export default ZoneForm;
+export default ZoneDetailsForm;

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.test.tsx
@@ -19,9 +19,6 @@ describe("DeleteConfirm", () => {
   beforeEach(() => {
     initialState = rootStateFactory({
       zone: zoneStateFactory({
-        errors: {},
-        loading: false,
-        loaded: true,
         items: [
           zoneFactory({
             id: 1,
@@ -41,6 +38,7 @@ describe("DeleteConfirm", () => {
         <DeleteConfirm
           closeExpanded={closeExpanded}
           confirmLabel="Delete AZ"
+          deleting={false}
           onConfirm={onConfirm}
         />
       </Provider>
@@ -59,6 +57,7 @@ describe("DeleteConfirm", () => {
         <DeleteConfirm
           closeExpanded={closeExpanded}
           confirmLabel="Delete AZ"
+          deleting={false}
           onConfirm={onConfirm}
         />
       </Provider>

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.tsx
@@ -4,10 +4,10 @@ import { ActionButton, Button, Col, Row } from "@canonical/react-components";
 import type { ActionButtonProps } from "@canonical/react-components";
 
 type Props = {
-  confirmLabel: string;
-  eventName?: string;
-  message?: ReactNode;
   closeExpanded: () => void;
+  confirmLabel: string;
+  deleting: boolean;
+  message?: ReactNode;
   onConfirm: () => void;
   submitAppearance?: ActionButtonProps["appearance"];
 };
@@ -15,6 +15,7 @@ type Props = {
 const DeleteConfirm = ({
   closeExpanded,
   confirmLabel,
+  deleting,
   message,
   onConfirm,
   submitAppearance = "negative",
@@ -36,6 +37,7 @@ const DeleteConfirm = ({
         <ActionButton
           appearance={submitAppearance}
           data-testid="delete-az"
+          loading={deleting}
           onClick={onConfirm}
         >
           {confirmLabel}

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
@@ -10,6 +10,7 @@ import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
   zone as zoneFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
   user as userFactory,
@@ -22,9 +23,7 @@ describe("ZoneDetailsHeader", () => {
   let initialState: RootState;
 
   const testZones = zoneStateFactory({
-    errors: {},
-    loading: false,
-    loaded: true,
+    genericActions: zoneGenericActionsFactory({ fetch: "success" }),
     items: [
       zoneFactory({
         id: 1,

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
@@ -10,6 +10,7 @@ import SectionHeader from "app/base/components/SectionHeader";
 import authSelectors from "app/store/auth/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
+import { ZONE_ACTIONS } from "app/store/zone/constants";
 import zoneSelectors from "app/store/zone/selectors";
 import zonesURLs from "app/zones/urls";
 
@@ -20,7 +21,9 @@ type Props = {
 const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
   const [showConfirm, setShowConfirm] = useState(false);
   const zonesLoaded = useSelector(zoneSelectors.loaded);
-  const zonesSaved = useSelector(zoneSelectors.saved);
+  const deleteStatus = useSelector((state: RootState) =>
+    zoneSelectors.getModelActionStatus(state, ZONE_ACTIONS.delete, id)
+  );
   const zone = useSelector((state: RootState) =>
     zoneSelectors.getById(state, Number(id))
   );
@@ -32,18 +35,18 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (zonesSaved) {
-      dispatch(zoneActions.cleanup());
+    if (deleteStatus === "success") {
+      dispatch(zoneActions.cleanup([ZONE_ACTIONS.delete]));
       navigate({ pathname: zonesURLs.index });
     }
-  }, [dispatch, zonesSaved, navigate]);
+  }, [dispatch, deleteStatus, navigate]);
 
   const isAdmin = useSelector(authSelectors.isAdmin);
   const isDefaultZone = id === 1;
 
   const deleteZone = () => {
     if (isAdmin && !isDefaultZone) {
-      dispatch(zoneActions.delete(id));
+      dispatch(zoneActions.delete({ id }));
     }
   };
 
@@ -74,6 +77,7 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
         <DeleteConfirm
           closeExpanded={closeExpanded}
           confirmLabel="Delete AZ"
+          deleting={deleteStatus === "loading"}
           message="Are you sure you want to delete this AZ?"
           onConfirm={deleteZone}
         />

--- a/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.tsx
@@ -5,7 +5,9 @@ import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
+import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
+import { ZONE_ACTIONS } from "app/store/zone/constants";
 import zoneSelectors from "app/store/zone/selectors";
 
 type Props = {
@@ -19,10 +21,15 @@ export type CreateZoneValues = {
 
 const ZonesListForm = ({ closeForm }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const errors = useSelector(zoneSelectors.errors);
-  const saved = useSelector(zoneSelectors.saved);
-  const saving = useSelector(zoneSelectors.saving);
-  const cleanup = useCallback(() => zoneActions.cleanup(), []);
+  const cleanup = useCallback(
+    () => zoneActions.cleanup([ZONE_ACTIONS.create]),
+    []
+  );
+  const created = useSelector(zoneSelectors.created);
+  const creating = useSelector(zoneSelectors.creating);
+  const errors = useSelector((state: RootState) =>
+    zoneSelectors.getLatestError(state, ZONE_ACTIONS.create)
+  );
 
   return (
     <FormikForm<CreateZoneValues>
@@ -45,8 +52,8 @@ const ZonesListForm = ({ closeForm }: Props): JSX.Element => {
       }}
       onSuccess={closeForm}
       resetOnSave={true}
-      saved={saved}
-      saving={saving}
+      saved={created}
+      saving={creating}
       submitLabel="Add AZ"
     >
       <Row>

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -70,6 +70,10 @@ export {
   vlanStatuses,
   vmClusterState,
   vmClusterStatuses,
+  zoneError,
+  zoneGenericActions,
+  zoneModelAction,
+  zoneModelActions,
   zoneState,
 } from "./state";
 export {

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -3,6 +3,7 @@ import type { RouterState } from "redux-first-history";
 
 import { bondOptions } from "./general";
 
+import { ACTION_STATUS } from "app/base/constants";
 import type { APIError } from "app/base/types";
 import type { BootResourceState } from "app/store/bootresource/types";
 import type { ConfigState } from "app/store/config/types";
@@ -96,7 +97,14 @@ import type {
 } from "app/store/vlan/types";
 import type { VMClusterState } from "app/store/vmcluster/types";
 import type { VMClusterStatuses } from "app/store/vmcluster/types/base";
-import type { ZoneState } from "app/store/zone/types";
+import { ZONE_ACTIONS } from "app/store/zone/constants";
+import type {
+  ZoneGenericActions,
+  ZoneModelAction,
+  ZoneModelActions,
+  ZoneState,
+  ZoneStateError,
+} from "app/store/zone/types";
 
 const defaultState = {
   errors: () => ({}),
@@ -502,8 +510,33 @@ export const vmClusterState = define<VMClusterState>({
   statuses: vmClusterStatuses,
 });
 
+export const zoneGenericActions = define<ZoneGenericActions>({
+  [ZONE_ACTIONS.create]: ACTION_STATUS.idle,
+  [ZONE_ACTIONS.fetch]: ACTION_STATUS.idle,
+});
+
+export const zoneModelAction = define<ZoneModelAction>({
+  [ACTION_STATUS.error]: () => [],
+  [ACTION_STATUS.loading]: () => [],
+  [ACTION_STATUS.success]: () => [],
+});
+
+export const zoneModelActions = define<ZoneModelActions>({
+  [ZONE_ACTIONS.delete]: zoneModelAction,
+  [ZONE_ACTIONS.update]: zoneModelAction,
+});
+
+export const zoneError = define<ZoneStateError>({
+  action: ZONE_ACTIONS.fetch,
+  error: "There was an error",
+  identifier: null,
+});
+
 export const zoneState = define<ZoneState>({
-  ...defaultState,
+  errors: () => [],
+  genericActions: zoneGenericActions,
+  items: () => [],
+  modelActions: zoneModelActions,
 });
 
 export const locationState = define<RouterState["location"]>({

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -71,6 +71,9 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     dispatchMultiple?: boolean;
     // A key to be used to identify a file in the file context.
     fileContextKey?: string;
+    // A key used to identify a websocket response. This is commonly the primary
+    // key of a model in order to track a its loading/success/error states.
+    identifier?: number | string;
     // The endpoint method e.g. "list".
     method: string;
     // The endpoint model e.g. "machine".


### PR DESCRIPTION
## Done
- This branch updates the state shape for the zone model in order to better handle actions and errors. It will serve as the blueprint for updating the rest of the models to the same shape.
- Supersedes https://github.com/canonical-web-and-design/maas-ui/pull/3503

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open Redux DevTools
- For the following actions, check that they work and that you like how the changes in state occur:
  - Go to the zone list and check that zones are fetched
  - Check that creating a zone works
  - Try to create another zone with the same name and check that an error shows
  - Go to a zone details page
  - Check that updating the zone works
  - Try updating the zone name to something that already exists and check that an error shows
  - Check that you can delete a zone and get redirected to the list

## Fixes

Fixes #3055 
