### PR TITLE
refactor: make url object consistent

### DIFF
--- a/src/app/Routes.test.tsx
+++ b/src/app/Routes.test.tsx
@@ -6,24 +6,114 @@ import configureStore from "redux-mock-store";
 
 import Routes from "./Routes";
 
-import baseURLs from "app/base/urls";
-import controllersURLs from "app/controllers/urls";
-import dashboardURLs from "app/dashboard/urls";
-import devicesURLs from "app/devices/urls";
-import domainsURLs from "app/domains/urls";
-import imagesURLs from "app/images/urls";
-import introURLs from "app/intro/urls";
-import kvmURLs from "app/kvm/urls";
-import machineURLs from "app/machines/urls";
-import poolsURLs from "app/pools/urls";
-import prefsURLs from "app/preferences/urls";
-import settingsURLs from "app/settings/urls";
-import subnetsURLs from "app/subnets/urls";
-import tagsURLs from "app/tags/urls";
-import zonesURLs from "app/zones/urls";
+import urls from "app/base/urls";
 import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
+
+const componentPaths: { component: string; path: string }[] = [
+  {
+    // Redirects to machines:
+    component: "Redirect",
+    path: urls.index,
+  },
+  {
+    component: "Intro",
+    path: urls.intro.index,
+  },
+  {
+    component: "Preferences",
+    path: urls.preferences.index,
+  },
+  {
+    component: "Controllers",
+    path: urls.controllers.index,
+  },
+  {
+    component: "DeviceList",
+    path: urls.devices.index,
+  },
+  {
+    component: "DeviceDetails",
+    path: urls.devices.device.index({ id: "abc123" }),
+  },
+  {
+    component: "Domains",
+    path: urls.domains.index,
+  },
+  {
+    component: "Domains",
+    path: urls.domains.details({ id: 1 }),
+  },
+  {
+    component: "Images",
+    path: urls.images.index,
+  },
+  {
+    component: "KVM",
+    path: urls.kvm.index,
+  },
+  {
+    component: "Machines",
+    path: urls.machines.index,
+  },
+  {
+    component: "MachineDetails",
+    path: urls.machines.machine.index({ id: "abc123" }),
+  },
+  {
+    component: "Pools",
+    path: urls.pools.index,
+  },
+  {
+    component: "Settings",
+    path: urls.settings.index,
+  },
+  {
+    component: "SubnetsList",
+    path: urls.subnets.index,
+  },
+  {
+    component: "FabricDetails",
+    path: urls.subnets.fabric.index({ id: 1 }),
+  },
+  {
+    component: "SpaceDetails",
+    path: urls.subnets.space.index({ id: 1 }),
+  },
+  {
+    component: "SubnetDetails",
+    path: urls.subnets.subnet.index({ id: 1 }),
+  },
+  {
+    component: "VLANDetails",
+    path: urls.subnets.vlan.index({ id: 1 }),
+  },
+  {
+    component: "Tags",
+    path: urls.tags.index,
+  },
+  {
+    component: "Tags",
+    path: urls.tags.tag.index({ id: 1 }),
+  },
+  {
+    component: "NotFound",
+    path: "/not/a/path",
+  },
+  {
+    component: "Zones",
+    path: urls.zones.index,
+  },
+  {
+    component: "Zones",
+    path: urls.zones.details({ id: 1 }),
+  },
+  {
+    component: "Dashboard",
+    path: urls.dashboard.index,
+  },
+];
 
 describe("Routes", () => {
   beforeEach(() => {
@@ -34,109 +124,7 @@ describe("Routes", () => {
     jest.restoreAllMocks();
   });
 
-  [
-    {
-      // Redirects to machines:
-      component: "Redirect",
-      path: baseURLs.index,
-    },
-    {
-      component: "Intro",
-      path: introURLs.index,
-    },
-    {
-      component: "Preferences",
-      path: prefsURLs.prefs,
-    },
-    {
-      component: "Controllers",
-      path: controllersURLs.controllers.index,
-    },
-    {
-      component: "DeviceList",
-      path: devicesURLs.devices.index,
-    },
-    {
-      component: "DeviceDetails",
-      path: devicesURLs.device.index({ id: "abc123" }),
-    },
-    {
-      component: "Domains",
-      path: domainsURLs.domains,
-    },
-    {
-      component: "Domains",
-      path: domainsURLs.details({ id: 1 }),
-    },
-    {
-      component: "Images",
-      path: imagesURLs.index,
-    },
-    {
-      component: "KVM",
-      path: kvmURLs.kvm,
-    },
-    {
-      component: "Machines",
-      path: machineURLs.machines.index,
-    },
-    {
-      component: "MachineDetails",
-      path: machineURLs.machine.index({ id: "abc123" }),
-    },
-    {
-      component: "Pools",
-      path: poolsURLs.pools,
-    },
-    {
-      component: "Settings",
-      path: settingsURLs.index,
-    },
-    {
-      component: "SubnetsList",
-      path: subnetsURLs.index,
-    },
-    {
-      component: "FabricDetails",
-      path: subnetsURLs.fabric.index({ id: 1 }),
-    },
-    {
-      component: "SpaceDetails",
-      path: subnetsURLs.space.index({ id: 1 }),
-    },
-    {
-      component: "SubnetDetails",
-      path: subnetsURLs.subnet.index({ id: 1 }),
-    },
-    {
-      component: "VLANDetails",
-      path: subnetsURLs.vlan.index({ id: 1 }),
-    },
-    {
-      component: "Tags",
-      path: tagsURLs.tags.index,
-    },
-    {
-      component: "Tags",
-      path: tagsURLs.tag.index({ id: 1 }),
-    },
-    {
-      component: "NotFound",
-      path: "/not/a/path",
-    },
-    {
-      component: "Zones",
-      path: zonesURLs.index,
-    },
-    {
-      component: "Zones",
-      path: zonesURLs.details({ id: 1 }),
-    },
-    {
-      component: "Dashboard",
-      path: dashboardURLs.index,
-    },
-  ].forEach(({ component, path }) => {
+  componentPaths.forEach(({ component, path }) => {
     it(`Displays: ${component} at: ${path}`, () => {
       const store = mockStore(rootStateFactory());
       const wrapper = mount(

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -5,54 +5,37 @@ import Pools from "./pools/views/Pools";
 import Tags from "./tags/views/Tags";
 
 import ErrorBoundary from "app/base/components/ErrorBoundary";
-import baseURLs from "app/base/urls";
+import urls from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
-import controllersURLs from "app/controllers/urls";
 import Controllers from "app/controllers/views/Controllers";
-import dashboardURLs from "app/dashboard/urls";
 import Dashboard from "app/dashboard/views/Dashboard";
-import devicesURLs from "app/devices/urls";
 import DeviceDetails from "app/devices/views/DeviceDetails";
 import DeviceList from "app/devices/views/DeviceList";
-import domainsURLs from "app/domains/urls";
 import Domains from "app/domains/views/Domains";
-import imagesURLs from "app/images/urls";
 import Images from "app/images/views/Images";
-import introURLs from "app/intro/urls";
 import Intro from "app/intro/views/Intro";
-import kvmURLs from "app/kvm/urls";
 import KVM from "app/kvm/views/KVM";
-import machineURLs from "app/machines/urls";
 import MachineDetails from "app/machines/views/MachineDetails";
 import Machines from "app/machines/views/Machines";
-import poolsURLs from "app/pools/urls";
-import prefsURLs from "app/preferences/urls";
 import Preferences from "app/preferences/views/Preferences";
-import settingsURLs from "app/settings/urls";
 import Settings from "app/settings/views/Settings";
-import subnetsURLs from "app/subnets/urls";
 import FabricDetails from "app/subnets/views/FabricDetails";
 import SpaceDetails from "app/subnets/views/SpaceDetails";
 import SubnetDetails from "app/subnets/views/SubnetDetails";
 import SubnetsList from "app/subnets/views/SubnetsList";
 import VLANDetails from "app/subnets/views/VLANDetails";
-import tagURLs from "app/tags/urls";
-import zonesURLs from "app/zones/urls";
 import Zones from "app/zones/views/Zones";
 
 const Routes = (): JSX.Element => (
   <ReactRouterRoutes>
-    <Route
-      element={<Redirect to={machineURLs.machines.index} />}
-      path={baseURLs.index}
-    />
+    <Route element={<Redirect to={urls.machines.index} />} path={urls.index} />
     <Route
       element={
         <ErrorBoundary>
           <Intro />
         </ErrorBoundary>
       }
-      path={`${introURLs.index}/*`}
+      path={`${urls.intro.index}/*`}
     />
     <Route
       element={
@@ -60,7 +43,7 @@ const Routes = (): JSX.Element => (
           <Preferences />
         </ErrorBoundary>
       }
-      path={`${prefsURLs.prefs}/*`}
+      path={`${urls.preferences.index}/*`}
     />
     <Route
       element={
@@ -68,7 +51,7 @@ const Routes = (): JSX.Element => (
           <Controllers />
         </ErrorBoundary>
       }
-      path={`${controllersURLs.controllers.index}/*`}
+      path={`${urls.controllers.index}/*`}
     />
     <Route
       element={
@@ -76,7 +59,7 @@ const Routes = (): JSX.Element => (
           <Controllers />
         </ErrorBoundary>
       }
-      path={`${controllersURLs.controller.index(null, true)}/*`}
+      path={`${urls.controllers.controller.index(null)}/*`}
     />
     <Route
       element={
@@ -84,7 +67,7 @@ const Routes = (): JSX.Element => (
           <DeviceList />
         </ErrorBoundary>
       }
-      path={`${devicesURLs.devices.index}/*`}
+      path={`${urls.devices.index}/*`}
     />
     <Route
       element={
@@ -92,7 +75,7 @@ const Routes = (): JSX.Element => (
           <DeviceDetails />
         </ErrorBoundary>
       }
-      path={`${devicesURLs.device.index(null, true)}/*`}
+      path={`${urls.devices.device.index(null)}/*`}
     />
     <Route
       element={
@@ -100,7 +83,7 @@ const Routes = (): JSX.Element => (
           <Domains />
         </ErrorBoundary>
       }
-      path={`${domainsURLs.domains}/*`}
+      path={`${urls.domains.index}/*`}
     />
     <Route
       element={
@@ -108,7 +91,7 @@ const Routes = (): JSX.Element => (
           <Domains />
         </ErrorBoundary>
       }
-      path={`${domainsURLs.details(null, true)}/*`}
+      path={`${urls.domains.details(null)}/*`}
     />
     <Route
       element={
@@ -116,7 +99,7 @@ const Routes = (): JSX.Element => (
           <Images />
         </ErrorBoundary>
       }
-      path={`${imagesURLs.index}/*`}
+      path={`${urls.images.index}/*`}
     />
     <Route
       element={
@@ -124,7 +107,7 @@ const Routes = (): JSX.Element => (
           <KVM />
         </ErrorBoundary>
       }
-      path={`${kvmURLs.kvm}/*`}
+      path={`${urls.kvm.index}/*`}
     />
     <Route
       element={
@@ -132,7 +115,7 @@ const Routes = (): JSX.Element => (
           <Machines />
         </ErrorBoundary>
       }
-      path={`${machineURLs.machines.index}/*`}
+      path={`${urls.machines.index}/*`}
     />
     <Route
       element={
@@ -140,7 +123,7 @@ const Routes = (): JSX.Element => (
           <MachineDetails />
         </ErrorBoundary>
       }
-      path={`${machineURLs.machine.index(null, true)}/*`}
+      path={`${urls.machines.machine.index(null)}/*`}
     />
     <Route
       element={
@@ -148,7 +131,7 @@ const Routes = (): JSX.Element => (
           <Pools />
         </ErrorBoundary>
       }
-      path={`${poolsURLs.pools}/*`}
+      path={`${urls.pools.index}/*`}
     />
     <Route
       element={
@@ -156,7 +139,7 @@ const Routes = (): JSX.Element => (
           <Tags />
         </ErrorBoundary>
       }
-      path={`${tagURLs.tags.index}/*`}
+      path={`${urls.tags.index}/*`}
     />
     <Route
       element={
@@ -164,7 +147,7 @@ const Routes = (): JSX.Element => (
           <Tags />
         </ErrorBoundary>
       }
-      path={`${tagURLs.tag.index(null, true)}/*`}
+      path={`${urls.tags.tag.index(null)}/*`}
     />
     <Route
       element={
@@ -172,7 +155,7 @@ const Routes = (): JSX.Element => (
           <Settings />
         </ErrorBoundary>
       }
-      path={`${settingsURLs.index}/*`}
+      path={`${urls.settings.index}/*`}
     />
     <Route
       element={
@@ -180,7 +163,7 @@ const Routes = (): JSX.Element => (
           <SubnetsList />
         </ErrorBoundary>
       }
-      path={`${subnetsURLs.index}/*`}
+      path={`${urls.subnets.index}/*`}
     />
     <Route
       element={
@@ -188,7 +171,7 @@ const Routes = (): JSX.Element => (
           <FabricDetails />
         </ErrorBoundary>
       }
-      path={`${subnetsURLs.fabric.index(null, true)}/*`}
+      path={`${urls.subnets.fabric.index(null)}/*`}
     />
     <Route
       element={
@@ -196,7 +179,7 @@ const Routes = (): JSX.Element => (
           <SpaceDetails />
         </ErrorBoundary>
       }
-      path={`${subnetsURLs.space.index(null, true)}/*`}
+      path={`${urls.subnets.space.index(null)}/*`}
     />
     <Route
       element={
@@ -204,7 +187,7 @@ const Routes = (): JSX.Element => (
           <SubnetDetails />
         </ErrorBoundary>
       }
-      path={`${subnetsURLs.subnet.index(null, true)}/*`}
+      path={`${urls.subnets.subnet.index(null)}/*`}
     />
     <Route
       element={
@@ -212,7 +195,7 @@ const Routes = (): JSX.Element => (
           <VLANDetails />
         </ErrorBoundary>
       }
-      path={`${subnetsURLs.vlan.index(null, true)}/*`}
+      path={`${urls.subnets.vlan.index(null)}/*`}
     />
     <Route
       element={
@@ -220,7 +203,7 @@ const Routes = (): JSX.Element => (
           <Zones />
         </ErrorBoundary>
       }
-      path={`${zonesURLs.index}/*`}
+      path={`${urls.zones.index}/*`}
     />
     <Route
       element={
@@ -228,7 +211,7 @@ const Routes = (): JSX.Element => (
           <Zones />
         </ErrorBoundary>
       }
-      path={`${zonesURLs.details(null, true)}/*`}
+      path={`${urls.zones.details(null)}/*`}
     />
     <Route
       element={
@@ -236,7 +219,7 @@ const Routes = (): JSX.Element => (
           <Dashboard />
         </ErrorBoundary>
       }
-      path={`${dashboardURLs.index}/*`}
+      path={`${urls.dashboard.index}/*`}
     />
     <Route element={<NotFound includeSection />} path="*" />
   </ReactRouterRoutes>

--- a/src/app/base/components/Header/Header.tsx
+++ b/src/app/base/components/Header/Header.tsx
@@ -39,61 +39,58 @@ type NavItem = {
 const navLinks: NavItem[] = [
   {
     highlight: [
-      urls.machines.machines.index,
-      urls.machines.machine.index(null, true),
-      urls.pools.pools,
-      urls.tags.tags.index,
-      urls.tags.tag.index(null, true),
+      urls.machines.index,
+      urls.machines.machine.index(null),
+      urls.pools.index,
+      urls.tags.index,
+      urls.tags.tag.index(null),
     ],
     inHardwareMenu: true,
     label: "Machines",
-    url: urls.machines.machines.index,
+    url: urls.machines.index,
   },
   {
-    highlight: [
-      urls.devices.devices.index,
-      urls.devices.device.index(null, true),
-    ],
+    highlight: [urls.devices.index, urls.devices.device.index(null)],
     inHardwareMenu: true,
     label: "Devices",
-    url: urls.devices.devices.index,
+    url: urls.devices.index,
   },
   {
     adminOnly: true,
     highlight: [
-      urls.controllers.controllers.index,
-      urls.controllers.controller.index(null, true),
+      urls.controllers.index,
+      urls.controllers.controller.index(null),
     ],
     inHardwareMenu: true,
     label: "Controllers",
-    url: urls.controllers.controllers.index,
+    url: urls.controllers.index,
   },
   {
     inHardwareMenu: true,
     label: "KVM",
-    url: urls.kvm.kvm,
+    url: urls.kvm.index,
   },
   {
     label: "Images",
     url: urls.images.index,
   },
   {
-    highlight: [urls.domains.domains, urls.domains.details(null, true)],
+    highlight: [urls.domains.index, urls.domains.details(null)],
     label: "DNS",
-    url: urls.domains.domains,
+    url: urls.domains.index,
   },
   {
-    highlight: [urls.zones.index, urls.zones.details(null, true)],
+    highlight: [urls.zones.index, urls.zones.details(null)],
     label: "AZs",
     url: urls.zones.index,
   },
   {
     highlight: [
       urls.subnets.index,
-      urls.subnets.subnet.index(null, true),
-      urls.subnets.space.index(null, true),
-      urls.subnets.fabric.index(null, true),
-      urls.subnets.vlan.index(null, true),
+      urls.subnets.subnet.index(null),
+      urls.subnets.space.index(null),
+      urls.subnets.fabric.index(null),
+      urls.subnets.vlan.index(null),
     ],
     label: "Subnets",
     url: urls.subnets.index,
@@ -207,7 +204,7 @@ export const Header = (): JSX.Element => {
     .filter(({ adminOnly }) => !adminOnly || isAdmin);
   const homepageLink = isAdmin
     ? { url: urls.dashboard.index, label: "Homepage" }
-    : { url: urls.machines.machines.index, label: "Homepage" };
+    : { url: urls.machines.index, label: "Homepage" };
   const path = location.pathname + location.search;
 
   return (
@@ -236,11 +233,11 @@ export const Header = (): JSX.Element => {
                   ? [
                       {
                         isSelected: !!matchPath(
-                          { path: urls.preferences.prefs, end: false },
+                          { path: urls.preferences.index, end: false },
                           location.pathname
                         ),
                         label: authUser.username,
-                        url: urls.preferences.prefs,
+                        url: urls.preferences.index,
                       },
                     ]
                   : []),

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -7,15 +7,13 @@ import { matchPath, Link } from "react-router-dom-v5-compat";
 
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
-import machineURLs from "app/machines/urls";
-import poolsURLs from "app/pools/urls";
+import urls from "app/base/urls";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
-import tagURLs from "app/tags/urls";
 
 type Props = SectionHeaderProps;
 
@@ -37,24 +35,24 @@ export const MachinesHeader = (props: Props): JSX.Element => {
       {...props}
       tabLinks={[
         {
-          active: !!matchPath(machineURLs.machines.index, location.pathname),
+          active: !!matchPath(urls.machines.index, location.pathname),
           component: Link,
           label: `${pluralize("Machine", machineCount, true)}`,
-          to: machineURLs.machines.index,
+          to: urls.machines.index,
         },
         {
-          active: !!matchPath(poolsURLs.pools, location.pathname),
+          active: !!matchPath(urls.pools.index, location.pathname),
           component: Link,
           label: `${pluralize("Resource pool", poolCount, true)}`,
-          to: poolsURLs.pools,
+          to: urls.pools.index,
         },
         {
           active:
-            !!matchPath(tagURLs.tags.index, location.pathname) ||
-            !!matchPath(tagURLs.tag.index(null, true), location.pathname),
+            !!matchPath(urls.tags.index, location.pathname) ||
+            !!matchPath(urls.tags.tag.index(null), location.pathname),
           component: Link,
           label: `${pluralize("Tag", tagCount, true)}`,
-          to: tagURLs.tags.index,
+          to: urls.tags.index,
         },
       ]}
       title={"title" in props && !!props.title ? props.title : "Machines"}

--- a/src/app/base/components/node/NodeLogs/NodeLogs.tsx
+++ b/src/app/base/components/node/NodeLogs/NodeLogs.tsx
@@ -55,10 +55,10 @@ const NodeLogs = ({ node, urls }: Props): JSX.Element => {
       </div>
       <Route
         exact
-        path={urls.installationOutput(null, true)}
+        path={urls.installationOutput(null)}
         render={() => <InstallationOutput node={node} />}
       />
-      {[urls.index(null, true), urls.events(null, true)].map((path) => (
+      {[urls.index(null), urls.events(null)].map((path) => (
         <Route
           exact
           key={path}

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.tsx
@@ -243,12 +243,12 @@ const normaliseRowData = (
                     const filter = FilterMachines.filtersToQueryString({
                       storage_tags: [`=${tag}`],
                     });
-                    return `${machineURLs.machines.index}${filter}`;
+                    return `${machineURLs.index}${filter}`;
                   }
                   const filter = FilterControllers.filtersToQueryString({
                     storage_tags: [`=${tag}`],
                   });
-                  return `${controllerURLs.controllers.index}${filter}`;
+                  return `${controllerURLs.index}${filter}`;
                 }}
                 tags={storageDevice.tags}
               />

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
@@ -83,7 +83,7 @@ it("can render storage tag links for a controller", () => {
   const filter = FilterControllers.filtersToQueryString({
     storage_tags: ["=abc"],
   });
-  const href = `${controllerURLs.controllers.index}${filter}`;
+  const href = `${controllerURLs.index}${filter}`;
 
   render(
     <MemoryRouter>
@@ -112,7 +112,7 @@ it("can render storage tag links for a machine", () => {
   const filter = FilterMachines.filtersToQueryString({
     storage_tags: ["=abc"],
   });
-  const href = `${machineURLs.machines.index}${filter}`;
+  const href = `${machineURLs.index}${filter}`;
 
   render(
     <MemoryRouter>

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.tsx
@@ -101,12 +101,12 @@ const normaliseColumns = (
                   const filter = FilterMachines.filtersToQueryString({
                     storage_tags: [`=${tag}`],
                   });
-                  return `${machineURLs.machines.index}${filter}`;
+                  return `${machineURLs.index}${filter}`;
                 }
                 const filter = FilterControllers.filtersToQueryString({
                   storage_tags: [`=${tag}`],
                 });
-                return `${controllerURLs.controllers.index}${filter}`;
+                return `${controllerURLs.index}${filter}`;
               }}
               tags={storageDevice.tags}
             />

--- a/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
@@ -87,7 +87,7 @@ export const ControllerActionFormWrapper = ({
                 );
               });
             }}
-            redirectURL={controllerURLs.controllers.index}
+            redirectURL={controllerURLs.index}
             {...commonNodeFormProps}
           />
         );

--- a/src/app/controllers/urls.ts
+++ b/src/app/controllers/urls.ts
@@ -1,55 +1,35 @@
-import type { Controller, ControllerMeta } from "app/store/controller/types";
-import type {
-  ScriptResult,
-  ScriptResultMeta,
-} from "app/store/scriptresult/types";
+import { Controller, ControllerMeta } from "app/store/controller/types";
+import { ScriptResult, ScriptResultMeta } from "app/store/scriptresult/types";
 import { argPath } from "app/utils";
+
+const withId = argPath<{ id: Controller[ControllerMeta.PK] }>;
+const withIdScriptResultId = argPath<{
+  id: Controller[ControllerMeta.PK];
+  scriptResultId: ScriptResult[ScriptResultMeta.PK];
+}>;
 
 const urls = {
   index: "/controllers",
   controller: {
     commissioning: {
-      index: argPath<{ id: Controller[ControllerMeta.PK] }>(
-        "/controller/:id/commissioning"
+      index: withId("/controller/:id/commissioning"),
+      scriptResult: withIdScriptResultId(
+        "/controller/:id/commissioning/:scriptResultId/details"
       ),
-      scriptResult: argPath<{
-        id: Controller[ControllerMeta.PK];
-        scriptResultId: ScriptResult[ScriptResultMeta.PK];
-      }>("/controller/:id/commissioning/:scriptResultId/details"),
     },
-    configuration: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/configuration"
-    ),
-    index: argPath<{ id: Controller[ControllerMeta.PK] }>("/controller/:id"),
+    configuration: withId("/controller/:id/configuration"),
+    index: withId("/controller/:id"),
     logs: {
-      events: argPath<{ id: Controller[ControllerMeta.PK] }>(
-        "/controller/:id/logs/events"
-      ),
-      index: argPath<{ id: Controller[ControllerMeta.PK] }>(
-        "/controller/:id/logs"
-      ),
-      installationOutput: argPath<{ id: Controller[ControllerMeta.PK] }>(
-        "/controller/:id/logs/installation-output"
-      ),
+      events: withId("/controller/:id/logs/events"),
+      index: withId("/controller/:id/logs"),
+      installationOutput: withId("/controller/:id/logs/installation-output"),
     },
-    network: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/network"
-    ),
-    pciDevices: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/pci-devices"
-    ),
-    storage: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/storage"
-    ),
-    summary: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/summary"
-    ),
-    usbDevices: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/usb-devices"
-    ),
-    vlans: argPath<{ id: Controller[ControllerMeta.PK] }>(
-      "/controller/:id/vlans"
-    ),
+    network: withId("/controller/:id/network"),
+    pciDevices: withId("/controller/:id/pci-devices"),
+    storage: withId("/controller/:id/storage"),
+    summary: withId("/controller/:id/summary"),
+    usbDevices: withId("/controller/:id/usb-devices"),
+    vlans: withId("/controller/:id/vlans"),
   },
 } as const;
 

--- a/src/app/controllers/urls.ts
+++ b/src/app/controllers/urls.ts
@@ -6,9 +6,7 @@ import type {
 import { argPath } from "app/utils";
 
 const urls = {
-  controllers: {
-    index: "/controllers",
-  },
+  index: "/controllers",
   controller: {
     commissioning: {
       index: argPath<{ id: Controller[ControllerMeta.PK] }>(

--- a/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfigurationForm.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfigurationForm.tsx
@@ -105,7 +105,7 @@ const ControllerConfigurationForm = ({
                     const filter = FilterControllers.filtersToQueryString({
                       tags: [`=${tag.name}`],
                     });
-                    return `${controllerURLs.controllers.index}${filter}`;
+                    return `${controllerURLs.index}${filter}`;
                   }}
                   tags={controllerTags}
                 />

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
@@ -41,7 +41,7 @@ it("gets and sets the controller as active", () => {
           <Routes>
             <Route
               element={<ControllerDetails />}
-              path={controllerURLs.controller.index(null, true)}
+              path={controllerURLs.controller.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -88,7 +88,7 @@ it("unsets active controller and cleans up when unmounting", () => {
           <Routes>
             <Route
               element={<ControllerDetails />}
-              path={controllerURLs.controller.index(null, true)}
+              path={controllerURLs.controller.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -140,7 +140,7 @@ it("displays a message if the controller does not exist", () => {
           <Routes>
             <Route
               element={<ControllerDetails />}
-              path={controllerURLs.controller.index(null, true)}
+              path={controllerURLs.controller.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
@@ -54,7 +54,7 @@ const ControllerDetails = (): JSX.Element => {
     return (
       <ModelNotFound
         id={id}
-        linkURL={controllerURLs.controllers.index}
+        linkURL={controllerURLs.index}
         modelName="controller"
       />
     );
@@ -74,45 +74,42 @@ const ControllerDetails = (): JSX.Element => {
         <Switch>
           <Route
             exact
-            path={controllerURLs.controller.summary(null, true)}
+            path={controllerURLs.controller.summary(null)}
             render={() => <ControllerSummary systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.vlans(null, true)}
+            path={controllerURLs.controller.vlans(null)}
             render={() => <ControllerVLANs systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.network(null, true)}
+            path={controllerURLs.controller.network(null)}
             render={() => <ControllerNetwork systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.storage(null, true)}
+            path={controllerURLs.controller.storage(null)}
             render={() => <ControllerStorage systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.pciDevices(null, true)}
+            path={controllerURLs.controller.pciDevices(null)}
             render={() => <ControllerPCIDevices systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.usbDevices(null, true)}
+            path={controllerURLs.controller.usbDevices(null)}
             render={() => <ControllerUSBDevices systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.commissioning.index(null, true)}
+            path={controllerURLs.controller.commissioning.index(null)}
             render={() => <ControllerCommissioning systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.commissioning.scriptResult(
-              null,
-              true
-            )}
+            path={controllerURLs.controller.commissioning.scriptResult(null)}
             render={() => (
               <NodeTestDetails
                 getReturnPath={(id) =>
@@ -123,27 +120,27 @@ const ControllerDetails = (): JSX.Element => {
           />
           <Route
             exact
-            path={controllerURLs.controller.logs.index(null, true)}
+            path={controllerURLs.controller.logs.index(null)}
             render={() => <ControllerLogs systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.logs.events(null, true)}
+            path={controllerURLs.controller.logs.events(null)}
             render={() => <ControllerLogs systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.logs.installationOutput(null, true)}
+            path={controllerURLs.controller.logs.installationOutput(null)}
             render={() => <ControllerLogs systemId={id} />}
           />
           <Route
             exact
-            path={controllerURLs.controller.configuration(null, true)}
+            path={controllerURLs.controller.configuration(null)}
             render={() => <ControllerConfiguration systemId={id} />}
           />
           <Redirect
-            from={controllerURLs.controller.index(null, true)}
-            to={controllerURLs.controller.summary(null, true)}
+            from={controllerURLs.controller.index(null)}
+            to={controllerURLs.controller.summary(null)}
           />
         </Switch>
       )}

--- a/src/app/controllers/views/Controllers.test.tsx
+++ b/src/app/controllers/views/Controllers.test.tsx
@@ -25,11 +25,11 @@ describe("Controllers", () => {
   [
     {
       component: "ControllerList",
-      path: controllersURLs.controllers.index,
+      path: controllersURLs.index,
     },
     {
       component: "NotFound",
-      path: `${controllerURLs.controllers.index}/not/a/path`,
+      path: `${controllerURLs.index}/not/a/path`,
     },
   ].forEach(({ component, path }) => {
     it(`Displays: ${component} at: ${path}`, () => {
@@ -41,7 +41,7 @@ describe("Controllers", () => {
               <Routes>
                 <Route
                   element={<Controllers />}
-                  path={`${controllerURLs.controllers.index}/*`}
+                  path={`${controllerURLs.index}/*`}
                 />
               </Routes>
             </CompatRouter>
@@ -78,7 +78,7 @@ it("gets and sets the controller as active only once when navigating within the 
           <Routes>
             <Route
               element={<Controllers />}
-              path={`${controllerURLs.controller.index(null, true)}/*`}
+              path={`${controllerURLs.controller.index(null)}/*`}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/controllers/views/Controllers.tsx
+++ b/src/app/controllers/views/Controllers.tsx
@@ -14,23 +14,23 @@ const Controllers = (): JSX.Element => {
     <Switch>
       <Route
         exact
-        path={controllersURLs.controllers.index}
+        path={controllersURLs.index}
         render={() => <ControllerList />}
       />
       {[
-        controllersURLs.controller.commissioning.index(null, true),
-        controllersURLs.controller.commissioning.scriptResult(null, true),
-        controllersURLs.controller.configuration(null, true),
-        controllersURLs.controller.index(null, true),
-        controllersURLs.controller.logs.index(null, true),
-        controllersURLs.controller.logs.events(null, true),
-        controllersURLs.controller.logs.installationOutput(null, true),
-        controllersURLs.controller.network(null, true),
-        controllersURLs.controller.pciDevices(null, true),
-        controllersURLs.controller.storage(null, true),
-        controllersURLs.controller.summary(null, true),
-        controllersURLs.controller.usbDevices(null, true),
-        controllersURLs.controller.vlans(null, true),
+        controllersURLs.controller.commissioning.index(null),
+        controllersURLs.controller.commissioning.scriptResult(null),
+        controllersURLs.controller.configuration(null),
+        controllersURLs.controller.index(null),
+        controllersURLs.controller.logs.index(null),
+        controllersURLs.controller.logs.events(null),
+        controllersURLs.controller.logs.installationOutput(null),
+        controllersURLs.controller.network(null),
+        controllersURLs.controller.pciDevices(null),
+        controllersURLs.controller.storage(null),
+        controllersURLs.controller.summary(null),
+        controllersURLs.controller.usbDevices(null),
+        controllersURLs.controller.vlans(null),
       ].map((path) => (
         <Route
           // using a single key as a workaround for Controller details pages

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
@@ -12,7 +12,7 @@ import type { DiscoveryAddValues } from "./types";
 import FormikForm from "app/base/components/FormikForm";
 import { useCycled } from "app/base/hooks";
 import { hostnameValidation } from "app/base/validation";
-import deviceURLs from "app/devices/urls";
+import devicesURLs from "app/devices/urls";
 import machineURLs from "app/machines/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
@@ -94,7 +94,7 @@ const setRedirectURL = (
   setRedirect(
     values.parent
       ? machineURLs.machine.index({ id: values.parent })
-      : deviceURLs.devices.index
+      : devicesURLs.index
   );
 };
 

--- a/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.tsx
@@ -4,7 +4,7 @@ import DeleteForm from "app/base/components/node/DeleteForm";
 import NodeActionFormWrapper from "app/base/components/node/NodeActionFormWrapper";
 import SetZoneForm from "app/base/components/node/SetZoneForm";
 import type { ClearHeaderContent } from "app/base/types";
-import deviceURLs from "app/devices/urls";
+import devicesURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device, DeviceActions } from "app/store/device/types";
@@ -69,7 +69,7 @@ export const ActionFormWrapper = ({
               dispatch(deviceActions.delete({ system_id: device.system_id }));
             });
           }}
-          redirectURL={deviceURLs.devices.index}
+          redirectURL={devicesURLs.index}
           {...commonNodeFormProps}
         />
       ) : (

--- a/src/app/devices/urls.ts
+++ b/src/app/devices/urls.ts
@@ -1,15 +1,15 @@
-import type { Device, DeviceMeta } from "app/store/device/types";
+import { Device, DeviceMeta } from "app/store/device/types";
 import { argPath } from "app/utils";
+
+const withId = argPath<{ id: Device[DeviceMeta.PK] }>;
 
 const urls = {
   index: "/devices",
   device: {
-    configuration: argPath<{ id: Device[DeviceMeta.PK] }>(
-      "/device/:id/configuration"
-    ),
-    index: argPath<{ id: Device[DeviceMeta.PK] }>("/device/:id"),
-    network: argPath<{ id: Device[DeviceMeta.PK] }>("/device/:id/network"),
-    summary: argPath<{ id: Device[DeviceMeta.PK] }>("/device/:id/summary"),
+    configuration: withId("/device/:id/configuration"),
+    index: withId("/device/:id"),
+    network: withId("/device/:id/network"),
+    summary: withId("/device/:id/summary"),
   },
 } as const;
 

--- a/src/app/devices/urls.ts
+++ b/src/app/devices/urls.ts
@@ -2,9 +2,7 @@ import type { Device, DeviceMeta } from "app/store/device/types";
 import { argPath } from "app/utils";
 
 const urls = {
-  devices: {
-    index: "/devices",
-  },
+  index: "/devices",
   device: {
     configuration: argPath<{ id: Device[DeviceMeta.PK] }>(
       "/device/:id/configuration"

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
@@ -12,7 +12,7 @@ import NodeConfigurationFields, {
 import type { NodeConfigurationValues } from "app/base/components/NodeConfigurationFields/types";
 import TagLinks from "app/base/components/TagLinks";
 import { useWindowTitle } from "app/base/hooks";
-import deviceURLs from "app/devices/urls";
+import devicesURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device, DeviceMeta } from "app/store/device/types";
@@ -110,7 +110,7 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
                     const filter = FilterDevices.filtersToQueryString({
                       tags: [`=${tag.name}`],
                     });
-                    return `${deviceURLs.devices.index}${filter}`;
+                    return `${devicesURLs.index}${filter}`;
                   }}
                   tags={deviceTags}
                 />

--- a/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
@@ -54,7 +54,7 @@ describe("DeviceDetails", () => {
               <Routes>
                 <Route
                   element={<DeviceDetails />}
-                  path={`${deviceURLs.device.index(null, true)}/*`}
+                  path={`${deviceURLs.device.index(null)}/*`}
                 />
               </Routes>
             </CompatRouter>
@@ -78,7 +78,7 @@ describe("DeviceDetails", () => {
             <Routes>
               <Route
                 element={<DeviceDetails />}
-                path={deviceURLs.device.index(null, true)}
+                path={deviceURLs.device.index(null)}
               />
             </Routes>
           </CompatRouter>
@@ -113,7 +113,7 @@ describe("DeviceDetails", () => {
             <Routes>
               <Route
                 element={<DeviceDetails />}
-                path={deviceURLs.device.index(null, true)}
+                path={deviceURLs.device.index(null)}
               />
             </Routes>
           </CompatRouter>
@@ -154,7 +154,7 @@ describe("DeviceDetails", () => {
             <Routes>
               <Route
                 element={<DeviceDetails />}
-                path={deviceURLs.device.index(null, true)}
+                path={deviceURLs.device.index(null)}
               />
             </Routes>
           </CompatRouter>

--- a/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -12,7 +12,7 @@ import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import { useGetURLId } from "app/base/hooks/urls";
 import type { DeviceHeaderContent } from "app/devices/types";
-import deviceURLs from "app/devices/urls";
+import devicesURLs from "app/devices/urls";
 import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import { DeviceMeta } from "app/store/device/types";
@@ -47,11 +47,7 @@ const DeviceDetails = (): JSX.Element => {
 
   if (!isId(id) || (!devicesLoading && !device)) {
     return (
-      <ModelNotFound
-        id={id}
-        linkURL={deviceURLs.devices.index}
-        modelName="device"
-      />
+      <ModelNotFound id={id} linkURL={devicesURLs.index} modelName="device" />
     );
   }
 
@@ -69,22 +65,22 @@ const DeviceDetails = (): JSX.Element => {
         <Switch>
           <Route
             exact
-            path={deviceURLs.device.summary(null, true)}
+            path={devicesURLs.device.summary(null)}
             render={() => <DeviceSummary systemId={id} />}
           />
           <Route
             exact
-            path={deviceURLs.device.network(null, true)}
+            path={devicesURLs.device.network(null)}
             render={() => <DeviceNetwork systemId={id} />}
           />
           <Route
             exact
-            path={deviceURLs.device.configuration(null, true)}
+            path={devicesURLs.device.configuration(null)}
             render={() => <DeviceConfiguration systemId={id} />}
           />
           <Redirect
-            from={deviceURLs.device.index(null, true)}
-            to={deviceURLs.device.summary(null, true)}
+            from={devicesURLs.device.index(null)}
+            to={devicesURLs.device.summary(null)}
           />
         </Switch>
       )}

--- a/src/app/domains/urls.ts
+++ b/src/app/domains/urls.ts
@@ -3,7 +3,7 @@ import { argPath } from "app/utils";
 
 const urls = {
   details: argPath<{ id: Domain["id"] }>("/domain/:id"),
-  domains: "/domains",
+  index: "/domains",
 } as const;
 
 export default urls;

--- a/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -10,7 +10,7 @@ import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
-import domainURLs from "app/domains/urls";
+import domainsURLs from "app/domains/urls";
 import { actions as domainsActions } from "app/store/domain";
 import domainsSelectors from "app/store/domain/selectors";
 import { DomainMeta } from "app/store/domain/types";
@@ -41,7 +41,7 @@ const DomainDetails = (): JSX.Element => {
 
   if (!isId(id) || (!domainsLoading && !domain)) {
     return (
-      <ModelNotFound id={id} linkURL={domainURLs.domains} modelName="domain" />
+      <ModelNotFound id={id} linkURL={domainsURLs.index} modelName="domain" />
     );
   }
   return (

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import FormikForm from "app/base/components/FormikForm";
 import type { EmptyObject } from "app/base/types";
-import domainsURLs from "app/domains/urls";
+import urls from "app/base/urls";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import type { Domain } from "app/store/domain/types";
@@ -49,7 +49,7 @@ const DeleteDomainForm = ({ closeForm, id }: Props): JSX.Element | null => {
         dispatch(domainActions.delete(id));
       }}
       saved={saved}
-      savedRedirect={domainsURLs.domains}
+      savedRedirect={urls.domains.index}
       saving={saving}
       submitAppearance="negative"
       submitDisabled={!canBeDeleted}

--- a/src/app/domains/views/Domains.test.tsx
+++ b/src/app/domains/views/Domains.test.tsx
@@ -15,7 +15,7 @@ describe("Domains", () => {
   [
     {
       component: "DomainsList",
-      path: domainsURLs.domains,
+      path: domainsURLs.index,
     },
     {
       component: "DomainDetails",

--- a/src/app/domains/views/Domains.tsx
+++ b/src/app/domains/views/Domains.tsx
@@ -9,10 +9,10 @@ import domainsURLs from "app/domains/urls";
 const Domains = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={domainsURLs.domains} render={() => <DomainsList />} />
+      <Route exact path={domainsURLs.index} render={() => <DomainsList />} />
       <Route
         exact
-        path={domainsURLs.details(null, true)}
+        path={domainsURLs.details(null)}
         render={() => <DomainDetails />}
       />
       <Route path="*" render={() => <NotFound />} />

--- a/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -19,7 +19,7 @@ describe("DomainsList", () => {
   [
     {
       component: "DomainsTable",
-      path: domainsURLs.domains,
+      path: domainsURLs.index,
     },
   ].forEach(({ component, path }) => {
     it(`Displays: ${component} at: ${path}`, () => {

--- a/src/app/domains/views/DomainsList/DomainsList.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.tsx
@@ -27,7 +27,7 @@ const DomainsList = (): JSX.Element => {
       <Switch>
         <Route
           exact
-          path={domainsURLs.domains}
+          path={domainsURLs.index}
           render={() => <>{domains.length > 0 && <DomainsTable />}</>}
         />
       </Switch>

--- a/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -112,7 +112,7 @@ describe("IntroSection", () => {
       </Provider>
     );
     expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      machineURLs.machines.index
+      machineURLs.index
     );
   });
 

--- a/src/app/intro/hooks.test.tsx
+++ b/src/app/intro/hooks.test.tsx
@@ -61,7 +61,7 @@ describe("hooks", () => {
       const { result } = renderHook(() => useExitURL(), {
         wrapper: generateWrapper(store),
       });
-      expect(result.current).toBe(machineURLs.machines.index);
+      expect(result.current).toBe(machineURLs.index);
     });
   });
 });

--- a/src/app/intro/hooks.ts
+++ b/src/app/intro/hooks.ts
@@ -10,7 +10,5 @@ import authSelectors from "app/store/auth/selectors";
  */
 export const useExitURL = (): string => {
   const authUser = useSelector(authSelectors.get);
-  return authUser?.is_superuser
-    ? dashboardURLs.index
-    : machineURLs.machines.index;
+  return authUser?.is_superuser ? dashboardURLs.index : machineURLs.index;
 };

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -99,7 +99,7 @@ describe("MaasIntroSuccess", () => {
       </Provider>
     );
     expect(wrapper.find("Link[data-testid='continue-button']").prop("to")).toBe(
-      machineURLs.machines.index
+      machineURLs.index
     );
   });
 

--- a/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -118,7 +118,7 @@ const DeleteForm = ({
             NotificationSeverity.INFORMATION
           )
         );
-        navigate({ pathname: kvmURLs.kvm });
+        navigate({ pathname: kvmURLs.index });
         clearHeaderContent();
       }}
       processingCount={deletingCount}

--- a/src/app/kvm/urls.ts
+++ b/src/app/kvm/urls.ts
@@ -3,7 +3,7 @@ import type { VMCluster } from "app/store/vmcluster/types";
 import { argPath } from "app/utils";
 
 const urls = {
-  kvm: "/kvm",
+  index: "/kvm",
   lxd: {
     index: "/kvm/lxd",
     cluster: {

--- a/src/app/kvm/urls.ts
+++ b/src/app/kvm/urls.ts
@@ -1,54 +1,47 @@
-import type { BasePod } from "app/store/pod/types";
-import type { VMCluster } from "app/store/vmcluster/types";
+import { BasePod } from "app/store/pod/types";
+import { VMCluster } from "app/store/vmcluster/types";
 import { argPath } from "app/utils";
+
+const withClusterId = argPath<{ clusterId: VMCluster["id"] }>;
+const withId = argPath<{ id: BasePod["id"] }>;
+const withClusterIdHostId = argPath<{
+  clusterId: VMCluster["id"];
+  hostId: BasePod["id"];
+}>;
 
 const urls = {
   index: "/kvm",
   lxd: {
     index: "/kvm/lxd",
     cluster: {
-      index: argPath<{ clusterId: VMCluster["id"] }>(
-        "/kvm/lxd/cluster/:clusterId"
-      ),
-      edit: argPath<{ clusterId: VMCluster["id"] }>(
-        "/kvm/lxd/cluster/:clusterId/edit"
-      ),
-      hosts: argPath<{ clusterId: VMCluster["id"] }>(
-        "/kvm/lxd/cluster/:clusterId/hosts"
-      ),
+      index: withClusterId("/kvm/lxd/cluster/:clusterId"),
+      edit: withClusterId("/kvm/lxd/cluster/:clusterId/edit"),
+      hosts: withClusterId("/kvm/lxd/cluster/:clusterId/hosts"),
       host: {
-        index: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
-          "/kvm/lxd/cluster/:clusterId/host/:hostId"
-        ),
-        edit: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
+        index: withClusterIdHostId("/kvm/lxd/cluster/:clusterId/host/:hostId"),
+        edit: withClusterIdHostId(
           "/kvm/lxd/cluster/:clusterId/host/:hostId/edit"
         ),
       },
-      resources: argPath<{ clusterId: VMCluster["id"] }>(
-        "/kvm/lxd/cluster/:clusterId/resources"
-      ),
+      resources: withClusterId("/kvm/lxd/cluster/:clusterId/resources"),
       vms: {
-        index: argPath<{ clusterId: VMCluster["id"] }>(
-          "/kvm/lxd/cluster/:clusterId/vms"
-        ),
-        host: argPath<{ clusterId: VMCluster["id"]; hostId: BasePod["id"] }>(
-          "/kvm/lxd/cluster/:clusterId/vms/:hostId"
-        ),
+        index: withClusterId("/kvm/lxd/cluster/:clusterId/vms"),
+        host: withClusterIdHostId("/kvm/lxd/cluster/:clusterId/vms/:hostId"),
       },
     },
     single: {
-      index: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id"),
-      edit: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/edit"),
-      resources: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/resources"),
-      vms: argPath<{ id: BasePod["id"] }>("/kvm/lxd/:id/vms"),
+      index: withId("/kvm/lxd/:id"),
+      edit: withId("/kvm/lxd/:id/edit"),
+      resources: withId("/kvm/lxd/:id/resources"),
+      vms: withId("/kvm/lxd/:id/vms"),
     },
   },
   virsh: {
     index: "/kvm/virsh",
     details: {
-      index: argPath<{ id: BasePod["id"] }>("/kvm/virsh/:id"),
-      edit: argPath<{ id: BasePod["id"] }>("/kvm/virsh/:id/edit"),
-      resources: argPath<{ id: BasePod["id"] }>("/kvm/virsh/:id/resources"),
+      index: withId("/kvm/virsh/:id"),
+      edit: withId("/kvm/virsh/:id/edit"),
+      resources: withId("/kvm/virsh/:id/resources"),
     },
   },
 } as const;

--- a/src/app/kvm/views/KVM.test.tsx
+++ b/src/app/kvm/views/KVM.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 
 import KVM from "./KVM";
 
-import kvmURLs from "app/kvm/urls";
+import urls from "app/base/urls";
 import { Label as KVMListLabel } from "app/kvm/views/KVMList/KVMList";
 import { Label as LXDClusterDetailsLabel } from "app/kvm/views/LXDClusterDetails/LXDClusterDetails";
 import { Label as LXDSingleDetailsLabel } from "app/kvm/views/LXDSingleDetails/LXDSingleDetails";
@@ -41,27 +41,27 @@ describe("KVM", () => {
   [
     {
       label: KVMListLabel.Title,
-      path: kvmURLs.kvm,
+      path: urls.kvm.index,
     },
     {
       label: KVMListLabel.Title,
-      path: kvmURLs.lxd.index,
+      path: urls.kvm.lxd.index,
     },
     {
       label: KVMListLabel.Title,
-      path: kvmURLs.virsh.index,
+      path: urls.kvm.virsh.index,
     },
     {
       label: LXDClusterDetailsLabel.Title,
-      path: kvmURLs.lxd.cluster.index({ clusterId: 1 }),
+      path: urls.kvm.lxd.cluster.index({ clusterId: 1 }),
     },
     {
       label: LXDSingleDetailsLabel.Title,
-      path: kvmURLs.lxd.single.index({ id: 4 }),
+      path: urls.kvm.lxd.single.index({ id: 4 }),
     },
     {
       label: VirshDetailsLabel.Title,
-      path: kvmURLs.virsh.details.index({ id: 3 }),
+      path: urls.kvm.virsh.details.index({ id: 3 }),
     },
   ].forEach(({ label, path }) => {
     it(`Displays: ${label} at: ${path}`, () => {
@@ -69,7 +69,7 @@ describe("KVM", () => {
         route: path,
         wrapperProps: {
           state,
-          routePattern: `${kvmURLs.kvm}/*`,
+          routePattern: `${urls.kvm.index}/*`,
         },
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/app/kvm/views/KVM.tsx
+++ b/src/app/kvm/views/KVM.tsx
@@ -5,42 +5,33 @@ import LXDClusterDetails from "./LXDClusterDetails";
 import LXDSingleDetails from "./LXDSingleDetails";
 import VirshDetails from "./VirshDetails";
 
-import kvmURLs from "app/kvm/urls";
+import urls from "app/base/urls";
 import { getRelativeRoute } from "app/utils";
 
 const KVM = (): JSX.Element => {
-  const base = kvmURLs.kvm;
+  const base = urls.kvm.index;
   return (
     <Routes>
       <Route element={<KVMList />} path="/" />
       <Route
         element={<KVMList />}
-        path={getRelativeRoute(kvmURLs.lxd.index, base)}
+        path={getRelativeRoute(urls.kvm.lxd.index, base)}
       />
       <Route
         element={<KVMList />}
-        path={getRelativeRoute(kvmURLs.virsh.index, base)}
+        path={getRelativeRoute(urls.kvm.virsh.index, base)}
       />
       <Route
         element={<LXDClusterDetails />}
-        path={`${getRelativeRoute(
-          kvmURLs.lxd.cluster.index(null, true),
-          base
-        )}/*`}
+        path={`${getRelativeRoute(urls.kvm.lxd.cluster.index(null), base)}/*`}
       />
       <Route
         element={<LXDSingleDetails />}
-        path={`${getRelativeRoute(
-          kvmURLs.lxd.single.index(null, true),
-          base
-        )}/*`}
+        path={`${getRelativeRoute(urls.kvm.lxd.single.index(null), base)}/*`}
       />
       <Route
         element={<VirshDetails />}
-        path={`${getRelativeRoute(
-          kvmURLs.virsh.details.index(null, true),
-          base
-        )}/*`}
+        path={`${getRelativeRoute(urls.kvm.virsh.details.index(null), base)}/*`}
       />
     </Routes>
   );

--- a/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -121,7 +121,7 @@ describe("KVMList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
+          initialEntries={[{ pathname: kvmURLs.index, key: "testKey" }]}
         >
           <CompatRouter>
             <KVMList />
@@ -204,7 +204,7 @@ describe("KVMList", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: kvmURLs.kvm, key: "testKey" }]}
+          initialEntries={[{ pathname: kvmURLs.index, key: "testKey" }]}
         >
           <CompatRouter>
             <KVMList />

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -67,7 +67,7 @@ describe("LXDClusterDetails", () => {
         route: path,
         wrapperProps: {
           state,
-          routePattern: `${kvmURLs.lxd.cluster.index(null, true)}/*`,
+          routePattern: `${kvmURLs.lxd.cluster.index(null)}/*`,
         },
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -88,7 +88,7 @@ const LXDClusterDetails = (): JSX.Element => {
     );
   }
 
-  const base = kvmURLs.lxd.cluster.index(null, true);
+  const base = kvmURLs.lxd.cluster.index(null);
   return (
     <Section
       aria-label={Label.Title}
@@ -109,7 +109,7 @@ const LXDClusterDetails = (): JSX.Element => {
               setHeaderContent={setHeaderContent}
             />
           }
-          path={getRelativeRoute(kvmURLs.lxd.cluster.hosts(null, true), base)}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.hosts(null), base)}
         />
         <Route
           element={
@@ -120,17 +120,11 @@ const LXDClusterDetails = (): JSX.Element => {
               setSearchFilter={setSearchFilter}
             />
           }
-          path={getRelativeRoute(
-            kvmURLs.lxd.cluster.vms.index(null, true),
-            base
-          )}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.vms.index(null), base)}
         />
         <Route
           element={<LXDClusterResources clusterId={clusterId} />}
-          path={getRelativeRoute(
-            kvmURLs.lxd.cluster.resources(null, true),
-            base
-          )}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.resources(null), base)}
         />
         <Route
           element={
@@ -139,7 +133,7 @@ const LXDClusterDetails = (): JSX.Element => {
               setHeaderContent={setHeaderContent}
             />
           }
-          path={getRelativeRoute(kvmURLs.lxd.cluster.edit(null, true), base)}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.edit(null), base)}
         />
         <Route
           element={
@@ -150,28 +144,19 @@ const LXDClusterDetails = (): JSX.Element => {
               setSearchFilter={setSearchFilter}
             />
           }
-          path={getRelativeRoute(
-            kvmURLs.lxd.cluster.vms.host(null, true),
-            base
-          )}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.vms.host(null), base)}
         />
         <Route
           element={<LXDClusterHostSettings clusterId={clusterId} />}
-          path={getRelativeRoute(
-            kvmURLs.lxd.cluster.host.edit(null, true),
-            base
-          )}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.host.edit(null), base)}
         />
         <Route
           element={<Redirect to={kvmURLs.lxd.cluster.hosts({ clusterId })} />}
-          path={getRelativeRoute(kvmURLs.lxd.cluster.index(null, true), base)}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.index(null), base)}
         />
         <Route
           element={<LXDClusterDetailsRedirect clusterId={clusterId} />}
-          path={getRelativeRoute(
-            kvmURLs.lxd.cluster.host.index(null, true),
-            base
-          )}
+          path={getRelativeRoute(kvmURLs.lxd.cluster.host.index(null), base)}
         />
       </Routes>
     </Section>

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
@@ -66,7 +66,7 @@ it("redirects to the config form", async () => {
           <Routes>
             <Route
               element={<LXDClusterDetailsRedirect clusterId={1} />}
-              path={kvmURLs.lxd.cluster.host.index(null, true)}
+              path={kvmURLs.lxd.cluster.host.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
@@ -37,7 +37,7 @@ describe("LXDClusterHostSettings", () => {
       route: kvmURLs.lxd.cluster.host.edit({ clusterId: 1, hostId: 2 }),
       wrapperProps: {
         state,
-        routePattern: kvmURLs.lxd.cluster.host.edit(null, true),
+        routePattern: kvmURLs.lxd.cluster.host.edit(null),
       },
     });
     expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
@@ -49,7 +49,7 @@ describe("LXDClusterHostSettings", () => {
       route: kvmURLs.lxd.cluster.host.edit({ clusterId: 1, hostId: 2 }),
       wrapperProps: {
         state,
-        routePattern: kvmURLs.lxd.cluster.host.edit(null, true),
+        routePattern: kvmURLs.lxd.cluster.host.edit(null),
       },
     });
     expect(screen.getByText("LXD host not found")).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe("LXDClusterHostSettings", () => {
       route: kvmURLs.lxd.cluster.host.edit({ clusterId: 1, hostId: 2 }),
       wrapperProps: {
         state,
-        routePattern: kvmURLs.lxd.cluster.host.edit(null, true),
+        routePattern: kvmURLs.lxd.cluster.host.edit(null),
       },
     });
     expect(screen.getByRole("combobox", { name: "Zone" })).toBeDisabled();

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
@@ -48,7 +48,7 @@ describe("LXDClusterHostVMs", () => {
         route: kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 2 }),
         wrapperProps: {
           state,
-          routePattern: kvmURLs.lxd.cluster.vms.host(null, true),
+          routePattern: kvmURLs.lxd.cluster.vms.host(null),
         },
       }
     );
@@ -68,7 +68,7 @@ describe("LXDClusterHostVMs", () => {
         route: kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 2 }),
         wrapperProps: {
           state,
-          routePattern: kvmURLs.lxd.cluster.vms.host(null, true),
+          routePattern: kvmURLs.lxd.cluster.vms.host(null),
         },
       }
     );
@@ -88,7 +88,7 @@ describe("LXDClusterHostVMs", () => {
         route: kvmURLs.lxd.cluster.vms.host({ clusterId: 1, hostId: 2 }),
         wrapperProps: {
           state,
-          routePattern: kvmURLs.lxd.cluster.vms.host(null, true),
+          routePattern: kvmURLs.lxd.cluster.vms.host(null),
         },
       }
     );

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -58,7 +58,7 @@ describe("LXDSingleDetails", () => {
         route: path,
         wrapperProps: {
           state,
-          routePattern: `${kvmURLs.lxd.single.index(null, true)}/*`,
+          routePattern: `${kvmURLs.lxd.single.index(null)}/*`,
         },
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -81,7 +81,7 @@ const LXDSingleDetails = (): JSX.Element => {
         <Switch>
           <Route
             exact
-            path={kvmURLs.lxd.single.vms(null, true)}
+            path={kvmURLs.lxd.single.vms(null)}
             render={() => (
               <LXDSingleVMs
                 id={id}
@@ -93,19 +93,19 @@ const LXDSingleDetails = (): JSX.Element => {
           />
           <Route
             exact
-            path={kvmURLs.lxd.single.resources(null, true)}
+            path={kvmURLs.lxd.single.resources(null)}
             render={() => <LXDSingleResources id={id} />}
           />
           <Route
             exact
-            path={kvmURLs.lxd.single.edit(null, true)}
+            path={kvmURLs.lxd.single.edit(null)}
             render={() => (
               <LXDSingleSettings id={id} setHeaderContent={setHeaderContent} />
             )}
           />
           <Redirect
-            from={kvmURLs.lxd.single.index(null, true)}
-            to={kvmURLs.lxd.single.vms(null, true)}
+            from={kvmURLs.lxd.single.index(null)}
+            to={kvmURLs.lxd.single.vms(null)}
           />
         </Switch>
       )}

--- a/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
@@ -53,7 +53,7 @@ describe("VirshDetails", () => {
         route: path,
         wrapperProps: {
           state,
-          routePattern: `${kvmURLs.virsh.details.index(null, true)}/*`,
+          routePattern: `${kvmURLs.virsh.details.index(null)}/*`,
         },
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/app/kvm/views/VirshDetails/VirshDetails.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetails.tsx
@@ -67,17 +67,17 @@ const VirshDetails = (): JSX.Element => {
         <Switch>
           <Route
             exact
-            path={kvmURLs.virsh.details.resources(null, true)}
+            path={kvmURLs.virsh.details.resources(null)}
             render={() => <VirshResources id={id} />}
           />
           <Route
             exact
-            path={kvmURLs.virsh.details.edit(null, true)}
+            path={kvmURLs.virsh.details.edit(null)}
             render={() => <VirshSettings id={id} />}
           />
           <Redirect
-            from={kvmURLs.virsh.details.index(null, true)}
-            to={kvmURLs.virsh.details.resources(null, true)}
+            from={kvmURLs.virsh.details.index(null)}
+            to={kvmURLs.virsh.details.resources(null)}
           />
         </Switch>
       )}

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
@@ -136,7 +136,7 @@ export const ActionFormWrapper = ({
                 );
               });
             }}
-            redirectURL={machineURLs.machines.index}
+            redirectURL={machineURLs.index}
             {...commonNodeFormProps}
           />
         );

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -272,8 +272,7 @@ export const TagFormChanges = ({
       {hasAutomaticTags && (
         <p className="u-text--muted u-nudge-right--small">
           These tags cannot be unassigned. Go to the{" "}
-          <Link to={tagsURLs.tags.index}>Tags tab</Link> to manage automatic
-          tags.
+          <Link to={tagsURLs.index}>Tags tab</Link> to manage automatic tags.
         </p>
       )}
       {isOpen && tagDetails ? (

--- a/src/app/machines/urls.ts
+++ b/src/app/machines/urls.ts
@@ -3,9 +3,7 @@ import type { ScriptResult } from "app/store/scriptresult/types";
 import { argPath } from "app/utils";
 
 const urls = {
-  machines: {
-    index: "/machines",
-  },
+  index: "/machines",
   machine: {
     commissioning: {
       index: argPath<{ id: Machine["system_id"] }>(

--- a/src/app/machines/urls.ts
+++ b/src/app/machines/urls.ts
@@ -1,48 +1,42 @@
-import type { Machine } from "app/store/machine/types";
-import type { ScriptResult } from "app/store/scriptresult/types";
+import { Machine } from "app/store/machine/types";
+import { ScriptResult } from "app/store/scriptresult/types";
 import { argPath } from "app/utils";
+
+const withId = argPath<{ id: Machine["system_id"] }>;
+const withIdScriptResultId = argPath<{
+  id: Machine["system_id"];
+  scriptResultId: ScriptResult["id"];
+}>;
 
 const urls = {
   index: "/machines",
   machine: {
     commissioning: {
-      index: argPath<{ id: Machine["system_id"] }>(
-        "/machine/:id/commissioning"
+      index: withId("/machine/:id/commissioning"),
+      scriptResult: withIdScriptResultId(
+        "/machine/:id/commissioning/:scriptResultId/details"
       ),
-      scriptResult: argPath<{
-        id: Machine["system_id"];
-        scriptResultId: ScriptResult["id"];
-      }>("/machine/:id/commissioning/:scriptResultId/details"),
     },
-    configuration: argPath<{ id: Machine["system_id"] }>(
-      "/machine/:id/configuration"
-    ),
-    events: argPath<{ id: Machine["system_id"] }>("/machine/:id/events"),
-    index: argPath<{ id: Machine["system_id"] }>("/machine/:id"),
-    instances: argPath<{ id: Machine["system_id"] }>("/machine/:id/instances"),
+    configuration: withId("/machine/:id/configuration"),
+    events: withId("/machine/:id/events"),
+    index: withId("/machine/:id"),
+    instances: withId("/machine/:id/instances"),
     logs: {
-      events: argPath<{ id: Machine["system_id"] }>("/machine/:id/logs/events"),
-      index: argPath<{ id: Machine["system_id"] }>("/machine/:id/logs"),
-      installationOutput: argPath<{ id: Machine["system_id"] }>(
-        "/machine/:id/logs/installation-output"
+      events: withId("/machine/:id/logs/events"),
+      index: withId("/machine/:id/logs"),
+      installationOutput: withId("/machine/:id/logs/installation-output"),
+    },
+    network: withId("/machine/:id/network"),
+    pciDevices: withId("/machine/:id/pci-devices"),
+    storage: withId("/machine/:id/storage"),
+    summary: withId("/machine/:id/summary"),
+    testing: {
+      index: withId("/machine/:id/testing"),
+      scriptResult: withIdScriptResultId(
+        "/machine/:id/testing/:scriptResultId/details"
       ),
     },
-    network: argPath<{ id: Machine["system_id"] }>("/machine/:id/network"),
-    pciDevices: argPath<{ id: Machine["system_id"] }>(
-      "/machine/:id/pci-devices"
-    ),
-    storage: argPath<{ id: Machine["system_id"] }>("/machine/:id/storage"),
-    summary: argPath<{ id: Machine["system_id"] }>("/machine/:id/summary"),
-    testing: {
-      index: argPath<{ id: Machine["system_id"] }>("/machine/:id/testing"),
-      scriptResult: argPath<{
-        id: Machine["system_id"];
-        scriptResultId: ScriptResult["id"];
-      }>("/machine/:id/testing/:scriptResultId/details"),
-    },
-    usbDevices: argPath<{ id: Machine["system_id"] }>(
-      "/machine/:id/usb-devices"
-    ),
+    usbDevices: withId("/machine/:id/usb-devices"),
   },
 } as const;
 

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -103,13 +103,13 @@ describe("TagForm", () => {
     expect(screen.queryByLabelText("tag-form")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "tag-1" })).toHaveAttribute(
       "href",
-      `${machineURLs.machines.index}${FilterMachines.filtersToQueryString({
+      `${machineURLs.index}${FilterMachines.filtersToQueryString({
         tags: ["=tag-1"],
       })}`
     );
     expect(screen.getByRole("link", { name: "tag-2" })).toHaveAttribute(
       "href",
-      `${machineURLs.machines.index}${FilterMachines.filtersToQueryString({
+      `${machineURLs.index}${FilterMachines.filtersToQueryString({
         tags: ["=tag-2"],
       })}`
     );

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -65,7 +65,7 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
                 const filter = FilterMachines.filtersToQueryString({
                   tags: [`=${tag.name}`],
                 });
-                return `${machineURLs.machines.index}${filter}`;
+                return `${machineURLs.index}${filter}`;
               }}
               tags={tags}
             />

--- a/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -45,42 +45,42 @@ describe("MachineDetails", () => {
   [
     {
       component: "MachineSummary",
-      route: machineURLs.machine.summary(null, true),
+      route: machineURLs.machine.summary(null),
       path: machineURLs.machine.summary({ id: "abc123" }),
     },
     {
       component: "MachineInstances",
-      route: machineURLs.machine.instances(null, true),
+      route: machineURLs.machine.instances(null),
       path: machineURLs.machine.instances({ id: "abc123" }),
     },
     {
       component: "MachineNetwork",
-      route: machineURLs.machine.network(null, true),
+      route: machineURLs.machine.network(null),
       path: machineURLs.machine.network({ id: "abc123" }),
     },
     {
       component: "MachineStorage",
-      route: machineURLs.machine.storage(null, true),
+      route: machineURLs.machine.storage(null),
       path: machineURLs.machine.storage({ id: "abc123" }),
     },
     {
       component: "MachinePCIDevices",
-      route: machineURLs.machine.pciDevices(null, true),
+      route: machineURLs.machine.pciDevices(null),
       path: machineURLs.machine.pciDevices({ id: "abc123" }),
     },
     {
       component: "MachineUSBDevices",
-      route: machineURLs.machine.usbDevices(null, true),
+      route: machineURLs.machine.usbDevices(null),
       path: machineURLs.machine.usbDevices({ id: "abc123" }),
     },
     {
       component: "MachineCommissioning",
-      route: machineURLs.machine.commissioning.index(null, true),
+      route: machineURLs.machine.commissioning.index(null),
       path: machineURLs.machine.commissioning.index({ id: "abc123" }),
     },
     {
       component: "NodeTestDetails",
-      route: machineURLs.machine.commissioning.scriptResult(null, true),
+      route: machineURLs.machine.commissioning.scriptResult(null),
       path: machineURLs.machine.commissioning.scriptResult({
         id: "abc123",
         scriptResultId: 1,
@@ -88,12 +88,12 @@ describe("MachineDetails", () => {
     },
     {
       component: "MachineTests",
-      route: machineURLs.machine.testing.index(null, true),
+      route: machineURLs.machine.testing.index(null),
       path: machineURLs.machine.testing.index({ id: "abc123" }),
     },
     {
       component: "NodeTestDetails",
-      route: machineURLs.machine.testing.scriptResult(null, true),
+      route: machineURLs.machine.testing.scriptResult(null),
       path: machineURLs.machine.testing.scriptResult({
         id: "abc123",
         scriptResultId: 1,
@@ -101,18 +101,18 @@ describe("MachineDetails", () => {
     },
     {
       component: "NodeLogs",
-      route: machineURLs.machine.logs.index(null, true),
+      route: machineURLs.machine.logs.index(null),
       path: machineURLs.machine.logs.index({ id: "abc123" }),
     },
     {
       component: "MachineConfiguration",
-      route: machineURLs.machine.configuration(null, true),
+      route: machineURLs.machine.configuration(null),
       path: machineURLs.machine.configuration({ id: "abc123" }),
     },
     {
       // Redirects to summary:
       component: "MachineSummary",
-      route: machineURLs.machine.index(null, true),
+      route: machineURLs.machine.index(null),
       path: machineURLs.machine.index({ id: "abc123" }),
     },
   ].forEach(({ component, path, route }) => {

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -63,11 +63,7 @@ const MachineDetails = (): JSX.Element => {
 
   if (!isId(id) || (!machinesLoading && !machine)) {
     return (
-      <ModelNotFound
-        id={id}
-        linkURL={machineURLs.machines.index}
-        modelName="machine"
-      />
+      <ModelNotFound id={id} linkURL={machineURLs.index} modelName="machine" />
     );
   }
 
@@ -85,7 +81,7 @@ const MachineDetails = (): JSX.Element => {
         <Switch>
           <Route
             exact
-            path={machineURLs.machine.summary(null, true)}
+            path={machineURLs.machine.summary(null)}
             render={() => (
               <>
                 <SummaryNotifications id={id} />
@@ -95,12 +91,12 @@ const MachineDetails = (): JSX.Element => {
           />
           <Route
             exact
-            path={machineURLs.machine.instances(null, true)}
+            path={machineURLs.machine.instances(null)}
             render={() => <MachineInstances />}
           />
           <Route
             exact
-            path={machineURLs.machine.network(null, true)}
+            path={machineURLs.machine.network(null)}
             render={() => (
               <>
                 <NetworkNotifications id={id} />
@@ -110,7 +106,7 @@ const MachineDetails = (): JSX.Element => {
           />
           <Route
             exact
-            path={machineURLs.machine.storage(null, true)}
+            path={machineURLs.machine.storage(null)}
             render={() => (
               <>
                 <StorageNotifications id={id} />
@@ -120,26 +116,26 @@ const MachineDetails = (): JSX.Element => {
           />
           <Route
             exact
-            path={machineURLs.machine.pciDevices(null, true)}
+            path={machineURLs.machine.pciDevices(null)}
             render={() => (
               <MachinePCIDevices setHeaderContent={setHeaderContent} />
             )}
           />
           <Route
             exact
-            path={machineURLs.machine.usbDevices(null, true)}
+            path={machineURLs.machine.usbDevices(null)}
             render={() => (
               <MachineUSBDevices setHeaderContent={setHeaderContent} />
             )}
           />
           <Route
             exact
-            path={machineURLs.machine.commissioning.index(null, true)}
+            path={machineURLs.machine.commissioning.index(null)}
             render={() => <MachineCommissioning />}
           />
           <Route
             exact
-            path={machineURLs.machine.commissioning.scriptResult(null, true)}
+            path={machineURLs.machine.commissioning.scriptResult(null)}
             render={() => (
               <NodeTestDetails
                 getReturnPath={(id) =>
@@ -150,12 +146,12 @@ const MachineDetails = (): JSX.Element => {
           />
           <Route
             exact
-            path={machineURLs.machine.testing.index(null, true)}
+            path={machineURLs.machine.testing.index(null)}
             render={() => <MachineTests />}
           />
           <Route
             exact
-            path={machineURLs.machine.testing.scriptResult(null, true)}
+            path={machineURLs.machine.testing.scriptResult(null)}
             render={() => (
               <NodeTestDetails
                 getReturnPath={(id) =>
@@ -165,24 +161,24 @@ const MachineDetails = (): JSX.Element => {
             )}
           />
           <Route
-            path={machineURLs.machine.logs.index(null, true)}
+            path={machineURLs.machine.logs.index(null)}
             render={() => <MachineLogs systemId={id} />}
           />
           <Route
             exact
-            path={machineURLs.machine.events(null, true)}
+            path={machineURLs.machine.events(null)}
             render={() => (
               <Redirect to={machineURLs.machine.logs.events({ id })} />
             )}
           />
           <Route
             exact
-            path={machineURLs.machine.configuration(null, true)}
+            path={machineURLs.machine.configuration(null)}
             render={() => <MachineConfiguration />}
           />
           <Route
             exact
-            path={machineURLs.machine.index(null, true)}
+            path={machineURLs.machine.index(null)}
             render={() => <Redirect to={machineURLs.machine.summary({ id })} />}
           />
         </Switch>

--- a/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
@@ -44,9 +44,7 @@ const WorkloadCard = ({ id }: Props): JSX.Element => {
                     });
                     return (
                       <div key={`${key}-${val}`}>
-                        <RouterLink
-                          to={`${machineURLs.machines.index}${filter}`}
-                        >
+                        <RouterLink to={`${machineURLs.index}${filter}`}>
                           {val}
                         </RouterLink>
                       </div>

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -50,7 +50,7 @@ export const MachineListHeader = ({
   }, [dispatch]);
 
   useEffect(() => {
-    if (location.pathname !== machineURLs.machines.index) {
+    if (location.pathname !== machineURLs.index) {
       setHeaderContent(null);
     }
   }, [location.pathname, setHeaderContent]);

--- a/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
@@ -85,7 +85,7 @@ export const PoolColumn = ({
           {updating !== null ? (
             <Spinner className="u-nudge-left--small" />
           ) : null}
-          <Link className="p-link--soft" to={poolsURLs.pools}>
+          <Link className="p-link--soft" to={poolsURLs.index}>
             {machine.pool.name}
           </Link>
         </span>

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -68,7 +68,7 @@ describe("Machines", () => {
   [
     {
       component: "MachineList",
-      path: machineURLs.machines.index,
+      path: machineURLs.index,
     },
     {
       component: "NotFound",

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -62,7 +62,7 @@ const Machines = (): JSX.Element => {
       <Switch>
         <Route
           exact
-          path={machineURLs.machines.index}
+          path={machineURLs.index}
           render={() => (
             <MachineList
               headerFormOpen={!!headerContent}

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -83,7 +83,7 @@ describe("PoolForm", () => {
       </Provider>
     );
     expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      poolsURLs.pools
+      poolsURLs.index
     );
   });
 

--- a/src/app/pools/components/PoolForm/PoolForm.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.tsx
@@ -66,7 +66,7 @@ export const PoolForm = ({ pool }: Props): JSX.Element => {
         cleanup={poolActions.cleanup}
         errors={errors}
         initialValues={initialValues}
-        onCancel={() => navigate({ pathname: poolsURLs.pools })}
+        onCancel={() => navigate({ pathname: poolsURLs.index })}
         onSaveAnalytics={{
           action: "Saved",
           category: "Resource pool",
@@ -87,7 +87,7 @@ export const PoolForm = ({ pool }: Props): JSX.Element => {
           setSaving(values.name);
         }}
         saved={saved}
-        savedRedirect={poolsURLs.pools}
+        savedRedirect={poolsURLs.index}
         saving={saving}
         submitLabel="Save pool"
         validationSchema={PoolSchema}

--- a/src/app/pools/urls.ts
+++ b/src/app/pools/urls.ts
@@ -4,7 +4,7 @@ import { argPath } from "app/utils";
 const urls = {
   add: "/pools/add",
   edit: argPath<{ id: ResourcePool["id"] }>("/pools/:id/edit"),
-  pools: "/pools",
+  index: "/pools",
 };
 
 export default urls;

--- a/src/app/pools/views/PoolEdit/PoolEdit.tsx
+++ b/src/app/pools/views/PoolEdit/PoolEdit.tsx
@@ -23,7 +23,7 @@ export const PoolEdit = (): JSX.Element => {
     return (
       <ModelNotFound
         id={id}
-        linkURL={poolURLs.pools}
+        linkURL={poolURLs.index}
         modelName="resource pool"
       />
     );

--- a/src/app/pools/views/PoolList/PoolList.tsx
+++ b/src/app/pools/views/PoolList/PoolList.tsx
@@ -34,7 +34,7 @@ const getMachinesLabel = (row: ResourcePool) => {
     pool: [`=${row.name}`],
   });
   return (
-    <Link to={`${machineURLs.machines.index}${filters}`}>
+    <Link to={`${machineURLs.index}${filters}`}>
       {`${row.machine_ready_count} of ${row.machine_total_count} ready`}
     </Link>
   );

--- a/src/app/pools/views/Pools.test.tsx
+++ b/src/app/pools/views/Pools.test.tsx
@@ -15,7 +15,7 @@ describe("Pools", () => {
   [
     {
       component: "Pools",
-      path: poolsURLs.pools,
+      path: poolsURLs.index,
     },
     {
       component: "PoolAdd",

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -24,11 +24,11 @@ const Pools = (): JSX.Element => (
     }
   >
     <Switch>
-      <Route exact path={poolsURLs.pools} render={() => <PoolList />} />
+      <Route exact path={poolsURLs.index} render={() => <PoolList />} />
       <Route exact path={poolsURLs.add} render={() => <PoolAdd />} />
       <Route
         exact
-        path={poolsURLs.edit(null, true)}
+        path={poolsURLs.edit(null)}
         render={() => <PoolEdit />}
       />
       <Route path="*" render={() => <NotFound />} />

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -26,11 +26,7 @@ const Pools = (): JSX.Element => (
     <Switch>
       <Route exact path={poolsURLs.index} render={() => <PoolList />} />
       <Route exact path={poolsURLs.add} render={() => <PoolAdd />} />
-      <Route
-        exact
-        path={poolsURLs.edit(null)}
-        render={() => <PoolEdit />}
-      />
+      <Route exact path={poolsURLs.edit(null)} render={() => <PoolEdit />} />
       <Route path="*" render={() => <NotFound />} />
     </Switch>
   </Section>

--- a/src/app/preferences/components/Routes/Routes.tsx
+++ b/src/app/preferences/components/Routes/Routes.tsx
@@ -14,7 +14,7 @@ import SSLKeyList from "app/preferences/views/SSLKeys/SSLKeyList";
 const Routes = (): JSX.Element => {
   return (
     <Switch>
-      <Redirect exact from={prefsURLs.prefs} to={prefsURLs.details} />
+      <Redirect exact from={prefsURLs.index} to={prefsURLs.details} />
       <Route exact path={prefsURLs.details} render={() => <Details />} />
       <Route
         exact
@@ -24,7 +24,7 @@ const Routes = (): JSX.Element => {
       <Route exact path={prefsURLs.apiKeys.add} render={() => <APIKeyAdd />} />
       <Route
         exact
-        path={prefsURLs.apiKeys.edit(null, true)}
+        path={prefsURLs.apiKeys.edit(null)}
         render={() => <APIKeyEdit />}
       />
       <Route

--- a/src/app/preferences/urls.ts
+++ b/src/app/preferences/urls.ts
@@ -8,7 +8,7 @@ const urls = {
     index: "/account/prefs/api-keys",
   },
   details: "/account/prefs/details",
-  prefs: "/account/prefs",
+  index: "/account/prefs",
   sshKeys: {
     add: "/account/prefs/ssh-keys/add",
     index: "/account/prefs/ssh-keys",

--- a/src/app/settings/components/Routes/Routes.tsx
+++ b/src/app/settings/components/Routes/Routes.tsx
@@ -76,7 +76,7 @@ const Routes = (): JSX.Element => {
       <Route exact path={settingsURLs.users.add} render={() => <UserAdd />} />
       <Route
         exact
-        path={settingsURLs.users.edit(null, true)}
+        path={settingsURLs.users.edit(null)}
         render={() => <UserEdit />}
       />
       <Route
@@ -91,7 +91,7 @@ const Routes = (): JSX.Element => {
       />
       <Route
         exact
-        path={settingsURLs.licenseKeys.edit(null, true)}
+        path={settingsURLs.licenseKeys.edit(null)}
         render={() => <LicenseKeyEdit />}
       />
       <Route exact path={settingsURLs.storage} render={() => <StorageForm />} />
@@ -141,7 +141,7 @@ const Routes = (): JSX.Element => {
       <Route exact path={settingsURLs.dhcp.add} render={() => <DhcpAdd />} />
       <Route
         exact
-        path={settingsURLs.dhcp.edit(null, true)}
+        path={settingsURLs.dhcp.edit(null)}
         render={() => <DhcpEdit />}
       />
       <Route
@@ -151,12 +151,12 @@ const Routes = (): JSX.Element => {
       />
       <Route
         exact
-        path={settingsURLs.repositories.add(null, true)}
+        path={settingsURLs.repositories.add(null)}
         render={() => <RepositoryAdd />}
       />
       <Route
         exact
-        path={settingsURLs.repositories.edit(null, true)}
+        path={settingsURLs.repositories.edit(null)}
         render={() => <RepositoryEdit />}
       />
       <Route

--- a/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
+++ b/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
@@ -71,7 +71,7 @@ it("selects the correct subnets to display in the table", () => {
             />
           )}
           exact
-          path={subnetsURLs.subnet.index(null, true)}
+          path={subnetsURLs.subnet.index(null)}
         />
       </MemoryRouter>
     </Provider>

--- a/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -28,7 +28,7 @@ it("dispatches actions to fetch necessary data and set fabric as active on mount
           <Routes>
             <Route
               element={<FabricDetails />}
-              path={subnetsURLs.fabric.index(null, true)}
+              path={subnetsURLs.fabric.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -63,7 +63,7 @@ it("dispatches actions to unset active fabric and clean up on unmount", () => {
           <Routes>
             <Route
               element={<FabricDetails />}
-              path={subnetsURLs.fabric.index(null, true)}
+              path={subnetsURLs.fabric.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -107,7 +107,7 @@ it("displays a message if the fabric does not exist", () => {
           <Routes>
             <Route
               element={<FabricDetails />}
-              path={subnetsURLs.fabric.index(null, true)}
+              path={subnetsURLs.fabric.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -135,7 +135,7 @@ it("shows a spinner if the fabric has not loaded yet", () => {
           <Routes>
             <Route
               element={<FabricDetails />}
-              path={subnetsURLs.fabric.index(null, true)}
+              path={subnetsURLs.fabric.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -28,7 +28,7 @@ it("dispatches actions to get and set space as active on mount", () => {
           <Routes>
             <Route
               element={<SpaceDetails />}
-              path={subnetsURLs.space.index(null, true)}
+              path={subnetsURLs.space.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -59,7 +59,7 @@ it("dispatches actions to unset active space and clean up on unmount", () => {
           <Routes>
             <Route
               element={<SpaceDetails />}
-              path={subnetsURLs.space.index(null, true)}
+              path={subnetsURLs.space.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -103,7 +103,7 @@ it("displays a message if the space does not exist", () => {
           <Routes>
             <Route
               element={<SpaceDetails />}
-              path={subnetsURLs.space.index(null, true)}
+              path={subnetsURLs.space.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -131,7 +131,7 @@ it("shows a spinner if the space has not loaded yet", () => {
           <Routes>
             <Route
               element={<SpaceDetails />}
-              path={subnetsURLs.space.index(null, true)}
+              path={subnetsURLs.space.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -166,7 +166,7 @@ it("displays space details", async () => {
           <Routes>
             <Route
               element={<SpaceDetails />}
-              path={subnetsURLs.space.index(null, true)}
+              path={subnetsURLs.space.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -28,7 +28,7 @@ it("dispatches actions to fetch necessary data and set subnet as active on mount
           <Routes>
             <Route
               element={<SubnetDetails />}
-              path={subnetsURLs.subnet.index(null, true)}
+              path={subnetsURLs.subnet.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -63,7 +63,7 @@ it("dispatches actions to unset active subnet and clean up on unmount", () => {
           <Routes>
             <Route
               element={<SubnetDetails />}
-              path={subnetsURLs.subnet.index(null, true)}
+              path={subnetsURLs.subnet.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -107,7 +107,7 @@ it("displays a message if the subnet does not exist", () => {
           <Routes>
             <Route
               element={<SubnetDetails />}
-              path={subnetsURLs.subnet.index(null, true)}
+              path={subnetsURLs.subnet.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -135,7 +135,7 @@ it("shows a spinner if the subnet has not loaded yet", () => {
           <Routes>
             <Route
               element={<SubnetDetails />}
-              path={subnetsURLs.subnet.index(null, true)}
+              path={subnetsURLs.subnet.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
@@ -32,7 +32,7 @@ it("dispatches actions to fetch necessary data and set vlan as active on mount",
           <Routes>
             <Route
               element={<VLANDetails />}
-              path={subnetsURLs.vlan.index(null, true)}
+              path={subnetsURLs.vlan.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -63,7 +63,7 @@ it("dispatches actions to unset active vlan and clean up on unmount", () => {
           <Routes>
             <Route
               element={<VLANDetails />}
-              path={subnetsURLs.vlan.index(null, true)}
+              path={subnetsURLs.vlan.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -104,7 +104,7 @@ it("displays a message if the vlan does not exist", () => {
           <Routes>
             <Route
               element={<VLANDetails />}
-              path={subnetsURLs.vlan.index(null, true)}
+              path={subnetsURLs.vlan.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -132,7 +132,7 @@ it("shows a spinner if the vlan has not loaded yet", () => {
           <Routes>
             <Route
               element={<VLANDetails />}
-              path={subnetsURLs.vlan.index(null, true)}
+              path={subnetsURLs.vlan.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -8,10 +8,10 @@ import configureStore from "redux-mock-store";
 import AddTagForm, { Label } from "./AddTagForm";
 
 import * as baseHooks from "app/base/hooks/base";
+import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { Label as KernelOptionsLabel } from "app/tags/components/KernelOptionsField";
-import tagsURLs from "app/tags/urls";
 import {
   tag as tagFactory,
   rootState as rootStateFactory,
@@ -79,7 +79,7 @@ it("returns the newly created tag on save", async () => {
               <AddTagForm name="new-tag" onTagCreated={onTagCreated} />
             )}
             exact
-            path={tagsURLs.tags.index}
+            path={urls.tags.index}
           />
         </CompatRouter>
       </MemoryRouter>

--- a/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
+++ b/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
@@ -68,15 +68,15 @@ it("links to nodes", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags=%3Da-tag`
+    `${machineURLs.index}?tags=%3Da-tag`
   );
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags=%3Da-tag`
+    `${controllerURLs.index}?tags=%3Da-tag`
   );
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags=%3Da-tag`
+    `${deviceURLs.index}?tags=%3Da-tag`
   );
 });
 

--- a/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
+++ b/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
@@ -29,7 +29,7 @@ it("create a link to machines", () => {
   expect(machineLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags=%3Da-tag`
+    `${machineURLs.index}?tags=%3Da-tag`
   );
 });
 
@@ -51,7 +51,7 @@ it("create a link to controllers", () => {
   expect(controllerLink).toBeInTheDocument();
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags=%3Da-tag`
+    `${controllerURLs.index}?tags=%3Da-tag`
   );
 });
 
@@ -69,6 +69,6 @@ it("create a link to devices", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags=%3Da-tag`
+    `${deviceURLs.index}?tags=%3Da-tag`
   );
 });

--- a/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
+++ b/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
@@ -2,7 +2,7 @@ import pluralize from "pluralize";
 import { Link } from "react-router-dom-v5-compat";
 
 import controllerURLs from "app/controllers/urls";
-import deviceURLs from "app/devices/urls";
+import devicesURLs from "app/devices/urls";
 import machineURLs from "app/machines/urls";
 import { ControllerMeta } from "app/store/controller/types";
 import { DeviceMeta } from "app/store/device/types";
@@ -26,15 +26,15 @@ const NodesTagsLink = ({
   let nodeName: string | null = null;
   switch (nodeType) {
     case MachineMeta.MODEL:
-      url = machineURLs.machines.index;
+      url = machineURLs.index;
       nodeName = "machine";
       break;
     case ControllerMeta.MODEL:
-      url = controllerURLs.controllers.index;
+      url = controllerURLs.index;
       nodeName = "controller";
       break;
     case DeviceMeta.MODEL:
-      url = deviceURLs.devices.index;
+      url = devicesURLs.index;
       nodeName = "device";
       break;
   }

--- a/src/app/tags/components/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/components/TagDetails/TagDetails.test.tsx
@@ -46,7 +46,7 @@ it("dispatches actions to fetch necessary data", () => {
           <Route
             component={() => <TagDetails id={1} />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={tagURLs.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>
@@ -81,7 +81,7 @@ it("displays a message if the tag does not exist", () => {
           <Route
             component={() => <TagDetails id={1} />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={tagURLs.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>
@@ -108,7 +108,7 @@ it("shows a spinner if the tag has not loaded yet", () => {
           <Route
             component={() => <TagDetails id={1} />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={tagURLs.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>
@@ -129,7 +129,7 @@ it("displays the tag name when not narrow", () => {
           <Route
             component={() => <TagDetails id={1} />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={tagURLs.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>
@@ -149,7 +149,7 @@ it("does not display the tag name when narrow", () => {
           <Route
             component={() => <TagDetails id={1} narrow />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={tagURLs.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>

--- a/src/app/tags/components/TagDetails/TagDetails.tsx
+++ b/src/app/tags/components/TagDetails/TagDetails.tsx
@@ -40,9 +40,7 @@ const TagDetails = ({ id, narrow }: Props): JSX.Element => {
   }, [dispatch]);
 
   if (!isId(id) || (!tagsLoading && !tag)) {
-    return (
-      <ModelNotFound id={id} linkURL={tagURLs.tags.index} modelName="tag" />
-    );
+    return <ModelNotFound id={id} linkURL={tagURLs.index} modelName="tag" />;
   }
 
   if (!tag || tagsLoading) {

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -10,12 +10,12 @@ import AddTagForm, { Label } from "./AddTagForm";
 
 import * as analyticsHooks from "app/base/hooks/analytics";
 import * as baseHooks from "app/base/hooks/base";
+import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { Label as DefinitionLabel } from "app/tags/components/DefinitionField";
 import { Label as KernelOptionsLabel } from "app/tags/components/KernelOptionsField";
 import { NewDefinitionMessage } from "app/tags/constants";
-import tagsURLs from "app/tags/urls";
 import {
   tag as tagFactory,
   rootState as rootStateFactory,
@@ -82,7 +82,7 @@ it("dispatches an action to create a tag", async () => {
 
 it("redirects to the newly created tag on save", async () => {
   const history = createMemoryHistory({
-    initialEntries: [{ pathname: tagsURLs.tags.index }],
+    initialEntries: [{ pathname: urls.tags.index }],
   });
   const onClose = jest.fn();
   const store = mockStore(state);
@@ -93,14 +93,14 @@ it("redirects to the newly created tag on save", async () => {
           <Route
             component={() => <AddTagForm onClose={onClose} />}
             exact
-            path={tagsURLs.tags.index}
+            path={urls.tags.index}
           />
         </CompatRouter>
       </Router>
     </Provider>
   );
   render(<TagForm />);
-  expect(history.location.pathname).toBe(tagsURLs.tags.index);
+  expect(history.location.pathname).toBe(urls.tags.index);
   await userEvent.type(
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
@@ -117,7 +117,7 @@ it("redirects to the newly created tag on save", async () => {
     saved: true,
   });
   await userEvent.click(screen.getByRole("button", { name: "Save" }));
-  expect(history.location.pathname).toBe(tagsURLs.tag.index({ id: 8 }));
+  expect(history.location.pathname).toBe(urls.tags.tag.index({ id: 8 }));
   expect(onClose).toBeCalled();
 });
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -170,7 +170,7 @@ it("can return to the list on cancel", async () => {
     </Provider>
   );
   await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-  expect(history.location.pathname).toBe(tagsURLs.tags.index);
+  expect(history.location.pathname).toBe(tagsURLs.index);
   expect(onClose).toBeCalled();
 });
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
@@ -52,7 +52,7 @@ export const DeleteTagForm = ({
       // the list of machines.
       navigate({ pathname: tagsURLs.tag.index({ id: id }) });
     } else {
-      navigate({ pathname: tagsURLs.tags.index });
+      navigate({ pathname: tagsURLs.index });
     }
   };
   if (!tag) {
@@ -81,7 +81,7 @@ export const DeleteTagForm = ({
         onClose();
       }}
       saved={saved}
-      savedRedirect={tagsURLs.tags.index}
+      savedRedirect={tagsURLs.index}
       saving={saving}
       submitAppearance="negative"
       submitLabel="Delete"

--- a/src/app/tags/urls.ts
+++ b/src/app/tags/urls.ts
@@ -2,9 +2,7 @@ import type { Tag, TagMeta } from "app/store/tag/types";
 import { argPath } from "app/utils";
 
 const urls = {
-  tags: {
-    index: "/tags",
-  },
+  index: "/tags",
   tag: {
     index: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id"),
     machines: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id/machines"),

--- a/src/app/tags/urls.ts
+++ b/src/app/tags/urls.ts
@@ -1,12 +1,14 @@
-import type { Tag, TagMeta } from "app/store/tag/types";
+import { Tag, TagMeta } from "app/store/tag/types";
 import { argPath } from "app/utils";
+
+const withId = argPath<{ id: Tag[TagMeta.PK] }>;
 
 const urls = {
   index: "/tags",
   tag: {
-    index: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id"),
-    machines: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id/machines"),
-    update: argPath<{ id: Tag[TagMeta.PK] }>("/tag/:id/edit"),
+    index: withId("/tag/:id"),
+    machines: withId("/tag/:id/machines"),
+    update: withId("/tag/:id/edit"),
   },
 } as const;
 

--- a/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -51,7 +51,7 @@ it("dispatches actions to fetch necessary data", () => {
           <Routes>
             <Route
               element={<TagDetails onDelete={jest.fn()} />}
-              path={tagURLs.tag.index(null, true)}
+              path={tagURLs.tag.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -87,7 +87,7 @@ it("displays a message if the tag does not exist", () => {
           <Routes>
             <Route
               element={<TagDetails onDelete={jest.fn()} />}
-              path={tagURLs.tag.index(null, true)}
+              path={tagURLs.tag.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -115,7 +115,7 @@ it("shows a spinner if the tag has not loaded yet", () => {
           <Routes>
             <Route
               element={<TagDetails onDelete={jest.fn()} />}
-              path={tagURLs.tag.index(null, true)}
+              path={tagURLs.tag.index(null)}
             />
           </Routes>
         </CompatRouter>
@@ -142,7 +142,7 @@ it("can display the edit form", () => {
                   tagViewState={TagViewState.Updating}
                 />
               }
-              path={tagURLs.tag.update(null, true)}
+              path={tagURLs.tag.update(null)}
             />
           </Routes>
         </CompatRouter>
@@ -165,7 +165,7 @@ it("can go to the tag edit page", async () => {
           <Routes>
             <Route
               element={<TagDetails onDelete={jest.fn()} />}
-              path={tagURLs.tag.index(null, true)}
+              path={tagURLs.tag.index(null)}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/tags/views/TagDetails/TagDetails.tsx
+++ b/src/app/tags/views/TagDetails/TagDetails.tsx
@@ -53,9 +53,7 @@ const TagDetails = ({ onDelete, tagViewState }: Props): JSX.Element => {
   }, [dispatch]);
 
   if (!isId(id) || (!tagsLoading && !tag)) {
-    return (
-      <ModelNotFound id={id} linkURL={tagURLs.tags.index} modelName="tag" />
-    );
+    return <ModelNotFound id={id} linkURL={tagURLs.index} modelName="tag" />;
   }
 
   if (!tag || tagsLoading) {
@@ -74,7 +72,7 @@ const TagDetails = ({ onDelete, tagViewState }: Props): JSX.Element => {
     <div aria-label={Label.Title}>
       <Row>
         <Col size={6}>
-          <Link className="u-sv3" to={tagURLs.tags.index}>
+          <Link className="u-sv3" to={tagURLs.index}>
             &lsaquo; Back to all tags
           </Link>
         </Col>

--- a/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -326,15 +326,15 @@ it("can link to nodes", () => {
   expect(deviceLink).toBeInTheDocument();
   expect(machineLink).toHaveAttribute(
     "href",
-    `${machineURLs.machines.index}?tags=%3Da-tag`
+    `${machineURLs.index}?tags=%3Da-tag`
   );
   expect(controllerLink).toHaveAttribute(
     "href",
-    `${controllerURLs.controllers.index}?tags=%3Da-tag`
+    `${controllerURLs.index}?tags=%3Da-tag`
   );
   expect(deviceLink).toHaveAttribute(
     "href",
-    `${deviceURLs.devices.index}?tags=%3Da-tag`
+    `${deviceURLs.index}?tags=%3Da-tag`
   );
 });
 

--- a/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -57,10 +57,7 @@ it("dispatches actions to fetch necessary data", () => {
       >
         <CompatRouter>
           <Routes>
-            <Route
-              element={<TagMachines />}
-              path={tagURLs.tag.index(null, true)}
-            />
+            <Route element={<TagMachines />} path={tagURLs.tag.index(null)} />
           </Routes>
         </CompatRouter>
       </MemoryRouter>
@@ -92,10 +89,7 @@ it("displays a message if the tag does not exist", () => {
       >
         <CompatRouter>
           <Routes>
-            <Route
-              element={<TagMachines />}
-              path={tagURLs.tag.index(null, true)}
-            />
+            <Route element={<TagMachines />} path={tagURLs.tag.index(null)} />
           </Routes>
         </CompatRouter>
       </MemoryRouter>
@@ -119,10 +113,7 @@ it("shows a spinner if the tag has not loaded yet", () => {
       >
         <CompatRouter>
           <Routes>
-            <Route
-              element={<TagMachines />}
-              path={tagURLs.tag.index(null, true)}
-            />
+            <Route element={<TagMachines />} path={tagURLs.tag.index(null)} />
           </Routes>
         </CompatRouter>
       </MemoryRouter>
@@ -140,10 +131,7 @@ it("displays the machine list", () => {
       >
         <CompatRouter>
           <Routes>
-            <Route
-              element={<TagMachines />}
-              path={tagURLs.tag.index(null, true)}
-            />
+            <Route element={<TagMachines />} path={tagURLs.tag.index(null)} />
           </Routes>
         </CompatRouter>
       </MemoryRouter>

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -39,9 +39,7 @@ const TagMachines = (): JSX.Element => {
   }, [dispatch]);
 
   if (!isId(id) || (!tagsLoading && !tag)) {
-    return (
-      <ModelNotFound id={id} linkURL={tagURLs.tags.index} modelName="tag" />
-    );
+    return <ModelNotFound id={id} linkURL={tagURLs.index} modelName="tag" />;
   }
 
   if (!tag || tagsLoading) {

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -139,7 +139,7 @@ it("can update the tag", async () => {
 
 it("can return to the previous page on save", async () => {
   const history = createMemoryHistory({
-    initialEntries: [{ pathname: urls.index }],
+    initialEntries: [{ pathname: urls.tags.index }],
   });
   history.push({
     pathname: urls.tags.tag.update({ id: 1 }),

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -9,11 +9,11 @@ import configureStore from "redux-mock-store";
 import TagUpdate from "./TagUpdate";
 
 import * as baseHooks from "app/base/hooks/base";
+import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { Label as KernelOptionsLabel } from "app/tags/components/KernelOptionsField";
 import { NewDefinitionMessage } from "app/tags/constants";
-import tagURLs from "app/tags/urls";
 import { Label } from "app/tags/views/TagDetails";
 import {
   rootState as rootStateFactory,
@@ -49,13 +49,13 @@ it("dispatches actions to fetch necessary data", () => {
   render(
     <Provider store={store}>
       <MemoryRouter
-        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+        initialEntries={[{ pathname: urls.tags.tag.index({ id: 1 }) }]}
       >
         <CompatRouter>
           <Route
             component={() => <TagUpdate id={1} />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={urls.tags.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>
@@ -84,13 +84,13 @@ it("shows a spinner if the tag has not loaded yet", () => {
   render(
     <Provider store={store}>
       <MemoryRouter
-        initialEntries={[{ pathname: tagURLs.tag.index({ id: 1 }) }]}
+        initialEntries={[{ pathname: urls.tags.tag.index({ id: 1 }) }]}
       >
         <CompatRouter>
           <Route
             component={() => <TagUpdate id={1} />}
             exact
-            path={tagURLs.tag.index(null, true)}
+            path={urls.tags.tag.index(null)}
           />
         </CompatRouter>
       </MemoryRouter>
@@ -139,10 +139,10 @@ it("can update the tag", async () => {
 
 it("can return to the previous page on save", async () => {
   const history = createMemoryHistory({
-    initialEntries: [{ pathname: tagURLs.tags.index }],
+    initialEntries: [{ pathname: urls.index }],
   });
   history.push({
-    pathname: tagURLs.tag.update({ id: 1 }),
+    pathname: urls.tags.tag.update({ id: 1 }),
     state: { canGoBack: true },
   });
   const store = mockStore(state);
@@ -153,13 +153,13 @@ it("can return to the previous page on save", async () => {
           <Route
             component={() => <TagUpdate id={1} />}
             exact
-            path={tagURLs.tag.update(null, true)}
+            path={urls.tags.tag.update(null)}
           />
         </CompatRouter>
       </Router>
     </Provider>
   );
-  expect(history.location.pathname).toBe(tagURLs.tag.update({ id: 1 }));
+  expect(history.location.pathname).toBe(urls.tags.tag.update({ id: 1 }));
   await userEvent.type(
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
@@ -172,16 +172,14 @@ it("can return to the previous page on save", async () => {
     .spyOn(baseHooks, "useCycled")
     .mockImplementation(() => [true, () => null]);
   await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
-  await waitFor(() =>
-    expect(history.location.pathname).toBe(tagURLs.tags.index)
-  );
+  await waitFor(() => expect(history.location.pathname).toBe(urls.tags.index));
 });
 
 it("goes to the tag details page if it can't go back", async () => {
   const history = createMemoryHistory({
     initialEntries: [
       {
-        pathname: tagURLs.tag.update({ id: 1 }),
+        pathname: urls.tags.tag.update({ id: 1 }),
       },
     ],
   });
@@ -193,13 +191,13 @@ it("goes to the tag details page if it can't go back", async () => {
           <Route
             component={() => <TagUpdate id={1} />}
             exact
-            path={tagURLs.tag.update(null, true)}
+            path={urls.tags.tag.update(null)}
           />
         </CompatRouter>
       </Router>
     </Provider>
   );
-  expect(history.location.pathname).toBe(tagURLs.tag.update({ id: 1 }));
+  expect(history.location.pathname).toBe(urls.tags.tag.update({ id: 1 }));
   await userEvent.type(
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
@@ -213,7 +211,7 @@ it("goes to the tag details page if it can't go back", async () => {
     .mockImplementation(() => [true, () => null]);
   await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
   await waitFor(() =>
-    expect(history.location.pathname).toBe(tagURLs.tag.index({ id: 1 }))
+    expect(history.location.pathname).toBe(urls.tags.tag.index({ id: 1 }))
   );
 });
 

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -8,9 +8,9 @@ import { Label as TagListLabel } from "./TagList/TagList";
 import { Label as TagUpdateLabel } from "./TagUpdate/TagUpdate";
 import Tags from "./Tags";
 
+import urls from "app/base/urls";
 import { Label as NotFoundLabel } from "app/base/views/NotFound/NotFound";
 import type { RootState } from "app/store/root/types";
-import tagURLs from "app/tags/urls";
 import {
   rootState as rootStateFactory,
   tag as tagFactory,
@@ -41,38 +41,36 @@ describe("Tags", () => {
   [
     {
       label: TagDetailsLabel.Title,
-      path: tagURLs.tag.index({ id: 1 }),
+      path: urls.tags.tag.index({ id: 1 }),
     },
     {
       label: TagUpdateLabel.Form,
-      path: tagURLs.tag.update({ id: 1 }),
+      path: urls.tags.tag.update({ id: 1 }),
     },
     {
       label: TagListLabel.Title,
-      path: tagURLs.tags.index,
-      pattern: `${tagURLs.tags.index}/*`,
+      path: urls.tags.index,
+      pattern: `${urls.tags.index}/*`,
     },
     {
       label: NotFoundLabel.Title,
-      path: `${tagURLs.tags.index}/not/a/path`,
-      pattern: `${tagURLs.tags.index}/*`,
+      path: `${urls.tags.index}/not/a/path`,
+      pattern: `${urls.tags.index}/*`,
     },
-  ].forEach(
-    ({ label, path, pattern = `${tagURLs.tag.index(null, true)}/*` }) => {
-      it(`Displays: ${label} at: ${path}`, () => {
-        renderWithBrowserRouter(<Tags />, {
-          wrapperProps: { routePattern: pattern, state },
-          route: path,
-        });
-        expect(screen.getByLabelText(label)).toBeInTheDocument();
+  ].forEach(({ label, path, pattern = `${urls.tags.tag.index(null)}/*` }) => {
+    it(`Displays: ${label} at: ${path}`, () => {
+      renderWithBrowserRouter(<Tags />, {
+        wrapperProps: { routePattern: pattern, state },
+        route: path,
       });
-    }
-  );
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+  });
 
   it("shows buttons when not displaying forms", () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: { routePattern: tagURLs.tag.index(null, true), state },
-      route: tagURLs.tag.index({ id: 1 }),
+      wrapperProps: { routePattern: urls.tags.tag.index(null), state },
+      route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
     const details = screen.getByLabelText(TagDetailsLabel.Title);
@@ -91,8 +89,8 @@ describe("Tags", () => {
 
   it("hides buttons when deleting tags", async () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: { routePattern: tagURLs.tag.index(null, true), state },
-      route: tagURLs.tag.index({ id: 1 }),
+      wrapperProps: { routePattern: urls.tags.tag.index(null), state },
+      route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
     const details = screen.getByLabelText(TagDetailsLabel.Title);
@@ -119,10 +117,10 @@ describe("Tags", () => {
   it("hides buttons when updating tags", () => {
     renderWithBrowserRouter(<Tags />, {
       wrapperProps: {
-        routePattern: `${tagURLs.tag.index(null, true)}/*`,
+        routePattern: `${urls.tags.tag.index(null)}/*`,
         state,
       },
-      route: tagURLs.tag.update({ id: 1 }),
+      route: urls.tags.tag.update({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
     const details = screen.getByLabelText(TagUpdateLabel.Form);
@@ -144,10 +142,10 @@ describe("Tags", () => {
   it("hides buttons when creating tags", async () => {
     renderWithBrowserRouter(<Tags />, {
       wrapperProps: {
-        routePattern: `${tagURLs.tag.index(null, true)}/*`,
+        routePattern: `${urls.tags.tag.index(null)}/*`,
         state,
       },
-      route: tagURLs.tag.index({ id: 1 }),
+      route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
     const details = screen.getByLabelText(TagDetailsLabel.Title);

--- a/src/app/tags/views/Tags.tsx
+++ b/src/app/tags/views/Tags.tsx
@@ -27,7 +27,7 @@ const getViewState = (
     return TagViewState.Creating;
   }
   const isUpdating = matchPath(pathname, {
-    path: tagsURLs.tag.update(null, true),
+    path: tagsURLs.tag.update(null),
     exact: true,
     strict: false,
   });
@@ -61,26 +61,26 @@ const Tags = (): JSX.Element => {
       <Switch>
         <Route
           exact
-          path={tagsURLs.tag.index(null, true)}
+          path={tagsURLs.tag.index(null)}
           render={() => (
             <TagDetails onDelete={onDelete} tagViewState={tagViewState} />
           )}
         />
         <Route
           exact
-          path={tagsURLs.tag.update(null, true)}
+          path={tagsURLs.tag.update(null)}
           render={() => (
             <TagDetails onDelete={onDelete} tagViewState={tagViewState} />
           )}
         />
         <Route
           exact
-          path={tagsURLs.tag.machines(null, true)}
+          path={tagsURLs.tag.machines(null)}
           render={() => <TagMachines />}
         />
         <Route
           exact
-          path={tagsURLs.tags.index}
+          path={tagsURLs.index}
           render={() => <TagList onDelete={onDelete} />}
         />
         <Route path="*" render={() => <NotFound />} />

--- a/src/app/utils/argPath.test.ts
+++ b/src/app/utils/argPath.test.ts
@@ -12,6 +12,6 @@ describe("argPath", () => {
     const urls = {
       machine: argPath<{ id: number }>("/machine/:id"),
     };
-    expect(urls.machine(null, true)).toBe("/machine/:id");
+    expect(urls.machine(null)).toBe("/machine/:id");
   });
 });

--- a/src/app/utils/argPath.ts
+++ b/src/app/utils/argPath.ts
@@ -15,12 +15,10 @@ export const argPath =
    * @param args An object of URL parameters. The object keys match the URL
    * params, e.g. for `/machine/:id` you would pass `{id: 1}`. This should be
    * `null` when you wish to return the unmodified react-router URL.
-   * @param unmodified Whether to return the URL in the react-router format
-   * .e.g. `/machine/:id`.
    * @returns The complete or unmodified URL.
    */
-  (args: A | null, unmodified = false): string => {
-    if (unmodified || !args) {
+  (args: A | null): string => {
+    if (!args) {
       return path;
     }
     return Object.entries(args).reduce((exactPath, [param, value]) => {

--- a/src/app/zones/urls.ts
+++ b/src/app/zones/urls.ts
@@ -1,8 +1,10 @@
-import type { Zone } from "app/store/zone/types";
+import { Zone } from "app/store/zone/types";
 import { argPath } from "app/utils";
 
+const withId = argPath<{ id: Zone["id"] }>;
+
 const urls = {
-  details: argPath<{ id: Zone["id"] }>("/zone/:id"),
+  details: withId("/zone/:id"),
   index: "/zones",
 } as const;
 

--- a/src/app/zones/views/Zones.tsx
+++ b/src/app/zones/views/Zones.tsx
@@ -11,7 +11,7 @@ const Zones = (): JSX.Element => {
       <Route exact path={zonesURLs.index} render={() => <ZonesList />} />
       <Route
         exact
-        path={zonesURLs.details(null, true)}
+        path={zonesURLs.details(null)}
         render={() => <ZoneDetails />}
       />
       <Route path="*" render={() => <NotFound />} />

--- a/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
@@ -5,7 +5,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
 import controllersURLs from "app/controllers/urls";
-import deviceURLs from "app/devices/urls";
+import devicesURLs from "app/devices/urls";
 import machineURLs from "app/machines/urls";
 import { FilterDevices } from "app/store/device/utils";
 import { FilterMachines } from "app/store/machine/utils";
@@ -55,7 +55,7 @@ const ZonesListTable = (): JSX.Element => {
         },
         {
           content: (
-            <Link to={`${machineURLs.machines.index}${machinesFilter}`}>
+            <Link to={`${machineURLs.index}${machinesFilter}`}>
               {zone.machines_count}
             </Link>
           ),
@@ -63,7 +63,7 @@ const ZonesListTable = (): JSX.Element => {
         },
         {
           content: (
-            <Link to={`${deviceURLs.devices.index}${devicesFilter}`}>
+            <Link to={`${devicesURLs.index}${devicesFilter}`}>
               {zone.devices_count}
             </Link>
           ),
@@ -71,9 +71,7 @@ const ZonesListTable = (): JSX.Element => {
         },
         {
           content: (
-            <Link to={controllersURLs.controllers.index}>
-              {zone.controllers_count}
-            </Link>
+            <Link to={controllersURLs.index}>{zone.controllers_count}</Link>
           ),
           className: "u-align--right",
         },


### PR DESCRIPTION
## Done

- refactor: make url object more consistent
- simplify by using a single export/import for URLs 
- remove redundant parameter from `argPath`
- use instantiation expressions to reduce repetition and enhance readability

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4054

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
