### PR TITLE
refactor: replace remaining header url strings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,13 +24,13 @@ import status from "app/store/status/selectors";
 
 export const App = (): JSX.Element => {
   const dispatch = useDispatch();
+  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const authenticated = useSelector(status.authenticated);
   const authenticating = useSelector(status.authenticating);
   const authLoading = useSelector(authSelectors.loading);
   const connected = useSelector(status.connected);
   const connecting = useSelector(status.connecting);
   const connectionError = useSelector(status.error);
-  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const previousAuthenticated = usePrevious(authenticated, false);
 
   useEffect(() => {

--- a/src/app/base/components/Header/Header.tsx
+++ b/src/app/base/components/Header/Header.tsx
@@ -9,8 +9,12 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
+import {
+  Link,
+  useNavigate,
+  useLocation,
+  matchPath,
+} from "react-router-dom-v5-compat";
 
 import {
   useCompletedIntro,
@@ -32,20 +36,32 @@ type NavItem = {
 
 const navLinks: NavItem[] = [
   {
-    highlight: ["/machine", "/pool", "/tag"],
+    highlight: [
+      urls.machines.machines.index,
+      urls.machines.machine.index(null, true),
+      urls.pools.pools,
+      urls.tags.tags.index,
+      urls.tags.tag.index(null, true),
+    ],
     inHardwareMenu: true,
     label: "Machines",
     url: urls.machines.machines.index,
   },
   {
-    highlight: "/device",
+    highlight: [
+      urls.devices.devices.index,
+      urls.devices.device.index(null, true),
+    ],
     inHardwareMenu: true,
     label: "Devices",
     url: urls.devices.devices.index,
   },
   {
     adminOnly: true,
-    highlight: "/controller",
+    highlight: [
+      urls.controllers.controllers.index,
+      urls.controllers.controller.index(null, true),
+    ],
     inHardwareMenu: true,
     label: "Controllers",
     url: urls.controllers.controllers.index,
@@ -60,17 +76,23 @@ const navLinks: NavItem[] = [
     url: urls.images.index,
   },
   {
-    highlight: "/domain",
+    highlight: [urls.domains.domains, urls.domains.details(null, true)],
     label: "DNS",
     url: urls.domains.domains,
   },
   {
-    highlight: "/zone",
+    highlight: [urls.zones.index, urls.zones.details(null, true)],
     label: "AZs",
     url: urls.zones.index,
   },
   {
-    highlight: ["/networks", "/subnet", "/space", "/fabric", "/vlan"],
+    highlight: [
+      urls.subnets.index,
+      urls.subnets.subnet.index(null, true),
+      urls.subnets.space.index(null, true),
+      urls.subnets.fabric.index(null, true),
+      urls.subnets.vlan.index(null, true),
+    ],
     label: "Subnets",
     url: urls.subnets.index,
   },
@@ -109,10 +131,10 @@ const isSelected = (path: string, link: NavItem) => {
     highlights = [highlights];
   }
   // Check if one of the highlight urls matches the current path.
-  return highlights.some((start) =>
+  return highlights.some((highlight) =>
     // Check the full path, for both legacy/new clients as sometimes the lists
     // are in one client and the details in the other.
-    path.startsWith(start)
+    matchPath({ path: highlight, end: false }, path)
   );
 };
 
@@ -175,8 +197,8 @@ export const Header = (): JSX.Element => {
     // Remove the admin only items if the user is not an admin.
     .filter(({ adminOnly }) => !adminOnly || isAdmin);
   const homepageLink = isAdmin
-    ? { url: "/dashboard", label: "Homepage" }
-    : { url: "/machines", label: "Homepage" };
+    ? { url: urls.dashboard.index, label: "Homepage" }
+    : { url: urls.machines.machines.index, label: "Homepage" };
   const path = location.pathname + location.search;
 
   return (
@@ -204,10 +226,12 @@ export const Header = (): JSX.Element => {
                 ...(showLinks
                   ? [
                       {
-                        isSelected:
-                          location.pathname.startsWith("/account/prefs"),
+                        isSelected: !!matchPath(
+                          { path: urls.preferences.prefs, end: false },
+                          location.pathname
+                        ),
                         label: authUser.username,
-                        url: "/account/prefs",
+                        url: urls.preferences.prefs,
                       },
                     ]
                   : []),

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { matchPath, Link } from "react-router-dom-v5-compat";
 
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
@@ -37,21 +37,21 @@ export const MachinesHeader = (props: Props): JSX.Element => {
       {...props}
       tabLinks={[
         {
-          active: location.pathname.startsWith(machineURLs.machines.index),
+          active: !!matchPath(machineURLs.machines.index, location.pathname),
           component: Link,
           label: `${pluralize("Machine", machineCount, true)}`,
           to: machineURLs.machines.index,
         },
         {
-          active: location.pathname.startsWith(poolsURLs.pools),
+          active: !!matchPath(poolsURLs.pools, location.pathname),
           component: Link,
           label: `${pluralize("Resource pool", poolCount, true)}`,
           to: poolsURLs.pools,
         },
         {
           active:
-            location.pathname.startsWith(tagURLs.tags.index) ||
-            location.pathname.startsWith(tagURLs.tag.base),
+            !!matchPath(tagURLs.tags.index, location.pathname) ||
+            !!matchPath(tagURLs.tag.index(null, true), location.pathname),
           component: Link,
           label: `${pluralize("Tag", tagCount, true)}`,
           to: tagURLs.tags.index,


### PR DESCRIPTION
## Done

- refactor: replace remaining header url strings
- use matchPath util from react-router

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify menu items are highlighted as before

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/1031

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
