### PR TITLE
fix: rack controller instructions for correct version

### DIFF
--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import docsUrls from "app/base/docsUrls";
 import type { ClearHeaderContent } from "app/base/types";
 import configSelectors from "app/store/config/selectors";
+import { version as versionSelectors } from "app/store/general/selectors";
 
 type Props = {
   clearHeaderContent: ClearHeaderContent;
@@ -12,6 +13,7 @@ type Props = {
 export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
   const maasUrl = useSelector(configSelectors.maasUrl);
   const rpcSharedSecret = useSelector(configSelectors.rpcSharedSecret);
+  const minorVersion = useSelector(versionSelectors.minor);
 
   return (
     <>
@@ -22,6 +24,8 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
       </p>
       <CodeSnippet
         blocks={[
+          { code: `sudo apt-add-repository ppa:maas/${minorVersion}` },
+          { code: "sudo apt update" },
           {
             code: "sudo apt install maas-rack-controller",
           },
@@ -31,7 +35,7 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
       <CodeSnippet
         blocks={[
           {
-            code: "sudo snap install maas",
+            code: `sudo snap install maas --channel=${minorVersion}`,
           },
         ]}
       />

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -24,8 +24,7 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
       </p>
       <CodeSnippet
         blocks={[
-          { code: `sudo apt-add-repository ppa:maas/${minorVersion}` },
-          { code: "sudo apt update" },
+          { code: `sudo add-apt-repository ppa:maas/${minorVersion}` },
           {
             code: "sudo apt install maas-rack-controller",
           },

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -20,6 +20,7 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
   const [variant, setVariant] = useState("Snap");
 
   const variantDropdown = {
+    "aria-label": "version",
     value: variant,
     onChange: (e: ChangeEvent<HTMLSelectElement>) => {
       setVariant(e.target.value);
@@ -83,6 +84,7 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
         />
       ) : (
         <CodeSnippet
+          data-testid="register-snippet"
           blocks={[
             {
               dropdowns,

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -1,3 +1,6 @@
+import type { ChangeEvent } from "react";
+import { useState } from "react";
+
 import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
@@ -14,51 +17,81 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
   const maasUrl = useSelector(configSelectors.maasUrl);
   const rpcSharedSecret = useSelector(configSelectors.rpcSharedSecret);
   const minorVersion = useSelector(versionSelectors.minor);
+  const [variant, setVariant] = useState("Snap");
+
+  const variantDropdown = {
+    value: variant,
+    onChange: (e: ChangeEvent<HTMLSelectElement>) => {
+      setVariant(e.target.value);
+    },
+    options: [
+      {
+        label: `v${minorVersion} Snap`,
+        value: "snap",
+      },
+      {
+        label: `v${minorVersion} Packages`,
+        value: "packages",
+      },
+    ],
+  };
+  const dropdowns = [variantDropdown];
 
   return (
     <>
       <p>
-        To add a new rack controller, SSH into the rack controller. Install the
-        maas-rack-controller package. Confirm that the MAAS version is the same
-        as the main rack controller.
+        To add a new rack controller, SSH into the rack controller and run the
+        commands below. Confirm that the MAAS version is the same as the main
+        rack controller.
       </p>
-      <CodeSnippet
-        blocks={[
-          { code: `sudo add-apt-repository ppa:maas/${minorVersion}` },
-          {
-            code: "sudo apt install maas-rack-controller",
-          },
-        ]}
-      />
-      <p>Or if you use snap</p>
-      <CodeSnippet
-        blocks={[
-          {
-            code: `sudo snap install maas --channel=${minorVersion}`,
-          },
-        ]}
-      />
+      {variant === "packages" ? (
+        <CodeSnippet
+          blocks={[
+            {
+              dropdowns,
+              code: `sudo apt-add-repository ppa:maas/${minorVersion}`,
+            },
+            {
+              code: "sudo apt install maas-rack-controller",
+            },
+          ]}
+        />
+      ) : (
+        <CodeSnippet
+          blocks={[
+            {
+              dropdowns,
+              code: `sudo snap install maas --channel=${minorVersion}`,
+            },
+          ]}
+        />
+      )}
       <p>
         Register the rack controller with this MAAS. If the rack controller (and
         machines) don't have access to the URL, use a different IP address to
         allow connection.
       </p>
-      <CodeSnippet
-        blocks={[
-          {
-            code: `sudo maas-rack register --url ${maasUrl} --secret ${rpcSharedSecret}`,
-          },
-        ]}
-        data-testid="register-snippet"
-      />
-      <p>Or if you use snap</p>
-      <CodeSnippet
-        blocks={[
-          {
-            code: `sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`,
-          },
-        ]}
-      />
+      {variant === "packages" ? (
+        <CodeSnippet
+          blocks={[
+            {
+              dropdowns,
+              code: `sudo maas-rack register --url ${maasUrl} --secret ${rpcSharedSecret}`,
+            },
+          ]}
+          data-testid="register-snippet"
+        />
+      ) : (
+        <CodeSnippet
+          blocks={[
+            {
+              dropdowns,
+              code: `sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`,
+            },
+          ]}
+        />
+      )}
+
       <Row>
         <Col size={6}>
           <a

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.tsx
@@ -84,13 +84,13 @@ export const AddController = ({ clearHeaderContent }: Props): JSX.Element => {
         />
       ) : (
         <CodeSnippet
-          data-testid="register-snippet"
           blocks={[
             {
               dropdowns,
               code: `sudo maas init rack --maas-url ${maasUrl} --secret ${rpcSharedSecret}`,
             },
           ]}
+          data-testid="register-snippet"
         />
       )}
 


### PR DESCRIPTION
## Done

- fix: rack controller instructions for installing the correct version
- add a dropdown for different instructions (snap/deb packages)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to controllers
- Click "Add new rack controller"
- Verify following instructions installs the rack controller with the correct version (matching the main maas)

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/903

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/174729914-1205395e-e01e-4710-9d2b-a7391c60cf4f.png)

### After
![image](https://user-images.githubusercontent.com/7452681/174287639-4e5d9535-b5b2-430a-a802-e4b05e980f42.png)
![image](https://user-images.githubusercontent.com/7452681/174290817-f57cae04-8331-4c1a-bd67-58233c2260e7.png)
