### PR TITLE
refactor: replace instances of fireEvent with userEvent and enforce with linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,6 +127,14 @@ module.exports = {
       rules: {
         "testing-library/prefer-find-by": "off",
         "testing-library/prefer-explicit-assert": "error",
+        "testing-library/prefer-user-event": [
+          "error",
+          {
+            // Remove once sliders can be updated with user-event
+            // https://github.com/testing-library/user-event/issues/871
+            allowedMethods: ["change"],
+          },
+        ],
       },
     },
     {

--- a/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
+++ b/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -140,7 +140,9 @@ it("updates the new tags after creating a tag", async () => {
   const newTag = tagFactory({ id: 8, name: "new-tag" });
   state.tag.saved = true;
   state.tag.items.push(newTag);
-  fireEvent.submit(screen.getByRole("form", { name: AddTagFormLabel.Form }));
+  await userEvent.click(
+    screen.getByRole("button", { name: AddTagFormLabel.Submit })
+  );
   rerender(<Form tags={[newTag.id]} />);
   await waitFor(() =>
     expect(screen.getByRole("button", { name: /new-tag/i })).toBeInTheDocument()

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -132,7 +132,7 @@ describe("DeviceConfiguration", () => {
     screen.getByRole("textbox", { name: TagFieldLabel.Input }).focus();
     await userEvent.click(screen.getByRole("option", { name: "tag1" }));
     await userEvent.click(screen.getByRole("option", { name: "tag2" }));
-    fireEvent.submit(screen.getByRole("form", { name: Label.Form }));
+    await userEvent.click(screen.getByRole("button", { name: Label.Submit }));
     const expectedAction = deviceActions.update({
       description: "it's a device",
       tags: [1, 2],

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.tsx
@@ -28,6 +28,7 @@ type Props = {
 
 export enum Label {
   Form = "Device configuration",
+  Submit = "Save changed",
 }
 
 const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
@@ -93,7 +94,7 @@ const DeviceConfiguration = ({ systemId }: Props): JSX.Element => {
             onSuccess={() => setEditing(false)}
             saved={deviceSaved}
             saving={deviceSaving}
-            submitLabel="Save changes"
+            submitLabel={Label.Submit}
             validationSchema={NodeConfigurationSchema}
           >
             <NodeConfigurationFields />

--- a/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -58,12 +59,14 @@ it("can handle updating a lxd KVM", async () => {
     </Provider>
   );
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Zone" }), {
-    target: { value: "3" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Resource pool" }), {
-    target: { value: "2" },
-  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Zone" }),
+    "3"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Resource pool" }),
+    "2"
+  );
   fireEvent.change(screen.getByRole("slider", { name: "CPU overcommit" }), {
     target: { value: "5" },
   });
@@ -73,7 +76,7 @@ it("can handle updating a lxd KVM", async () => {
   await waitFor(() => {
     expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
   });
-  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
   const expectedAction = podActions.update({
     cpu_over_commit_ratio: 5,
@@ -111,15 +114,18 @@ it("can handle updating a virsh KVM", async () => {
     </Provider>
   );
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Zone" }), {
-    target: { value: "3" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Resource pool" }), {
-    target: { value: "2" },
-  });
-  fireEvent.change(screen.getByLabelText("Password (optional)"), {
-    target: { value: "password" },
-  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Zone" }),
+    "3"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Resource pool" }),
+    "2"
+  );
+  await userEvent.type(
+    screen.getByLabelText("Password (optional)"),
+    "password"
+  );
   fireEvent.change(screen.getByRole("slider", { name: "CPU overcommit" }), {
     target: { value: "5" },
   });
@@ -129,7 +135,7 @@ it("can handle updating a virsh KVM", async () => {
   await waitFor(() => {
     expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
   });
-  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
   const expectedAction = podActions.update({
     cpu_over_commit_ratio: 5,

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -1,10 +1,4 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -201,7 +195,9 @@ it("updates the new tags after creating a tag", async () => {
   const newTag = tagFactory({ id: 8, name: "new-tag" });
   state.tag.saved = true;
   state.tag.items.push(newTag);
-  fireEvent.submit(screen.getByRole("form", { name: AddTagFormLabel.Form }));
+  await userEvent.click(
+    screen.getByRole("button", { name: AddTagFormLabel.Submit })
+  );
   rerender(<Form tags={[newTag.id]} />);
   const changes = screen.getByRole("table", {
     name: TagFormChangesLabel.Table,

--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -160,15 +161,15 @@ it("enables submit when a power type with no fields is chosen", async () => {
 
   // Choose the "manual" power type which has no power fields, and fill in other
   // required fields.
-  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
-    target: { value: "manual" },
-  });
-  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
-    target: { value: "11:11:11:11:11:11" },
-  });
-  await waitFor(() => {
-    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
-  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Power type" }),
+    "manual"
+  );
+  await userEvent.type(
+    screen.getByRole("textbox", { name: "MAC address" }),
+    "11:11:11:11:11:11"
+  );
+  expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
 });
 
 it("can handle saving a machine", async () => {
@@ -185,34 +186,39 @@ it("can handle saving a machine", async () => {
     </Provider>
   );
 
-  fireEvent.change(screen.getByRole("textbox", { name: "Machine name" }), {
-    target: { value: "mean-bean" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Domain" }), {
-    target: { value: "maas" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Architecture" }), {
-    target: { value: "amd64/generic" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Minimum kernel" }), {
-    target: { value: "ga-16.04" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Zone" }), {
-    target: { value: "twilight" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Resource pool" }), {
-    target: { value: "swimming" },
-  });
-  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
-    target: { value: "11:11:11:11:11:11" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
-    target: { value: "manual" },
-  });
-  await waitFor(() => {
-    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Save machine" }));
+  await userEvent.type(
+    screen.getByRole("textbox", { name: "Machine name" }),
+    "mean-bean"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Domain" }),
+    "maas"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Architecture" }),
+    "amd64/generic"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Minimum kernel" }),
+    "ga-16.04"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Zone" }),
+    "twilight"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Resource pool" }),
+    "swimming"
+  );
+  await userEvent.type(
+    screen.getByRole("textbox", { name: "MAC address" }),
+    "11:11:11:11:11:11"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Power type" }),
+    "manual"
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Save machine" }));
 
   const expectedAction = machineActions.create({
     architecture: "amd64/generic",
@@ -248,25 +254,26 @@ it("correctly trims power parameters before dispatching action", async () => {
   );
 
   // Choose initial power type and fill in fields.
-  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
-    target: { value: "11:11:11:11:11:11" },
-  });
-  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
-    target: { value: "amt" },
-  });
-  const amtField = await screen.findByRole("textbox", { name: "IP address" });
-  fireEvent.change(amtField, { target: { value: "192.168.1.1" } });
+  await userEvent.type(
+    screen.getByRole("textbox", { name: "MAC address" }),
+    "11:11:11:11:11:11"
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Power type" }),
+    "amt"
+  );
+  const amtField = screen.getByRole("textbox", { name: "IP address" });
+  await userEvent.type(amtField, "192.168.1.1");
 
   // Change power type and fill in new fields.
-  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
-    target: { value: "apc" },
-  });
-  const apcField = await screen.findByRole("textbox", { name: "Power ID" });
-  fireEvent.change(apcField, { target: { value: "12345" } });
-  await waitFor(() => {
-    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Save machine" }));
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Power type" }),
+    "apc"
+  );
+  const apcField = screen.getByRole("textbox", { name: "Power ID" });
+  await userEvent.clear(apcField);
+  await userEvent.type(apcField, "12345");
+  await userEvent.click(screen.getByRole("button", { name: "Save machine" }));
 
   const expectedAction = machineActions.create({
     architecture: "amd64/generic",
@@ -306,24 +313,26 @@ it("correctly filters empty extra mac fields", async () => {
   );
 
   // Submit the form with two extra macs, where one is an empty string
-  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
-    target: { value: "manual" },
-  });
-  fireEvent.change(screen.getByRole("textbox", { name: "MAC address" }), {
-    target: { value: "11:11:11:11:11:11" },
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Add MAC address" }));
-  fireEvent.click(screen.getByRole("button", { name: "Add MAC address" }));
-  fireEvent.change(screen.getByLabelText("Extra MAC address 1"), {
-    target: { value: "22:22:22:22:22:22" },
-  });
-  fireEvent.change(screen.getByLabelText("Extra MAC address 2"), {
-    target: { value: "" },
-  });
-  await waitFor(() => {
-    expect(screen.getByRole("button", { name: "Save machine" })).toBeEnabled();
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Save machine" }));
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Power type" }),
+    "manual"
+  );
+  await userEvent.type(
+    screen.getByRole("textbox", { name: "MAC address" }),
+    "11:11:11:11:11:11"
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: "Add MAC address" })
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: "Add MAC address" })
+  );
+  await userEvent.type(
+    screen.getByLabelText("Extra MAC address 1"),
+    "22:22:22:22:22:22"
+  );
+  await userEvent.clear(screen.getByLabelText("Extra MAC address 2"));
+  await userEvent.click(screen.getByRole("button", { name: "Save machine" }));
 
   const expectedAction = machineActions.create({
     architecture: "amd64/generic",

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -137,6 +137,7 @@ it("renders read-only text fields until edit button is pressed", async () => {
 it("correctly dispatches an action to update a machine's power", async () => {
   const machine = machineDetailsFactory({
     permissions: ["edit"],
+    pod: undefined,
     power_type: PowerTypeNames.AMT,
     system_id: "abc123",
   });
@@ -155,14 +156,10 @@ it("correctly dispatches an action to update a machine's power", async () => {
   await userEvent.click(
     screen.getAllByRole("button", { name: Labels.EditButton })[0]
   );
-  fireEvent.change(screen.getByRole("combobox", { name: "Power type" }), {
-    target: { value: PowerTypeNames.APC },
-  });
-  await waitFor(() => {
-    expect(
-      screen.getByRole("textbox", { name: "APC field" })
-    ).toBeInTheDocument();
-  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Power type" }),
+    PowerTypeNames.APC
+  );
   await userEvent.clear(screen.getByRole("textbox", { name: "APC field" }));
   await userEvent.type(
     screen.getByRole("textbox", { name: "APC field" }),

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.test.tsx
@@ -1,10 +1,4 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -107,11 +101,9 @@ describe("NetworkFields", () => {
         within(vlanSelect).getByRole("option", { selected: true })
       ).toHaveAttribute("value", state.vlan.items[0].id.toString())
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: FabricSelectLabel.Select }),
-      {
-        target: { value: fabric.id.toString() },
-      }
+      fabric.id.toString()
     );
     await waitFor(() =>
       expect(
@@ -145,25 +137,22 @@ describe("NetworkFields", () => {
       ).toHaveAttribute("value", "")
     );
     // Set the values of the fields so they're all visible and have values.
-    fireEvent.change(subnetSelect, {
-      target: { value: state.subnet.items[1].id.toString() },
-    });
-    fireEvent.change(
+    await userEvent.selectOptions(
+      subnetSelect,
+      state.subnet.items[1].id.toString()
+    );
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select }),
-      {
-        target: { value: NetworkLinkMode.STATIC },
-      }
+      NetworkLinkMode.STATIC
     );
     await userEvent.type(
       screen.getByRole("textbox", { name: NetworkFieldsLabel.IPAddress }),
       "1.2.3.4"
     );
     // Change the fabric and the other fields should reset.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: FabricSelectLabel.Select }),
-      {
-        target: { value: state.fabric.items[1].id.toString() },
-      }
+      state.fabric.items[1].id.toString()
     );
     await waitFor(() =>
       expect(
@@ -199,28 +188,22 @@ describe("NetworkFields", () => {
       </Provider>
     );
     // Set the values of the fields so they're all visible and have values.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.subnet.items[1].id.toString()
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select }),
-      {
-        target: { value: NetworkLinkMode.STATIC },
-      }
+      NetworkLinkMode.STATIC
     );
     await userEvent.type(
       screen.getByRole("textbox", { name: NetworkFieldsLabel.IPAddress }),
       "1.2.3.4"
     );
     // Change the VLAN and the other fields should reset.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: VLANSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.vlan.items[1].id.toString()
     );
     const subnetSelect = screen.getByRole("combobox", {
       name: SubnetSelectLabel.Select,
@@ -257,28 +240,22 @@ describe("NetworkFields", () => {
       </Provider>
     );
     // Set the values of the fields so they're all visible and have values.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.subnet.items[1].id.toString()
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select }),
-      {
-        target: { value: NetworkLinkMode.STATIC },
-      }
+      NetworkLinkMode.STATIC
     );
     await userEvent.type(
       screen.getByRole("textbox", { name: NetworkFieldsLabel.IPAddress }),
       "1.2.3.4"
     );
     // Change the subnet and the other fields should reset.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: "" },
-      }
+      ""
     );
     expect(
       screen.queryByRole("combobox", { name: LinkModeSelectLabel.Select })
@@ -315,17 +292,13 @@ describe("NetworkFields", () => {
       </Provider>
     );
     // Set the values of the fields so they're all visible and have values.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[2].id },
-      }
+      state.subnet.items[2].id.toString()
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select }),
-      {
-        target: { value: NetworkLinkMode.STATIC },
-      }
+      NetworkLinkMode.STATIC
     );
     await waitFor(() =>
       expect(
@@ -376,11 +349,9 @@ describe("NetworkFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.subnet.items[1].id.toString()
     );
     expect(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select })
@@ -414,11 +385,9 @@ describe("NetworkFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.subnet.items[1].id.toString()
     );
     expect(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select })
@@ -454,6 +423,7 @@ describe("NetworkFields", () => {
                   interfaceType={NetworkInterfaceTypes.PHYSICAL}
                   editing
                 />
+                <button type="submit">Save</button>
               </form>
             )}
           </Formik>
@@ -461,16 +431,14 @@ describe("NetworkFields", () => {
       </Provider>
     );
     // Remove the subnet.
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: "" },
-      }
+      ""
     );
     expect(
       screen.queryByRole("combobox", { name: LinkModeSelectLabel.Select })
     ).not.toBeInTheDocument();
-    fireEvent.submit(screen.getByRole("form", { name: "test form" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() =>
       expect(onSubmit.mock.calls[0][0].mode).toBe(NetworkLinkMode.LINK_UP)
     );
@@ -515,17 +483,13 @@ describe("NetworkFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.subnet.items[1].id.toString()
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select }),
-      {
-        target: { value: NetworkLinkMode.AUTO },
-      }
+      NetworkLinkMode.AUTO
     );
     await waitFor(() =>
       expect(
@@ -550,17 +514,13 @@ describe("NetworkFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: SubnetSelectLabel.Select }),
-      {
-        target: { value: state.subnet.items[1].id.toString() },
-      }
+      state.subnet.items[1].id.toString()
     );
-    fireEvent.change(
+    await userEvent.selectOptions(
       screen.getByRole("combobox", { name: LinkModeSelectLabel.Select }),
-      {
-        target: { value: NetworkLinkMode.STATIC },
-      }
+      NetworkLinkMode.STATIC
     );
     await waitFor(() =>
       expect(

--- a/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -147,7 +147,7 @@ describe("ReservedRangeForm", () => {
       screen.getByRole("textbox", { name: Labels.Comment }),
       "reserved"
     );
-    fireEvent.submit(screen.getByRole("form"));
+    await userEvent.click(screen.getByRole("button", { name: "Reserve" }));
     const expected = ipRangeActions.create({
       comment: "reserved",
       end_ip: "1.1.1.2",
@@ -175,12 +175,15 @@ describe("ReservedRangeForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.submit(screen.getByRole("form"));
+    const startIpField = screen.getByRole("textbox", { name: Labels.StartIp });
+    await userEvent.clear(startIpField);
+    await userEvent.type(startIpField, "1.2.3.4");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
     const expected = ipRangeActions.update({
       comment: ipRange.comment,
       end_ip: ipRange.end_ip,
       id: ipRange.id,
-      start_ip: ipRange.start_ip,
+      start_ip: "1.2.3.4",
     });
     await waitFor(() =>
       expect(
@@ -204,12 +207,15 @@ describe("ReservedRangeForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.submit(screen.getByRole("form"));
+    const startIpField = screen.getByRole("textbox", { name: Labels.StartIp });
+    await userEvent.clear(startIpField);
+    await userEvent.type(startIpField, "1.2.3.4");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
     const expected = ipRangeActions.update({
       comment: ipRange.comment,
       end_ip: ipRange.end_ip,
       id: ipRange.id,
-      start_ip: ipRange.start_ip,
+      start_ip: "1.2.3.4",
     });
     await waitFor(() => {
       const actual = store

--- a/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -253,7 +254,7 @@ it("displays an edit form", async () => {
       </MemoryRouter>
     </Provider>
   );
-  fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+  await userEvent.click(screen.getByRole("button", { name: "Edit" }));
 
   await waitFor(() =>
     expect(
@@ -273,7 +274,7 @@ it("displays confirm delete message", async () => {
       </MemoryRouter>
     </Provider>
   );
-  fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+  await userEvent.click(screen.getByRole("button", { name: "Delete" }));
 
   await waitFor(() => {
     expect(
@@ -295,8 +296,8 @@ it("dispatches an action to delete a reserved range", async () => {
       </MemoryRouter>
     </Provider>
   );
-  fireEvent.click(screen.getByTestId("table-actions-delete"));
-  fireEvent.click(screen.getByTestId("action-confirm"));
+  await userEvent.click(screen.getByTestId("table-actions-delete"));
+  await userEvent.click(screen.getByTestId("action-confirm"));
 
   const expectedAction = ipRangeActions.delete(ipRange.id);
 
@@ -341,12 +342,12 @@ it("displays an add button when it is dynamic", async () => {
       </MemoryRouter>
     </Provider>
   );
-  fireEvent.click(
+  await userEvent.click(
     screen.queryAllByRole("button", {
       name: Labels.ReserveRange,
     })[0]
   );
-  fireEvent.click(screen.getByTestId("reserve-dynamic-range-menu-item"));
+  await userEvent.click(screen.getByTestId("reserve-dynamic-range-menu-item"));
 
   await waitFor(() => {
     expect(
@@ -386,12 +387,12 @@ it("can display an add form", async () => {
       </MemoryRouter>
     </Provider>
   );
-  fireEvent.click(
+  await userEvent.click(
     screen.queryAllByRole("button", {
       name: Labels.ReserveRange,
     })[0]
   );
-  fireEvent.click(screen.getByTestId("reserve-range-menu-item"));
+  await userEvent.click(screen.getByTestId("reserve-range-menu-item"));
 
   await waitFor(() => {
     expect(

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -1,10 +1,5 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -110,8 +105,8 @@ it("can update the arches to disable", async () => {
   );
   const nameCells = screen.getAllByRole("gridcell", { name: Headers.Name });
 
-  fireEvent.click(within(nameCells[0]).getByRole("checkbox"));
-  fireEvent.click(within(nameCells[1]).getByRole("checkbox"));
+  await userEvent.click(within(nameCells[0]).getByRole("checkbox"));
+  await userEvent.click(within(nameCells[1]).getByRole("checkbox"));
 
   await waitFor(() =>
     expect(within(nameCells[0]).getByRole("checkbox")).toBeChecked()
@@ -148,10 +143,10 @@ it("can dispatch an action to update subnet's disabled boot architectures", asyn
   );
   const nameCells = screen.getAllByRole("gridcell", { name: Headers.Name });
 
-  fireEvent.click(within(nameCells[0]).getByRole("checkbox"));
-  fireEvent.click(within(nameCells[1]).getByRole("checkbox"));
+  await userEvent.click(within(nameCells[0]).getByRole("checkbox"));
+  await userEvent.click(within(nameCells[1]).getByRole("checkbox"));
 
-  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
   const expectedAction = subnetActions.update({
     id: subnet.id,

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -69,7 +70,7 @@ it("can map an IPv4 subnet", async () => {
     </Provider>
   );
 
-  fireEvent.click(screen.getByRole("button", { name: "Map subnet" }));
+  await userEvent.click(screen.getByRole("button", { name: "Map subnet" }));
 
   await waitFor(() => {
     const expectedAction = subnetActions.scan(subnet.id);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -54,36 +55,42 @@ it("can dispatch an action to update the subnet", async () => {
       </MemoryRouter>
     </Provider>
   );
+  const cidrField = screen.getByRole("textbox", { name: "CIDR" });
+  const nameField = screen.getByRole("textbox", { name: "Name" });
+  const descriptionField = screen.getByRole("textbox", { name: "Description" });
+  const gatewayIpField = screen.getByRole("textbox", { name: "Gateway IP" });
+  const dnsField = screen.getByRole("textbox", { name: "DNS" });
 
-  fireEvent.input(screen.getByRole("textbox", { name: "CIDR" }), {
-    target: { value: "192.168.2.0/24" },
-  });
-  fireEvent.input(screen.getByRole("textbox", { name: "Name" }), {
-    target: { value: "New Name" },
-  });
-  fireEvent.input(screen.getByRole("textbox", { name: "Description" }), {
-    target: { value: "I'm a supernet" },
-  });
-  fireEvent.input(screen.getByRole("textbox", { name: "Gateway IP" }), {
-    target: { value: "192.168.2.1" },
-  });
-  fireEvent.input(screen.getByRole("textbox", { name: "DNS" }), {
-    target: { value: "fghij" },
-  });
-  fireEvent.click(screen.getByRole("checkbox", { name: "Managed allocation" }));
-  fireEvent.click(screen.getByRole("checkbox", { name: "Active discovery" }));
-  fireEvent.click(
+  await userEvent.clear(cidrField);
+  await userEvent.type(cidrField, "192.168.2.0/24");
+  await userEvent.clear(nameField);
+  await userEvent.type(nameField, "New Name");
+  await userEvent.clear(descriptionField);
+  await userEvent.type(descriptionField, "I'm a supernet");
+  await userEvent.clear(gatewayIpField);
+  await userEvent.type(gatewayIpField, "192.168.2.1");
+  await userEvent.clear(dnsField);
+  await userEvent.type(dnsField, "fghij");
+  await userEvent.click(
+    screen.getByRole("checkbox", { name: "Managed allocation" })
+  );
+  await userEvent.click(
+    screen.getByRole("checkbox", { name: "Active discovery" })
+  );
+  await userEvent.click(
     screen.getByRole("checkbox", { name: "Allow DNS resolution" })
   );
-  fireEvent.click(screen.getByRole("checkbox", { name: "Proxy access" }));
-  fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
-    target: { value: fabrics[1].id.toString() },
-  });
+  await userEvent.click(screen.getByRole("checkbox", { name: "Proxy access" }));
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Fabric" }),
+    fabrics[1].id.toString()
+  );
 
-  fireEvent.change(screen.getByRole("combobox", { name: "VLAN" }), {
-    target: { value: vlans[1].id.toString() },
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "VLAN" }),
+    vlans[1].id.toString()
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
   const expectedAction = subnetActions.update({
     active_discovery: true,

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -38,9 +39,10 @@ it("updates to use the fabric's default VLAN on fabric change", async () => {
 
   expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("3");
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Fabric" }), {
-    target: { value: fabrics[1].id.toString() },
-  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Fabric" }),
+    fabrics[1].id.toString()
+  );
 
   await waitFor(() =>
     expect(screen.getByRole("combobox", { name: "VLAN" })).toHaveValue("5")

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -1,10 +1,5 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -178,9 +173,10 @@ it(`renders a subnet select field and prepopulated fields for a reserved range
     </Provider>
   );
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Subnet" }), {
-    target: { value: subnet.id },
-  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", { name: "Subnet" }),
+    subnet.id.toString()
+  );
 
   await waitFor(() =>
     expect(

--- a/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
+++ b/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
@@ -1,10 +1,5 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -121,13 +116,16 @@ describe("EditVLAN", () => {
         </MemoryRouter>
       </Provider>
     );
-    fireEvent.submit(screen.getByRole("form"));
+    const nameField = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(nameField);
+    await userEvent.type(nameField, "new-name");
+    await userEvent.click(screen.getByRole("button", { name: "Save summary" }));
     const expected = vlanActions.update({
       description: vlan.description,
       fabric: vlan.fabric,
       id: vlan.id,
       mtu: vlan.mtu,
-      name: vlan.name,
+      name: "new-name",
       space: vlan.space,
       vid: vlan.vid,
     });
@@ -152,14 +150,15 @@ describe("EditVLAN", () => {
       </Provider>
     );
 
-    fireEvent.change(screen.getByRole("combobox", { name: "Space" }), {
-      target: { value: null },
-    });
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Space" }),
+      ""
+    );
     await waitFor(() =>
       expect(
         within(screen.getByRole("combobox", { name: "Space" })).getByRole(
           "option",
-          { name: "No space", selected: true }
+          { name: "No space" }
         )
       ).toBeInTheDocument()
     );

--- a/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
@@ -54,7 +54,7 @@ it("dispatches an action to create a tag", async () => {
     screen.getByRole("textbox", { name: KernelOptionsLabel.KernelOptions }),
     "options1"
   );
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: Label.Submit }));
   const expected = tagActions.create({
     comment: "comment1",
     kernel_opts: "options1",
@@ -97,6 +97,6 @@ it("returns the newly created tag on save", async () => {
     items: [newTag],
     saved: true,
   });
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: Label.Submit }));
   await waitFor(() => expect(onTagCreated).toHaveBeenCalledWith(newTag));
 });

--- a/src/app/tags/components/AddTagForm/AddTagForm.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.tsx
@@ -26,9 +26,10 @@ type Props = PropsWithSpread<
 >;
 
 export enum Label {
-  Form = "Create tag",
   Comment = "Comment",
+  Form = "Create tag",
   Name = "Tag name",
+  Submit = "Create and add to tag changes",
 }
 
 const AddTagFormSchema = Yup.object().shape({
@@ -84,7 +85,7 @@ export const AddTagForm = ({
       saved={saved}
       saving={saving}
       submitAppearance="neutral"
-      submitLabel="Create and add to tag changes"
+      submitLabel={Label.Submit}
       validationSchema={AddTagFormSchema}
       {...props}
     >

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -66,7 +66,7 @@ it("dispatches an action to create a tag", async () => {
     screen.getByRole("textbox", { name: KernelOptionsLabel.KernelOptions }),
     "options1"
   );
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
   const expected = tagActions.create({
     comment: "comment1",
     definition: "definition1",
@@ -116,7 +116,7 @@ it("redirects to the newly created tag on save", async () => {
     items: [tagFactory({ id: 8, name: "tag1" })],
     saved: true,
   });
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
   expect(history.location.pathname).toBe(tagsURLs.tag.index({ id: 8 }));
   expect(onClose).toBeCalled();
 });
@@ -153,7 +153,7 @@ it("sends analytics when there is a definition", async () => {
     items: [tagFactory({ id: 8, name: "tag1", definition: "def1" })],
     saved: true,
   });
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
   await waitFor(() => {
     expect(mockSendAnalytics).toHaveBeenCalled();
   });
@@ -196,7 +196,7 @@ it("sends analytics when there is no definition", async () => {
     items: [tagFactory({ id: 8, name: "tag1" })],
     saved: true,
   });
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
   await waitFor(() => {
     expect(mockSendAnalytics).toHaveBeenCalled();
   });
@@ -229,11 +229,11 @@ it("shows a confirmation when an automatic tag is added", async () => {
     }),
     "definition"
   );
-  fireEvent.submit(screen.getByRole("form"));
   // Mock state.tag.saved transitioning from "false" to "true"
   jest
     .spyOn(baseHooks, "useCycled")
     .mockImplementation(() => [true, () => null]);
+  await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
   await waitFor(() => {
     const action = store

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,5 +1,5 @@
 import { NotificationSeverity } from "@canonical/react-components";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -61,7 +61,7 @@ it("dispatches an action to delete a tag", async () => {
       </MemoryRouter>
     </Provider>
   );
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Delete" }));
   const expected = tagActions.delete(1);
   await waitFor(() =>
     expect(

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -122,7 +122,7 @@ it("can update the tag", async () => {
   });
   await userEvent.clear(optionsInput);
   await userEvent.type(optionsInput, "options1");
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
   const expected = tagActions.update({
     id: 1,
     comment: "comment1",
@@ -171,7 +171,7 @@ it("can return to the previous page on save", async () => {
   jest
     .spyOn(baseHooks, "useCycled")
     .mockImplementation(() => [true, () => null]);
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
   await waitFor(() =>
     expect(history.location.pathname).toBe(tagURLs.tags.index)
   );
@@ -211,7 +211,7 @@ it("goes to the tag details page if it can't go back", async () => {
   jest
     .spyOn(baseHooks, "useCycled")
     .mockImplementation(() => [true, () => null]);
-  fireEvent.submit(screen.getByRole("form"));
+  await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
   await waitFor(() =>
     expect(history.location.pathname).toBe(tagURLs.tag.index({ id: 1 }))
   );
@@ -236,17 +236,17 @@ it("shows a confirmation when a tag's definition is updated", async () => {
   });
   await userEvent.clear(definitionInput);
   await userEvent.type(definitionInput, "def");
-  fireEvent.submit(screen.getByRole("form"));
   // Mock state.tag.saved transitioning from "false" to "true"
   jest
     .spyOn(baseHooks, "useCycled")
     .mockImplementation(() => [true, () => null]);
+  await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
   await waitFor(() => {
     const action = store
       .getActions()
       .find((action) => action.type === "message/add");
-    const strippedMessage = action.payload.message.replace(/\s+/g, " ").trim();
+    const strippedMessage = action.payload?.message.replace(/\s+/g, " ").trim();
     expect(strippedMessage).toBe(`Updated baggage. ${NewDefinitionMessage}`);
   });
 });

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { Label as TagsHeaderLabel } from "../components/TagsHeader/TagsHeader";
 
@@ -84,14 +85,14 @@ describe("Tags", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides buttons when deleting tags", () => {
+  it("hides buttons when deleting tags", async () => {
     renderWithBrowserRouter(<Tags />, {
       wrapperProps: { state },
       route: tagURLs.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
     const details = screen.getByLabelText(TagDetailsLabel.Title);
-    fireEvent.click(
+    await userEvent.click(
       within(details).getByRole("button", {
         name: TagDetailsLabel.DeleteButton,
       })
@@ -133,14 +134,14 @@ describe("Tags", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides buttons when creating tags", () => {
+  it("hides buttons when creating tags", async () => {
     renderWithBrowserRouter(<Tags />, {
       wrapperProps: { state },
       route: tagURLs.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
     const details = screen.getByLabelText(TagDetailsLabel.Title);
-    fireEvent.click(
+    await userEvent.click(
       within(header).getByRole("button", { name: TagsHeaderLabel.CreateButton })
     );
     expect(


### PR DESCRIPTION
## Done

- Replaced most instances of `fireEvent` with `userEvent`
- Added a rule to our eslint config to only allow `fireEvent` for change methods (currently it's needed for changing sliders)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes #3934 
