### PR TITLE
refactor: connect Header and Footer components to the store

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,8 +5,6 @@ import { Notification } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
 
 import Routes from "app/Routes";
 import Footer from "app/base/components/Footer";
@@ -16,36 +14,24 @@ import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
 import StatusBar from "app/base/components/StatusBar";
 import FileContext, { fileContextStore } from "app/base/file-context";
-import { useCompletedIntro, useCompletedUserIntro } from "app/base/hooks";
-import introURLs from "app/intro/urls";
 import { actions as authActions } from "app/store/auth";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
 import { actions as generalActions } from "app/store/general";
-import { version as versionSelectors } from "app/store/general/selectors";
 import { actions as statusActions } from "app/store/status";
 import status from "app/store/status/selectors";
 
 export const App = (): JSX.Element => {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const authenticated = useSelector(status.authenticated);
   const authenticating = useSelector(status.authenticating);
   const authLoading = useSelector(authSelectors.loading);
-  const authUser = useSelector(authSelectors.get);
-  const configLoaded = useSelector(configSelectors.loaded);
   const connected = useSelector(status.connected);
   const connecting = useSelector(status.connecting);
   const connectionError = useSelector(status.error);
-  const uuid = useSelector(configSelectors.uuid);
-  const version = useSelector(versionSelectors.get);
+  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const previousAuthenticated = usePrevious(authenticated, false);
-  const completedIntro = useCompletedIntro();
-  const completedUserIntro = useCompletedUserIntro();
-  const debug = process.env.NODE_ENV === "development";
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
@@ -75,24 +61,6 @@ export const App = (): JSX.Element => {
       dispatch(configActions.fetch());
     }
   }, [dispatch, connected]);
-
-  // Redirect to the intro pages if not completed.
-  useEffect(() => {
-    if (configLoaded) {
-      if (!completedIntro) {
-        navigate({ pathname: introURLs.index }, { replace: true });
-      } else if (!!authUser && !completedUserIntro) {
-        navigate({ pathname: introURLs.user }, { replace: true });
-      }
-    }
-  }, [
-    authUser,
-    connected,
-    completedIntro,
-    completedUserIntro,
-    configLoaded,
-    navigate,
-  ]);
 
   let content: ReactNode = null;
   if (authLoading || connecting || authenticating) {
@@ -124,26 +92,9 @@ export const App = (): JSX.Element => {
 
   return (
     <div id="maas-ui">
-      <Header
-        authUser={authUser}
-        completedIntro={completedIntro && completedUserIntro}
-        debug={debug}
-        enableAnalytics={analyticsEnabled}
-        location={location}
-        logout={() => {
-          dispatch(statusActions.logout());
-        }}
-        uuid={uuid}
-        version={version}
-      />
+      <Header />
       <main id="main-content">{content}</main>
-      {version && (
-        <Footer
-          debug={debug}
-          enableAnalytics={analyticsEnabled}
-          version={version}
-        />
-      )}
+      <Footer />
       <StatusBar />
     </div>
   );

--- a/src/app/base/components/Footer/Footer.tsx
+++ b/src/app/base/components/Footer/Footer.tsx
@@ -1,42 +1,9 @@
-import { useEffect } from "react";
+import { Button } from "@canonical/react-components";
 
-import type { UsabillaLive } from "app/base/types";
+import { useUsabilla } from "app/base/hooks";
 
-declare global {
-  export interface Window {
-    usabilla_live: UsabillaLive;
-    lightningjs: {
-      require: (variable: string, url: string) => Window["usabilla_live"];
-    };
-  }
-}
-
-type Props = {
-  debug?: boolean;
-  enableAnalytics?: boolean | null;
-  version: string;
-};
-
-export const Footer = ({
-  debug,
-  enableAnalytics,
-  version,
-}: Props): JSX.Element => {
-  useEffect(() => {
-    if (!debug && enableAnalytics && version) {
-      // Inject the the Usabilla script.
-      // prettier-ignore
-      // eslint-disable-next-line
-      // @ts-ignore
-      // eslint-disable-next-line
-      window.lightningjs||function(n){var e="lightningjs";function t(e,t){var r,i,a,o,d,c;return t&&(t+=(/\?/.test(t)?"&":"?")+"lv=1"),n[e]||(r=window,i=document,a=e,o=i.location.protocol,d="load",c=0,function(){n[a]=function(){var t=arguments,i=this,o=++c,d=i&&i!=r&&i.id||0;function s(){return s.id=o,n[a].apply(s,arguments)}return(e.s=e.s||[]).push([o,d,t]),s.then=function(n,t,r){var i=e.fh[o]=e.fh[o]||[],a=e.eh[o]=e.eh[o]||[],d=e.ph[o]=e.ph[o]||[];return n&&i.push(n),t&&a.push(t),r&&d.push(r),s},s};var e=n[a]._={};function s(){e.P(d),e.w=1,n[a]("_load")}e.fh={},e.eh={},e.ph={},e.l=t?t.replace(/^\/\//,("https:"==o?o:"http:")+"//"):t,e.p={0:+new Date},e.P=function(n){e.p[n]=new Date-e.p[0]},e.w&&s(),r.addEventListener?r.addEventListener(d,s,!1):r.attachEvent("onload",s);var l=function(){function n(){return["<!DOCTYPE ",o,"><",o,"><head></head><",t,"><",r,' src="',e.l,'"></',r,"></",t,"></",o,">"].join("")}var t="body",r="script",o="html",d=i[t];if(!d)return setTimeout(l,100);e.P(1);var c,s=i.createElement("div"),h=s.appendChild(i.createElement("div")),u=i.createElement("iframe");s.style.display="none",d.insertBefore(s,d.firstChild).id="lightningjs-"+a,u.frameBorder="0",u.id="lightningjs-frame-"+a,/MSIE[ ]+6/.test(navigator.userAgent)&&(u.src="javascript:false"),u.allowTransparency="true",h.appendChild(u);try{u.contentWindow.document.open()}catch(n){e.domain=i.domain,c="javascript:var d=document.open();d.domain='"+i.domain+"';",u.src=c+"void(0);"}try{var p=u.contentWindow.document;p.write(n()),p.close()}catch(e){u.src=c+'d.write("'+n().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}e.P(2)};e.l&&l()}()),n[e].lv="1",n[e]}var r=window.lightningjs=t(e);r.require=t,r.modules=n}({});
-      window.usabilla_live = window.lightningjs.require("usabilla_live", "//w.usabilla.com/a49be804ee59.js"); // prettier-ignore
-      // Hide Usabilla default button
-      window.usabilla_live("hide");
-      // Add MAAS version to the custom data
-      window.usabilla_live("data", { custom: { "MAAS version": version } });
-    }
-  }, [debug, enableAnalytics, version]);
+export const Footer = (): JSX.Element => {
+  const allowUsabilla = useUsabilla();
 
   return (
     <footer className="p-strip--light is-shallow p-footer">
@@ -56,18 +23,15 @@ export const Footer = ({
                 Legal information
               </a>
             </li>
-            {!debug && enableAnalytics ? (
+            {allowUsabilla ? (
               <li className="p-inline-list__item">
-                {/* eslint-disable-next-line */}
-                <a
-                  href=""
-                  onClick={(e) => {
-                    e.preventDefault();
-                    window.usabilla_live("click");
-                  }}
+                <Button
+                  appearance="link"
+                  className="u-no-margin u-no-padding"
+                  onClick={() => window.usabilla_live("click")}
                 >
                   Give feedback
-                </a>
+                </Button>
               </li>
             ) : null}
           </ul>

--- a/src/app/base/hooks/analytics.ts
+++ b/src/app/base/hooks/analytics.ts
@@ -1,12 +1,19 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { useSelector } from "react-redux";
 
+import type { UsabillaLive } from "app/base/types";
+import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
+import { version as versionSelectors } from "app/store/general/selectors";
 
 declare global {
   interface Window {
     ga: (...args: unknown[]) => void;
+    lightningjs: {
+      require: (variable: string, url: string) => Window["usabilla_live"];
+    };
+    usabilla_live: UsabillaLive;
   }
 }
 
@@ -66,4 +73,105 @@ export const useSendAnalyticsWhen = (
       sendAnalytics(eventCategory, eventAction, eventLabel);
     }
   }, [eventCategory, eventAction, eventLabel, sendCondition, sendAnalytics]);
+};
+
+export const useGoogleAnalytics = (): boolean => {
+  const sendPageview = useRef<(() => void) | null>(null);
+  const previousURL = useRef<string>();
+  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
+  const authUser = useSelector(authSelectors.get);
+  const uuid = useSelector(configSelectors.uuid);
+  const version = useSelector(versionSelectors.get);
+  const debug = process.env.NODE_ENV === "development";
+  const allowGoogleAnalytics = !!(
+    analyticsEnabled &&
+    authUser &&
+    uuid &&
+    version &&
+    !debug
+  );
+
+  useEffect(() => {
+    if (allowGoogleAnalytics) {
+      (function (w, d, s, l, i) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        w[l] = w[l] || [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        const f = d.getElementsByTagName(s)[0],
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          j = d.createElement(s),
+          dl = l !== "dataLayer" ? "&l=" + l : "";
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        j.async = true;
+        const src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        j.src = src;
+        if (document.querySelectorAll(`script[src="${src}"]`).length === 0) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          f.parentNode.insertBefore(j, f);
+        }
+      })(window, document, "script", "dataLayer", "GTM-P4TGJR9");
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      window.ga =
+        window.ga ||
+        function () {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          // eslint-disable-next-line prefer-rest-params
+          (window.ga.q = window.ga.q || []).push(arguments);
+          return window.ga;
+        };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      window.ga.l = +new Date();
+      window.ga("create", "UA-1018242-63", "auto", {
+        userId: `${uuid}-${authUser.id}`,
+      });
+      window.ga("set", "dimension1", version);
+      window.ga("set", "dimension2", uuid);
+
+      sendPageview.current = () => {
+        const path = window.location.pathname + window.location.search;
+        if (path !== previousURL.current) {
+          window.ga("send", "pageview", path);
+          previousURL.current = path;
+        }
+      };
+    }
+  }, [allowGoogleAnalytics, authUser, uuid, version]);
+
+  return allowGoogleAnalytics;
+};
+
+export const useUsabilla = (): boolean => {
+  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
+  const version = useSelector(versionSelectors.get);
+  const debug = process.env.NODE_ENV === "development";
+  const allowUsabilla = !!(analyticsEnabled && !debug);
+
+  useEffect(() => {
+    if (allowUsabilla && version) {
+      // Inject the the Usabilla script.
+      // prettier-ignore
+      // eslint-disable-next-line
+      // @ts-ignore
+      // eslint-disable-next-line
+      window.lightningjs||function(n){var e="lightningjs";function t(e,t){var r,i,a,o,d,c;return t&&(t+=(/\?/.test(t)?"&":"?")+"lv=1"),n[e]||(r=window,i=document,a=e,o=i.location.protocol,d="load",c=0,function(){n[a]=function(){var t=arguments,i=this,o=++c,d=i&&i!=r&&i.id||0;function s(){return s.id=o,n[a].apply(s,arguments)}return(e.s=e.s||[]).push([o,d,t]),s.then=function(n,t,r){var i=e.fh[o]=e.fh[o]||[],a=e.eh[o]=e.eh[o]||[],d=e.ph[o]=e.ph[o]||[];return n&&i.push(n),t&&a.push(t),r&&d.push(r),s},s};var e=n[a]._={};function s(){e.P(d),e.w=1,n[a]("_load")}e.fh={},e.eh={},e.ph={},e.l=t?t.replace(/^\/\//,("https:"==o?o:"http:")+"//"):t,e.p={0:+new Date},e.P=function(n){e.p[n]=new Date-e.p[0]},e.w&&s(),r.addEventListener?r.addEventListener(d,s,!1):r.attachEvent("onload",s);var l=function(){function n(){return["<!DOCTYPE ",o,"><",o,"><head></head><",t,"><",r,' src="',e.l,'"></',r,"></",t,"></",o,">"].join("")}var t="body",r="script",o="html",d=i[t];if(!d)return setTimeout(l,100);e.P(1);var c,s=i.createElement("div"),h=s.appendChild(i.createElement("div")),u=i.createElement("iframe");s.style.display="none",d.insertBefore(s,d.firstChild).id="lightningjs-"+a,u.frameBorder="0",u.id="lightningjs-frame-"+a,/MSIE[ ]+6/.test(navigator.userAgent)&&(u.src="javascript:false"),u.allowTransparency="true",h.appendChild(u);try{u.contentWindow.document.open()}catch(n){e.domain=i.domain,c="javascript:var d=document.open();d.domain='"+i.domain+"';",u.src=c+"void(0);"}try{var p=u.contentWindow.document;p.write(n()),p.close()}catch(e){u.src=c+'d.write("'+n().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}e.P(2)};e.l&&l()}()),n[e].lv="1",n[e]}var r=window.lightningjs=t(e);r.require=t,r.modules=n}({});
+      window.usabilla_live = window.lightningjs.require("usabilla_live", "//w.usabilla.com/a49be804ee59.js"); // prettier-ignore
+      // Hide Usabilla default button
+      window.usabilla_live("hide");
+      // Add MAAS version to the custom data
+      window.usabilla_live("data", { custom: { "MAAS version": version } });
+    }
+  }, [allowUsabilla, version]);
+
+  return allowUsabilla;
 };

--- a/src/app/base/hooks/index.ts
+++ b/src/app/base/hooks/index.ts
@@ -1,4 +1,9 @@
-export { useSendAnalytics, useSendAnalyticsWhen } from "./analytics";
+export {
+  useGoogleAnalytics,
+  useSendAnalytics,
+  useSendAnalyticsWhen,
+  useUsabilla,
+} from "./analytics";
 export {
   useAddMessage,
   useCycled,


### PR DESCRIPTION
## Done

- Connect `Header` and `Footer` components to the store
- Move analytics `useEffect`s to their own hooks

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that you can still log in and log out as before
- Check that all the links work as before (i.e. they go to the right place, highlights in sub-urls)
- Create a new user and log in as them
- Check that you get redirected to the user intro
- Open `src/app/App.tsx` and edit line 35 to:
  ``` ts
  const debug = false;
  ```
- Enable analytics in settings if it isn't already
- Check that the "Give feedback" link shows up in the footer 

## Fixes

Fixes canonical-web-and-design/app-tribe#1042

