### PR TITLE
refactor: use an enum for config names

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import { App } from "./App";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import { actions as statusActions } from "app/store/status";
 import {
@@ -27,7 +28,7 @@ describe("App", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "completed_intro", value: true }],
+        items: [{ name: ConfigNames.COMPLETED_INTRO, value: true }],
       }),
     });
   });

--- a/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
+++ b/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 import CertificateDetails from "./CertificateDetails";
 
 import * as hooks from "app/base/hooks/analytics";
+import { ConfigNames } from "app/store/config/types";
 import {
   certificateMetadata as metadataFactory,
   config as configFactory,
@@ -23,7 +24,9 @@ describe("CertificateDetails", () => {
       .mockImplementation(() => mockSendAnalytics);
     const state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "analytics_enabled", value: true })],
+        items: [
+          configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: true }),
+        ],
       }),
     });
     const store = mockStore(state);

--- a/src/app/base/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/app/base/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import ErrorBoundary from "./ErrorBoundary";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
@@ -55,7 +56,7 @@ describe("ErrorBoundary", () => {
 
     state.config.items = [
       {
-        name: "enable_analytics",
+        name: ConfigNames.ENABLE_ANALYTICS,
         value: false,
       },
     ];
@@ -82,7 +83,7 @@ describe("ErrorBoundary", () => {
 
     state.config.items = [
       {
-        name: "enable_analytics",
+        name: ConfigNames.ENABLE_ANALYTICS,
         value: true,
       },
     ];

--- a/src/app/base/components/Footer/Footer.test.tsx
+++ b/src/app/base/components/Footer/Footer.test.tsx
@@ -3,6 +3,7 @@ import MockDate from "mockdate";
 
 import Footer from "./Footer";
 
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -26,7 +27,9 @@ it("displays the feedback link when analytics enabled and not in development env
   process.env = { ...originalEnv, NODE_ENV: "production" };
   const state = rootStateFactory({
     config: configStateFactory({
-      items: [configFactory({ name: "enable_analytics", value: true })],
+      items: [
+        configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: true }),
+      ],
     }),
   });
   renderWithMockStore(<Footer />, { state });
@@ -40,7 +43,9 @@ it("hides the feedback link when analytics disabled", () => {
   process.env = { ...originalEnv, NODE_ENV: "production" };
   const state = rootStateFactory({
     config: configStateFactory({
-      items: [configFactory({ name: "enable_analytics", value: false })],
+      items: [
+        configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: false }),
+      ],
     }),
   });
   renderWithMockStore(<Footer />, { state });
@@ -54,7 +59,9 @@ it("hides the feedback link in development environment", () => {
   process.env = { ...originalEnv, NODE_ENV: "development" };
   const state = rootStateFactory({
     config: configStateFactory({
-      items: [configFactory({ name: "enable_analytics", value: true })],
+      items: [
+        configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: true }),
+      ],
     }),
   });
   renderWithMockStore(<Footer />, { state });

--- a/src/app/base/components/FormikForm/FormikForm.test.tsx
+++ b/src/app/base/components/FormikForm/FormikForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import FormikForm from "./FormikForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
@@ -20,7 +21,9 @@ describe("FormikForm", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "analytics_enabled", value: false })],
+        items: [
+          configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: false }),
+        ],
       }),
     });
   });

--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -10,6 +10,7 @@ import * as Yup from "yup";
 import FormikFormContent from "./FormikFormContent";
 
 import * as hooks from "app/base/hooks/analytics";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
@@ -25,7 +26,9 @@ describe("FormikFormContent", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "analytics_enabled", value: false })],
+        items: [
+          configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: false }),
+        ],
       }),
     });
   });

--- a/src/app/base/components/Header/Header.test.tsx
+++ b/src/app/base/components/Header/Header.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import { Header } from "./Header";
 
 import urls from "app/base/urls";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import { actions as statusActions } from "app/store/status";
 import {
@@ -31,7 +32,9 @@ let state: RootState;
 beforeEach(() => {
   state = rootStateFactory({
     config: configStateFactory({
-      items: [configFactory({ name: "completed_intro", value: true })],
+      items: [
+        configFactory({ name: ConfigNames.COMPLETED_INTRO, value: true }),
+      ],
       loaded: true,
     }),
     user: userStateFactory({
@@ -241,7 +244,7 @@ it("links from the logo to the machine list for non admins", () => {
 
 it("redirects to the intro page if intro not completed", () => {
   state.config.items = [
-    configFactory({ name: "completed_intro", value: false }),
+    configFactory({ name: ConfigNames.COMPLETED_INTRO, value: false }),
   ];
   state.user.auth.user = userFactory({ completed_intro: true });
   renderWithBrowserRouter(<Header />, {
@@ -254,7 +257,7 @@ it("redirects to the intro page if intro not completed", () => {
 
 it("redirects to the user intro page if user intro not completed", () => {
   state.config.items = [
-    configFactory({ name: "completed_intro", value: true }),
+    configFactory({ name: ConfigNames.COMPLETED_INTRO, value: true }),
   ];
   state.user.auth.user = userFactory({ completed_intro: false });
   renderWithBrowserRouter(<Header />, {

--- a/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import NotificationGroupNotification from "./Notification";
 
 import type { ConfigState } from "app/store/config/types";
+import { ConfigNames } from "app/store/config/types";
 import { NotificationIdent } from "app/store/notification/types";
 import type { UserState } from "app/store/user/types";
 import {
@@ -28,7 +29,9 @@ describe("NotificationGroupNotification", () => {
 
   beforeEach(() => {
     config = configStateFactory({
-      items: [configFactory({ name: "release_notifications", value: true })],
+      items: [
+        configFactory({ name: ConfigNames.RELEASE_NOTIFICATIONS, value: true }),
+      ],
     });
     user = userStateFactory({
       auth: authStateFactory({

--- a/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import NotificationList from "./NotificationList";
 
+import { ConfigNames } from "app/store/config/types";
 import type { Notification } from "app/store/notification/types";
 import {
   NotificationCategory,
@@ -40,7 +41,12 @@ describe("NotificationList", () => {
     ];
     state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: false })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: false,
+          }),
+        ],
       }),
       message: messageStateFactory({
         items: [messageFactory({ id: 1, message: "User deleted" })],
@@ -166,7 +172,12 @@ describe("NotificationList", () => {
   it("can display a release notification", () => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: true })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: true,
+          }),
+        ],
       }),
       notification: notificationStateFactory({
         items: [
@@ -198,7 +209,12 @@ describe("NotificationList", () => {
   it("does not display a release notification for some urls", () => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: true })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: true,
+          }),
+        ],
       }),
       notification: notificationStateFactory({
         items: [

--- a/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 
 import StatusBar from "./StatusBar";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import { NodeStatus, NodeType } from "app/store/types/node";
 import {
@@ -24,7 +25,7 @@ beforeEach(() => {
   jest.setSystemTime(new Date(Date.UTC(2020, 11, 31, 23, 0, 0)));
   state = rootStateFactory({
     config: configStateFactory({
-      items: [configFactory({ name: "maas_name", value: "bolla" })],
+      items: [configFactory({ name: ConfigNames.MAAS_NAME, value: "bolla" })],
     }),
     controller: controllerStateFactory({
       items: [],

--- a/src/app/base/hooks/intro.test.tsx
+++ b/src/app/base/hooks/intro.test.tsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 
 import { useCompletedIntro, useCompletedUserIntro } from "./intro";
 
+import { ConfigNames } from "app/store/config/types";
 import { getCookie } from "app/utils";
 import {
   authState as authStateFactory,
@@ -26,7 +27,9 @@ describe("intro hooks", () => {
     it("gets whether the intro has been completed", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "completed_intro", value: true })],
+          items: [
+            configFactory({ name: ConfigNames.COMPLETED_INTRO, value: true }),
+          ],
         }),
       });
       const store = mockStore(state);
@@ -43,7 +46,9 @@ describe("intro hooks", () => {
       getCookieMock.mockImplementation(() => "true");
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "completed_intro", value: false })],
+          items: [
+            configFactory({ name: ConfigNames.COMPLETED_INTRO, value: false }),
+          ],
         }),
       });
       const store = mockStore(state);

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import AddController from "./AddController";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -20,8 +21,8 @@ describe("AddController", () => {
     state = rootStateFactory({
       config: configStateFactory({
         items: [
-          { name: "maas_url", value: "http://1.2.3.4/MAAS" },
-          { name: "rpc_shared_secret", value: "veryverysecret" },
+          { name: ConfigNames.MAAS_URL, value: "http://1.2.3.4/MAAS" },
+          { name: ConfigNames.RPC_SHARED_SECRET, value: "veryverysecret" },
         ],
       }),
     });

--- a/src/app/dashboard/views/Dashboard.test.tsx
+++ b/src/app/dashboard/views/Dashboard.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import Dashboard from "./Dashboard";
 
 import dashboardURLs from "app/dashboard/urls";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -24,7 +25,7 @@ describe("Dashboard", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "network_discovery", value: "enabled" }],
+        items: [{ name: ConfigNames.NETWORK_DISCOVERY, value: "enabled" }],
       }),
       user: userStateFactory({
         auth: authStateFactory({ user: userFactory({ is_superuser: true }) }),
@@ -63,7 +64,7 @@ describe("Dashboard", () => {
 
   it("displays a notification when discovery is disabled", () => {
     state.config = configStateFactory({
-      items: [{ name: "network_discovery", value: "disabled" }],
+      items: [{ name: ConfigNames.NETWORK_DISCOVERY, value: "disabled" }],
     });
     const store = mockStore(state);
     const wrapper = mount(
@@ -82,7 +83,7 @@ describe("Dashboard", () => {
 
   it("does not display a notification when discovery is enabled", () => {
     state.config = configStateFactory({
-      items: [{ name: "network_discovery", value: "enabled" }],
+      items: [{ name: ConfigNames.NETWORK_DISCOVERY, value: "enabled" }],
     });
     const store = mockStore(state);
     const wrapper = mount(

--- a/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 
 import DashboardConfigurationSubnetForm from "./DashboardConfigurationSubnetForm";
 
-import { NetworkDiscovery } from "app/store/config/types";
+import { ConfigNames, NetworkDiscovery } from "app/store/config/types";
 import { actions as subnetActions } from "app/store/subnet";
 import {
   configState as configStateFactory,
@@ -80,7 +80,10 @@ describe("DashboardConfigurationSubnetForm", () => {
     const state = rootStateFactory({
       config: configStateFactory({
         items: [
-          { name: "network_discovery", value: NetworkDiscovery.DISABLED },
+          {
+            name: ConfigNames.NETWORK_DISCOVERY,
+            value: NetworkDiscovery.DISABLED,
+          },
         ],
       }),
       fabric: fabricStateFactory({ loaded: true }),

--- a/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 import ClearAllForm from "./ClearAllForm";
 
 import FormikForm from "app/base/components/FormikForm";
-import { NetworkDiscovery } from "app/store/config/types";
+import { ConfigNames, NetworkDiscovery } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -25,7 +25,12 @@ describe("ClearAllForm", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "network_discovery", value: NetworkDiscovery.ENABLED }],
+        items: [
+          {
+            name: ConfigNames.NETWORK_DISCOVERY,
+            value: NetworkDiscovery.ENABLED,
+          },
+        ],
       }),
       discovery: discoveryStateFactory({
         loaded: true,
@@ -43,7 +48,12 @@ describe("ClearAllForm", () => {
 
   it("displays a message when discovery is enabled", () => {
     state.config = configStateFactory({
-      items: [{ name: "network_discovery", value: NetworkDiscovery.ENABLED }],
+      items: [
+        {
+          name: ConfigNames.NETWORK_DISCOVERY,
+          value: NetworkDiscovery.ENABLED,
+        },
+      ],
     });
     const store = mockStore(state);
     const wrapper = mount(
@@ -62,7 +72,12 @@ describe("ClearAllForm", () => {
 
   it("displays a message when discovery is enabled", () => {
     state.config = configStateFactory({
-      items: [{ name: "network_discovery", value: NetworkDiscovery.DISABLED }],
+      items: [
+        {
+          name: ConfigNames.NETWORK_DISCOVERY,
+          value: NetworkDiscovery.DISABLED,
+        },
+      ],
     });
     const store = mockStore(state);
     const wrapper = mount(

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 
 import ImagesTable from "./ImagesTable";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   bootResource as resourceFactory,
@@ -27,7 +28,7 @@ describe("ImagesTable", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "focal",
           }),
         ],
@@ -175,7 +176,7 @@ describe("ImagesTable", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "focal",
           }),
         ],
@@ -222,7 +223,7 @@ describe("ImagesTable", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "focal",
           }),
         ],

--- a/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.test.tsx
+++ b/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import NonUbuntuImageSelect from "./NonUbuntuImageSelect";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   bootResource as bootResourceFactory,
@@ -29,7 +30,7 @@ describe("NonUbuntuImageSelect", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "focal",
           }),
         ],

--- a/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
+++ b/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import ArchSelect from "./ArchSelect";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
@@ -23,7 +24,7 @@ describe("ArchSelect", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "bionic",
           }),
         ],
@@ -119,7 +120,10 @@ describe("ArchSelect", () => {
   it(`disables a checkbox if it's the last checked arch for the default
     commissioning release`, () => {
     state.config.items = [
-      configFactory({ name: "commissioning_distro_series", value: "focal" }),
+      configFactory({
+        name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
+        value: "focal",
+      }),
     ];
     const release = bootResourceUbuntuReleaseFactory({
       name: "focal",

--- a/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
+++ b/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import UbuntuImageSelect from "./UbuntuImageSelect";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
@@ -23,7 +24,7 @@ describe("UbuntuImageSelect", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "focal",
           }),
         ],

--- a/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/src/app/images/views/ImageList/ImageList.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ImageList from "./ImageList";
 
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -19,7 +20,10 @@ describe("ImageList", () => {
     const state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "boot_images_auto_import", value: false }),
+          configFactory({
+            name: ConfigNames.BOOT_IMAGES_AUTO_IMPORT,
+            value: false,
+          }),
         ],
         loaded: true,
       }),
@@ -48,7 +52,10 @@ describe("ImageList", () => {
     const state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "boot_images_auto_import", value: false }),
+          configFactory({
+            name: ConfigNames.BOOT_IMAGES_AUTO_IMPORT,
+            value: false,
+          }),
         ],
         loaded: true,
       }),

--- a/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import ImageListHeader from "./ImageListHeader";
 
 import { actions as configActions } from "app/store/config";
+import { ConfigNames } from "app/store/config/types";
 import {
   bootResourceState as bootResourceStateFactory,
   bootResourceStatuses as bootResourceStatusesFactory,
@@ -68,7 +69,10 @@ describe("ImageListHeader", () => {
     const state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "boot_images_auto_import", value: true }),
+          configFactory({
+            name: ConfigNames.BOOT_IMAGES_AUTO_IMPORT,
+            value: true,
+          }),
         ],
         loaded: true,
       }),

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -9,6 +9,7 @@ import FetchedImages from "./FetchedImages";
 
 import { actions as bootResourceActions } from "app/store/bootresource";
 import { BootResourceSourceType } from "app/store/bootresource/types";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   bootResourceFetchedArch as fetchedArchFactory,
@@ -37,7 +38,7 @@ describe("FetchedImages", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "focal",
           }),
         ],

--- a/src/app/intro/views/Intro.test.tsx
+++ b/src/app/intro/views/Intro.test.tsx
@@ -8,6 +8,7 @@ import Intro from "./Intro";
 
 import dashboardURLs from "app/dashboard/urls";
 import introURLs from "app/intro/urls";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -25,7 +26,7 @@ describe("Intro", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "completed_intro", value: false }],
+        items: [{ name: ConfigNames.COMPLETED_INTRO, value: false }],
       }),
       user: userStateFactory({
         auth: authStateFactory({
@@ -71,7 +72,7 @@ describe("Intro", () => {
 
   it("exits the intro if both intros have been completed", () => {
     state.config = configStateFactory({
-      items: [{ name: "completed_intro", value: true }],
+      items: [{ name: ConfigNames.COMPLETED_INTRO, value: true }],
     });
     state.user = userStateFactory({
       auth: authStateFactory({
@@ -111,7 +112,7 @@ describe("Intro", () => {
 
   it("skips to the user intro when loading the main intro when it is complete", () => {
     state.config = configStateFactory({
-      items: [{ name: "completed_intro", value: true }],
+      items: [{ name: ConfigNames.COMPLETED_INTRO, value: true }],
     });
     const store = mockStore(state);
     const wrapper = mount(

--- a/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import MaasIntro from "./MaasIntro";
 
 import { actions as configActions } from "app/store/config";
+import { ConfigNames } from "app/store/config/types";
 import { actions as repoActions } from "app/store/packagerepository";
 import type { RootState } from "app/store/root/types";
 import {
@@ -40,10 +41,13 @@ describe("MaasIntro", () => {
     state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "completed_intro", value: false }),
-          configFactory({ name: "maas_name", value: "bionic-maas" }),
-          configFactory({ name: "http_proxy", value: "http://www.site.com" }),
-          configFactory({ name: "upstream_dns", value: "8.8.8.8" }),
+          configFactory({ name: ConfigNames.COMPLETED_INTRO, value: false }),
+          configFactory({ name: ConfigNames.MAAS_NAME, value: "bionic-maas" }),
+          configFactory({
+            name: ConfigNames.HTTP_PROXY,
+            value: "http://www.site.com",
+          }),
+          configFactory({ name: ConfigNames.UPSTREAM_DNS, value: "8.8.8.8" }),
         ],
       }),
       packagerepository: repoStateFactory({

--- a/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
+++ b/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
@@ -7,6 +7,7 @@ import { MaasIntroSchema } from "../MaasIntro";
 
 import NameCard from "./NameCard";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -26,8 +27,8 @@ describe("NameCard", () => {
     state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "completed_intro", value: false }),
-          configFactory({ name: "maas_name", value: "bionic-maas" }),
+          configFactory({ name: ConfigNames.COMPLETED_INTRO, value: false }),
+          configFactory({ name: ConfigNames.MAAS_NAME, value: "bionic-maas" }),
         ],
       }),
       user: userStateFactory({

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -10,6 +10,7 @@ import dashboardURLs from "app/dashboard/urls";
 import introURLs from "app/intro/urls";
 import machineURLs from "app/machines/urls";
 import { actions as configActions } from "app/store/config";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -27,7 +28,9 @@ describe("MaasIntroSuccess", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "completed_intro", value: false })],
+        items: [
+          configFactory({ name: ConfigNames.COMPLETED_INTRO, value: false }),
+        ],
       }),
       user: userStateFactory({
         auth: authStateFactory({

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import AddLxd from "./AddLxd";
 import CredentialsForm from "./CredentialsForm";
 
+import { ConfigNames } from "app/store/config/types";
 import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
@@ -36,7 +37,7 @@ describe("AddLxd", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "maas_name", value: "MAAS" }],
+        items: [{ name: ConfigNames.MAAS_NAME, value: "MAAS" }],
       }),
       general: generalStateFactory({
         generatedCertificate: generatedCertificateStateFactory({

--- a/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import AddVirsh from "./AddVirsh";
 
+import { ConfigNames } from "app/store/config/types";
 import { actions as generalActions } from "app/store/general";
 import { PodType } from "app/store/pod/constants";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
@@ -35,7 +36,7 @@ describe("AddVirsh", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "maas_name", value: "MAAS" }],
+        items: [{ name: ConfigNames.MAAS_NAME, value: "MAAS" }],
       }),
       general: generalStateFactory({
         powerTypes: powerTypesStateFactory({

--- a/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirshFields/AddVirshFields.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirshFields/AddVirshFields.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import AddVirsh from "../AddVirsh";
 
+import { ConfigNames } from "app/store/config/types";
 import { PowerTypeNames } from "app/store/general/constants";
 import { PowerFieldScope } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
@@ -31,7 +32,7 @@ describe("AddVirshFields", () => {
   beforeEach(() => {
     state = rootStateFactory({
       config: configStateFactory({
-        items: [{ name: "maas_name", value: "MAAS" }],
+        items: [{ name: ConfigNames.MAAS_NAME, value: "MAAS" }],
       }),
       general: generalStateFactory({
         powerTypes: powerTypesStateFactory({

--- a/src/app/kvm/components/KVMStorageCards/KVMStorageCards.test.tsx
+++ b/src/app/kvm/components/KVMStorageCards/KVMStorageCards.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import KVMStorageCards, { TRUNCATION_POINT } from "./KVMStorageCards";
 
 import * as hooks from "app/base/hooks/analytics";
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -106,7 +107,7 @@ describe("KVMStorageCards", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "enable_analytics",
+            name: ConfigNames.ENABLE_ANALYTICS,
             value: false,
           }),
         ],

--- a/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
+++ b/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
@@ -8,6 +8,7 @@ import LXDHostToolbar from "./LXDHostToolbar";
 
 import * as hooks from "app/base/hooks/analytics";
 import kvmURLs from "app/kvm/urls";
+import { ConfigNames } from "app/store/config/types";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
 import {
@@ -216,7 +217,7 @@ describe("LXDHostToolbar", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "enable_analytics",
+            name: ConfigNames.ENABLE_ANALYTICS,
             value: true,
           }),
         ],

--- a/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResources.test.tsx
+++ b/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResources.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import NumaResources, { TRUNCATION_POINT } from "./NumaResources";
 
 import * as hooks from "app/base/hooks/analytics";
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -85,7 +86,7 @@ describe("NumaResources", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "enable_analytics",
+            name: ConfigNames.ENABLE_ANALYTICS,
             value: false,
           }),
         ],

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import DeployForm from "./DeployForm";
 
 import * as hooks from "app/base/hooks/analytics";
+import { ConfigNames } from "app/store/config/types";
 import { actions as machineActions } from "app/store/machine";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
@@ -34,7 +35,7 @@ describe("DeployForm", () => {
       config: configStateFactory({
         items: [
           configFactory({
-            name: "default_osystem",
+            name: ConfigNames.DEFAULT_OSYSTEM,
             value: "ubuntu",
             choices: [
               ["centos", "CentOS"],
@@ -42,7 +43,7 @@ describe("DeployForm", () => {
             ],
           }),
           configFactory({
-            name: "enable_analytics",
+            name: ConfigNames.ENABLE_ANALYTICS,
             value: true,
           }),
         ],

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import DeployForm from "../DeployForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
@@ -30,7 +31,7 @@ describe("DeployFormFields", () => {
       config: configStateFactory({
         items: [
           {
-            name: "default_osystem",
+            name: ConfigNames.DEFAULT_OSYSTEM,
             value: "ubuntu",
             choices: [
               ["centos", "CentOS"],
@@ -453,7 +454,7 @@ describe("DeployFormFields", () => {
 
   it("displays 'periodically sync hardware' checkbox with global setting and additional tooltip information", async () => {
     state.config.items.push({
-      name: "hardware_sync_interval",
+      name: ConfigNames.HARDWARE_SYNC_INTERVAL,
       value: "15m",
     });
     const store = mockStore(state);
@@ -485,7 +486,10 @@ describe("DeployFormFields", () => {
   });
 
   it("displays a correct description text for an invalid sync interval", () => {
-    state.config.items.push({ name: "hardware_sync_interval", value: "" });
+    state.config.items.push({
+      name: ConfigNames.HARDWARE_SYNC_INTERVAL,
+      value: "",
+    });
     const store = mockStore(state);
     render(
       <Provider store={store}>

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import ReleaseForm from "./ReleaseForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
@@ -29,11 +30,17 @@ describe("ReleaseForm", () => {
         loaded: true,
         items: [
           configFactory({
-            name: "enable_disk_erasing_on_release",
+            name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
             value: false,
           }),
-          configFactory({ name: "disk_erase_with_secure_erase", value: false }),
-          configFactory({ name: "disk_erase_with_quick_erase", value: false }),
+          configFactory({
+            name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE,
+            value: false,
+          }),
+          configFactory({
+            name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE,
+            value: false,
+          }),
         ],
       }),
       machine: machineStateFactory({
@@ -53,9 +60,18 @@ describe("ReleaseForm", () => {
     const store = mockStore(state);
     state.machine.selected = ["abc123", "def456"];
     state.config.items = [
-      configFactory({ name: "enable_disk_erasing_on_release", value: true }),
-      configFactory({ name: "disk_erase_with_secure_erase", value: false }),
-      configFactory({ name: "disk_erase_with_quick_erase", value: true }),
+      configFactory({
+        name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
+        value: true,
+      }),
+      configFactory({
+        name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE,
+        value: false,
+      }),
+      configFactory({
+        name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE,
+        value: true,
+      }),
     ];
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
+++ b/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import Commissioning from "./Commissioning";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,12 +25,12 @@ describe("Commissioning", () => {
       config: configStateFactory({
         items: [
           {
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "bionic",
             choices: [],
           },
           {
-            name: "default_min_hwe_kernel",
+            name: ConfigNames.DEFAULT_MIN_HWE_KERNEL,
             value: "ga-16.04-lowlatency",
             choices: [],
           },

--- a/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import CommissioningForm from "./CommissioningForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -27,7 +28,7 @@ describe("CommissioningForm", () => {
         loaded: true,
         items: [
           {
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "bionic",
             choices: [
               ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
@@ -37,7 +38,7 @@ describe("CommissioningForm", () => {
             ],
           },
           {
-            name: "default_min_hwe_kernel",
+            name: ConfigNames.DEFAULT_MIN_HWE_KERNEL,
             value: "ga-16.04-lowlatency",
             choices: [
               ["", "--- No minimum kernel ---"],

--- a/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import CommissioningForm from "../CommissioningForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -26,7 +27,7 @@ describe("CommissioningFormFields", () => {
         loaded: true,
         items: [
           {
-            name: "commissioning_distro_series",
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
             value: "bionic",
             choices: [
               ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
@@ -36,15 +37,15 @@ describe("CommissioningFormFields", () => {
             ],
           },
           {
-            name: "default_min_hwe_kernel",
+            name: ConfigNames.DEFAULT_MIN_HWE_KERNEL,
             value: "ga-16.04-lowlatency",
           },
           {
-            name: "maas_auto_ipmi_user",
+            name: ConfigNames.MAAS_AUTO_IPMI_USER,
             value: "maas",
           },
           {
-            name: "maas_auto_ipmi_user_privilege_level",
+            name: ConfigNames.MAAS_AUTO_IPMI_USER_PRIVILEGE_LEVEL,
             value: "OPERATOR",
           },
         ],

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import DeployForm from "./DeployForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -28,7 +29,7 @@ describe("DeployFormFields", () => {
         loaded: true,
         items: [
           {
-            name: "default_osystem",
+            name: ConfigNames.DEFAULT_OSYSTEM,
             value: "ubuntu",
             choices: [
               ["centos", "CentOS"],
@@ -36,7 +37,7 @@ describe("DeployFormFields", () => {
             ],
           },
           {
-            name: "default_distro_series",
+            name: ConfigNames.DEFAULT_DISTRO_SERIES,
             value: "bionic",
             choices: [
               ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
@@ -99,7 +100,7 @@ describe("DeployFormFields", () => {
     const syncIntervalValue = "15m";
     // TODO: Investigate mutating state in integration tests https://github.com/canonical-web-and-design/app-tribe/issues/794
     state.config.items.push({
-      name: "hardware_sync_interval",
+      name: ConfigNames.HARDWARE_SYNC_INTERVAL,
       value: syncIntervalValue,
     });
     const store = mockStore(state);

--- a/src/app/settings/views/Configuration/General/General.test.tsx
+++ b/src/app/settings/views/Configuration/General/General.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import General from "./General";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -22,15 +23,15 @@ describe("General", () => {
       config: configStateFactory({
         items: [
           {
-            name: "maas_name",
+            name: ConfigNames.MAAS_NAME,
             value: "bionic",
           },
           {
-            name: "enable_analytics",
+            name: ConfigNames.ENABLE_ANALYTICS,
             value: true,
           },
           {
-            name: "release_notifications",
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
             value: true,
           },
         ],

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import GeneralForm from "./GeneralForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
@@ -22,9 +23,12 @@ describe("GeneralForm", () => {
     state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "maas_name", value: "bionic-maas" }),
-          configFactory({ name: "enable_analytics", value: true }),
-          configFactory({ name: "release_notifications", value: true }),
+          configFactory({ name: ConfigNames.MAAS_NAME, value: "bionic-maas" }),
+          configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: true }),
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: true,
+          }),
         ],
       }),
     });

--- a/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import KernelParameters from "./KernelParameters";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -22,7 +23,7 @@ describe("KernelParameters", () => {
       config: configStateFactory({
         items: [
           {
-            name: "kernel_opts",
+            name: ConfigNames.KERNEL_OPTS,
             value: "foo",
           },
         ],

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import KernelParametersForm from "./KernelParametersForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -22,7 +23,7 @@ describe("KernelParametersForm", () => {
       config: configStateFactory({
         items: [
           {
-            name: "kernel_opts",
+            name: ConfigNames.KERNEL_OPTS,
             value: "foo",
           },
         ],

--- a/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
+++ b/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabled.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import TLSEnabled, { Labels } from "./TLSEnabled";
 
 import { actions as configActions } from "app/store/config";
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -93,11 +94,11 @@ it("disables the interval field if notification is not enabled", async () => {
     config: configStateFactory({
       items: [
         configFactory({
-          name: "tls_cert_expiration_notification_enabled",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED,
           value: false,
         }),
         configFactory({
-          name: "tls_cert_expiration_notification_interval",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL,
           value: 45,
         }),
       ],
@@ -137,11 +138,11 @@ it("shows an error if TLS notification is enabled but interval is invalid", asyn
     config: configStateFactory({
       items: [
         configFactory({
-          name: "tls_cert_expiration_notification_enabled",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED,
           value: true,
         }),
         configFactory({
-          name: "tls_cert_expiration_notification_interval",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL,
           value: 45,
         }),
       ],
@@ -183,11 +184,11 @@ it("dispatches an action to update TLS notification config with notification ena
     config: configStateFactory({
       items: [
         configFactory({
-          name: "tls_cert_expiration_notification_enabled",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED,
           value: false,
         }),
         configFactory({
-          name: "tls_cert_expiration_notification_interval",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL,
           value: 60,
         }),
       ],
@@ -236,11 +237,11 @@ it("dispatches an action to update TLS notification config with notification dis
     config: configStateFactory({
       items: [
         configFactory({
-          name: "tls_cert_expiration_notification_enabled",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED,
           value: true,
         }),
         configFactory({
-          name: "tls_cert_expiration_notification_interval",
+          name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL,
           value: 45,
         }),
       ],

--- a/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ThirdPartyDrivers from "./ThirdPartyDrivers";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
@@ -22,7 +23,10 @@ describe("ThirdPartyDrivers", () => {
     state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "enable_third_party_drivers", value: false }),
+          configFactory({
+            name: ConfigNames.ENABLE_THIRD_PARTY_DRIVERS,
+            value: false,
+          }),
         ],
       }),
     });

--- a/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ThirdPartyDriversForm from "./ThirdPartyDriversForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -22,7 +23,7 @@ describe("ThirdPartyDriversForm", () => {
       config: configStateFactory({
         items: [
           {
-            name: "enable_third_party_drivers",
+            name: ConfigNames.ENABLE_THIRD_PARTY_DRIVERS,
             value: true,
           },
         ],

--- a/src/app/settings/views/Images/VMWare/VMWare.test.tsx
+++ b/src/app/settings/views/Images/VMWare/VMWare.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import VMWare from "./VMWare";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
@@ -22,10 +23,10 @@ describe("VMWare", () => {
     state = rootStateFactory({
       config: configStateFactory({
         items: [
-          configFactory({ name: "vcenter_server", value: "" }),
-          configFactory({ name: "vcenter_username", value: "" }),
-          configFactory({ name: "vcenter_password", value: "" }),
-          configFactory({ name: "vcenter_datacenter", value: "" }),
+          configFactory({ name: ConfigNames.VCENTER_SERVER, value: "" }),
+          configFactory({ name: ConfigNames.VCENTER_USERNAME, value: "" }),
+          configFactory({ name: ConfigNames.VCENTER_PASSWORD, value: "" }),
+          configFactory({ name: ConfigNames.VCENTER_DATACENTER, value: "" }),
         ],
       }),
     });

--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import VMWareForm from "./VMWareForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -22,19 +23,19 @@ describe("VMWareForm", () => {
       config: configStateFactory({
         items: [
           {
-            name: "vcenter_server",
+            name: ConfigNames.VCENTER_SERVER,
             value: "my server",
           },
           {
-            name: "vcenter_username",
+            name: ConfigNames.VCENTER_USERNAME,
             value: "admin",
           },
           {
-            name: "vcenter_password",
+            name: ConfigNames.VCENTER_PASSWORD,
             value: "passwd",
           },
           {
-            name: "vcenter_datacenter",
+            name: ConfigNames.VCENTER_DATACENTER,
             value: "my datacenter",
           },
         ],

--- a/src/app/settings/views/Images/Windows/Windows.test.tsx
+++ b/src/app/settings/views/Images/Windows/Windows.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import Windows from "./Windows";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
@@ -25,7 +26,7 @@ describe("Windows", () => {
         loaded: true,
         items: [
           configFactory({
-            name: "windows_kms_host",
+            name: ConfigNames.WINDOWS_KMS_HOST,
             value: "127.0.0.1",
           }),
         ],

--- a/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
+++ b/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import WindowsForm from "./WindowsForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +25,7 @@ describe("WindowsForm", () => {
         loaded: true,
         items: [
           {
-            name: "windows_kms_host",
+            name: ConfigNames.WINDOWS_KMS_HOST,
             value: "127.0.0.1",
           },
         ],

--- a/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import DnsForm from "./DnsForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +25,7 @@ describe("DnsForm", () => {
         loaded: true,
         items: [
           {
-            name: "dnssec_validation",
+            name: ConfigNames.DNSSEC_VALIDATION,
             value: "auto",
             choices: [
               ["auto", "Automatic (use default root key)"],
@@ -35,8 +36,8 @@ describe("DnsForm", () => {
               ],
             ],
           },
-          { name: "dns_trusted_acl", value: "" },
-          { name: "upstream_dns", value: "" },
+          { name: ConfigNames.DNS_TRUSTED_ACL, value: "" },
+          { name: ConfigNames.UPSTREAM_DNS, value: "" },
         ],
       }),
     });

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +25,7 @@ describe("NetworkDiscoveryForm", () => {
         loaded: true,
         items: [
           {
-            name: "active_discovery_interval",
+            name: ConfigNames.ACTIVE_DISCOVERY_INTERVAL,
             value: "0",
             choices: [
               [0, "Never (disabled)"],
@@ -39,7 +40,7 @@ describe("NetworkDiscoveryForm", () => {
             ],
           },
           {
-            name: "network_discovery",
+            name: ConfigNames.NETWORK_DISCOVERY,
             value: "enabled",
             choices: [
               ["enabled", "Enabled"],

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
@@ -5,7 +5,7 @@ import configureStore from "redux-mock-store";
 
 import NetworkDiscoveryFormFields from "./NetworkDiscoveryFormFields";
 
-import { NetworkDiscovery } from "app/store/config/types";
+import { ConfigNames, NetworkDiscovery } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +24,7 @@ describe("NetworkDiscoveryFormFields", () => {
         loaded: true,
         items: [
           {
-            name: "active_discovery_interval",
+            name: ConfigNames.ACTIVE_DISCOVERY_INTERVAL,
             value: "0",
             choices: [
               [0, "Never (disabled)"],
@@ -39,7 +39,7 @@ describe("NetworkDiscoveryFormFields", () => {
             ],
           },
           {
-            name: "network_discovery",
+            name: ConfigNames.NETWORK_DISCOVERY,
             value: "enabled",
             choices: [
               ["enabled", "Enabled"],

--- a/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import NtpForm from "./NtpForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,10 +25,10 @@ describe("NtpForm", () => {
         loaded: true,
         items: [
           {
-            name: "ntp_external_only",
+            name: ConfigNames.NTP_EXTERNAL_ONLY,
             value: false,
           },
-          { name: "ntp_servers", value: "" },
+          { name: ConfigNames.NTP_SERVERS, value: "" },
         ],
       }),
     });

--- a/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
+++ b/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ProxyForm from "./ProxyForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,15 +25,15 @@ describe("ProxyForm", () => {
         loaded: true,
         items: [
           {
-            name: "http_proxy",
+            name: ConfigNames.HTTP_PROXY,
             value: "http://www.url.com",
           },
           {
-            name: "enable_http_proxy",
+            name: ConfigNames.ENABLE_HTTP_PROXY,
             value: false,
           },
           {
-            name: "use_peer_proxy",
+            name: ConfigNames.USE_PEER_PROXY,
             value: false,
           },
         ],
@@ -61,7 +62,7 @@ describe("ProxyForm", () => {
     state.config.items = reduceInitialState(
       state.config.items,
       "name",
-      "enable_http_proxy",
+      ConfigNames.ENABLE_HTTP_PROXY,
       { value: true }
     );
     const store = mockStore(state);

--- a/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
+++ b/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import ProxyForm from "../ProxyForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -23,15 +24,15 @@ describe("ProxyFormFields", () => {
         loaded: true,
         items: [
           {
-            name: "http_proxy",
+            name: ConfigNames.HTTP_PROXY,
             value: "http://www.url.com",
           },
           {
-            name: "enable_http_proxy",
+            name: ConfigNames.ENABLE_HTTP_PROXY,
             value: false,
           },
           {
-            name: "use_peer_proxy",
+            name: ConfigNames.USE_PEER_PROXY,
             value: false,
           },
         ],

--- a/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import SyslogForm from "./SyslogForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +25,7 @@ describe("SyslogForm", () => {
         loaded: true,
         items: [
           {
-            name: "remote_syslog",
+            name: ConfigNames.REMOTE_SYSLOG,
             value: "",
           },
         ],

--- a/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import StorageForm from "./StorageForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +25,7 @@ describe("StorageForm", () => {
         loaded: true,
         items: [
           {
-            name: "default_storage_layout",
+            name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
             value: "bcache",
             choices: [
               ["bcache", "Bcache layout"],
@@ -35,15 +36,15 @@ describe("StorageForm", () => {
             ],
           },
           {
-            name: "enable_disk_erasing_on_release",
+            name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
             value: false,
           },
           {
-            name: "disk_erase_with_secure_erase",
+            name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE,
             value: false,
           },
           {
-            name: "disk_erase_with_quick_erase",
+            name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE,
             value: false,
           },
         ],
@@ -74,10 +75,10 @@ describe("StorageForm", () => {
         type: "config/update",
         payload: {
           params: [
-            { name: "default_storage_layout", value: "bcache" },
-            { name: "disk_erase_with_quick_erase", value: false },
-            { name: "disk_erase_with_secure_erase", value: false },
-            { name: "enable_disk_erasing_on_release", value: false },
+            { name: ConfigNames.DEFAULT_STORAGE_LAYOUT, value: "bcache" },
+            { name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE, value: false },
+            { name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE, value: false },
+            { name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE, value: false },
           ],
         },
         meta: {

--- a/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import StorageForm from "../StorageForm";
 
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
@@ -24,7 +25,7 @@ describe("StorageFormFields", () => {
         loaded: true,
         items: [
           {
-            name: "default_storage_layout",
+            name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
             value: "bcache",
             choices: [
               ["bcache", "Bcache layout"],
@@ -35,15 +36,15 @@ describe("StorageFormFields", () => {
             ],
           },
           {
-            name: "enable_disk_erasing_on_release",
+            name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
             value: false,
           },
           {
-            name: "disk_erase_with_secure_erase",
+            name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE,
             value: false,
           },
           {
-            name: "disk_erase_with_quick_erase",
+            name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE,
             value: false,
           },
         ],

--- a/src/app/store/config/reducers.test.ts
+++ b/src/app/store/config/reducers.test.ts
@@ -1,5 +1,6 @@
 import reducers from "./slice";
 
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -47,9 +48,12 @@ describe("config reducer", () => {
         {
           type: "config/fetchSuccess",
           payload: [
-            configFactory({ name: "default_storage_layout", value: "bcache" }),
             configFactory({
-              name: "enable_disk_erasing_on_release",
+              name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
+              value: "bcache",
+            }),
+            configFactory({
+              name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
               value: "foo",
             }),
           ],
@@ -61,9 +65,12 @@ describe("config reducer", () => {
         loaded: true,
         saving: false,
         items: [
-          configFactory({ name: "default_storage_layout", value: "bcache" }),
           configFactory({
-            name: "enable_disk_erasing_on_release",
+            name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
+            value: "bcache",
+          }),
+          configFactory({
+            name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
             value: "foo",
           }),
         ],
@@ -105,12 +112,15 @@ describe("config reducer", () => {
           saving: true,
           saved: false,
           items: [
-            configFactory({ name: "default_storage_layout", value: "bcache" }),
+            configFactory({
+              name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
+              value: "bcache",
+            }),
           ],
         }),
         {
           type: "config/updateSuccess",
-          payload: { name: "default_storage_layout", value: "flat" },
+          payload: { name: ConfigNames.DEFAULT_STORAGE_LAYOUT, value: "flat" },
         }
       )
     ).toEqual(
@@ -120,7 +130,10 @@ describe("config reducer", () => {
         saving: false,
         saved: true,
         items: [
-          configFactory({ name: "default_storage_layout", value: "bcache" }),
+          configFactory({
+            name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
+            value: "bcache",
+          }),
         ],
       })
     );
@@ -135,13 +148,16 @@ describe("config reducer", () => {
           saving: false,
           saved: true,
           items: [
-            { name: "maas_name", value: "my-maas" },
-            configFactory({ name: "default_storage_layout", value: "bcache" }),
+            configFactory({ name: ConfigNames.MAAS_NAME, value: "my-maas" }),
+            configFactory({
+              name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
+              value: "bcache",
+            }),
           ],
         }),
         {
           type: "config/updateNotify",
-          payload: { name: "default_storage_layout", value: "flat" },
+          payload: { name: ConfigNames.DEFAULT_STORAGE_LAYOUT, value: "flat" },
         }
       )
     ).toEqual(
@@ -151,8 +167,8 @@ describe("config reducer", () => {
         saving: false,
         saved: true,
         items: [
-          { name: "maas_name", value: "my-maas" },
-          { name: "default_storage_layout", value: "flat" },
+          { name: ConfigNames.MAAS_NAME, value: "my-maas" },
+          { name: ConfigNames.DEFAULT_STORAGE_LAYOUT, value: "flat" },
         ],
       })
     );

--- a/src/app/store/config/selectors.test.ts
+++ b/src/app/store/config/selectors.test.ts
@@ -1,5 +1,6 @@
 import config from "./selectors";
 
+import { ConfigNames } from "app/store/config/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -68,7 +69,10 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "default_storage_layout", value: "bcache" }),
+            configFactory({
+              name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
+              value: "bcache",
+            }),
           ],
         }),
       });
@@ -82,7 +86,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "default_storage_layout",
+              name: ConfigNames.DEFAULT_STORAGE_LAYOUT,
               value: "bcache",
               choices: [
                 ["bcache", "Bcache layout"],
@@ -111,7 +115,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "enable_disk_erasing_on_release",
+              name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
               value: "foo",
             }),
           ],
@@ -127,7 +131,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "disk_erase_with_secure_erase",
+              name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE,
               value: "bar",
             }),
           ],
@@ -143,7 +147,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "disk_erase_with_quick_erase",
+              name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE,
               value: "baz",
             }),
           ],
@@ -157,7 +161,9 @@ describe("config selectors", () => {
     it("returns MAAS config for http proxy", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "http_proxy", value: "foo" })],
+          items: [
+            configFactory({ name: ConfigNames.HTTP_PROXY, value: "foo" }),
+          ],
         }),
       });
       expect(config.httpProxy(state)).toBe("foo");
@@ -168,7 +174,12 @@ describe("config selectors", () => {
     it("returns MAAS config for enabling httpProxy", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "enable_http_proxy", value: "bar" })],
+          items: [
+            configFactory({
+              name: ConfigNames.ENABLE_HTTP_PROXY,
+              value: "bar",
+            }),
+          ],
         }),
       });
       expect(config.enableHttpProxy(state)).toBe("bar");
@@ -179,7 +190,9 @@ describe("config selectors", () => {
     it("returns MAAS config for enabling peer proxy", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "use_peer_proxy", value: "baz" })],
+          items: [
+            configFactory({ name: ConfigNames.USE_PEER_PROXY, value: "baz" }),
+          ],
         }),
       });
       expect(config.usePeerProxy(state)).toBe("baz");
@@ -190,7 +203,12 @@ describe("config selectors", () => {
     it("returns 'noProxy' if enable_http_proxy is false", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "enable_http_proxy", value: false })],
+          items: [
+            configFactory({
+              name: ConfigNames.ENABLE_HTTP_PROXY,
+              value: false,
+            }),
+          ],
         }),
       });
       expect(config.proxyType(state)).toBe("noProxy");
@@ -200,8 +218,8 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "enable_http_proxy", value: true }),
-            configFactory({ name: "http_proxy", value: "" }),
+            configFactory({ name: ConfigNames.ENABLE_HTTP_PROXY, value: true }),
+            configFactory({ name: ConfigNames.HTTP_PROXY, value: "" }),
           ],
         }),
       });
@@ -212,8 +230,11 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "enable_http_proxy", value: true }),
-            configFactory({ name: "http_proxy", value: "http://www.url.com" }),
+            configFactory({ name: ConfigNames.ENABLE_HTTP_PROXY, value: true }),
+            configFactory({
+              name: ConfigNames.HTTP_PROXY,
+              value: "http://www.url.com",
+            }),
           ],
         }),
       });
@@ -224,9 +245,12 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "enable_http_proxy", value: true }),
-            configFactory({ name: "http_proxy", value: "http://www.url.com" }),
-            configFactory({ name: "use_peer_proxy", value: true }),
+            configFactory({ name: ConfigNames.ENABLE_HTTP_PROXY, value: true }),
+            configFactory({
+              name: ConfigNames.HTTP_PROXY,
+              value: "http://www.url.com",
+            }),
+            configFactory({ name: ConfigNames.USE_PEER_PROXY, value: true }),
           ],
         }),
       });
@@ -238,7 +262,12 @@ describe("config selectors", () => {
     it("returns MAAS config for maas name", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "maas_name", value: "bionic-maas" })],
+          items: [
+            configFactory({
+              name: ConfigNames.MAAS_NAME,
+              value: "bionic-maas",
+            }),
+          ],
         }),
       });
       expect(config.maasName(state)).toBe("bionic-maas");
@@ -249,7 +278,9 @@ describe("config selectors", () => {
     it("returns MAAS config for enable analytics", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "enable_analytics", value: true })],
+          items: [
+            configFactory({ name: ConfigNames.ENABLE_ANALYTICS, value: true }),
+          ],
         }),
       });
       expect(config.analyticsEnabled(state)).toBe(true);
@@ -257,12 +288,12 @@ describe("config selectors", () => {
   });
 
   describe("commissioningDistroSeries", () => {
-    it("returns MAAS config for default distro series", () => {
+    it("returns MAAS config for commissioning distro series", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
             configFactory({
-              name: "commissioning_distro_series",
+              name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
               value: "bionic",
             }),
           ],
@@ -278,7 +309,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "commissioning_distro_series",
+              name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
               value: "bionic",
               choices: [["bionic", "Ubuntu 18.04 LTS 'Bionic-Beaver'"]],
             }),
@@ -298,7 +329,12 @@ describe("config selectors", () => {
     it("returns MAAS config for default kernel version", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "default_min_hwe_kernel", value: "" })],
+          items: [
+            configFactory({
+              name: ConfigNames.DEFAULT_MIN_HWE_KERNEL,
+              value: "",
+            }),
+          ],
         }),
       });
       expect(config.defaultMinKernelVersion(state)).toBe("");
@@ -309,7 +345,9 @@ describe("config selectors", () => {
     it("returns MAAS config for kernel parameters", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "kernel_opts", value: "foo" })],
+          items: [
+            configFactory({ name: ConfigNames.KERNEL_OPTS, value: "foo" }),
+          ],
         }),
       });
       expect(config.kernelParams(state)).toBe("foo");
@@ -321,7 +359,10 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "windows_kms_host", value: "127.0.0.1" }),
+            configFactory({
+              name: ConfigNames.WINDOWS_KMS_HOST,
+              value: "127.0.0.1",
+            }),
           ],
         }),
       });
@@ -334,7 +375,10 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "vcenter_server", value: "my server" }),
+            configFactory({
+              name: ConfigNames.VCENTER_SERVER,
+              value: "my server",
+            }),
           ],
         }),
       });
@@ -346,7 +390,12 @@ describe("config selectors", () => {
     it("returns vCenter username", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "vcenter_username", value: "admin" })],
+          items: [
+            configFactory({
+              name: ConfigNames.VCENTER_USERNAME,
+              value: "admin",
+            }),
+          ],
         }),
       });
       expect(config.vCenterUsername(state)).toBe("admin");
@@ -357,7 +406,12 @@ describe("config selectors", () => {
     it("returns vCenter password", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "vcenter_password", value: "passwd" })],
+          items: [
+            configFactory({
+              name: ConfigNames.VCENTER_PASSWORD,
+              value: "passwd",
+            }),
+          ],
         }),
       });
       expect(config.vCenterPassword(state)).toBe("passwd");
@@ -370,7 +424,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "vcenter_datacenter",
+              name: ConfigNames.VCENTER_DATACENTER,
               value: "my datacenter",
             }),
           ],
@@ -385,7 +439,10 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "enable_third_party_drivers", value: true }),
+            configFactory({
+              name: ConfigNames.ENABLE_THIRD_PARTY_DRIVERS,
+              value: true,
+            }),
           ],
         }),
       });
@@ -397,7 +454,12 @@ describe("config selectors", () => {
     it("returns MAAS config for default OS", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "default_osystem", value: "bionic" })],
+          items: [
+            configFactory({
+              name: ConfigNames.DEFAULT_OSYSTEM,
+              value: "bionic",
+            }),
+          ],
         }),
       });
       expect(config.defaultOSystem(state)).toBe("bionic");
@@ -410,7 +472,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "default_osystem",
+              name: ConfigNames.DEFAULT_OSYSTEM,
               value: "ubuntu",
               choices: [
                 ["centos", "CentOS"],
@@ -438,7 +500,10 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "default_distro_series", value: "bionic" }),
+            configFactory({
+              name: ConfigNames.DEFAULT_DISTRO_SERIES,
+              value: "bionic",
+            }),
           ],
         }),
       });
@@ -450,7 +515,9 @@ describe("config selectors", () => {
     it("returns MAAS config for completed intro", () => {
       const state = rootStateFactory({
         config: configStateFactory({
-          items: [configFactory({ name: "completed_intro", value: true })],
+          items: [
+            configFactory({ name: ConfigNames.COMPLETED_INTRO, value: true }),
+          ],
         }),
       });
       expect(config.completedIntro(state)).toBe(true);
@@ -458,11 +525,14 @@ describe("config selectors", () => {
   });
 
   describe("releaseNotifications", () => {
-    it("returns MAAS config for completed intro", () => {
+    it("returns MAAS config for release notifications", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "release_notifications", value: true }),
+            configFactory({
+              name: ConfigNames.RELEASE_NOTIFICATIONS,
+              value: true,
+            }),
           ],
         }),
       });
@@ -475,7 +545,10 @@ describe("config selectors", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
-            configFactory({ name: "boot_images_auto_import", value: true }),
+            configFactory({
+              name: ConfigNames.BOOT_IMAGES_AUTO_IMPORT,
+              value: true,
+            }),
           ],
         }),
       });
@@ -484,12 +557,12 @@ describe("config selectors", () => {
   });
 
   describe("maasUrl", () => {
-    it("returns MAAS config for boot images auto import", () => {
+    it("returns MAAS config for MAAS URL", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
             configFactory({
-              name: "maas_url",
+              name: ConfigNames.MAAS_URL,
               value: "http://1.2.3.4/MAAS",
             }),
           ],
@@ -500,12 +573,12 @@ describe("config selectors", () => {
   });
 
   describe("rpcSharedSecret", () => {
-    it("returns MAAS config for boot images auto import", () => {
+    it("returns MAAS config for RPC shared secret", () => {
       const state = rootStateFactory({
         config: configStateFactory({
           items: [
             configFactory({
-              name: "rpc_shared_secret",
+              name: ConfigNames.RPC_SHARED_SECRET,
               value: "veryverysecret",
             }),
           ],
@@ -521,7 +594,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "tls_cert_expiration_notification_enabled",
+              name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED,
               value: true,
             }),
           ],
@@ -537,7 +610,7 @@ describe("config selectors", () => {
         config: configStateFactory({
           items: [
             configFactory({
-              name: "tls_cert_expiration_notification_interval",
+              name: ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL,
               value: 45,
             }),
           ],

--- a/src/app/store/config/selectors.ts
+++ b/src/app/store/config/selectors.ts
@@ -8,6 +8,7 @@ import type {
   ConfigValues,
   NetworkDiscovery,
 } from "app/store/config/types";
+import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 import type { StorageLayout } from "app/store/types/enum";
 /**
@@ -107,7 +108,7 @@ const saved = (state: RootState): boolean => state.config.saved;
  * @returns Default storage layout.
  */
 const defaultStorageLayout = createSelector([all], (configs) =>
-  getValueFromName<StorageLayout>(configs, "default_storage_layout")
+  getValueFromName<StorageLayout>(configs, ConfigNames.DEFAULT_STORAGE_LAYOUT)
 );
 
 /**
@@ -116,7 +117,7 @@ const defaultStorageLayout = createSelector([all], (configs) =>
  * @returns {Option[]} Storage layout options.
  */
 const storageLayoutOptions = createSelector([all], (configs) =>
-  getOptionsFromName<string>(configs, "default_storage_layout")
+  getOptionsFromName<string>(configs, ConfigNames.DEFAULT_STORAGE_LAYOUT)
 );
 
 /**
@@ -125,7 +126,7 @@ const storageLayoutOptions = createSelector([all], (configs) =>
  * @returns Enable disk erasing on release.
  */
 const enableDiskErasing = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "enable_disk_erasing_on_release")
+  getValueFromName<boolean>(configs, ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE)
 );
 
 /**
@@ -134,7 +135,7 @@ const enableDiskErasing = createSelector([all], (configs) =>
  * @returns Enable disk erasing with secure erase.
  */
 const diskEraseWithSecure = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "disk_erase_with_secure_erase")
+  getValueFromName<boolean>(configs, ConfigNames.DISK_ERASE_WITH_SECURE_ERASE)
 );
 
 /**
@@ -143,7 +144,7 @@ const diskEraseWithSecure = createSelector([all], (configs) =>
  * @returns Enable disk erasing with quick erase.
  */
 const diskEraseWithQuick = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "disk_erase_with_quick_erase")
+  getValueFromName<boolean>(configs, ConfigNames.DISK_ERASE_WITH_QUICK_ERASE)
 );
 
 /**
@@ -152,7 +153,7 @@ const diskEraseWithQuick = createSelector([all], (configs) =>
  * @returns HTTP proxy.
  */
 const httpProxy = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "http_proxy")
+  getValueFromName<string>(configs, ConfigNames.HTTP_PROXY)
 );
 
 /**
@@ -161,7 +162,7 @@ const httpProxy = createSelector([all], (configs) =>
  * @returns Enable HTTP proxy.
  */
 const enableHttpProxy = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "enable_http_proxy")
+  getValueFromName<boolean>(configs, ConfigNames.ENABLE_HTTP_PROXY)
 );
 
 /**
@@ -170,7 +171,7 @@ const enableHttpProxy = createSelector([all], (configs) =>
  * @returns Use peer proxy.
  */
 const usePeerProxy = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "use_peer_proxy")
+  getValueFromName<boolean>(configs, ConfigNames.USE_PEER_PROXY)
 );
 
 /**
@@ -202,7 +203,7 @@ const proxyType = createSelector(
  * @returns Then MAAS name.
  */
 const maasName = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "maas_name")
+  getValueFromName<string>(configs, ConfigNames.MAAS_NAME)
 );
 
 /**
@@ -211,7 +212,7 @@ const maasName = createSelector([all], (configs) =>
  * @returns Then MAAS uuid.
  */
 const uuid = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "uuid")
+  getValueFromName<string>(configs, ConfigNames.UUID)
 );
 
 /**
@@ -220,7 +221,7 @@ const uuid = createSelector([all], (configs) =>
  * @returns Enable analytics.
  */
 const analyticsEnabled = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "enable_analytics")
+  getValueFromName<boolean>(configs, ConfigNames.ENABLE_ANALYTICS)
 );
 
 /**
@@ -229,7 +230,7 @@ const analyticsEnabled = createSelector([all], (configs) =>
  * @returns Default distro series.
  */
 const commissioningDistroSeries = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "commissioning_distro_series")
+  getValueFromName<string>(configs, ConfigNames.COMMISSIONING_DISTRO_SERIES)
 );
 
 /**
@@ -238,7 +239,7 @@ const commissioningDistroSeries = createSelector([all], (configs) =>
  * @returns {Option[]} Distro series options.
  */
 const distroSeriesOptions = createSelector([all], (configs) =>
-  getOptionsFromName<string>(configs, "commissioning_distro_series")
+  getOptionsFromName<string>(configs, ConfigNames.COMMISSIONING_DISTRO_SERIES)
 );
 
 /**
@@ -247,7 +248,7 @@ const distroSeriesOptions = createSelector([all], (configs) =>
  * @returns Default min kernal version.
  */
 const defaultMinKernelVersion = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "default_min_hwe_kernel")
+  getValueFromName<string>(configs, ConfigNames.DEFAULT_MIN_HWE_KERNEL)
 );
 
 /**
@@ -256,7 +257,7 @@ const defaultMinKernelVersion = createSelector([all], (configs) =>
  * @returns DNSSEC validation type.
  */
 const dnssecValidation = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "dnssec_validation")
+  getValueFromName<string>(configs, ConfigNames.DNSSEC_VALIDATION)
 );
 
 /**
@@ -265,7 +266,7 @@ const dnssecValidation = createSelector([all], (configs) =>
  * @returns {Option[]} DNSSEC validation options.
  */
 const dnssecOptions = createSelector([all], (configs) =>
-  getOptionsFromName<string>(configs, "dnssec_validation")
+  getOptionsFromName<string>(configs, ConfigNames.DNSSEC_VALIDATION)
 );
 
 /**
@@ -274,7 +275,7 @@ const dnssecOptions = createSelector([all], (configs) =>
  * @returns External networks.
  */
 const dnsTrustedAcl = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "dns_trusted_acl")
+  getValueFromName<string>(configs, ConfigNames.DNS_TRUSTED_ACL)
 );
 
 /**
@@ -283,7 +284,7 @@ const dnsTrustedAcl = createSelector([all], (configs) =>
  * @returns Upstream DNS(s).
  */
 const upstreamDns = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "upstream_dns")
+  getValueFromName<string>(configs, ConfigNames.UPSTREAM_DNS)
 );
 
 /**
@@ -292,7 +293,7 @@ const upstreamDns = createSelector([all], (configs) =>
  * @returns NTP server(s).
  */
 const ntpServers = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "ntp_servers")
+  getValueFromName<string>(configs, ConfigNames.NTP_SERVERS)
 );
 
 /**
@@ -301,7 +302,7 @@ const ntpServers = createSelector([all], (configs) =>
  * @returns Enable external NTP servers only.
  */
 const ntpExternalOnly = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "ntp_external_only")
+  getValueFromName<boolean>(configs, ConfigNames.NTP_EXTERNAL_ONLY)
 );
 
 /**
@@ -310,7 +311,7 @@ const ntpExternalOnly = createSelector([all], (configs) =>
  * @returns Remote syslog server.
  */
 const remoteSyslog = createSelector([all], (configs) =>
-  getValueFromName<string | null>(configs, "remote_syslog")
+  getValueFromName<string | null>(configs, ConfigNames.REMOTE_SYSLOG)
 );
 
 /**
@@ -319,7 +320,7 @@ const remoteSyslog = createSelector([all], (configs) =>
  * @returns Enable network discovery.
  */
 const networkDiscovery = createSelector([all], (configs) =>
-  getValueFromName<NetworkDiscovery>(configs, "network_discovery")
+  getValueFromName<NetworkDiscovery>(configs, ConfigNames.NETWORK_DISCOVERY)
 );
 
 /**
@@ -328,7 +329,7 @@ const networkDiscovery = createSelector([all], (configs) =>
  * @returns {Option[]} Network discovery options.
  */
 const networkDiscoveryOptions = createSelector([all], (configs) =>
-  getOptionsFromName<string>(configs, "network_discovery")
+  getOptionsFromName<string>(configs, ConfigNames.NETWORK_DISCOVERY)
 );
 
 /**
@@ -337,7 +338,7 @@ const networkDiscoveryOptions = createSelector([all], (configs) =>
  * @returns Active discovery interval in ms.
  */
 const activeDiscoveryInterval = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "active_discovery_interval")
+  getValueFromName<string>(configs, ConfigNames.ACTIVE_DISCOVERY_INTERVAL)
 );
 
 /**
@@ -346,7 +347,7 @@ const activeDiscoveryInterval = createSelector([all], (configs) =>
  * @returns {Option[]} Active discovery intervals.
  */
 const discoveryIntervalOptions = createSelector([all], (configs) =>
-  getOptionsFromName<string>(configs, "active_discovery_interval")
+  getOptionsFromName<string>(configs, ConfigNames.ACTIVE_DISCOVERY_INTERVAL)
 );
 
 /**
@@ -355,7 +356,7 @@ const discoveryIntervalOptions = createSelector([all], (configs) =>
  * @returns Kernel parameters.
  */
 const kernelParams = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "kernel_opts")
+  getValueFromName<string>(configs, ConfigNames.KERNEL_OPTS)
 );
 
 /**
@@ -364,7 +365,7 @@ const kernelParams = createSelector([all], (configs) =>
  * @returns Windows KMS host.
  */
 const windowsKmsHost = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "windows_kms_host")
+  getValueFromName<string>(configs, ConfigNames.WINDOWS_KMS_HOST)
 );
 
 /**
@@ -373,7 +374,7 @@ const windowsKmsHost = createSelector([all], (configs) =>
  * @returns - vCenter server.
  */
 const vCenterServer = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "vcenter_server")
+  getValueFromName<string>(configs, ConfigNames.VCENTER_SERVER)
 );
 
 /**
@@ -382,7 +383,7 @@ const vCenterServer = createSelector([all], (configs) =>
  * @returns - vCenter username.
  */
 const vCenterUsername = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "vcenter_username")
+  getValueFromName<string>(configs, ConfigNames.VCENTER_USERNAME)
 );
 
 /**
@@ -391,7 +392,7 @@ const vCenterUsername = createSelector([all], (configs) =>
  * @returns - vCenter password.
  */
 const vCenterPassword = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "vcenter_password")
+  getValueFromName<string>(configs, ConfigNames.VCENTER_PASSWORD)
 );
 
 /**
@@ -400,7 +401,7 @@ const vCenterPassword = createSelector([all], (configs) =>
  * @returns - vCenter datacenter.
  */
 const vCenterDatacenter = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "vcenter_datacenter")
+  getValueFromName<string>(configs, ConfigNames.VCENTER_DATACENTER)
 );
 
 /**
@@ -409,7 +410,7 @@ const vCenterDatacenter = createSelector([all], (configs) =>
  * @returns - The value of enable_third_party_drivers
  */
 const thirdPartyDriversEnabled = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "enable_third_party_drivers")
+  getValueFromName<boolean>(configs, ConfigNames.ENABLE_THIRD_PARTY_DRIVERS)
 );
 
 /**
@@ -418,7 +419,7 @@ const thirdPartyDriversEnabled = createSelector([all], (configs) =>
  * @returns Default OS.
  */
 const defaultOSystem = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "default_osystem")
+  getValueFromName<string>(configs, ConfigNames.DEFAULT_OSYSTEM)
 );
 
 /**
@@ -427,7 +428,7 @@ const defaultOSystem = createSelector([all], (configs) =>
  * @returns {Option[]} Default OS options.
  */
 const defaultOSystemOptions = createSelector([all], (configs) =>
-  getOptionsFromName<string>(configs, "default_osystem")
+  getOptionsFromName<string>(configs, ConfigNames.DEFAULT_OSYSTEM)
 );
 
 /**
@@ -436,7 +437,7 @@ const defaultOSystemOptions = createSelector([all], (configs) =>
  * @returns Default distro series.
  */
 const defaultDistroSeries = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "default_distro_series")
+  getValueFromName<string>(configs, ConfigNames.DEFAULT_DISTRO_SERIES)
 );
 
 /**
@@ -445,7 +446,7 @@ const defaultDistroSeries = createSelector([all], (configs) =>
  * @returns Default IPMI user.
  */
 const maasAutoIpmiUser = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "maas_auto_ipmi_user")
+  getValueFromName<string>(configs, ConfigNames.MAAS_AUTO_IPMI_USER)
 );
 
 /**
@@ -456,7 +457,7 @@ const maasAutoIpmiUser = createSelector([all], (configs) =>
 const maasAutoUserPrivilegeLevel = createSelector([all], (configs) =>
   getValueFromName<AutoIpmiPrivilegeLevel>(
     configs,
-    "maas_auto_ipmi_user_privilege_level"
+    ConfigNames.MAAS_AUTO_IPMI_USER_PRIVILEGE_LEVEL
   )
 );
 
@@ -466,7 +467,7 @@ const maasAutoUserPrivilegeLevel = createSelector([all], (configs) =>
  * @returns BMC key.
  */
 const maasAutoIpmiKGBmcKey = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "maas_auto_ipmi_k_g_bmc_key")
+  getValueFromName<string>(configs, ConfigNames.MAAS_AUTO_IPMI_K_G_BMC_KEY)
 );
 
 /**
@@ -475,7 +476,7 @@ const maasAutoIpmiKGBmcKey = createSelector([all], (configs) =>
  * @returns MAAS url.
  */
 const maasUrl = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "maas_url")
+  getValueFromName<string>(configs, ConfigNames.MAAS_URL)
 );
 
 /**
@@ -484,7 +485,7 @@ const maasUrl = createSelector([all], (configs) =>
  * @returns Whether the intro has been completed
  */
 const completedIntro = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "completed_intro")
+  getValueFromName<boolean>(configs, ConfigNames.COMPLETED_INTRO)
 );
 
 /**
@@ -493,7 +494,7 @@ const completedIntro = createSelector([all], (configs) =>
  * @returns Whether the release notifications are enabled.
  */
 const releaseNotifications = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "release_notifications")
+  getValueFromName<boolean>(configs, ConfigNames.RELEASE_NOTIFICATIONS)
 );
 
 /**
@@ -502,7 +503,7 @@ const releaseNotifications = createSelector([all], (configs) =>
  * @returns RPC shared secret.
  */
 const rpcSharedSecret = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "rpc_shared_secret")
+  getValueFromName<string>(configs, ConfigNames.RPC_SHARED_SECRET)
 );
 
 /**
@@ -511,11 +512,11 @@ const rpcSharedSecret = createSelector([all], (configs) =>
  * @returns Whether the release notifications are enabled.
  */
 const bootImagesAutoImport = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "boot_images_auto_import")
+  getValueFromName<boolean>(configs, ConfigNames.BOOT_IMAGES_AUTO_IMPORT)
 );
 
 const hardwareSyncInterval = createSelector([all], (configs) =>
-  getValueFromName<TimeSpan>(configs, "hardware_sync_interval")
+  getValueFromName<TimeSpan>(configs, ConfigNames.HARDWARE_SYNC_INTERVAL)
 );
 
 /**
@@ -524,7 +525,10 @@ const hardwareSyncInterval = createSelector([all], (configs) =>
  * @returns Whether the TLS expiration notification is enabled.
  */
 const tlsCertExpirationNotificationEnabled = createSelector([all], (configs) =>
-  getValueFromName<boolean>(configs, "tls_cert_expiration_notification_enabled")
+  getValueFromName<boolean>(
+    configs,
+    ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED
+  )
 );
 
 /**
@@ -533,7 +537,10 @@ const tlsCertExpirationNotificationEnabled = createSelector([all], (configs) =>
  * @returns The interval in which to show TLS expiration notification.
  */
 const tlsCertExpirationNotificationInterval = createSelector([all], (configs) =>
-  getValueFromName<Days>(configs, "tls_cert_expiration_notification_interval")
+  getValueFromName<Days>(
+    configs,
+    ConfigNames.TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL
+  )
 );
 
 const config = {

--- a/src/app/store/config/types/base.ts
+++ b/src/app/store/config/types/base.ts
@@ -1,3 +1,5 @@
+import type { ConfigNames } from "./enum";
+
 import type { APIError } from "app/base/types";
 import type { GenericState } from "app/store/types/state";
 
@@ -6,7 +8,7 @@ export type ConfigChoice = [string | number, string];
 export type ConfigValues = boolean | null | number | string;
 
 export type Config<V> = {
-  name: string;
+  name: ConfigNames;
   value: V;
   choices?: ConfigChoice[];
 };

--- a/src/app/store/config/types/enum.ts
+++ b/src/app/store/config/types/enum.ts
@@ -4,13 +4,78 @@ export enum AutoIpmiPrivilegeLevel {
   USER = "USER",
 }
 
+export enum ConfigMeta {
+  MODEL = "config",
+}
+
+export enum ConfigNames {
+  ACTIVE_DISCOVERY_INTERVAL = "active_discovery_interval",
+  BOOT_IMAGES_AUTO_IMPORT = "boot_images_auto_import",
+  BOOT_IMAGES_NO_PROXY = "boot_images_no_proxy",
+  COMMISSIONING_DISTRO_SERIES = "commissioning_distro_series",
+  COMPLETED_INTRO = "completed_intro",
+  CURTIN_VERBOSE = "curtin_verbose",
+  DEFAULT_DISTRO_SERIES = "default_distro_series",
+  DEFAULT_DNS_TTL = "default_dns_ttl",
+  DEFAULT_MIN_HWE_KERNEL = "default_min_hwe_kernel",
+  DEFAULT_OSYSTEM = "default_osystem",
+  DEFAULT_STORAGE_LAYOUT = "default_storage_layout",
+  DISK_ERASE_WITH_QUICK_ERASE = "disk_erase_with_quick_erase",
+  DISK_ERASE_WITH_SECURE_ERASE = "disk_erase_with_secure_erase",
+  DNS_TRUSTED_ACL = "dns_trusted_acl",
+  DNSSEC_VALIDATION = "dnssec_validation",
+  ENABLE_ANALYTICS = "enable_analytics",
+  ENABLE_DISK_ERASING_ON_RELEASE = "enable_disk_erasing_on_release",
+  ENABLE_HTTP_PROXY = "enable_http_proxy",
+  ENABLE_THIRD_PARTY_DRIVERS = "enable_third_party_drivers",
+  ENLIST_COMMISSIONING = "enlist_commissioning",
+  FORCE_V1_NETWORK_YAML = "force_v1_network_yaml",
+  HARDWARE_SYNC_INTERVAL = "hardware_sync_interval",
+  HTTP_PROXY = "http_proxy",
+  KERNEL_OPTS = "kernel_opts",
+  MAAS_AUTO_IPMI_CIPHER_SUITE_ID = "maas_auto_ipmi_cipher_suite_id",
+  MAAS_AUTO_IPMI_K_G_BMC_KEY = "maas_auto_ipmi_k_g_bmc_key",
+  MAAS_AUTO_IPMI_USER = "maas_auto_ipmi_user",
+  MAAS_AUTO_IPMI_USER_PRIVILEGE_LEVEL = "maas_auto_ipmi_user_privilege_level",
+  MAAS_AUTO_IPMI_WORKAROUND_FLAGS = "maas_auto_ipmi_workaround_flags",
+  MAAS_INTERNAL_DOMAIN = "maas_internal_domain",
+  MAAS_NAME = "maas_name",
+  MAAS_PROXY_PORT = "maas_proxy_port",
+  MAAS_SYSLOG_PORT = "maas_syslog_port",
+  MAAS_URL = "maas_url",
+  MAX_NODE_COMMISSIONING_RESULTS = "max_node_commissioning_results",
+  MAX_NODE_INSTALLATION_RESULTS = "max_node_installation_results",
+  MAX_NODE_TESTING_RESULTS = "max_node_testing_results",
+  NETWORK_DISCOVERY = "network_discovery",
+  NODE_TIMEOUT = "node_timeout",
+  NTP_EXTERNAL_ONLY = "ntp_external_only",
+  NTP_SERVERS = "ntp_servers",
+  PREFER_V4_PROXY = "prefer_v4_proxy",
+  PROMETHEUS_ENABLED = "prometheus_enabled",
+  PROMETHEUS_PUSH_GATEWAY = "prometheus_push_gateway",
+  PROMETHEUS_PUSH_INTERVAL = "prometheus_push_interval",
+  PROMTAIL_ENABLED = "promtail_enabled",
+  PROMTAIL_PORT = "promtail_port",
+  RELEASE_NOTIFICATIONS = "release_notifications",
+  REMOTE_SYSLOG = "remote_syslog",
+  RPC_SHARED_SECRET = "rpc_shared_secret",
+  SUBNET_IP_EXHAUSTION_THRESHOLD_COUNT = "subnet_ip_exhaustion_threshold_count",
+  TLS_CERT_EXPIRATION_NOTIFICATION_ENABLED = "tls_cert_expiration_notification_enabled",
+  TLS_CERT_EXPIRATION_NOTIFICATION_INTERVAL = "tls_cert_expiration_notification_interval",
+  UPSTREAM_DNS = "upstream_dns",
+  USE_PEER_PROXY = "use_peer_proxy",
+  USE_RACK_PROXY = "use_rack_proxy",
+  UUID = "uuid",
+  VCENTER_DATACENTER = "vcenter_datacenter",
+  VCENTER_PASSWORD = "vcenter_password",
+  VCENTER_SERVER = "vcenter_server",
+  VCENTER_USERNAME = "vcenter_username",
+  WINDOWS_KMS_HOST = "windows_kms_host",
+}
+
 export enum NetworkDiscovery {
   DISABLED = "disabled",
   ENABLED = "enabled",
-}
-
-export enum ConfigMeta {
-  MODEL = "config",
 }
 
 export enum TLSExpiryNotificationInterval {

--- a/src/app/store/config/types/index.ts
+++ b/src/app/store/config/types/index.ts
@@ -3,6 +3,7 @@ export type { Config, ConfigChoice, ConfigState, ConfigValues } from "./base";
 export {
   AutoIpmiPrivilegeLevel,
   ConfigMeta,
+  ConfigNames,
   NetworkDiscovery,
   TLSExpiryNotificationInterval,
 } from "./enum";

--- a/src/app/store/notification/selectors.test.ts
+++ b/src/app/store/notification/selectors.test.ts
@@ -1,5 +1,6 @@
 import notification from "./selectors";
 
+import { ConfigNames } from "app/store/config/types";
 import { NotificationIdent } from "app/store/notification/types";
 import {
   config as configFactory,
@@ -26,7 +27,12 @@ describe("notification selectors", () => {
   it("can get all enabled items", () => {
     const state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: false })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: false,
+          }),
+        ],
       }),
       notification: notificationStateFactory({
         items: [
@@ -48,7 +54,12 @@ describe("notification selectors", () => {
   it("does not include release notifications if the config is off", () => {
     const state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: false })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: false,
+          }),
+        ],
       }),
       notification: notificationStateFactory({
         items: [
@@ -70,7 +81,12 @@ describe("notification selectors", () => {
   it("does not include release notifications for some paths", () => {
     const state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: true })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: true,
+          }),
+        ],
       }),
       notification: notificationStateFactory({
         items: [
@@ -96,7 +112,12 @@ describe("notification selectors", () => {
     ];
     const state = rootStateFactory({
       config: configStateFactory({
-        items: [configFactory({ name: "release_notifications", value: true })],
+        items: [
+          configFactory({
+            name: ConfigNames.RELEASE_NOTIFICATIONS,
+            value: true,
+          }),
+        ],
       }),
       notification: notificationStateFactory({
         items: notifications,

--- a/src/testing/factories/config.ts
+++ b/src/testing/factories/config.ts
@@ -1,8 +1,9 @@
 import { define } from "cooky-cutter";
 
 import type { Config, ConfigValues } from "app/store/config/types";
+import { ConfigNames } from "app/store/config/types";
 
 export const config = define<Config<ConfigValues>>({
-  name: "test name",
-  value: null,
+  name: ConfigNames.MAAS_NAME,
+  value: "maas",
 });


### PR DESCRIPTION
## Done

- Create an enum for config names and use throughout the app

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes canonical-web-and-design/app-tribe#1044
