### PR TITLE
fix: render datastore actions for VMFS7 layout

### DIFF
--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/BulkActions.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/BulkActions.test.tsx
@@ -105,12 +105,12 @@ describe("BulkActions", () => {
     ).toBe(false);
   });
 
-  it("renders VMFS6 bulk actions if the detected layout is VMFS6", () => {
+  it("renders datastore bulk actions if the detected layout is a VMWare layout", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
           machineDetailsFactory({
-            detected_storage_layout: StorageLayout.VMFS6,
+            detected_storage_layout: StorageLayout.VMFS7,
             system_id: "abc123",
           }),
         ],
@@ -135,7 +135,7 @@ describe("BulkActions", () => {
       </Provider>
     );
 
-    expect(wrapper.find("[data-testid='vmfs6-bulk-actions']").exists()).toBe(
+    expect(wrapper.find("[data-testid='vmware-bulk-actions']").exists()).toBe(
       true
     );
   });

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/BulkActions.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/BulkActions.tsx
@@ -12,13 +12,13 @@ import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
-import { StorageLayout } from "app/store/types/enum";
 import type { Disk, Partition } from "app/store/types/node";
 import {
   canCreateOrUpdateDatastore,
   canCreateRaid,
   canCreateVolumeGroup,
   isDatastore,
+  isVMWareLayout,
 } from "app/store/utils";
 
 type Props = {
@@ -82,7 +82,7 @@ const BulkActions = ({
     );
   }
 
-  if (machine.detected_storage_layout === StorageLayout.VMFS6) {
+  if (isVMWareLayout(machine.detected_storage_layout)) {
     const hasDatastores = machine.disks.some((disk) =>
       isDatastore(disk.filesystem)
     );
@@ -100,7 +100,7 @@ const BulkActions = ({
     return (
       <List
         className="u-no-margin--bottom"
-        data-testid="vmfs6-bulk-actions"
+        data-testid="vmware-bulk-actions"
         inline
         items={[
           <Tooltip
@@ -144,7 +144,6 @@ const BulkActions = ({
   return (
     <List
       className="u-no-margin--bottom"
-      data-testid="vmfs6-bulk-actions"
       inline
       items={[
         <Tooltip


### PR DESCRIPTION
## Done

- Fixed bug where datastore actions only showed for VMFS6 layout and not VMFS7

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready/Allocated machine whose boot disk has more than 32GB (e.g. http://bolla.internal:5240/MAAS/r/machine/xxgpsf/storage)
- Click "Change storage layout" and choose "VMFS7"
- Check that there are actions to create and add to an existing datastore below the "Available disks and partitions" table

## Fixes

Fixes #4106 
