### PR TITLE
ci: upload build to the asset server

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -7,6 +7,8 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Upload build artifacts
     runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
     strategy:
       matrix:
         node-version: [16.x]
@@ -26,11 +28,14 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
       - name: Build
-        run: yarn build-all
+        run: yarn build
         env:
           CI: true
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: maas-ui-${{ github.sha }}
-          path: build/
+      - name: Compress
+        run: tar -czf ${{env.PACKAGE_NAME}} build/
+      - name: Install upload-assets snap
+        run: sudo snap install upload-assets
+      - name: Upload to assets server
+        run: upload-assets --url-path ${{env.PACKAGE_NAME}} ${{env.PACKAGE_NAME}}
+        env:
+          UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}


### PR DESCRIPTION
## Done

- Update the publish action to push to the asset server.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1047.