### PR TITLE
Publish asset server action

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           CI: true
       - name: Compress
-      - name: Compress
+        run: cd build && tar -czf ../${{env.PACKAGE_NAME}} ./
       - name: Install upload-assets snap
         run: sudo snap install upload-assets
       - name: Upload to assets server

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -28,7 +28,7 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
       - name: Build
-        run: yarn build
+        run: CI=false yarn build
         env:
           CI: true
       - name: Compress

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           CI: true
       - name: Compress
-        run: tar -czf ${{env.PACKAGE_NAME}} build/
+      - name: Compress
       - name: Install upload-assets snap
         run: sudo snap install upload-assets
       - name: Upload to assets server

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -7,6 +7,8 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Upload build artifacts
     runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
     strategy:
       matrix:
         node-version: [16.x]
@@ -26,11 +28,14 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
       - name: Build
-        run: yarn build-all
+        run: yarn build
         env:
           CI: true
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: maas-ui-${{ github.sha }}
-          path: build/
+      - name: Compress
+        run: tar -czf ${{env.PACKAGE_NAME}} build/
+      - name: Install upload-assets snap
+        run: sudo snap install upload-assets
+      - name: Upload to assets server
+        run: upload-assets --url-path ${{env.PACKAGE_NAME}} ${{env.PACKAGE_NAME}}
+        env:
+          UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}


### PR DESCRIPTION
## Done

- Update the publish action to push to the asset server.

## QA

- View a passing run (I previously modified the action to run on this PR instead of on merge): https://github.com/canonical-web-and-design/maas-ui/runs/6975639664?check_suite_focus=true
- Open the "Upload to assets server" step and find the url of the published asset.
- Visit the URL and it should download a .tar.gz
- Check that the .tar.gz contains the built maas-ui files.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/1047.