### PR TITLE
test: add run-dotrun github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
           CI: true
 
   run-dotrun:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -90,9 +91,12 @@ jobs:
         run: /snap/bin/dotrun install
 
       - name: Build assets
-        run: /snap/bin/dotrun build
+        run: /snap/bin/dotrun --env CI=false build
 
       - name: Run dotrun
         run: |
           /snap/bin/dotrun &
-          curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8400
+
+      - name: Wait for MAAS UI to be ready
+        run: |
+          /snap/bin/dotrun wait-on-ui

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
         node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
+      - name: Install dotrun
+        uses: canonical/install-dotrun@main
       - name: Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
@@ -83,20 +85,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - name: Install dotrun
         uses: canonical/install-dotrun@main
-
       - name: Install dependencies
-        run: /snap/bin/dotrun install
-
+        run: dotrun install
       - name: Build assets
-        run: /snap/bin/dotrun --env CI=false build
-
+        run: dotrun --env CI=false build
       - name: Run dotrun
-        run: |
-          /snap/bin/dotrun &
-
+        run: dotrun &
       - name: Wait for MAAS UI to be ready
-        run: |
-          /snap/bin/dotrun wait-on-ui
+        run: dotrun wait-on-ui

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,3 +77,22 @@ jobs:
       - run: CI=false yarn build
         env:
           CI: true
+
+  run-dotrun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dotrun
+        uses: canonical/install-dotrun@main
+
+      - name: Install dependencies
+        run: /snap/bin/dotrun install
+
+      - name: Build assets
+        run: /snap/bin/dotrun build
+
+      - name: Run dotrun
+        run: |
+          /snap/bin/dotrun &
+          curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8400

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "serve-react": "BROWSER=none PORT=8401 react-scripts start",
     "serve": "yarn start",
     "show-ready": "wait-on http-get://0.0.0.0:8401 && nodemon ./scripts/proxy-ready.js",
+    "wait-on-ui": "wait-on http-get://0.0.0.0:8400/MAAS/r",
     "start": "concurrently \"yarn serve-proxy\" \"yarn serve-react\" \"yarn show-ready\"",
     "test-cypress": "start-server-and-test start '8401' serve-base 'tcp:8400' cypress-run",
     "test-ui": "TZ=UTC react-scripts test --testURL http://example.com/MAAS/r --watchAll=false",


### PR DESCRIPTION
## Done

- test: add run-dotrun github action
  - this is to prevent merging code that breaks the build via dotrun

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4131

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
