### PR TITLE
fix: initial config URL validation

### DIFF
--- a/src/app/base/validation.test.ts
+++ b/src/app/base/validation.test.ts
@@ -1,6 +1,11 @@
 import { ValidationError } from "yup";
 
-import { hostnameValidation, HostnameValidationLabel } from "./validation";
+import {
+  hostnameValidation,
+  HostnameValidationLabel,
+  UrlSchema,
+  UrlSchemaError,
+} from "./validation";
 
 describe("hostname regex", () => {
   it("handles valid characters", async () => {
@@ -40,6 +45,26 @@ describe("hostname regex", () => {
       )
     ).rejects.toStrictEqual(
       new ValidationError(HostnameValidationLabel.LengthError)
+    );
+  });
+});
+
+describe("UrlSchema", () => {
+  it("rejects invalid URLs", async () => {
+    await expect(UrlSchema.validate("test")).rejects.toStrictEqual(
+      new ValidationError(UrlSchemaError)
+    );
+  });
+
+  it("allows URLs with a TLD", async () => {
+    await expect(UrlSchema.validate("http://test.proxy")).resolves.toBe(
+      "http://test.proxy"
+    );
+  });
+
+  it("allows URLs without a TLD (e.g. test.proxy, )", async () => {
+    await expect(UrlSchema.validate("localhost:300")).resolves.toBe(
+      "localhost:300"
     );
   });
 });

--- a/src/app/base/validation.ts
+++ b/src/app/base/validation.ts
@@ -43,3 +43,17 @@ export const hostnameValidation = Yup.string()
   .matches(/^[a-zA-Z0-9]/, HostnameValidationLabel.DashStartError)
   // Validate host name does not end with a dash.
   .matches(/[a-zA-Z0-9]$/, HostnameValidationLabel.DashEndError);
+
+export const UrlSchemaError = "Must be a valid URL.";
+export const UrlSchema = Yup.string().test({
+  name: "url",
+  test: (value) => {
+    try {
+      const valid = value ? new URL(value) : false;
+      return !!valid;
+    } catch {
+      return false;
+    }
+  },
+  message: UrlSchemaError,
+});

--- a/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -125,7 +125,7 @@ describe("MaasIntro", () => {
       </Provider>
     );
     submitFormikForm(wrapper, {
-      httpProxy: "http://www.newproxy.com",
+      httpProxy: "http://localhost:3000",
       mainArchiveUrl: "http://www.newmainarchive.com",
       name: "my new maas",
       portsArchiveUrl: "http://www.newportsarchive.com",

--- a/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -20,16 +20,27 @@ import configSelectors from "app/store/config/selectors";
 import { actions as repoActions } from "app/store/packagerepository";
 import repoSelectors from "app/store/packagerepository/selectors";
 
+const UrlSchema = Yup.string().test({
+  name: "url",
+  test: (value) => {
+    try {
+      const valid = value ? new URL(value) : false;
+      return !!valid;
+    } catch {
+      return false;
+    }
+  },
+  message: "Must be a valid URL.",
+});
+
 export const MaasIntroSchema = Yup.object()
   .shape({
-    httpProxy: Yup.string().url("Must be a valid URL."),
-    mainArchiveUrl: Yup.string()
-      .url("Must be a valid URL.")
-      .required("Ubuntu archive is required."),
+    httpProxy: UrlSchema,
+    mainArchiveUrl: UrlSchema.required("Ubuntu archive is required."),
     name: Yup.string().required("MAAS name is required"),
-    portsArchiveUrl: Yup.string()
-      .url("Must be a valid URL.")
-      .required("Ubuntu extra architectures is required."),
+    portsArchiveUrl: UrlSchema.required(
+      "Ubuntu extra architectures is required."
+    ),
     upstreamDns: Yup.string(),
   })
   .defined();

--- a/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -11,6 +11,7 @@ import type { MaasIntroValues } from "./types";
 
 import FormikForm from "app/base/components/FormikForm";
 import TableConfirm from "app/base/components/TableConfirm";
+import { UrlSchema } from "app/base/validation";
 import IntroSection from "app/intro/components/IntroSection";
 import { useExitURL } from "app/intro/hooks";
 import introURLs from "app/intro/urls";
@@ -19,19 +20,6 @@ import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
 import { actions as repoActions } from "app/store/packagerepository";
 import repoSelectors from "app/store/packagerepository/selectors";
-
-const UrlSchema = Yup.string().test({
-  name: "url",
-  test: (value) => {
-    try {
-      const valid = value ? new URL(value) : false;
-      return !!valid;
-    } catch {
-      return false;
-    }
-  },
-  message: "Must be a valid URL.",
-});
 
 export const MaasIntroSchema = Yup.object()
   .shape({

--- a/src/app/settings/views/Network/ProxyForm/ProxyForm.tsx
+++ b/src/app/settings/views/Network/ProxyForm/ProxyForm.tsx
@@ -10,6 +10,7 @@ import type { ProxyFormValues } from "./types";
 
 import FormikForm from "app/base/components/FormikForm";
 import { useWindowTitle } from "app/base/hooks";
+import { UrlSchema } from "app/base/validation";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
 
@@ -17,9 +18,7 @@ const ProxySchema = Yup.object().shape({
   proxyType: Yup.string().required(),
   httpProxy: Yup.string().when("proxyType", {
     is: (val: string) => val === "externalProxy" || val === "peerProxy",
-    then: Yup.string()
-      .url("Must be a valid URL.")
-      .required("Please enter the proxy URL."),
+    then: UrlSchema.required("Please enter the proxy URL."),
   }),
 });
 


### PR DESCRIPTION
## Done

- fix: initial config URL validation

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open mass-ui using a fresh maas backend (with no configuration)
- test that input fields that accept a URL allow for entering URLs with without a TLD (e.g. `test.proxy`, `localhost:300`)

## Fixes

Fixes: #4129  

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
