### PR TITLE
fix(intro): fix navigating through intro

### DIFF
--- a/src/app/base/components/Header/Header.tsx
+++ b/src/app/base/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import {
   useNavigate,
   useLocation,
   matchPath,
+  useMatch,
 } from "react-router-dom-v5-compat";
 
 import {
@@ -22,6 +23,7 @@ import {
   useGoogleAnalytics,
 } from "app/base/hooks";
 import urls from "app/base/urls";
+import introURLs from "app/intro/urls";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 import { actions as statusActions } from "app/store/status";
@@ -172,10 +174,16 @@ export const Header = (): JSX.Element => {
   const completedUserIntro = useCompletedUserIntro();
   useGoogleAnalytics();
   const isAuthenticated = !!authUser;
-
+  const introMatch = useMatch({ path: introURLs.index, end: false });
+  const isAtIntro = !!introMatch;
   // Redirect to the intro pages if not completed.
   useEffect(() => {
-    if (configLoaded) {
+    // Check that we're not already at the intro to allow navigation through the
+    // intro pages. This is necessary beacuse this useEffect runs every time
+    // there is a navigation change as the `navigate` function is regenerated
+    // for every route change, see:
+    // https://github.com/remix-run/react-router/issues/7634
+    if (!isAtIntro && configLoaded) {
       if (!completedIntro) {
         navigate({ pathname: urls.intro.index }, { replace: true });
       } else if (isAuthenticated && !completedUserIntro) {
@@ -186,6 +194,7 @@ export const Header = (): JSX.Element => {
     completedIntro,
     completedUserIntro,
     configLoaded,
+    isAtIntro,
     isAuthenticated,
     navigate,
   ]);


### PR DESCRIPTION
## Done

- Fix the intro that wasn't navigating through the steps.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Set the intro to display in your MAAS: https://github.com/canonical-web-and-design/maas-ui/blob/main/docs/HACKING.md#show-intro.
- In the UI you should see the first screen of the intro.
- Navigate through the intro and you should see each screen (images and complete).

## Fixes

Fixes: #4127.
Fixes: #4128.