### PR TITLE
fix: proxy url required

### DIFF
--- a/cypress/e2e/with-users/intro/intro.ts
+++ b/cypress/e2e/with-users/intro/intro.ts
@@ -1,0 +1,32 @@
+import { generateMAASURL } from "../../utils";
+
+context("Intro", () => {
+  beforeEach(() => {
+    cy.login({ shouldSkipSetupIntro: false, shouldSkipIntro: false });
+    cy.visit(generateMAASURL("/"));
+    cy.waitForPageToLoad();
+  });
+
+  it("displays intro page after login", () => {
+    cy.findByRole("heading", { name: /Welcome to MAAS/i }).should("exist");
+    cy.location("pathname").should("eq", generateMAASURL("/intro"));
+  });
+
+  it("redirects to images setup after saving intro setup changes", () => {
+    cy.findByRole("heading", { name: /Welcome to MAAS/i }).should("exist");
+    cy.waitForPageToLoad();
+    cy.findByRole("button", { name: /Save/i }).click();
+
+    cy.location("pathname").should("eq", generateMAASURL("/intro/images"));
+  });
+
+  it("allows to skip the initial setup", () => {
+    cy.findByRole("heading", { name: /Welcome to MAAS/i }).should("exist");
+    cy.findByRole("button", { name: /Skip/i }).click();
+    cy.findByText(
+      /Are you sure you want to skip the initial MAAS setup?/i
+    ).should("exist");
+    cy.findByRole("button", { name: /Skip/i }).click();
+    cy.location("pathname").should("eq", generateMAASURL("/intro/user"));
+  });
+});

--- a/src/app/base/validation.test.ts
+++ b/src/app/base/validation.test.ts
@@ -8,6 +8,12 @@ import {
 } from "./validation";
 
 describe("hostname regex", () => {
+  it("is valid if undefined", async () => {
+    await expect(hostnameValidation.validate(undefined)).resolves.toBe(
+      undefined
+    );
+  });
+
   it("handles valid characters", async () => {
     await expect(hostnameValidation.validate("valid-name")).resolves.toBe(
       "valid-name"
@@ -50,6 +56,16 @@ describe("hostname regex", () => {
 });
 
 describe("UrlSchema", () => {
+  it("is valid if undefined", async () => {
+    await expect(UrlSchema.validate(undefined)).resolves.toBe(undefined);
+  });
+
+  it("is invalid if undefined when chained with .required()", async () => {
+    await expect(
+      UrlSchema.required("URL is required").validate(undefined)
+    ).rejects.toStrictEqual(new ValidationError("URL is required"));
+  });
+
   it("rejects invalid URLs", async () => {
     await expect(UrlSchema.validate("test")).rejects.toStrictEqual(
       new ValidationError(UrlSchemaError)

--- a/src/app/base/validation.ts
+++ b/src/app/base/validation.ts
@@ -45,11 +45,20 @@ export const hostnameValidation = Yup.string()
   .matches(/[a-zA-Z0-9]$/, HostnameValidationLabel.DashEndError);
 
 export const UrlSchemaError = "Must be a valid URL.";
+
+/**
+ * Validate a URL e.g. "http://example.com"
+ * If a URL is required, chain with the Yup .required() method
+ * The URL value is optional
+ */
 export const UrlSchema = Yup.string().test({
   name: "url",
   test: (value) => {
+    if (!value) {
+      return true;
+    }
     try {
-      const valid = value ? new URL(value) : false;
+      const valid = new URL(value);
       return !!valid;
     } catch {
       return false;


### PR DESCRIPTION
## Done

- make url optional by default in `UrlSchema`
- add e2e tests to intro pages

## Why
- Yup `test` is inconsistent with `.matches` and doesn't allow empty values when not `.required()`
- The test needs to return true if a falsy value is passed to workaround this

https://github.com/jquense/yup/issues/1055

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open with MAAS with no prior configuration
- Login, on the intro page make sure entering the value for proxy is optional

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4147
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4149

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
