### PR TITLE
fix: ip hidden instead of subnet

### DIFF
--- a/cypress/e2e/with-users/machines/details.spec.ts
+++ b/cypress/e2e/with-users/machines/details.spec.ts
@@ -1,0 +1,27 @@
+import { generateMAASURL } from "../../utils";
+
+context("Machine details", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateMAASURL("/machines"));
+  });
+
+  it("hides the subnet column on small screens", () => {
+    cy.findByRole("grid").within(() => {
+      cy.findAllByRole("gridcell", { name: /FQDN/i })
+        .first()
+        .within(() => cy.findByRole("link").click());
+    });
+    cy.findByRole("link", { name: "Network" }).click();
+
+    cy.findAllByRole("columnheader", { name: /IP/i }).first().should("exist");
+    cy.findByRole("columnheader", { name: /subnet/i })
+      .first()
+      .should("exist");
+
+    cy.viewport("ipad-mini", "landscape");
+
+    cy.findAllByRole("columnheader", { name: /IP/i }).first().should("exist");
+    cy.findByRole("columnheader", { name: /subnet/i }).should("not.exist");
+  });
+});

--- a/src/app/base/components/node/networking/NetworkTable/_index.scss
+++ b/src/app/base/components/node/networking/NetworkTable/_index.scss
@@ -22,10 +22,10 @@
         @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
       }
       &:nth-child(6) {
-        @include breakpoint-widths(0, 0, 0.17, 0.13, 0.12, true);
+        @include breakpoint-widths(0, 0, 0, 0.13, 0.12, true);
       }
       &:nth-child(7) {
-        @include breakpoint-widths(0, 0, 0, 0.13, 0.13, true);
+        @include breakpoint-widths(0, 0, 0.17, 0.13, 0.13, true);
       }
       &:nth-child(8) {
         @include breakpoint-widths(0, 0, 0, 0, 0.14, true);
@@ -52,10 +52,10 @@
         @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
       }
       &:nth-child(6) {
-        @include breakpoint-widths(0, 0, 0.17, 0.13, 0.12, true);
+        @include breakpoint-widths(0, 0, 0, 0.13, 0.12, true);
       }
       &:nth-child(7) {
-        @include breakpoint-widths(0, 0, 0, 0.12, 0.11, true);
+        @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
       }
       &:nth-child(8) {
         @include breakpoint-widths(0, 0, 0, 0, 0.12, true);

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -853,6 +853,7 @@ export const MachineListTable = ({
   return (
     <>
       <MainTable
+        aria-label="Machines"
         className={classNames("p-table-expanding--light", "machine-list", {
           "machine-list--grouped": grouping !== "none",
         })}


### PR DESCRIPTION
## Done

- fix: ip hidden instead of subnet
- add machine details e2e test

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Got o machine details page
- Resize the window and make sure the subnet column disappears instead of IP on medium screen size

## Fixes

Fixes: #1868 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/7452681/175275145-da797713-9f30-45fe-820a-19af8f3b9d1f.png)
### After
![image](https://user-images.githubusercontent.com/7452681/175275174-dc051188-2503-4e9f-b6b7-b011b6edfd33.png)
