### PR TITLE
fix(ui): machine details routes

### DIFF
--- a/cypress/e2e/utils.ts
+++ b/cypress/e2e/utils.ts
@@ -15,6 +15,8 @@ export const generateMac = () =>
 export const generateEmail = () => `${nanoid()}@example.com`;
 export const generateId = () => nanoid();
 export const generateVid = () => `${Math.floor(Math.random() * 1000)}`;
+export const generateName = (name?: string) =>
+  `cy-${name ? `${name}-` : ""}${generateId()}`;
 
 export const generateMAASURL = (route?: string): string =>
   `${Cypress.env("BASENAME")}${Cypress.env("REACT_BASENAME")}${route || ""}`;

--- a/cypress/e2e/with-users/machines/details.spec.ts
+++ b/cypress/e2e/with-users/machines/details.spec.ts
@@ -1,10 +1,24 @@
 import { generateMAASURL } from "../../utils";
+import { generateName, generateMac } from "../../utils";
 
 context("Machine details", () => {
   beforeEach(() => {
     cy.login();
     cy.visit(generateMAASURL("/machines"));
   });
+
+  const completeAddMachineForm = () => {
+    const name = generateName("machine");
+    cy.findByRole("button", { name: /Add hardware/i }).click();
+    cy.findByLabelText("submenu").within(() => {
+      cy.findByRole("button", { name: /Machine/i }).click();
+    });
+    cy.findByLabelText("Machine name").type(name);
+    cy.findByLabelText("MAC address").type(generateMac());
+    cy.findByLabelText("Power type").select("Manual");
+    cy.get("button[type='submit']").click();
+    return { name };
+  };
 
   it("hides the subnet column on small screens", () => {
     cy.findByRole("grid").within(() => {
@@ -23,5 +37,50 @@ context("Machine details", () => {
 
     cy.findAllByRole("columnheader", { name: /IP/i }).first().should("exist");
     cy.findByRole("columnheader", { name: /subnet/i }).should("not.exist");
+  });
+
+  it.only("displays machine commissioning details", () => {
+    const { name } = completeAddMachineForm();
+
+    cy.findByRole("link", { name: new RegExp(name, "i") }).click();
+
+    cy.waitForPageToLoad();
+    cy.get("[data-testid='section-header-buttons']").within(() =>
+      cy
+        .findByRole("button", {
+          name: /Take action/i,
+        })
+        .click()
+    );
+
+    // abort commissioning
+    cy.findByLabelText("submenu").within(() => {
+      cy.findByRole("button", { name: /Abort/i }).click();
+    });
+    cy.findByRole("button", { name: /Abort actions for machine/i }).click();
+
+    cy.findByRole("link", { name: "Commissioning" }).click();
+    cy.findByRole("grid").within(() => {
+      cy.findAllByRole("button", { name: /Take action/i })
+        .first()
+        .click();
+    });
+    cy.findByLabelText("submenu").within(() => {
+      cy.findAllByRole("link", { name: /View details/i }).click();
+    });
+    cy.findByRole("heading", { level: 2, name: /details/i }).should("exist");
+
+    // delete the machine
+    cy.get("[data-testid='section-header-buttons']").within(() =>
+      cy
+        .findByRole("button", {
+          name: /Take action/i,
+        })
+        .click()
+    );
+    cy.findByLabelText("submenu").within(() => {
+      cy.findByRole("button", { name: /Delete/i }).click();
+    });
+    cy.findByRole("button", { name: /Delete machine/i }).click();
   });
 });

--- a/src/app/base/components/node/NodeTestsTable/NodeTestsTable.tsx
+++ b/src/app/base/components/node/NodeTestsTable/NodeTestsTable.tsx
@@ -174,6 +174,7 @@ const NodeTestsTable = ({ node, scriptResults }: Props): JSX.Element => {
   return (
     <>
       <MainTable
+        aria-label="Test results"
         className="node-tests-table p-table-expanding--light"
         expanding
         headers={[

--- a/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import { CompatRouter, Link, Route, Routes } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
@@ -45,42 +45,34 @@ describe("MachineDetails", () => {
   [
     {
       component: "MachineSummary",
-      route: urls.machines.machine.summary(null),
       path: urls.machines.machine.summary({ id: "abc123" }),
     },
     {
       component: "MachineInstances",
-      route: urls.machines.machine.instances(null),
       path: urls.machines.machine.instances({ id: "abc123" }),
     },
     {
       component: "MachineNetwork",
-      route: urls.machines.machine.network(null),
       path: urls.machines.machine.network({ id: "abc123" }),
     },
     {
       component: "MachineStorage",
-      route: urls.machines.machine.storage(null),
       path: urls.machines.machine.storage({ id: "abc123" }),
     },
     {
       component: "MachinePCIDevices",
-      route: urls.machines.machine.pciDevices(null),
       path: urls.machines.machine.pciDevices({ id: "abc123" }),
     },
     {
       component: "MachineUSBDevices",
-      route: urls.machines.machine.usbDevices(null),
       path: urls.machines.machine.usbDevices({ id: "abc123" }),
     },
     {
       component: "MachineCommissioning",
-      route: urls.machines.machine.commissioning.index(null),
       path: urls.machines.machine.commissioning.index({ id: "abc123" }),
     },
     {
       component: "NodeTestDetails",
-      route: urls.machines.machine.commissioning.scriptResult(null),
       path: urls.machines.machine.commissioning.scriptResult({
         id: "abc123",
         scriptResultId: 1,
@@ -88,12 +80,10 @@ describe("MachineDetails", () => {
     },
     {
       component: "MachineTests",
-      route: urls.machines.machine.testing.index(null),
       path: urls.machines.machine.testing.index({ id: "abc123" }),
     },
     {
       component: "NodeTestDetails",
-      route: urls.machines.machine.testing.scriptResult(null),
       path: urls.machines.machine.testing.scriptResult({
         id: "abc123",
         scriptResultId: 1,
@@ -101,29 +91,24 @@ describe("MachineDetails", () => {
     },
     {
       component: "NodeLogs",
-      route: urls.machines.machine.logs.index(null),
       path: urls.machines.machine.logs.index({ id: "abc123" }),
     },
     {
       component: "MachineConfiguration",
-      route: urls.machines.machine.configuration(null),
       path: urls.machines.machine.configuration({ id: "abc123" }),
     },
-    {
-      // Redirects to summary:
-      component: "MachineSummary",
-      route: urls.machines.machine.index(null),
-      path: urls.machines.machine.index({ id: "abc123" }),
-    },
-  ].forEach(({ component, path, route }) => {
-    it(`Displays: ${component} at: ${path}`, () => {
+  ].forEach(({ component, path }) => {
+    it(`Displays: ${component} at: ${path}`, async () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
           <MemoryRouter initialEntries={[{ pathname: path }]}>
             <CompatRouter>
               <Routes>
-                <Route element={<MachineDetails />} path={route || "*/:id/*"} />
+                <Route
+                  element={<MachineDetails />}
+                  path={`${urls.machines.machine.index(null)}/*`}
+                />
               </Routes>
             </CompatRouter>
           </MemoryRouter>
@@ -131,6 +116,32 @@ describe("MachineDetails", () => {
       );
       expect(wrapper.find(component).exists()).toBe(true);
     });
+  });
+
+  it("redirects to summary", () => {
+    window.history.pushState(
+      {},
+      "",
+      urls.machines.machine.index({ id: "abc123" })
+    );
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <BrowserRouter>
+          <CompatRouter>
+            <Routes>
+              <Route
+                element={<MachineDetails />}
+                path={urls.machines.machine.index(null)}
+              />
+            </Routes>
+          </CompatRouter>
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(window.location.pathname).toBe(
+      urls.machines.machine.summary({ id: "abc123" })
+    );
   });
 
   it("dispatches an action to set the machine as active", () => {
@@ -142,7 +153,10 @@ describe("MachineDetails", () => {
         >
           <CompatRouter>
             <Routes>
-              <Route element={<MachineDetails />} path="/machine/:id" />
+              <Route
+                element={<MachineDetails />}
+                path={urls.machines.machine.index(null)}
+              />
             </Routes>
           </CompatRouter>
         </MemoryRouter>
@@ -193,7 +207,10 @@ describe("MachineDetails", () => {
         >
           <CompatRouter>
             <Routes>
-              <Route element={<MachineDetails />} path="/machine/:id" />
+              <Route
+                element={<MachineDetails />}
+                path={urls.machines.machine.index(null)}
+              />
             </Routes>
           </CompatRouter>
         </MemoryRouter>
@@ -221,7 +238,7 @@ describe("MachineDetails", () => {
                     <MachineDetails />
                   </>
                 }
-                path="/machine/:id"
+                path={urls.machines.machine.index(null)}
               />
             </Routes>
           </CompatRouter>

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+import { Redirect, useLocation } from "react-router-dom";
+import { Route, Routes } from "react-router-dom-v5-compat";
 
 import MachineCommissioning from "./MachineCommissioning";
 import MachineConfiguration from "./MachineConfiguration";
@@ -29,7 +30,7 @@ import machineSelectors from "app/store/machine/selectors";
 import { MachineMeta } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
-import { isId } from "app/utils";
+import { getRelativeRoute, isId } from "app/utils";
 
 const MachineDetails = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -71,6 +72,8 @@ const MachineDetails = (): JSX.Element => {
     );
   }
 
+  const base = urls.machines.machine.index(null);
+
   return (
     <Section
       header={
@@ -82,112 +85,121 @@ const MachineDetails = (): JSX.Element => {
       }
     >
       {machine && (
-        <Switch>
+        <Routes>
           <Route
-            exact
-            path={urls.machines.machine.summary(null)}
-            render={() => (
+            element={<Redirect to={urls.machines.machine.summary({ id })} />}
+            index
+          />
+          <Route
+            element={
               <>
                 <SummaryNotifications id={id} />
                 <MachineSummary setHeaderContent={setHeaderContent} />
               </>
-            )}
+            }
+            path={getRelativeRoute(urls.machines.machine.summary(null), base)}
           />
           <Route
-            exact
-            path={urls.machines.machine.instances(null)}
-            render={() => <MachineInstances />}
+            element={<MachineInstances />}
+            path={getRelativeRoute(urls.machines.machine.instances(null), base)}
           />
           <Route
-            exact
-            path={urls.machines.machine.network(null)}
-            render={() => (
+            element={
               <>
                 <NetworkNotifications id={id} />
                 <MachineNetwork id={id} setHeaderContent={setHeaderContent} />
               </>
-            )}
+            }
+            path={getRelativeRoute(urls.machines.machine.network(null), base)}
           />
           <Route
-            exact
-            path={urls.machines.machine.storage(null)}
-            render={() => (
+            element={
               <>
                 <StorageNotifications id={id} />
                 <MachineStorage />
               </>
+            }
+            path={getRelativeRoute(urls.machines.machine.storage(null), base)}
+          />
+          <Route
+            element={<MachinePCIDevices setHeaderContent={setHeaderContent} />}
+            path={getRelativeRoute(
+              urls.machines.machine.pciDevices(null),
+              base
             )}
           />
           <Route
-            exact
-            path={urls.machines.machine.pciDevices(null)}
-            render={() => (
-              <MachinePCIDevices setHeaderContent={setHeaderContent} />
+            element={<MachineUSBDevices setHeaderContent={setHeaderContent} />}
+            path={getRelativeRoute(
+              urls.machines.machine.usbDevices(null),
+              base
             )}
           />
           <Route
-            exact
-            path={urls.machines.machine.usbDevices(null)}
-            render={() => (
-              <MachineUSBDevices setHeaderContent={setHeaderContent} />
+            element={<MachineCommissioning />}
+            path={getRelativeRoute(
+              urls.machines.machine.commissioning.index(null),
+              base
             )}
           />
           <Route
-            exact
-            path={urls.machines.machine.commissioning.index(null)}
-            render={() => <MachineCommissioning />}
-          />
-          <Route
-            exact
-            path={urls.machines.machine.commissioning.scriptResult(null)}
-            render={() => (
+            element={
               <NodeTestDetails
                 getReturnPath={(id) =>
                   urls.machines.machine.commissioning.index({ id })
                 }
               />
+            }
+            path={getRelativeRoute(
+              urls.machines.machine.commissioning.scriptResult(null),
+              base
             )}
           />
           <Route
-            exact
-            path={urls.machines.machine.testing.index(null)}
-            render={() => <MachineTests />}
+            element={<MachineTests />}
+            path={getRelativeRoute(
+              urls.machines.machine.testing.index(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.machines.machine.testing.scriptResult(null)}
-            render={() => (
+            element={
               <NodeTestDetails
                 getReturnPath={(id) =>
                   urls.machines.machine.testing.index({ id })
                 }
               />
+            }
+            path={getRelativeRoute(
+              urls.machines.machine.testing.scriptResult(null),
+              base
             )}
           />
           <Route
-            path={urls.machines.machine.logs.index(null)}
-            render={() => <MachineLogs systemId={id} />}
+            element={<MachineLogs systemId={id} />}
+            path={getRelativeRoute(
+              `${urls.machines.machine.logs.index(null)}/*`,
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.machines.machine.events(null)}
-            render={() => (
+            element={
               <Redirect to={urls.machines.machine.logs.events({ id })} />
+            }
+            path={getRelativeRoute(urls.machines.machine.events(null), base)}
+          />
+          <Route
+            element={<MachineConfiguration />}
+            path={getRelativeRoute(
+              urls.machines.machine.configuration(null),
+              base
             )}
           />
           <Route
-            exact
-            path={urls.machines.machine.configuration(null)}
-            render={() => <MachineConfiguration />}
+            element={<Redirect to={urls.machines.machine.summary({ id })} />}
+            path={base}
           />
-          <Route
-            exact
-            path={urls.machines.machine.index(null)}
-            render={() => (
-              <Redirect to={urls.machines.machine.summary({ id })} />
-            )}
-          />
-        </Switch>
+        </Routes>
       )}
     </Section>
   );


### PR DESCRIPTION
## Done

- fix machine details routes

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine commissioning details (e.g. `/MAAS/r/machine/pbpncx/commissioning/59674/details` on bolla) and verify the page is displayed correctly (and "Script result could not be found." is not shown)

## Fixes

Fixes: #4169

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
