### PR TITLE
feat: enable PR demos with polong

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:experimental
+
+# Build stage: Install yarn dependencies
+# ===
+FROM node:14 AS yarn-dependencies
+WORKDIR /srv
+COPY . .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn CYPRESS_INSTALL_BINARY=0 yarn install
+
+# Build stage: Run "yarn build"
+# ===
+FROM yarn-dependencies AS build-js
+RUN yarn run build
+
+# Setup commands to run server
+CMD yarn run serve-static-demo

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,0 +1,8 @@
+domain: maas-ui.demos.haus
+image: prod-web-team-demos.docker-registry.canonical.com/maas-ui.demos.haus
+readinessPath: "/"
+
+demo:
+  env:
+    - name: MAAS_URL
+      value: "http://polong.internal:5240/"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "serve-proxy": "nodemon ./scripts/proxy.js",
     "serve-react": "BROWSER=none PORT=8401 react-scripts start",
+    "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=80 nodemon ./scripts/proxy.js",
     "serve": "yarn start",
     "show-ready": "wait-on http-get://0.0.0.0:8401 && nodemon ./scripts/proxy-ready.js",
     "sitespeed": "docker run -v \"$(pwd)/sitespeed.io:/sitespeed.io\" --network=host sitespeedio/sitespeed.io:25.2.1 --config /sitespeed.io/config.json /sitespeed.io/scripts/machines.js --multi --spa",

--- a/scripts/proxy.js
+++ b/scripts/proxy.js
@@ -7,7 +7,7 @@ const REACT_BASENAME = process.env.REACT_BASENAME;
 
 var app = express();
 
-const PROXY_PORT = 8400;
+const PROXY_PORT = process.env.PROXY_PORT || 8400;
 const REACT_PORT = 8401;
 
 app.get(BASENAME, (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
@@ -48,11 +48,18 @@ app.use(
 );
 
 // Proxy to the React client.
-app.use(
-  createProxyMiddleware("/", {
-    target: `http://localhost:${REACT_PORT}/`,
-  })
-);
+if (process.env.STATIC_DEMO !== "true") {
+  app.use(
+    createProxyMiddleware("/", {
+      target: `http://localhost:${REACT_PORT}/`,
+    })
+  );
+}
+
+if (process.env.STATIC_DEMO === "true") {
+  app.use(`${BASENAME}${REACT_BASENAME}`, express.static("./build"));
+  app.use(`*`, express.static("./build"));
+}
 
 app.listen(PROXY_PORT);
 


### PR DESCRIPTION
## Done

- enable PR demos with `polong.internal` MAAS 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Make sure you can login (if I haven't sent you a message with password yet - contact me).

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
