### PR TITLE
fix(ui): controller details scriptresult not found

### DIFF
--- a/cypress/e2e/with-users/controllers/details.spec.ts
+++ b/cypress/e2e/with-users/controllers/details.spec.ts
@@ -1,0 +1,107 @@
+import { generateMAASURL, generateId } from "../../utils";
+
+context("Controller details", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateMAASURL("/controllers"));
+  });
+
+  it("can add a tag to the controller", () => {
+    const tagName = `tag-${generateId()}`;
+
+    // displays the controller details page on click of the controller name
+    cy.findAllByRole("gridcell", { name: "Name" })
+      .first()
+      .within(() => {
+        cy.findByRole("link").click();
+      });
+
+    cy.findByText(/Summary/).should("exist");
+
+    // can add a tag to the controller
+    cy.findByRole("link", {
+      name: /Configuration/,
+    }).click();
+    cy.findAllByRole("button", {
+      name: /Edit/,
+    })
+      .first()
+      .click();
+
+    cy.findByRole("form", { name: /Controller configuration/ }).should("exist");
+    cy.get("input[placeholder='Create or remove tags']").type(
+      `${tagName}{enter}`
+    );
+    cy.findByRole("button", { name: /Create and add to tag changes/ }).click();
+    cy.findByRole("button", { name: /Save changes/ }).click();
+
+    cy.findByRole("link", { name: /Summary/ }).click();
+    cy.findByTestId("machine-tags").contains(tagName);
+
+    // displays the controller listing page filtered by tag on click of the tag name
+    cy.findByRole("link", {
+      name: /Configuration/,
+    }).click();
+    cy.findByRole("link", {
+      name: tagName,
+    }).click();
+
+    // displays the correct tag in the searchbox
+    cy.findByRole("searchbox", { name: /Search/ }).should(
+      "have.value",
+      `tags:(=${tagName})`
+    );
+
+    // displays the correct number of controllers
+    cy.findByRole("grid", { name: "controllers list" }).within(() => {
+      cy.get("tbody tr").should("have.length", 1);
+    });
+  });
+
+  it("lists valid actions on the controller details page", () => {
+    cy.findAllByRole("gridcell", { name: "Name" })
+      .first()
+      .within(() => {
+        cy.findByRole("link").click();
+      });
+
+    cy.findByText(/Take action/).click();
+
+    [/Import images/i, /Delete/i].forEach((name) =>
+      cy
+        .findByRole("button", {
+          name,
+        })
+        .should("exist")
+    );
+    [/Deploy/i].forEach((name) =>
+      cy
+        .findByRole("button", {
+          name,
+        })
+        .should("not.exist")
+    );
+  });
+
+  it("displays controller commissioning details", () => {
+    cy.waitForPageToLoad();
+    cy.get("[data-testid='section-header-buttons']").within(() =>
+      cy
+        .findByRole("button", {
+          name: /Take action/i,
+        })
+        .click()
+    );
+
+    cy.findByRole("link", { name: "Commissioning" }).click();
+    cy.findByRole("grid").within(() => {
+      cy.findAllByRole("button", { name: /Take action/i })
+        .first()
+        .click();
+    });
+    cy.findByLabelText("submenu").within(() => {
+      cy.findAllByRole("link", { name: /View details/i }).click();
+    });
+    cy.findByRole("heading", { level: 2, name: /details/i }).should("exist");
+  });
+});

--- a/cypress/e2e/with-users/controllers/list.spec.ts
+++ b/cypress/e2e/with-users/controllers/list.spec.ts
@@ -1,4 +1,4 @@
-import { generateId, generateMAASURL } from "../../utils";
+import { generateMAASURL } from "../../utils";
 
 context("Controller listing", () => {
   beforeEach(() => {
@@ -15,83 +15,6 @@ context("Controller listing", () => {
       "have.attr",
       "href",
       generateMAASURL("/controllers")
-    );
-  });
-
-  it("can add a tag to the controller", () => {
-    const tagName = `tag-${generateId()}`;
-
-    // displays the controller details page on click of the controller name
-    cy.findAllByRole("gridcell", { name: "Name" })
-      .first()
-      .within(() => {
-        cy.findByRole("link").click();
-      });
-
-    cy.findByText(/Summary/).should("exist");
-
-    // can add a tag to the controller
-    cy.findByRole("link", {
-      name: /Configuration/,
-    }).click();
-    cy.findAllByRole("button", {
-      name: /Edit/,
-    })
-      .first()
-      .click();
-
-    cy.findByRole("form", { name: /Controller configuration/ }).should("exist");
-    cy.get("input[placeholder='Create or remove tags']").type(
-      `${tagName}{enter}`
-    );
-    cy.findByRole("button", { name: /Create and add to tag changes/ }).click();
-    cy.findByRole("button", { name: /Save changes/ }).click();
-
-    cy.findByRole("link", { name: /Summary/ }).click();
-    cy.findByTestId("machine-tags").contains(tagName);
-
-    // displays the controller listing page filtered by tag on click of the tag name
-    cy.findByRole("link", {
-      name: /Configuration/,
-    }).click();
-    cy.findByRole("link", {
-      name: tagName,
-    }).click();
-
-    // displays the correct tag in the searchbox
-    cy.findByRole("searchbox", { name: /Search/ }).should(
-      "have.value",
-      `tags:(=${tagName})`
-    );
-
-    // displays the correct number of controllers
-    cy.findByRole("grid", { name: "controllers list" }).within(() => {
-      cy.get("tbody tr").should("have.length", 1);
-    });
-  });
-
-  it("lists valid actions on the controller details page", () => {
-    cy.findAllByRole("gridcell", { name: "Name" })
-      .first()
-      .within(() => {
-        cy.findByRole("link").click();
-      });
-
-    cy.findByText(/Take action/).click();
-
-    [/Import images/i, /Delete/i].forEach((name) =>
-      cy
-        .findByRole("button", {
-          name,
-        })
-        .should("exist")
-    );
-    [/Deploy/i].forEach((name) =>
-      cy
-        .findByRole("button", {
-          name,
-        })
-        .should("not.exist")
     );
   });
 });

--- a/cypress/e2e/with-users/machines/details.spec.ts
+++ b/cypress/e2e/with-users/machines/details.spec.ts
@@ -39,7 +39,7 @@ context("Machine details", () => {
     cy.findByRole("columnheader", { name: /subnet/i }).should("not.exist");
   });
 
-  it.only("displays machine commissioning details", () => {
+  it("displays machine commissioning details", () => {
     const { name } = completeAddMachineForm();
 
     cy.findByRole("link", { name: new RegExp(name, "i") }).click();

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
@@ -41,7 +41,7 @@ it("gets and sets the controller as active", () => {
           <Routes>
             <Route
               element={<ControllerDetails />}
-              path={urls.controllers.controller.index(null)}
+              path={`${urls.controllers.controller.index(null)}/*`}
             />
           </Routes>
         </CompatRouter>

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Redirect } from "react-router-dom";
+import { Routes, Route } from "react-router-dom-v5-compat";
 
 import ControllerCommissioning from "./ControllerCommissioning";
 import ControllerConfiguration from "./ControllerConfiguration";
@@ -24,7 +25,7 @@ import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
 import { ControllerMeta } from "app/store/controller/types";
 import type { RootState } from "app/store/root/types";
-import { isId } from "app/utils";
+import { getRelativeRoute, isId } from "app/utils";
 
 const ControllerDetails = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -60,6 +61,8 @@ const ControllerDetails = (): JSX.Element => {
     );
   }
 
+  const base = urls.controllers.controller.index(null);
+
   return (
     <Section
       header={
@@ -71,78 +74,104 @@ const ControllerDetails = (): JSX.Element => {
       }
     >
       {controller && (
-        <Switch>
+        <Routes>
           <Route
-            exact
-            path={urls.controllers.controller.summary(null)}
-            render={() => <ControllerSummary systemId={id} />}
+            element={
+              <Redirect to={urls.controllers.controller.summary({ id })} />
+            }
+            index
           />
           <Route
-            exact
-            path={urls.controllers.controller.vlans(null)}
-            render={() => <ControllerVLANs systemId={id} />}
+            element={<ControllerSummary systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.summary(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.network(null)}
-            render={() => <ControllerNetwork systemId={id} />}
+            element={<ControllerVLANs systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.vlans(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.storage(null)}
-            render={() => <ControllerStorage systemId={id} />}
+            element={<ControllerNetwork systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.network(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.pciDevices(null)}
-            render={() => <ControllerPCIDevices systemId={id} />}
+            element={<ControllerStorage systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.storage(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.usbDevices(null)}
-            render={() => <ControllerUSBDevices systemId={id} />}
+            element={<ControllerPCIDevices systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.pciDevices(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.commissioning.index(null)}
-            render={() => <ControllerCommissioning systemId={id} />}
+            element={<ControllerUSBDevices systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.usbDevices(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.commissioning.scriptResult(null)}
-            render={() => (
+            element={<ControllerCommissioning systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.commissioning.index(null),
+              base
+            )}
+          />
+          <Route
+            element={
               <NodeTestDetails
                 getReturnPath={(id) =>
                   urls.controllers.controller.commissioning.index({ id })
                 }
               />
+            }
+            path={getRelativeRoute(
+              urls.controllers.controller.commissioning.scriptResult(null),
+              base
             )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.logs.index(null)}
-            render={() => <ControllerLogs systemId={id} />}
+            element={<ControllerLogs systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.logs.index(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.logs.events(null)}
-            render={() => <ControllerLogs systemId={id} />}
+            element={<ControllerLogs systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.logs.events(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.logs.installationOutput(null)}
-            render={() => <ControllerLogs systemId={id} />}
+            element={<ControllerLogs systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.logs.installationOutput(null),
+              base
+            )}
           />
           <Route
-            exact
-            path={urls.controllers.controller.configuration(null)}
-            render={() => <ControllerConfiguration systemId={id} />}
+            element={<ControllerConfiguration systemId={id} />}
+            path={getRelativeRoute(
+              urls.controllers.controller.configuration(null),
+              base
+            )}
           />
-          <Redirect
-            from={urls.controllers.controller.index(null)}
-            to={urls.controllers.controller.summary(null)}
-          />
-        </Switch>
+        </Routes>
       )}
     </Section>
   );


### PR DESCRIPTION
## Done

- fix controller details scriptresult not found
- add controller comissioning e2e test
- move controller details tests to own file

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that controller details subpages work correctly

## Fixes

Fixes: #4172 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/176893208-6041df75-80ba-406f-99b5-c338ca046f49.png)
### After
![image](https://user-images.githubusercontent.com/7452681/176893232-9e5e2652-0170-4fe1-930e-85760c8b9b0f.png)

