### PR TITLE
fix: subnet icons misaligned

### DIFF
--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.tsx
@@ -13,6 +13,7 @@ const ActiveDiscoveryLabel = ({ managed }: Props): JSX.Element => (
         message={`When enabled, MAAS will scan this subnet to discover hosts
         that have not been discovered passively.`}
         position="btm-right"
+        positionElementClassName="u-display--inline"
       />
     ) : null}
   </>

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/AllowDNSResolutionLabel/AllowDNSResolutionLabel.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/AllowDNSResolutionLabel/AllowDNSResolutionLabel.tsx
@@ -13,6 +13,7 @@ const AllowDNSResolutionLabel = ({ allowDNS }: Props): JSX.Element => (
         allowDNS ? "" : "not"
       } allow clients from this subnet to use MAAS for DNS resolution.`}
       position="btm-right"
+      positionElementClassName="u-display--inline"
     />
   </>
 );

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.tsx
@@ -13,6 +13,7 @@ const ManagedAllocationLabel = ({ managed }: Props): JSX.Element => (
         message={`MAAS allocates IP addresses from this subnet, excluding the
         reserved and dynamic ranges.`}
         position="btm-right"
+        positionElementClassName="u-display--inline"
       />
     )}
   </>

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.tsx
@@ -14,6 +14,7 @@ const ProxyAccessLabel = ({ allowProxy }: Props): JSX.Element => (
         allowProxy ? "" : "not"
       } allow clients from this subnet to access the MAAS proxy.`}
       position="btm-right"
+      positionElementClassName="u-display--inline"
     />
   </>
 );


### PR DESCRIPTION
## Done

- fix: subnet icons misaligned

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to subnet details (e.g. `/MAAS/r/subnet/1` on bolla) and click edit, verify that tooltips are aligned correctly

## Fixes

Fixes: #4099  .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

### After
![image](https://user-images.githubusercontent.com/7452681/176893472-0ab91901-fd20-41a7-b3db-0382b35333e8.png)

