### PR TITLE
refactor(pools): update pools to RRv6

### DIFF
--- a/src/app/pools/components/PoolForm/PoolForm.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.tsx
@@ -27,7 +27,7 @@ const PoolSchema = Yup.object().shape({
   description: Yup.string(),
 });
 
-export const PoolForm = ({ pool }: Props): JSX.Element => {
+export const PoolForm = ({ pool, ...props }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const saved = useSelector(poolSelectors.saved);
@@ -91,6 +91,7 @@ export const PoolForm = ({ pool }: Props): JSX.Element => {
         saving={saving}
         submitLabel="Save pool"
         validationSchema={PoolSchema}
+        {...props}
       >
         <FormikField label="Name (required)" name="name" type="text" />
         <FormikField label="Description" name="description" type="text" />

--- a/src/app/pools/views/PoolAdd/PoolAdd.tsx
+++ b/src/app/pools/views/PoolAdd/PoolAdd.tsx
@@ -1,7 +1,11 @@
 import PoolForm from "app/pools/components/PoolForm";
 
+export enum Label {
+  Title = "Add pool",
+}
+
 export const PoolAdd = (): JSX.Element => {
-  return <PoolForm />;
+  return <PoolForm aria-label={Label.Title} />;
 };
 
 export default PoolAdd;

--- a/src/app/pools/views/PoolEdit/PoolEdit.tsx
+++ b/src/app/pools/views/PoolEdit/PoolEdit.tsx
@@ -9,6 +9,10 @@ import poolSelectors from "app/store/resourcepool/selectors";
 import { ResourcePoolMeta } from "app/store/resourcepool/types";
 import type { RootState } from "app/store/root/types";
 
+export enum Label {
+  Title = "Edit pool",
+}
+
 export const PoolEdit = (): JSX.Element => {
   const id = useGetURLId(ResourcePoolMeta.PK);
   const loading = useSelector(poolSelectors.loading);
@@ -28,7 +32,7 @@ export const PoolEdit = (): JSX.Element => {
       />
     );
   }
-  return <PoolForm pool={pool} />;
+  return <PoolForm aria-label={Label.Title} pool={pool} />;
 };
 
 export default PoolEdit;

--- a/src/app/pools/views/PoolList/PoolList.tsx
+++ b/src/app/pools/views/PoolList/PoolList.tsx
@@ -25,6 +25,10 @@ import type {
 } from "app/store/resourcepool/types";
 import { formatErrors } from "app/utils";
 
+export enum Label {
+  Title = "Pool list",
+}
+
 const getMachinesLabel = (row: ResourcePool) => {
   if (row.machine_total_count === 0) {
     return "Empty pool";
@@ -139,7 +143,7 @@ const Pools = (): JSX.Element => {
   const resourcePools = useSelector(resourcePoolSelectors.all);
 
   return (
-    <>
+    <div aria-label={Label.Title}>
       {errorMessage ? (
         <Row>
           <Col size={12}>
@@ -199,7 +203,7 @@ const Pools = (): JSX.Element => {
           </div>
         </Col>
       </Row>
-    </>
+    </div>
   );
 };
 

--- a/src/app/pools/views/Pools.test.tsx
+++ b/src/app/pools/views/Pools.test.tsx
@@ -1,47 +1,58 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
+import { screen } from "@testing-library/react";
 
+import { Label as PoolAddLabel } from "./PoolAdd/PoolAdd";
+import { Label as PoolEditLabel } from "./PoolEdit/PoolEdit";
+import { Label as PoolListLabel } from "./PoolList/PoolList";
 import Pools from "./Pools";
 
 import urls from "app/base/urls";
-import { rootState as rootStateFactory } from "testing/factories";
-
-const mockStore = configureStore();
+import { Label as NotFoundLabel } from "app/base/views/NotFound/NotFound";
+import type { RootState } from "app/store/root/types";
+import {
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
 describe("Pools", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({
+        loaded: true,
+        items: [resourcePoolFactory({ id: 1 })],
+      }),
+    });
+  });
+
   [
     {
-      component: "Pools",
+      label: PoolListLabel.Title,
       path: urls.pools.index,
     },
     {
-      component: "PoolAdd",
+      label: PoolAddLabel.Title,
       path: urls.pools.add,
     },
     {
-      component: "PoolEdit",
+      label: PoolEditLabel.Title,
       path: urls.pools.edit({ id: 1 }),
     },
     {
-      component: "NotFound",
-      path: "/not/a/path",
+      label: NotFoundLabel.Title,
+      path: `${urls.pools.index}/not/a/path`,
     },
-  ].forEach(({ component, path }) => {
-    it(`Displays: ${component} at: ${path}`, () => {
-      const store = mockStore(rootStateFactory());
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <CompatRouter>
-              <Pools />
-            </CompatRouter>
-          </MemoryRouter>
-        </Provider>
-      );
-      expect(wrapper.find(component).exists()).toBe(true);
+  ].forEach(({ label, path }) => {
+    it(`Displays: ${label} at: ${path}`, () => {
+      renderWithBrowserRouter(<Pools />, {
+        route: path,
+        wrapperProps: {
+          routePattern: `${urls.pools.index}/*`,
+          state,
+        },
+      });
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
   });
 });

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@canonical/react-components";
-import { Route, Switch } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link, Route, Routes } from "react-router-dom-v5-compat";
 
 import PoolList from "./PoolList";
 
@@ -10,26 +9,39 @@ import urls from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
 import PoolAdd from "app/pools/views/PoolAdd";
 import PoolEdit from "app/pools/views/PoolEdit";
+import { getRelativeRoute } from "app/utils";
 
-const Pools = (): JSX.Element => (
-  <Section
-    header={
-      <MachinesHeader
-        buttons={[
-          <Button data-testid="add-pool" element={Link} to={urls.pools.add}>
-            Add pool
-          </Button>,
-        ]}
-      />
-    }
-  >
-    <Switch>
-      <Route exact path={urls.pools.index} render={() => <PoolList />} />
-      <Route exact path={urls.pools.add} render={() => <PoolAdd />} />
-      <Route exact path={urls.pools.edit(null)} render={() => <PoolEdit />} />
-      <Route path="*" render={() => <NotFound />} />
-    </Switch>
-  </Section>
-);
+const Pools = (): JSX.Element => {
+  const base = urls.pools.index;
+  return (
+    <Section
+      header={
+        <MachinesHeader
+          buttons={[
+            <Button data-testid="add-pool" element={Link} to={urls.pools.add}>
+              Add pool
+            </Button>,
+          ]}
+        />
+      }
+    >
+      <Routes>
+        <Route
+          element={<PoolList />}
+          path={getRelativeRoute(urls.pools.index, base)}
+        />
+        <Route
+          element={<PoolAdd />}
+          path={getRelativeRoute(urls.pools.add, base)}
+        />
+        <Route
+          element={<PoolEdit />}
+          path={getRelativeRoute(urls.pools.edit(null), base)}
+        />
+        <Route element={<NotFound />} path="*" />
+      </Routes>
+    </Section>
+  );
+};
 
 export default Pools;


### PR DESCRIPTION
## Done

- Update pools routes to React Router v6.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Machines -> Resource pools tab.
- The list of pools should appear.
- Click "Add pool" in the header and the form should appear.
- Go back to the pool list and click the edit icon and the edit form should appear.

## Fixes

Fixes: #4193.