### PR TITLE
test: add no-only eslint rule to cypress tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,8 +137,9 @@ module.exports = {
     {
       files: ["cypress/**/*.spec.[jt]s?(x)"],
       extends: ["plugin:cypress/recommended", "plugin:prettier/recommended"],
-      plugins: ["cypress"],
+      plugins: ["cypress", "no-only-tests"],
       rules: {
+        "no-only-tests/no-only-tests": "error",
         "cypress/no-force": "warn",
         "prettier/prettier": "error",
       },


### PR DESCRIPTION
## Done

- add no-only eslint rule to cypress tests

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
