### PR TITLE
refactor(tags): update tags to RRv6

### DIFF
--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -49,7 +49,10 @@ export const MachinesHeader = (props: Props): JSX.Element => {
         {
           active:
             !!matchPath(urls.tags.index, location.pathname) ||
-            !!matchPath(urls.tags.tag.index(null), location.pathname),
+            !!matchPath(
+              { path: urls.tags.tag.index(null), end: false },
+              location.pathname
+            ),
           component: Link,
           label: `${pluralize("Tag", tagCount, true)}`,
           to: urls.tags.index,

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -69,7 +69,7 @@ describe("Tags", () => {
 
   it("shows buttons when not displaying forms", () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: { routePattern: urls.tags.tag.index(null), state },
+      wrapperProps: { routePattern: `${urls.tags.tag.index(null)}/*`, state },
       route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
@@ -89,7 +89,7 @@ describe("Tags", () => {
 
   it("hides buttons when deleting tags", async () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: { routePattern: urls.tags.tag.index(null), state },
+      wrapperProps: { routePattern: `${urls.tags.tag.index(null)}/*`, state },
       route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);


### PR DESCRIPTION
## Done

- Update the tag routes to React Router v6.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Machines -> Tags tab.
- The list of tags should appear.
- Click on "Create new tag" and the form should appear.
- Go back to the list and click on a tag and the details should appear.
- Go back to the list and find or create a tag that has kernel options (e.g. this one: http://bolla.internal:5240/MAAS/r/tag/75).
- Click the delete icon and then in the warning in the header click "Show the deployed machines" and the list of machines should appear.

## Fixes

Fixes: #4195.