### PR TITLE
refactor(machines): remove routing from machine list

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -115,7 +115,7 @@ const Routes = (): JSX.Element => (
           <Machines />
         </ErrorBoundary>
       }
-      path={`${urls.machines.index}/*`}
+      path={urls.machines.index}
     />
     <Route
       element={

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -9,7 +9,6 @@ import MachineList from "./MachineList";
 import MachineListHeader from "./MachineList/MachineListHeader";
 import Machines from "./Machines";
 
-import urls from "app/base/urls";
 import { MachineHeaderViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
 import {
@@ -62,31 +61,6 @@ describe("Machines", () => {
         },
       }),
       router: routerStateFactory(),
-    });
-  });
-
-  [
-    {
-      component: "MachineList",
-      path: urls.machines.index,
-    },
-    {
-      component: "NotFound",
-      path: "/not/a/path",
-    },
-  ].forEach(({ component, path }) => {
-    it(`Displays: ${component} at: ${path}`, () => {
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter initialEntries={[{ pathname: path }]}>
-            <CompatRouter>
-              <Machines />
-            </CompatRouter>
-          </MemoryRouter>
-        </Provider>
-      );
-      expect(wrapper.find(component).exists()).toBe(true);
     });
   });
 

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -1,14 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import { Route, Switch, useLocation } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 
 import MachineListHeader from "./MachineList/MachineListHeader";
 
 import Section from "app/base/components/Section";
-import urls from "app/base/urls";
-import NotFound from "app/base/views/NotFound";
 import type { MachineHeaderContent } from "app/machines/types";
 import MachineList from "app/machines/views/MachineList";
 import { FilterMachines } from "app/store/machine/utils";
@@ -59,20 +56,11 @@ const Machines = (): JSX.Element => {
         />
       }
     >
-      <Switch>
-        <Route
-          exact
-          path={urls.machines.index}
-          render={() => (
-            <MachineList
-              headerFormOpen={!!headerContent}
-              searchFilter={searchFilter}
-              setSearchFilter={setSearchFilter}
-            />
-          )}
-        />
-        <Route path="*" render={() => <NotFound />} />
-      </Switch>
+      <MachineList
+        headerFormOpen={!!headerContent}
+        searchFilter={searchFilter}
+        setSearchFilter={setSearchFilter}
+      />
     </Section>
   );
 };


### PR DESCRIPTION
## Done

- Remove unnecessary routing from machine list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list. It should appear.

## Fixes

Fixes: #4192.