### PR TITLE
Changed status bar colour to dark theme default

### DIFF
--- a/src/scss/_patterns_status-bar.scss
+++ b/src/scss/_patterns_status-bar.scss
@@ -1,6 +1,6 @@
 @mixin maas-status-bar {
   .p-status-bar {
-    background-color: $color-mid-x-light;
+    background-color: $colors--dark-theme--background-default;
     bottom: 0;
     left: 0;
     padding: $spv--small 0;
@@ -11,6 +11,7 @@
 
   .p-status-bar__row {
     @extend %fixed-width-container;
+    color: $color-x-light;
     column-gap: $sph--small;
     flex-direction: column;
 


### PR DESCRIPTION
## Done

- Changed the background colour of the status bar to the default for the vanilla dark theme ( `hsl(0deg, 0%, 15%)` or `#262626`)
- Changed the text colour on the status bar to white

## Screenshots

![image](https://user-images.githubusercontent.com/35104482/177569955-a3403773-bffb-4264-9fa8-9227cbc593ad.png)

