### PR TITLE
fix(ui): settings top-level item no longer bold

### DIFF
--- a/src/app/base/components/SideNav/SideNav.tsx
+++ b/src/app/base/components/SideNav/SideNav.tsx
@@ -78,8 +78,8 @@ const _generateSection = (
   }
 
   return (
-    <li className="p-side-navigation__item" key={section.label}>
-      <span className="p-side-navigation__text p-side-navigation__item--title">
+    <li className="p-side-navigation__item--title" key={section.label}>
+      <span className="p-side-navigation__text p-side-navigation__item">
         {section.label}
       </span>
       {subNav}

--- a/src/app/base/components/SideNav/__snapshots__/SideNav.test.tsx.snap
+++ b/src/app/base/components/SideNav/__snapshots__/SideNav.test.tsx.snap
@@ -36,10 +36,10 @@ exports[`matches the snapshot 1`] = `
       class="p-side-navigation__list"
     >
       <li
-        class="p-side-navigation__item"
+        class="p-side-navigation__item--title"
       >
         <span
-          class="p-side-navigation__text p-side-navigation__item--title"
+          class="p-side-navigation__text p-side-navigation__item"
         >
           Configuration
         </span>


### PR DESCRIPTION
## Done

- fix: settings top-level item no longer bold

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to settings and verify that all top-level items are displayed with a bold font

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4184

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
<img src="https://user-images.githubusercontent.com/7452681/177581452-23f99660-24c0-4a97-8036-fdbf131bbf42.png" width="200" />

### After
<img src="https://user-images.githubusercontent.com/7452681/177581425-8149199c-0220-4fa5-8ff9-5ad8445768bc.png" width="200" />

