### PR TITLE
refactor(machines): remove batch fetching of machines

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -202,8 +202,6 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
-    // The machine list should also be visible as the machines are
-    // loaded in batches.
     expect(wrapper.find("Memo(MachineListTable)").exists()).toBe(true);
   });
 

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -21,10 +21,8 @@ describe("machine actions", () => {
     expect(actions.fetch()).toEqual({
       type: "machine/fetch",
       meta: {
-        batch: true,
         model: "machine",
         method: "list",
-        subsequentLimit: 100,
       },
       payload: {
         params: { limit: 25 },

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -52,8 +52,8 @@ describe("machine reducer", () => {
     ).toEqual(
       machineStateFactory({
         items: fetchedMachines,
-        loading: true,
-        loaded: false,
+        loading: false,
+        loaded: true,
         statuses: {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
@@ -85,26 +85,12 @@ describe("machine reducer", () => {
     ).toEqual(
       machineStateFactory({
         items: [existingMachine, fetchedMachines[1]],
-        loading: true,
-        loaded: false,
+        loading: false,
+        loaded: true,
         statuses: {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
         },
-      })
-    );
-  });
-
-  it("reduces fetchComplete", () => {
-    const initialState = machineStateFactory({
-      loaded: false,
-      loading: true,
-    });
-
-    expect(reducers(initialState, actions.fetchComplete())).toEqual(
-      machineStateFactory({
-        loaded: true,
-        loading: false,
       })
     );
   });

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -983,10 +983,8 @@ const machineSlice = createSlice({
     fetch: {
       prepare: () => ({
         meta: {
-          batch: true,
           model: MachineMeta.MODEL,
           method: "list",
-          subsequentLimit: 100,
         },
         payload: {
           params: { limit: 25 },
@@ -995,10 +993,6 @@ const machineSlice = createSlice({
       reducer: () => {
         // No state changes need to be handled for this action.
       },
-    },
-    fetchComplete: (state: MachineState) => {
-      state.loading = false;
-      state.loaded = true;
     },
     fetchSuccess: (state: MachineState, action: PayloadAction<Machine[]>) => {
       action.payload.forEach((newItem: Machine) => {
@@ -1015,6 +1009,8 @@ const machineSlice = createSlice({
           state.statuses[newItem.system_id] = DEFAULT_STATUSES;
         }
       });
+      state.loading = false;
+      state.loaded = true;
     },
     get: {
       prepare: (machineID: Machine[MachineMeta.PK]) => ({

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -62,8 +62,6 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
   },
   string,
   {
-    // Whether the request should be fetched in batches.
-    batch?: boolean;
     // Whether the request should only be fetched the first time.
     cache?: boolean;
     // Whether each item in the params should be dispatched separately. The
@@ -89,10 +87,6 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     pollInterval?: number;
     // Whether polling should be stopped for the request.
     pollStop?: boolean;
-    // Batch requests may set a limit for all requests after the first (i.e. the
-    // first action may set a limit of 5 and then use subsequentLimit to set all
-    // following requests to 10).
-    subsequentLimit?: number;
     // Whether the response should be stored in the file context.
     useFileContext?: boolean;
   }


### PR DESCRIPTION
## Done

- Remove batch fetching of machines as this will become a paginated list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- The machines should load, however if you have more than 25 machines you'll only see the first 25.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1153.