### PR TITLE
refactor(pools): remove machine fetching from pools

### DIFF
--- a/src/app/pools/views/PoolList/PoolList.test.tsx
+++ b/src/app/pools/views/PoolList/PoolList.test.tsx
@@ -146,7 +146,9 @@ describe("PoolList", () => {
       .find("ActionButton[data-testid='action-confirm']")
       .simulate("click");
 
-    expect(store.getActions()[2]).toEqual({
+    expect(
+      store.getActions().find(({ type }) => type === "resourcepool/delete")
+    ).toStrictEqual({
       type: "resourcepool/delete",
       payload: {
         params: {

--- a/src/app/pools/views/PoolList/PoolList.tsx
+++ b/src/app/pools/views/PoolList/PoolList.tsx
@@ -15,7 +15,6 @@ import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import { useAddMessage, useWindowTitle } from "app/base/hooks";
 import urls from "app/base/urls";
-import { actions as machineActions } from "app/store/machine";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
@@ -137,7 +136,6 @@ const Pools = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(resourcePoolActions.fetch());
-    dispatch(machineActions.fetch());
   }, [dispatch]);
 
   const resourcePools = useSelector(resourcePoolSelectors.all);


### PR DESCRIPTION
## Done

- Remove the call to fetch machines from the pools list as this is not required.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /MAAS/r/pools directly (or navigate to pools and refresh the page).
- The "x Machines" tab should show the count of machines.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1113.