### PR TITLE
refactor(machine): add a hook for getting a machine

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -16,6 +16,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
+import { useGetMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -44,6 +45,7 @@ export const CloneFormFields = ({
   const loadingData =
     loadingFabrics || loadingMachines || loadingSubnets || loadingVlans;
   const loadingMachineDetails = !!values.source && !selectedMachine;
+  useGetMachine(values.source);
 
   useEffect(() => {
     dispatch(fabricActions.fetch());
@@ -74,7 +76,6 @@ export const CloneFormFields = ({
         onMachineClick={(machine) => {
           if (machine) {
             setFieldValue("source", machine.system_id);
-            dispatch(machineActions.get(machine.system_id));
           } else {
             setFieldValue("source", "");
             setFieldValue("interfaces", false);

--- a/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -132,7 +132,7 @@ describe("MachineDetails", () => {
             <Routes>
               <Route
                 element={<MachineDetails />}
-                path={urls.machines.machine.index(null)}
+                path={`${urls.machines.machine.index(null)}/*`}
               />
             </Routes>
           </CompatRouter>
@@ -155,7 +155,7 @@ describe("MachineDetails", () => {
             <Routes>
               <Route
                 element={<MachineDetails />}
-                path={urls.machines.machine.index(null)}
+                path={`${urls.machines.machine.index(null)}/*`}
               />
             </Routes>
           </CompatRouter>
@@ -209,7 +209,7 @@ describe("MachineDetails", () => {
             <Routes>
               <Route
                 element={<MachineDetails />}
-                path={urls.machines.machine.index(null)}
+                path={`${urls.machines.machine.index(null)}/*`}
               />
             </Routes>
           </CompatRouter>
@@ -238,7 +238,7 @@ describe("MachineDetails", () => {
                     <MachineDetails />
                   </>
                 }
-                path={urls.machines.machine.index(null)}
+                path={`${urls.machines.machine.index(null)}/*`}
               />
             </Routes>
           </CompatRouter>

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -28,6 +28,7 @@ import type { MachineHeaderContent } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { MachineMeta } from "app/store/machine/types";
+import { useGetMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { getRelativeRoute, isId } from "app/utils";
@@ -42,6 +43,7 @@ const MachineDetails = (): JSX.Element => {
   const machinesLoading = useSelector(machineSelectors.loading);
   const [headerContent, setHeaderContent] =
     useState<MachineHeaderContent | null>(null);
+  useGetMachine(id);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -49,7 +51,6 @@ const MachineDetails = (): JSX.Element => {
 
   useEffect(() => {
     if (isId(id)) {
-      dispatch(machineActions.get(id));
       // Set machine as active to ensure all machine data is sent from the server.
       dispatch(machineActions.setActive(id));
       dispatch(tagActions.fetch());

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
@@ -24,6 +24,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
+import { useGetMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import { NodeActions } from "app/store/types/node";
@@ -54,10 +55,7 @@ const MachineHeader = ({
     NodeActions.ON,
   ]);
   const isDetails = isMachineDetails(machine);
-
-  useEffect(() => {
-    dispatch(machineActions.get(systemId));
-  }, [dispatch, systemId]);
+  useGetMachine(systemId);
 
   if (!machine || !isDetails) {
     return <SectionHeader loading />;

--- a/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -1,7 +1,5 @@
-import { useEffect } from "react";
-
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
 import NumaCard from "./NumaCard";
@@ -16,10 +14,10 @@ import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import urls from "app/base/urls";
 import type { MachineSetHeaderContent } from "app/machines/types";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { MachineMeta } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
+import { useGetMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { NodeStatusCode } from "app/store/types/node";
 import { isId } from "app/utils";
@@ -29,19 +27,12 @@ type Props = {
 };
 
 const MachineSummary = ({ setHeaderContent }: Props): JSX.Element => {
-  const dispatch = useDispatch();
   const id = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-
+  useGetMachine(id);
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} details`);
-
-  useEffect(() => {
-    if (isId(id)) {
-      dispatch(machineActions.get(id));
-    }
-  }, [dispatch, id]);
 
   if (!isId(id) || !isMachineDetails(machine)) {
     return <Spinner text="Loading" />;

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -11,8 +11,10 @@ import {
   useFormattedOS,
   useHasInvalidArchitecture,
   useIsLimitedEditingAllowed,
+  useGetMachine,
 } from "./hooks";
 
+import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
@@ -67,6 +69,19 @@ describe("machine hook utils", () => {
       machine: machineStateFactory({
         items: [machine],
       }),
+    });
+  });
+
+  describe("useGetMachine", () => {
+    it("can get a machine", () => {
+      const store = mockStore(state);
+      renderHook(() => useGetMachine("def456"), {
+        wrapper: generateWrapper(store),
+      });
+      const expected = machineActions.get("def456");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
     });
   });
 

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -8,7 +8,8 @@ import {
   architectures as architecturesSelectors,
   osInfo as osInfoSelectors,
 } from "app/store/general/selectors";
-import type { Machine } from "app/store/machine/types";
+import { actions as machineActions } from "app/store/machine";
+import type { Machine, MachineMeta } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import type { Host } from "app/store/types/host";
@@ -20,6 +21,24 @@ import {
   isNodeStorageConfigurable,
 } from "app/store/utils";
 import vlanSelectors from "app/store/vlan/selectors";
+import { isId } from "app/utils";
+
+/**
+ * Get a machine via the API.
+ * @param id - A machine's system id.
+ */
+export const useGetMachine = (id?: Machine[MachineMeta.PK] | null): void => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    // TODO: this should not fetch the machine again once the request has been
+    // made. This can be done by checking the request id once the action has
+    // been updated:
+    // https://github.com/canonical-web-and-design/app-tribe/issues/1167
+    if (isId(id)) {
+      dispatch(machineActions.get(id));
+    }
+  }, [dispatch, id]);
+};
 
 /**
  * Check whether a machine's storage can be edited based on permissions and the


### PR DESCRIPTION
## Done

- Move the dispatches for getting a machine to a hook.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the summary tab for a machine. The machine details should appear in the header and summary cards.
- Go to the machine list and tick some machines.
- Use the take action menu to open the clone form.
- Click on a machine to clone from. The machine's details should appear in the card.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1166.