### PR TITLE
feat(machine): add machine unsubscribe action

### DIFF
--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -1412,6 +1412,21 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle unsubscribing from machines", () => {
+    expect(actions.unsubscribe(["abc123", "def456"])).toEqual({
+      type: "machine/unsubscribe",
+      meta: {
+        model: "machine",
+        method: "unsubscribe",
+      },
+      payload: {
+        params: {
+          system_ids: ["abc123", "def456"],
+        },
+      },
+    });
+  });
+
   it("can handle setting a boot disk", () => {
     expect(
       actions.setBootDisk({

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -643,4 +643,54 @@ describe("machine reducer", () => {
       );
     });
   });
+
+  it("reduces unsubscribeStart", () => {
+    const items = [
+      machineFactory({ system_id: "abc123" }),
+      machineFactory({ system_id: "def456" }),
+    ];
+    expect(
+      reducers(
+        machineStateFactory({
+          items,
+          statuses: {
+            abc123: machineStatusFactory(),
+            def456: machineStatusFactory(),
+          },
+        }),
+        actions.unsubscribeStart(["abc123"])
+      )
+    ).toEqual(
+      machineStateFactory({
+        items,
+        statuses: {
+          abc123: machineStatusFactory({ unsubscribing: true }),
+          def456: machineStatusFactory(),
+        },
+      })
+    );
+  });
+
+  it("reduces unsubscribeSuccess", () => {
+    const initialState = machineStateFactory({
+      items: [
+        machineFactory({ system_id: "abc123" }),
+        machineFactory({ system_id: "def456" }),
+      ],
+      selected: ["abc123"],
+      statuses: {
+        abc123: machineStatusFactory(),
+        def456: machineStatusFactory(),
+      },
+    });
+    expect(
+      reducers(initialState, actions.unsubscribeSuccess(["abc123"]))
+    ).toEqual(
+      machineStateFactory({
+        items: [initialState.items[1]],
+        selected: [],
+        statuses: { def456: machineStatusFactory() },
+      })
+    );
+  });
 });

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -175,6 +175,7 @@ export type MachineStatus = {
   unlocking: boolean;
   unlinkingSubnet: boolean;
   unmountingSpecial: boolean;
+  unsubscribing: boolean;
   untagging: boolean;
   updatingDisk: boolean;
   updatingFilesystem: boolean;


### PR DESCRIPTION
## Done

- Add an action for unsubscribing to machines over the API.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the machine list in one tab and open a machine's details page in another tab.
- In the machine list tab open the redux dev tools.
- In the machine details page make a change to the machine e.g. add/remove a tag.
- In the redux dev tools in the list tab you should see a `machine/updateNotify` action.
- Now dispatch the following using the redux dev tools, substituting the id for the machine's system_id:
```
{
  type: 'machine/unsubscribe',
  payload: {
    params: {
      system_ids: ["<insert system id here>"]
    }
  },
  meta: {
    model: 'machine',
    method: 'unsubscribe'
  }
}
```
- you should see the `unsubscribe`, `unsubscribeStart` and `unsubscribeSuccess` actions get dispatched and reduced.
- In the machine details page make another change.
- In the redux dev tools you should not see a `machine/updateNotify` (though at the moment you'll see a `createNotify` which is a bug).

## Fixes

Fixes: canonical-web-and-design/app-tribe#1136.