### PR TITLE
feat(machine): store result of machine.get

### DIFF
--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -133,6 +133,35 @@ describe("websocket sagas", () => {
     );
   });
 
+  it("can send a WebSocket message with a request id", () => {
+    const action = {
+      type: "test/action",
+      meta: {
+        model: "test",
+        method: "method",
+        requestId: "123456",
+        type: WebSocketMessageType.REQUEST,
+      },
+      payload: {
+        params: { foo: "bar" },
+      },
+    };
+    const saga = sendMessage(socketClient, action);
+    expect(saga.next().value).toEqual(
+      put({
+        meta: { item: { foo: "bar" }, requestId: "123456" },
+        type: "test/actionStart",
+      })
+    );
+    expect(saga.next().value).toEqual(
+      call([socketClient, socketClient.send], action, {
+        method: "test.method",
+        type: WebSocketMessageType.REQUEST,
+        params: { foo: "bar" },
+      })
+    );
+  });
+
   it("can store a next action when sending a WebSocket message", () => {
     const action = {
       type: "test/action",

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -503,7 +503,11 @@ export function* sendMessage(
     setLoaded(endpoint);
   }
   yield* put({
-    meta: { item: params || payload, identifier },
+    meta: {
+      item: params || payload,
+      identifier,
+      requestId: action.meta?.requestId,
+    },
     type: `${type}Start`,
   });
   const requestIDs = [];

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -7,6 +7,7 @@ import {
   machineDetails as machineDetailsFactory,
   machineEventError as machineEventErrorFactory,
   machineState as machineStateFactory,
+  machineStateDetailsItem as machineStateDetailsItemFactory,
   machineStatus as machineStatusFactory,
 } from "testing/factories";
 
@@ -191,38 +192,69 @@ describe("machine reducer", () => {
   it("reduces getStart", () => {
     const initialState = machineStateFactory({ loading: false });
 
-    expect(reducers(initialState, actions.getStart())).toEqual(
-      machineStateFactory({ loading: true })
+    expect(
+      reducers(
+        initialState,
+        actions.getStart({ system_id: "abc123" }, "123456")
+      )
+    ).toEqual(
+      machineStateFactory({
+        details: {
+          123456: machineStateDetailsItemFactory({
+            loading: true,
+            system_id: "abc123",
+          }),
+        },
+      })
     );
   });
 
   it("reduces getError", () => {
-    const initialState = machineStateFactory({ errors: null, loading: true });
+    const initialState = machineStateFactory({
+      details: {
+        123456: machineStateDetailsItemFactory({
+          system_id: "abc123",
+        }),
+      },
+      errors: null,
+    });
 
     expect(
       reducers(
         initialState,
-        actions.getError({ system_id: "id was not supplied" })
+        actions.getError({ system_id: "abc123" }, "123456", {
+          system_id: "id was not supplied",
+        })
       )
     ).toEqual(
       machineStateFactory({
-        errors: { system_id: "id was not supplied" },
+        details: {
+          123456: machineStateDetailsItemFactory({
+            errors: { system_id: "id was not supplied" },
+            system_id: "abc123",
+          }),
+        },
+        errors: null,
         eventErrors: [
           machineEventErrorFactory({
             error: { system_id: "id was not supplied" },
             event: "get",
-            id: null,
+            id: "abc123",
           }),
         ],
-        loading: false,
       })
     );
   });
 
   it("should update if machine exists on getSuccess", () => {
     const initialState = machineStateFactory({
+      details: {
+        123456: machineStateDetailsItemFactory({
+          loading: true,
+          system_id: "abc123",
+        }),
+      },
       items: [machineFactory({ system_id: "abc123", hostname: "machine1" })],
-      loading: false,
       statuses: {
         abc123: machineStatusFactory(),
       },
@@ -232,8 +264,20 @@ describe("machine reducer", () => {
       hostname: "machine1-newname",
     });
 
-    expect(reducers(initialState, actions.getSuccess(updatedMachine))).toEqual(
+    expect(
+      reducers(
+        initialState,
+        actions.getSuccess({ system_id: "abc123" }, "123456", updatedMachine)
+      )
+    ).toEqual(
       machineStateFactory({
+        details: {
+          123456: machineStateDetailsItemFactory({
+            loaded: true,
+            loading: false,
+            system_id: "abc123",
+          }),
+        },
         items: [updatedMachine],
         loading: false,
         statuses: {
@@ -245,16 +289,33 @@ describe("machine reducer", () => {
 
   it("reduces getSuccess", () => {
     const initialState = machineStateFactory({
+      details: {
+        123456: machineStateDetailsItemFactory({
+          loading: true,
+          system_id: "abc123",
+        }),
+      },
       items: [machineFactory({ system_id: "abc123" })],
-      loading: true,
       statuses: {
         abc123: machineStatusFactory(),
       },
     });
     const newMachine = machineDetailsFactory({ system_id: "def456" });
 
-    expect(reducers(initialState, actions.getSuccess(newMachine))).toEqual(
+    expect(
+      reducers(
+        initialState,
+        actions.getSuccess({ system_id: "abc123" }, "123456", newMachine)
+      )
+    ).toEqual(
       machineStateFactory({
+        details: {
+          123456: machineStateDetailsItemFactory({
+            loaded: true,
+            loading: false,
+            system_id: "abc123",
+          }),
+        },
         items: [...initialState.items, newMachine],
         loading: false,
         statuses: {

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -27,6 +27,8 @@ import { objectHasKey } from "app/utils";
 
 export type GenericItemMeta<I> = {
   item: I;
+  requestId?: string;
+  identifier?: number | string;
 };
 
 // Get the models that follow the generic shape. The following models are excluded:

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -31,6 +31,8 @@ export {
   machineActionsState,
   machineEventError,
   machineState,
+  machineStateDetails,
+  machineStateDetailsItem,
   machineStateListGroup,
   machineStateList,
   machineStateLists,

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -1,11 +1,6 @@
 import { define, random } from "cooky-cutter";
 import type { RouterState } from "redux-first-history";
 
-import type {
-  MachineStateDetails,
-  MachineStateDetailsItem,
-} from "../../app/store/machine/types/base";
-
 import { bondOptions } from "./general";
 
 import { ACTION_STATUS } from "app/base/constants";
@@ -64,6 +59,8 @@ import type {
 } from "app/store/machine/types";
 import type {
   MachineEventErrors,
+  MachineStateDetails,
+  MachineStateDetailsItem,
   MachineStateList,
   MachineStateListGroup,
   MachineStateLists,

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -1,6 +1,11 @@
 import { define, random } from "cooky-cutter";
 import type { RouterState } from "redux-first-history";
 
+import type {
+  MachineStateDetails,
+  MachineStateDetailsItem,
+} from "../../app/store/machine/types/base";
+
 import { bondOptions } from "./general";
 
 import { ACTION_STATUS } from "app/base/constants";
@@ -269,6 +274,17 @@ export const machineStatus = define<MachineStatus>(DEFAULT_MACHINE_STATUSES);
 
 export const machineStatuses = define<MachineStatuses>({
   testNode: machineStatus,
+});
+
+export const machineStateDetailsItem = define<MachineStateDetailsItem>({
+  errors: null,
+  loaded: false,
+  loading: false,
+  system_id: () => random().toString(),
+});
+
+export const machineStateDetails = define<MachineStateDetails>({
+  testNode: machineStateDetailsItem,
 });
 
 export const machineEventError = define<


### PR DESCRIPTION
## Done

- Store the result of machine.get requests using the new details store.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load a machine details page and open redux devtools.
- You should see dispatches for `machine/get`, `machine/getStart` and `machine/getSuccess`.
- In the redux state there should an entry for each get request in machine -> details and each one should have `loaded: true`.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1167.