### PR TITLE
upgrade @canonical/macaroon-bakery to v1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "wait-on-ui": "wait-on http-get://0.0.0.0:8400/MAAS/r"
   },
   "dependencies": {
-    "@canonical/macaroon-bakery": "1.2.0",
+    "@canonical/macaroon-bakery": "1.2.1",
     "@canonical/react-components": "0.37.4",
     "@reduxjs/toolkit": "1.8.3",
     "@sentry/browser": "6.19.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "wait-on-ui": "wait-on http-get://0.0.0.0:8400/MAAS/r"
   },
   "dependencies": {
-    "@canonical/macaroon-bakery": "1.2.1",
+    "@canonical/macaroon-bakery": "1.2.2",
     "@canonical/react-components": "0.37.4",
     "@reduxjs/toolkit": "1.8.3",
     "@sentry/browser": "6.19.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,10 +1922,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.4.1.tgz#dcdd445ac2268a54cf60f2f8c725b6bdeb285d71"
   integrity sha512-lwrikCj0Y11X8Ln8D+elp6Ri3mYjMjsAOJtadNEFzhBrgmg8TVGYJjOdwy8TvRaxy7fHnvVajIKAYWX44Tfj6w==
 
-"@canonical/macaroon-bakery@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.2.0.tgz#cbe2024ce5edfea6155f9fbafc8400464c019074"
-  integrity sha512-docfGyIlNioBNAsyqK0BCtXTD5cmsHZkOAP/l3JZMNQxRlC63Twif3CCr51ud6LiDjo7SlrUhmmBjp8iQ6z1hw==
+"@canonical/macaroon-bakery@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.2.1.tgz#c3a7a9cda783a6f22f4f1fd01180c1ec63682cd7"
+  integrity sha512-CxPkLtZzIJstruiMMd3w4y6RflkotLhqVQPTkJZP3abKahfbJrm70Lqcyfblqth2WAVhmTz5pYvaEnVU/8swxQ==
   dependencies:
     macaroon "3.0.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,10 +1922,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.4.1.tgz#dcdd445ac2268a54cf60f2f8c725b6bdeb285d71"
   integrity sha512-lwrikCj0Y11X8Ln8D+elp6Ri3mYjMjsAOJtadNEFzhBrgmg8TVGYJjOdwy8TvRaxy7fHnvVajIKAYWX44Tfj6w==
 
-"@canonical/macaroon-bakery@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.2.1.tgz#c3a7a9cda783a6f22f4f1fd01180c1ec63682cd7"
-  integrity sha512-CxPkLtZzIJstruiMMd3w4y6RflkotLhqVQPTkJZP3abKahfbJrm70Lqcyfblqth2WAVhmTz5pYvaEnVU/8swxQ==
+"@canonical/macaroon-bakery@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.2.2.tgz#bba6ff4f9212f0a3c301edfb7af864ff9b9773ee"
+  integrity sha512-wiY9L4DMdff8uLgrABKzQVUQy92mYVApz2ffpvRdNw/G0U9p3H7HouIEQsWHQwSKJC+gLIT/fE5o+hUDoF5Ixw==
   dependencies:
     macaroon "3.0.4"
 


### PR DESCRIPTION
## Done

- upgrade @canonical/macaroon-bakery to v1.2.2

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- setup external authentication in your local MAAS using the guide: https://webteam.canonical.com/guides/maas-external-authentication-with-rbac
- make sure you can login to your local MAAS using RBAC

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

