### PR TITLE
Migrate Enzyme to RTL- app/settings/views/Storage

### DIFF
--- a/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.tsx
@@ -24,7 +24,10 @@ const StorageFormFields = (): JSX.Element => {
         options={storageLayoutOptions}
       />
       {values.default_storage_layout === StorageLayout.BLANK && (
-        <p className="p-form-validation__message">
+        <p
+          className="p-form-validation__message"
+          data-testid="blank-layout-warning"
+        >
           <i className="p-icon--warning" />
           <strong className="u-nudge-right--x-small">Caution:</strong> You will
           not be able to deploy machines with this storage layout. Manual
@@ -32,7 +35,10 @@ const StorageFormFields = (): JSX.Element => {
         </p>
       )}
       {isVMWareLayout(values.default_storage_layout) && (
-        <p className="p-form-validation__message">
+        <p
+          className="p-form-validation__message"
+          data-testid="vmfs6-layout-warning"
+        >
           <i className="p-icon--warning" />
           <strong className="u-nudge-right--x-small">Caution:</strong> This
           storage layout only allows for the deployment of{" "}


### PR DESCRIPTION
## Done

Migrated the following testes to RTL:
- [src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/main...ndv99:rtlMigration-Storage?expand=1#diff-4213ebe73a83ae87ea2aef50de17f459655dea563facf31c41f01dd97682849e)
- [src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/main...ndv99:rtlMigration-Storage?expand=1#diff-1ca365d0e38d3e285a3bc00713c0bdf197083a735ffed81abfc53b247e91a896)