### PR TITLE
refactor(machines): move machine fetching to a hook

### DIFF
--- a/src/app/base/components/DhcpForm/DhcpForm.tsx
+++ b/src/app/base/components/DhcpForm/DhcpForm.tsx
@@ -16,7 +16,7 @@ import { actions as deviceActions } from "app/store/device";
 import { actions as dhcpsnippetActions } from "app/store/dhcpsnippet";
 import dhcpsnippetSelectors from "app/store/dhcpsnippet/selectors";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
-import { actions as machineActions } from "app/store/machine";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 
@@ -71,6 +71,7 @@ export const DhcpForm = ({
     editing ? dhcpSnippet?.node : null,
     editing ? dhcpSnippet?.subnet : null
   );
+  useFetchMachines();
 
   useAddMessage(
     saved && !errors,
@@ -83,7 +84,6 @@ export const DhcpForm = ({
     dispatch(subnetActions.fetch());
     dispatch(controllerActions.fetch());
     dispatch(deviceActions.fetch());
-    dispatch(machineActions.fetch());
   }, [dispatch]);
 
   if (

--- a/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.tsx
@@ -1,13 +1,11 @@
-import { useEffect } from "react";
-
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
 import urls from "app/base/urls";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -19,15 +17,11 @@ export enum Labels {
 }
 
 const MachineLink = ({ systemId }: Props): JSX.Element | null => {
-  const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
   const machinesLoading = useSelector(machineSelectors.loading);
-
-  useEffect(() => {
-    dispatch(machineActions.fetch());
-  }, [dispatch]);
+  useFetchMachines();
 
   if (machinesLoading) {
     return <Spinner aria-label={Labels.Loading} />;

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -8,8 +8,8 @@ import { matchPath, Link } from "react-router-dom-v5-compat";
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
 import urls from "app/base/urls";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as tagActions } from "app/store/tag";
@@ -23,9 +23,9 @@ export const MachinesHeader = (props: Props): JSX.Element => {
   const machineCount = useSelector(machineSelectors.count);
   const poolCount = useSelector(resourcePoolSelectors.count);
   const tagCount = useSelector(tagSelectors.count);
+  useFetchMachines();
 
   useEffect(() => {
-    dispatch(machineActions.fetch());
     dispatch(resourcePoolActions.fetch());
     dispatch(tagActions.fetch());
   }, [dispatch]);

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
@@ -21,8 +21,8 @@ import { actions as discoveryActions } from "app/store/discovery";
 import type { Discovery } from "app/store/discovery/types";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as messageActions } from "app/store/message";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
@@ -146,11 +146,11 @@ const DiscoveryAddForm = ({ discovery, onClose }: Props): JSX.Element => {
   const processing =
     deviceType === DeviceType.DEVICE ? saving : creatingInterface;
   const processed = deviceType === DeviceType.DEVICE ? saved : createdInterface;
+  useFetchMachines();
 
   useEffect(() => {
     dispatch(deviceActions.fetch());
     dispatch(domainActions.fetch());
-    dispatch(machineActions.fetch());
     dispatch(subnetActions.fetch());
     dispatch(vlanActions.fetch());
   }, [dispatch]);

--- a/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,6 +15,14 @@ import {
 const mockStore = configureStore();
 
 describe("KVMResourcesCard", () => {
+  beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("fetches machines on load", () => {
     const state = rootStateFactory({
       pod: podStateFactory({
@@ -31,7 +40,7 @@ describe("KVMResourcesCard", () => {
       </Provider>
     );
 
-    const expectedAction = machineActions.fetch();
+    const expectedAction = machineActions.fetch("mocked-nanoid");
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);

--- a/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -1,15 +1,13 @@
-import { useEffect } from "react";
-
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import CoreResources from "../CoreResources";
 import RamResources from "../RamResources";
 import VfResources from "../VfResources";
 import VmResources from "../VmResources";
 
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import { resourceWithOverCommit } from "app/store/pod/utils";
@@ -18,7 +16,6 @@ import type { RootState } from "app/store/root/types";
 type Props = { id: Pod["id"] };
 
 const KVMResourcesCard = ({ id }: Props): JSX.Element => {
-  const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, id)
   );
@@ -26,10 +23,7 @@ const KVMResourcesCard = ({ id }: Props): JSX.Element => {
     podSelectors.getVMs(state, id)
   );
   const machinesLoading = useSelector(machineSelectors.loading);
-
-  useEffect(() => {
-    dispatch(machineActions.fetch());
-  }, [dispatch]);
+  useFetchMachines();
 
   if (pod) {
     const {

--- a/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
+++ b/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -22,6 +23,14 @@ import {
 const mockStore = configureStore();
 
 describe("NumaResourcesCard", () => {
+  beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("fetches machines on load", () => {
     const numaNode = podNumaFactory({ node_id: 111 });
     const pod = podFactory({
@@ -39,7 +48,7 @@ describe("NumaResourcesCard", () => {
         <NumaResourcesCard numaId={111} podId={1} />
       </Provider>
     );
-    const expectedAction = machineActions.fetch();
+    const expectedAction = machineActions.fetch("mocked-nanoid");
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);

--- a/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.tsx
+++ b/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.tsx
@@ -1,15 +1,13 @@
-import { useEffect } from "react";
-
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import CoreResources from "app/kvm/components/CoreResources";
 import RamResources from "app/kvm/components/RamResources";
 import VfResources from "app/kvm/components/VfResources";
 import VmResources from "app/kvm/components/VmResources";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod, PodNetworkInterface, PodNuma } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
@@ -19,7 +17,6 @@ export const TRUNCATION_POINT = 4;
 type Props = { numaId: PodNuma["node_id"]; podId: Pod["id"] };
 
 const NumaResourcesCard = ({ numaId, podId }: Props): JSX.Element => {
-  const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, podId)
   );
@@ -27,10 +24,7 @@ const NumaResourcesCard = ({ numaId, podId }: Props): JSX.Element => {
     podSelectors.getVMs(state, podId)
   );
   const machinesLoading = useSelector(machineSelectors.loading);
-
-  useEffect(() => {
-    dispatch(machineActions.fetch());
-  }, [dispatch]);
+  useFetchMachines();
 
   if (!!pod) {
     const { resources } = pod;

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -11,6 +12,14 @@ import { rootState as rootStateFactory } from "testing/factories";
 const mockStore = configureStore();
 
 describe("LXDVMsTable", () => {
+  beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("fetches machines on load", () => {
     const state = rootStateFactory();
     const store = mockStore(state);
@@ -30,7 +39,7 @@ describe("LXDVMsTable", () => {
       </Provider>
     );
 
-    const expectedAction = machineActions.fetch();
+    const expectedAction = machineActions.fetch("mocked-nanoid");
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -10,6 +10,7 @@ import type { SetSearchFilter } from "app/base/types";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 
 type Props = {
   displayForCluster?: boolean;
@@ -36,15 +37,15 @@ const LXDVMsTable = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(1);
+  useFetchMachines();
 
-  useEffect(() => {
-    dispatch(machineActions.fetch());
-
-    return () => {
+  useEffect(
+    () => () => {
       // Clear machine selected state when unmounting.
       dispatch(machineActions.setSelected([]));
-    };
-  }, [dispatch]);
+    },
+    [dispatch]
+  );
 
   return (
     <>

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -12,11 +12,10 @@ import SourceMachineSelect from "./SourceMachineSelect";
 import FormikField from "app/base/components/FormikField";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
-import { useGetMachine } from "app/store/machine/utils/hooks";
+import { useGetMachine, useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -46,10 +45,10 @@ export const CloneFormFields = ({
     loadingFabrics || loadingMachines || loadingSubnets || loadingVlans;
   const loadingMachineDetails = !!values.source && !selectedMachine;
   useGetMachine(values.source);
+  useFetchMachines();
 
   useEffect(() => {
     dispatch(fabricActions.fetch());
-    dispatch(machineActions.fetch());
     dispatch(subnetActions.fetch());
     dispatch(vlanActions.fetch());
   }, [dispatch]);

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { useStorageState } from "react-storage-hooks";
 
@@ -18,8 +18,8 @@ import type {
   MachineSetHeaderContent,
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 
@@ -34,7 +34,6 @@ export const MachineListHeader = ({
   setSearchFilter,
   setHeaderContent,
 }: Props): JSX.Element => {
-  const dispatch = useDispatch();
   const location = useLocation();
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
@@ -44,10 +43,7 @@ export const MachineListHeader = ({
     "machineViewTagsSeen",
     false
   );
-
-  useEffect(() => {
-    dispatch(machineActions.fetch());
-  }, [dispatch]);
+  useFetchMachines();
 
   useEffect(() => {
     if (location.pathname !== urls.machines.index) {

--- a/src/app/settings/hooks.ts
+++ b/src/app/settings/hooks.ts
@@ -9,9 +9,9 @@ import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -48,6 +48,7 @@ export const useDhcpTarget = (
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, nodeId)
   );
+  useFetchMachines();
   const isLoading =
     (!!subnetId && subnetLoading) ||
     (!!nodeId && (controllerLoading || deviceLoading || machineLoading));
@@ -59,7 +60,6 @@ export const useDhcpTarget = (
     dispatch(subnetActions.fetch());
     dispatch(controllerActions.fetch());
     dispatch(deviceActions.fetch());
-    dispatch(machineActions.fetch());
   }, [dispatch]);
 
   return {

--- a/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
+++ b/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
@@ -27,9 +27,9 @@ import type {
   DHCPSnippetMeta,
   DHCPSnippetState,
 } from "app/store/dhcpsnippet/types";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -204,6 +204,7 @@ const DhcpList = (): JSX.Element => {
   const devices = useSelector(deviceSelectors.all);
   const machines = useSelector(machineSelectors.all);
   const dispatch = useDispatch();
+  useFetchMachines();
 
   useWindowTitle("DHCP snippets");
 
@@ -226,7 +227,6 @@ const DhcpList = (): JSX.Element => {
     dispatch(subnetActions.fetch());
     dispatch(controllerActions.fetch());
     dispatch(deviceActions.fetch());
-    dispatch(machineActions.fetch());
   }, [dispatch]);
 
   return (

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -18,11 +18,12 @@ import { scriptResult as scriptResultFactory } from "testing/factories";
 
 describe("machine actions", () => {
   it("should handle fetching machines", () => {
-    expect(actions.fetch()).toEqual({
+    expect(actions.fetch("123456")).toEqual({
       type: "machine/fetch",
       meta: {
         model: "machine",
         method: "list",
+        requestId: "123456",
       },
       payload: {
         params: { limit: 25 },

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -970,10 +970,11 @@ const machineSlice = createSlice({
     exitRescueModeStart: statusHandlers.exitRescueMode.start,
     exitRescueModeSuccess: statusHandlers.exitRescueMode.success,
     fetch: {
-      prepare: () => ({
+      prepare: (requestId: string) => ({
         meta: {
           model: MachineMeta.MODEL,
           method: "list",
+          requestId,
         },
         payload: {
           params: { limit: 25 },

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -26,6 +26,24 @@ import vlanSelectors from "app/store/vlan/selectors";
 import { isId } from "app/utils";
 
 /**
+ * Fetch machines via the API.
+ */
+export const useFetchMachines = (): void => {
+  const requestId = useRef<string | null>(null);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    // TODO: request the machines again if the provided options change (filters,
+    // ordering, pagination etc.)
+    if (!requestId.current) {
+      requestId.current = nanoid();
+      dispatch(machineActions.fetch(requestId.current));
+    }
+  }, [dispatch]);
+  // TODO: clean up the previous request if the options change or the component is unmounted:
+  // https://github.com/canonical-web-and-design/app-tribe/issues/1128
+};
+
+/**
  * Get a machine via the API.
  * @param id - A machine's system id.
  */

--- a/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -25,6 +26,7 @@ const mockStore = configureStore();
 let state: RootState;
 
 beforeEach(() => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
   state = rootStateFactory({
     machine: machineStateFactory({
       items: [
@@ -48,6 +50,10 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 it("dispatches actions to fetch necessary data", () => {
   const store = mockStore(state);
   render(
@@ -63,7 +69,10 @@ it("dispatches actions to fetch necessary data", () => {
       </MemoryRouter>
     </Provider>
   );
-  const expectedActions = [machineActions.fetch(), tagActions.fetch()];
+  const expectedActions = [
+    machineActions.fetch("mocked-nanoid"),
+    tagActions.fetch(),
+  ];
   const actualActions = store.getActions();
   expectedActions.forEach((expectedAction) => {
     expect(

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -8,8 +8,8 @@ import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import urls from "app/base/urls";
 import MachineListTable from "app/machines/views/MachineList/MachineListTable";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
@@ -30,12 +30,12 @@ const TagMachines = (): JSX.Element => {
   const deployedMachines = useSelector((state: RootState) =>
     machineSelectors.getDeployedWithTag(state, id)
   );
+  useFetchMachines();
 
   useWindowTitle(tag ? `Deployed machines for: ${tag.name}` : "Tag");
 
   useEffect(() => {
     dispatch(tagActions.fetch());
-    dispatch(machineActions.fetch());
   }, [dispatch]);
 
   if (!isId(id) || (!tagsLoading && !tag)) {


### PR DESCRIPTION
## Done

- Move the calls to fetch the machines to a reusable hook.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

Brace yourself, this is a lot of places to check. Over time a number of these places will be replaced with calls to `machine.get` but right now this is all the places that fetch the list of machines.
- Go to the machine list and refresh the page. The machines should load.
- Tick all the machines and open the "Take action" menu and click "Clone from..." and then click the "update your selection" link.
- In the "Select the source machine" table you should see a list of machines.
- Go to Machines -> Tags and refresh the page.
- In the table find a tag with kernel options that has been applied to a deployed machine and click the delete button.
- In the warning in the header click "Show the deployed machine" and you should see a table of machines.
- Go to the dashboard and refresh the page.
- Using the menu in the actions column click "Add discovery..."
- In the Parent select box there should be a list of machines.
- Go to Subnets and click on a subnet and refresh the page.
- In the "Used IP addresses" table you should see the names of machines in the "Node" column (you might need to find a subnet that has machines in the table).
- Go to Settings -> DHCP snippets and refresh the page. You should see machine names in the "Applied to" column (if you have no applied machines you can add one in the next step).
- Click "Add snippet" and refresh the page. Change the Type select box to Machine. In the Applied to select box you should see a list of machines.
- Go to KVM - LXD tab -> LXD single host and refresh the page. You should see a list of machines in the table.
- - Toggle "View by NUMA node" and then click "Total VMs: x" on one of the NUMA cards (you might need to find a numa node with machines) and you should see a list of machines.
- Go to KVM - LXD tab -> LXD cluster and refresh the page. You should see a list of machines in the table.
- Click on a host with machines and refresh. You should see a list of machines in the table.
- Toggle "View by NUMA node" and then click "Total VMs: x" on one of the NUMA cards (you might need to find a numa node with machines) and you should see a list of machines.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1218.