### PR TITLE
Migrate Enzyme to RTL - app/settings/views/LicenseKeys

### DIFF
--- a/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
@@ -5,6 +5,7 @@ import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import { Labels as LicenseKeyFormLabels } from "../LicenseKeyForm/LicenseKeyForm";
+import { Labels as FormFieldsLabels } from "../LicenseKeyFormFields/LicenseKeyFormFields";
 
 import { LicenseKeyEdit, Labels as LicenseKeyLabels } from "./LicenseKeyEdit";
 
@@ -144,8 +145,8 @@ describe("LicenseKeyEdit", () => {
     }) as HTMLOptionElement;
     expect(release.selected).toBe(true);
 
-    expect(screen.getByRole("textbox", { name: "License key" })).toHaveValue(
-      "XXXXX-XXXXX-XXXXX-XXXXX-XXXXA"
-    );
+    expect(
+      screen.getByRole("textbox", { name: FormFieldsLabels.LicenseKey })
+    ).toHaveValue("XXXXX-XXXXX-XXXXX-XXXXX-XXXXA");
   });
 });

--- a/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
@@ -1,10 +1,12 @@
-import { mount } from "enzyme";
+import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
-import { LicenseKeyEdit } from "./LicenseKeyEdit";
+import { Labels as LicenseKeyFormLabels } from "../LicenseKeyForm/LicenseKeyForm";
+
+import { LicenseKeyEdit, Labels as LicenseKeyLabels } from "./LicenseKeyEdit";
 
 import type { RootState } from "app/store/root/types";
 import {
@@ -65,7 +67,7 @@ describe("LicenseKeyEdit", () => {
     state.licensekeys.loading = true;
     state.licensekeys.loaded = false;
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[
@@ -81,12 +83,12 @@ describe("LicenseKeyEdit", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(screen.getByText(LicenseKeyLabels.Loading)).toBeInTheDocument();
   });
 
   it("handles license key not found", () => {
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[
@@ -99,12 +101,12 @@ describe("LicenseKeyEdit", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("h4").text()).toBe("License key not found");
+    expect(screen.getByText(LicenseKeyLabels.KeyNotFound)).toBeInTheDocument();
   });
 
   it("can display a license key edit form", () => {
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[
@@ -126,8 +128,24 @@ describe("LicenseKeyEdit", () => {
       </Provider>
     );
 
-    const form = wrapper.find("LicenseKeyForm");
-    expect(form.exists()).toBe(true);
-    expect(form.prop("licenseKey")).toStrictEqual(state.licensekeys.items[0]);
+    expect(
+      screen.getByRole("form", {
+        name: LicenseKeyFormLabels.FormLabel,
+      })
+    ).toBeInTheDocument();
+
+    const operatingSystem = screen.getByRole("option", {
+      name: "Windows",
+    }) as HTMLOptionElement;
+    expect(operatingSystem.selected).toBe(true);
+
+    const release = screen.getByRole("option", {
+      name: "Windows Server 2012",
+    }) as HTMLOptionElement;
+    expect(release.selected).toBe(true);
+
+    expect(screen.getByRole("textbox", { name: "License key" })).toHaveValue(
+      "XXXXX-XXXXX-XXXXX-XXXXX-XXXXA"
+    );
   });
 });

--- a/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.tsx
@@ -11,6 +11,11 @@ import licenseKeysSelectors from "app/store/licensekeys/selectors";
 import type { LicenseKeys } from "app/store/licensekeys/types";
 import type { RootState } from "app/store/root/types";
 
+export enum Labels {
+  Loading = "Loading...",
+  KeyNotFound = "License key not found",
+}
+
 export const LicenseKeyEdit = (): JSX.Element => {
   const dispatch = useDispatch();
   const { osystem, distro_series } = useParams<{
@@ -32,10 +37,10 @@ export const LicenseKeyEdit = (): JSX.Element => {
   }, [dispatch]);
 
   if (loading) {
-    return <Spinner text="Loading..." />;
+    return <Spinner text={Labels.Loading} />;
   }
   if (!licenseKey) {
-    return <h4>License key not found</h4>;
+    return <h4>{Labels.KeyNotFound}</h4>;
   }
   return <LicenseKeyForm licenseKey={licenseKey} />;
 };

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
@@ -6,6 +6,8 @@ import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
+import { Labels as FormFieldsLabels } from "../LicenseKeyFormFields/LicenseKeyFormFields";
+
 import {
   LicenseKeyForm,
   Labels as LicenseKeyFormLabels,
@@ -154,17 +156,17 @@ describe("LicenseKeyForm", () => {
     );
 
     await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Operating System" }),
+      screen.getByRole("combobox", { name: FormFieldsLabels.OperatingSystem }),
       "Windows"
     );
 
     await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Release" }),
+      screen.getByRole("combobox", { name: FormFieldsLabels.Release }),
       "Windows Server 2012"
     );
 
     const licenseKeyInput = screen.getByRole("textbox", {
-      name: "License key",
+      name: FormFieldsLabels.LicenseKey,
     });
     await userEvent.clear(licenseKeyInput);
     await userEvent.type(licenseKeyInput, "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX");
@@ -204,7 +206,7 @@ describe("LicenseKeyForm", () => {
     );
 
     const licenseKeyInput = screen.getByRole("textbox", {
-      name: "License key",
+      name: FormFieldsLabels.LicenseKey,
     });
 
     // At least one field has to be updated in order for the submit button to be enabled

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
@@ -25,6 +25,7 @@ type Props = {
 };
 
 export enum Labels {
+  Loading = "Loading...",
   FormLabel = "License Key Form",
 }
 
@@ -72,7 +73,7 @@ export const LicenseKeyForm = ({ licenseKey }: Props): JSX.Element => {
   return (
     <FormCard title={title}>
       {!isLoaded ? (
-        <Spinner text="loading..." />
+        <Spinner text={Labels.Loading} />
       ) : osystems.length > 0 ? (
         <FormikForm<LicenseKeyFormValues>
           aria-label={Labels.FormLabel}

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
@@ -24,6 +24,10 @@ type Props = {
   licenseKey?: LicenseKeys;
 };
 
+export enum Labels {
+  FormLabel = "License Key Form",
+}
+
 const LicenseKeySchema = Yup.object().shape({
   osystem: Yup.string().required("Operating system is required"),
   distro_series: Yup.string().required("Release is required"),
@@ -71,6 +75,7 @@ export const LicenseKeyForm = ({ licenseKey }: Props): JSX.Element => {
         <Spinner text="loading..." />
       ) : osystems.length > 0 ? (
         <FormikForm<LicenseKeyFormValues>
+          aria-label={Labels.FormLabel}
           cleanup={licenseKeysActions.cleanup}
           errors={errors}
           initialValues={{

--- a/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.tsx
@@ -1,10 +1,12 @@
-import { mount } from "enzyme";
+import { screen, render } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import LicenseKeyFormFields from "./LicenseKeyFormFields";
+import LicenseKeyFormFields, {
+  Labels as FormFieldsLabels,
+} from "./LicenseKeyFormFields";
 
 import type { OSInfoOptions } from "app/store/general/selectors/osInfo";
 import type { RootState } from "app/store/root/types";
@@ -53,7 +55,7 @@ describe("LicenseKeyFormFields", () => {
 
   it("can render", () => {
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
           <Formik initialValues={{}} onSubmit={jest.fn()}>
@@ -62,6 +64,23 @@ describe("LicenseKeyFormFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("LicenseKeyFormFields").exists()).toBe(true);
+
+    expect(
+      screen.getByRole("combobox", {
+        name: FormFieldsLabels.OperatingSystem,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("combobox", {
+        name: FormFieldsLabels.Release,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("textbox", {
+        name: FormFieldsLabels.LicenseKey,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.tsx
@@ -13,6 +13,12 @@ type Props = {
   releases: OSInfoOptions;
 };
 
+export enum Labels {
+  OperatingSystem = "Operating System",
+  Release = "Release",
+  LicenseKey = "License key",
+}
+
 export const LicenseKeyFormFields = ({
   osystems,
   releases,
@@ -24,7 +30,7 @@ export const LicenseKeyFormFields = ({
     <>
       <FormikField
         component={Select}
-        label="Operating System"
+        label={Labels.OperatingSystem}
         name="osystem"
         onChange={(e: ChangeEvent<HTMLSelectElement>) => {
           formikProps.handleChange(e);
@@ -42,7 +48,7 @@ export const LicenseKeyFormFields = ({
       />
       <FormikField
         component={Select}
-        label="Release"
+        label={Labels.Release}
         name="distro_series"
         onChange={(e: ChangeEvent<HTMLSelectElement>) => {
           formikProps.handleChange(e);
@@ -52,7 +58,7 @@ export const LicenseKeyFormFields = ({
         required={true}
       />
       <FormikField
-        label="License key"
+        label={Labels.LicenseKey}
         name="license_key"
         required={true}
         type="text"

--- a/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme";
+import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -49,7 +49,7 @@ describe("LicenseKeyList", () => {
     const state = { ...initialState };
     const store = mockStore(state);
 
-    mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/" }]}>
           <CompatRouter>


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
- [src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/main...ndv99:rtlMigration-settingsLicenseKeys?expand=1#diff-fbbb14a2cc211ba17d437acd008f58f6edd4844677e9de1357d4814be84891d3)
- [src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/main...ndv99:rtlMigration-settingsLicenseKeys?expand=1#diff-86e099751c777da7d90ee6c6ee24e1408756f9530ba025291ad04cd91120aa2a)
- [src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/main...ndv99:rtlMigration-settingsLicenseKeys?expand=1#diff-bf0710c825faaca0ab353192b9818eade94c605e6fa7b1c7e5815b8ae0c51d31)
- [src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx](https://github.com/canonical-web-and-design/maas-ui/compare/main...ndv99:rtlMigration-settingsLicenseKeys?expand=1#diff-c578e86924f1a4ec99b956101d5f6667bc639eff5dd53337b6d600a1d6b911e9)


## Fixes

This PR closes https://github.com/canonical-web-and-design/app-tribe/issues/1051 
