### PR TITLE
fix(ui): fix main machine list

### DIFF
--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -48,7 +48,10 @@ describe("machine reducer", () => {
     ];
 
     expect(
-      reducers(initialState, actions.fetchSuccess(fetchedMachines))
+      reducers(
+        initialState,
+        actions.fetchSuccess({ groups: [{ items: fetchedMachines }] })
+      )
     ).toEqual(
       machineStateFactory({
         items: fetchedMachines,
@@ -81,7 +84,10 @@ describe("machine reducer", () => {
     ];
 
     expect(
-      reducers(initialState, actions.fetchSuccess(fetchedMachines))
+      reducers(
+        initialState,
+        actions.fetchSuccess({ groups: [{ items: fetchedMachines }] })
+      )
     ).toEqual(
       machineStateFactory({
         items: [existingMachine, fetchedMachines[1]],

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1000,20 +1000,27 @@ const machineSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    fetchSuccess: (state: MachineState, action: PayloadAction<Machine[]>) => {
-      action.payload.forEach((newItem: Machine) => {
-        // Add items that don't already exist in the store. Existing items
-        // are probably MachineDetails so this would overwrite them with the
-        // simple machine. Existing items will be kept up to date via the
-        // notify (sync) messages.
-        const existing = state.items.find(
-          (draftItem: Machine) => draftItem.id === newItem.id
-        );
-        if (!existing) {
-          state.items.push(newItem);
-          // Set up the statuses for this machine.
-          state.statuses[newItem.system_id] = DEFAULT_STATUSES;
-        }
+    fetchSuccess: (
+      state: MachineState,
+      // This is a partial type to get the machine list working while the server
+      // side machine list is being implemented.
+      action: PayloadAction<{ groups: { items: Machine[] }[] }>
+    ) => {
+      action.payload.groups.forEach(({ items }) => {
+        items.forEach((newItem: Machine) => {
+          // Add items that don't already exist in the store. Existing items
+          // are probably MachineDetails so this would overwrite them with the
+          // simple machine. Existing items will be kept up to date via the
+          // notify (sync) messages.
+          const existing = state.items.find(
+            (draftItem: Machine) => draftItem.id === newItem.id
+          );
+          if (!existing) {
+            state.items.push(newItem);
+            // Set up the statuses for this machine.
+            state.statuses[newItem.system_id] = DEFAULT_STATUSES;
+          }
+        });
       });
     },
     get: {


### PR DESCRIPTION
## Done

- Get the machine list on main working with the new API shape.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

Note: at the time of writing this isn't working with the demo service as the snap hasn't been updated to the version that breaks the machine list so this might need to be QAed locally.
- Go to the machine list.
- It should display the machines.

## Fixes

Fixes: #4284.