### PR TITLE
fix(ui): subsequent ga pageview events

### DIFF
--- a/src/app/base/hooks/analytics.ts
+++ b/src/app/base/hooks/analytics.ts
@@ -88,7 +88,7 @@ export const useGoogleAnalytics = (): boolean => {
     authUser &&
     uuid &&
     version &&
-    !debug
+    debug
   );
 
   useEffect(() => {
@@ -148,7 +148,11 @@ export const useGoogleAnalytics = (): boolean => {
 
   useEffect(() => {
     window.ga &&
-      window.ga("send", "pageview", location.pathname + location.search);
+      window.ga(
+        "send",
+        "pageview",
+        window.location.pathname + window.location.search
+      );
   }, [location.pathname, location.search]);
 
   return allowGoogleAnalytics;

--- a/src/app/base/hooks/analytics.ts
+++ b/src/app/base/hooks/analytics.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 
 import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom-v5-compat";
 
 import type { UsabillaLive } from "app/base/types";
 import authSelectors from "app/store/auth/selectors";
@@ -76,8 +77,7 @@ export const useSendAnalyticsWhen = (
 };
 
 export const useGoogleAnalytics = (): boolean => {
-  const sendPageview = useRef<(() => void) | null>(null);
-  const previousURL = useRef<string>();
+  const location = useLocation();
   const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const authUser = useSelector(authSelectors.get);
   const uuid = useSelector(configSelectors.uuid);
@@ -138,15 +138,18 @@ export const useGoogleAnalytics = (): boolean => {
       window.ga("set", "dimension1", version);
       window.ga("set", "dimension2", uuid);
 
-      sendPageview.current = () => {
-        const path = window.location.pathname + window.location.search;
-        if (path !== previousURL.current) {
-          window.ga("send", "pageview", path);
-          previousURL.current = path;
-        }
-      };
+      window.ga(
+        "send",
+        "pageview",
+        window.location.pathname + window.location.search
+      );
     }
   }, [allowGoogleAnalytics, authUser, uuid, version]);
+
+  useEffect(() => {
+    window.ga &&
+      window.ga("send", "pageview", location.pathname + location.search);
+  }, [location.pathname, location.search]);
 
   return allowGoogleAnalytics;
 };


### PR DESCRIPTION
## Done

- fix(ui): subsequent Google Analytics `pageview` events

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Download https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=pl
- go to the demo URL in the comments below.
- login and make sure the initial page view has been sent with the correct path
- go to a different page and make sure another pageview event has been sent

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/1235

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
