### PR TITLE
fix(ui): backport Native TLS QA fixes (#3949)

### DIFF
--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/TLSEnabledFields.tsx
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/TLSEnabledFields.tsx
@@ -33,7 +33,7 @@ const TLSEnabledFields = (): JSX.Element => {
           min={TLSExpiryNotificationInterval.MIN}
           name="notificationInterval"
           onChange={(e) =>
-            setFieldValue("notificationInterval", Number(e.currentTarget.value))
+            setFieldValue("notificationInterval", e.target.value)
           }
           showInput
           step={1}

--- a/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/_index.scss
+++ b/ui/src/app/settings/views/Configuration/Security/TLSEnabled/TLSEnabledFields/_index.scss
@@ -25,7 +25,7 @@
 
     .p-slider__input {
       flex: 0 1 3rem;
-      min-width: unset;
+      min-width: initial;
     }
 
     input[type="range"] {


### PR DESCRIPTION
## Done

- Backport Native TLS QA fixes https://github.com/canonical-web-and-design/maas-ui/pull/3949

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
