### PR TITLE
fix: show reverse proxy for region or region+rack

### DIFF
--- a/legacy/src/app/partials/cards/services.html
+++ b/legacy/src/app/partials/cards/services.html
@@ -80,6 +80,18 @@
     </li>
     <li
       class="p-list-tree__item"
+      data-ng-if="(node.node_type == 3 || node.node_type == 4) && services.reverse_proxy"
+    >
+      <span>
+        <span class="p-icon--{$ getServiceClass(services.reverse_proxy) $}"></span
+        >&nbsp;reverse-proxy
+        <span data-ng-if="services.reverse_proxy.status_info">
+          &ndash; <small>{$ services.reverse_proxy.status_info $}</small></span
+        >
+      </span>
+    </li>
+    <li
+      class="p-list-tree__item"
       data-ng-if="node.node_type == 2 || node.node_type == 4"
     >
       <span>
@@ -177,18 +189,6 @@
         >&nbsp;syslog
         <span data-ng-if="services.syslog_rack.status_info">
           &ndash; <small>{$ services.syslog_rack.status_info $}</small></span
-        >
-      </span>
-    </li>
-    <li
-      class="p-list-tree__item"
-      data-ng-if="(node.node_type == 2 || node.node_type == 4) && services.reverse_proxy"
-    >
-      <span>
-        <span class="p-icon--{$ getServiceClass(services.reverse_proxy) $}"></span
-        >&nbsp;reverse-proxy
-        <span data-ng-if="services.reverse_proxy.status_info">
-          &ndash; <small>{$ services.reverse_proxy.status_info $}</small></span
         >
       </span>
     </li>


### PR DESCRIPTION
## Done

- Fix a bug when `reverse-proxy` service is displayed for `rack` or `region+rack`. Should be `region` or `region+rack`.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #4292 .

## Launchpad issue

lp#1982984

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.

When MAAS is installed only with a `region` role, it didn't show the `reverse-proxy` service (the number of services is 6, but only 5 are displayed)
![Services](https://user-images.githubusercontent.com/3663203/181391937-5a065a11-aab7-4dea-843f-924543dfe408.png)

This PR fixes this, so it is displayed correctly:
![image](https://user-images.githubusercontent.com/3663203/181392141-9f5c4a9c-0c44-43cf-a1c3-ea5d2de6f4e9.png)
