### PR TITLE
fix: show reverse proxy for region or region+rack

### DIFF
--- a/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.test.tsx
@@ -164,6 +164,7 @@ it("only renders rack controller services for a rack controller", () => {
   const services = [
     serviceFactory({ name: ServiceName.RACKD }),
     serviceFactory({ name: ServiceName.REGIOND }),
+    serviceFactory({ name: ServiceName.REVERSE_PROXY }),
   ];
   const controller = controllerDetailsFactory({
     node_type: NodeType.RACK_CONTROLLER,
@@ -191,12 +192,16 @@ it("only renders rack controller services for a rack controller", () => {
   expect(
     screen.queryByText(getServiceDisplayName(ServiceName.REGIOND))
   ).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(getServiceDisplayName(ServiceName.REVERSE_PROXY))
+  ).not.toBeInTheDocument();
 });
 
 it("only renders region controller services for a region controller", () => {
   const services = [
     serviceFactory({ name: ServiceName.RACKD }),
     serviceFactory({ name: ServiceName.REGIOND }),
+    serviceFactory({ name: ServiceName.REVERSE_PROXY }),
   ];
   const controller = controllerDetailsFactory({
     node_type: NodeType.REGION_CONTROLLER,
@@ -222,6 +227,9 @@ it("only renders region controller services for a region controller", () => {
     screen.getByText(getServiceDisplayName(ServiceName.REGIOND))
   ).toBeInTheDocument();
   expect(
+    screen.getByText(getServiceDisplayName(ServiceName.REVERSE_PROXY))
+  ).toBeInTheDocument();
+  expect(
     screen.queryByText(getServiceDisplayName(ServiceName.RACKD))
   ).not.toBeInTheDocument();
 });
@@ -230,6 +238,7 @@ it("renders both region and rack controller services for a region+rack controlle
   const services = [
     serviceFactory({ name: ServiceName.RACKD }),
     serviceFactory({ name: ServiceName.REGIOND }),
+    serviceFactory({ name: ServiceName.REVERSE_PROXY }),
   ];
   const controller = controllerDetailsFactory({
     node_type: NodeType.REGION_AND_RACK_CONTROLLER,
@@ -256,5 +265,8 @@ it("renders both region and rack controller services for a region+rack controlle
   ).toBeInTheDocument();
   expect(
     screen.getByText(getServiceDisplayName(ServiceName.RACKD))
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(getServiceDisplayName(ServiceName.REVERSE_PROXY))
   ).toBeInTheDocument();
 });

--- a/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.tsx
@@ -49,6 +49,10 @@ const SERVICE_ITEMS: ServiceItem[] = [
     types: [NodeType.REGION_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
   },
   {
+    name: ServiceName.REVERSE_PROXY,
+    types: [NodeType.REGION_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
+  },
+  {
     name: ServiceName.RACKD,
     types: [NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
     children: [
@@ -84,10 +88,6 @@ const SERVICE_ITEMS: ServiceItem[] = [
   },
   {
     name: ServiceName.SYSLOG_RACK,
-    types: [NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
-  },
-  {
-    name: ServiceName.REVERSE_PROXY,
     types: [NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
   },
 ];


### PR DESCRIPTION
## Done

- Fix a bug when `reverse-proxy` service is displayed for `rack` or `region+rack`. Should be `region` or `region+rack`.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #4292 .

## Launchpad issue

lp#1982984

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.

When MAAS is installed only with a `region` role, it didn't show the `reverse-proxy` service (the number of services is 6, but only 5 are displayed)
![Services](https://user-images.githubusercontent.com/3663203/181391937-5a065a11-aab7-4dea-843f-924543dfe408.png)

This PR fixes this, so it is displayed correctly:
![image](https://user-images.githubusercontent.com/3663203/181392141-9f5c4a9c-0c44-43cf-a1c3-ea5d2de6f4e9.png)
