### PR TITLE
feat(machines): update machine.list to use new API

### DIFF
--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -1,4 +1,5 @@
 import { actions } from "./slice";
+import { FetchGroupKey, FetchSortDirection } from "./types";
 
 import { PowerTypeNames } from "app/store/general/constants";
 import {
@@ -23,10 +24,35 @@ describe("machine actions", () => {
       meta: {
         model: "machine",
         method: "list",
+        nocache: true,
+        requestId: "123456",
+      },
+      payload: null,
+    });
+  });
+
+  it("should handle fetching machines with params", () => {
+    const params = {
+      filter: {
+        owner: "admin",
+      },
+      group_key: FetchGroupKey.Owner,
+      group_collapsed: [],
+      page_size: 20,
+      page_number: 5,
+      sort_key: "owner",
+      sort_direction: FetchSortDirection.Ascending,
+    };
+    expect(actions.fetch("123456", params)).toEqual({
+      type: "machine/fetch",
+      meta: {
+        model: "machine",
+        method: "list",
+        nocache: true,
         requestId: "123456",
       },
       payload: {
-        params: { limit: 25 },
+        params,
       },
     });
   });

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -6,6 +6,8 @@ import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
   machineEventError as machineEventErrorFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
   machineState as machineStateFactory,
   machineStateDetailsItem as machineStateDetailsItemFactory,
   machineStatus as machineStatusFactory,
@@ -35,9 +37,13 @@ describe("machine reducer", () => {
   it("reduces fetchStart", () => {
     const initialState = machineStateFactory({ loading: false });
 
-    expect(reducers(initialState, actions.fetchStart())).toEqual(
+    expect(reducers(initialState, actions.fetchStart("123456"))).toEqual(
       machineStateFactory({
-        loading: true,
+        lists: {
+          "123456": machineStateListFactory({
+            loading: true,
+          }),
+        },
       })
     );
   });
@@ -45,8 +51,12 @@ describe("machine reducer", () => {
   it("reduces fetchSuccess", () => {
     const initialState = machineStateFactory({
       items: [],
-      loading: true,
-      loaded: false,
+      lists: {
+        "123456": machineStateListFactory({
+          loaded: true,
+          loading: true,
+        }),
+      },
       statuses: {},
     });
     const fetchedMachines = [
@@ -57,13 +67,40 @@ describe("machine reducer", () => {
     expect(
       reducers(
         initialState,
-        actions.fetchSuccess({ groups: [{ items: fetchedMachines }] })
+        actions.fetchSuccess("123456", {
+          count: 1,
+          cur_page: 2,
+          groups: [
+            {
+              collapsed: true,
+              count: 4,
+              items: fetchedMachines,
+              name: "admin",
+            },
+          ],
+          num_pages: 3,
+        })
       )
     ).toEqual(
       machineStateFactory({
         items: fetchedMachines,
-        loading: false,
-        loaded: true,
+        lists: {
+          "123456": machineStateListFactory({
+            count: 1,
+            cur_page: 2,
+            groups: [
+              machineStateListGroupFactory({
+                collapsed: true,
+                count: 4,
+                items: ["abc123", "def456"],
+                name: "admin",
+              }),
+            ],
+            num_pages: 3,
+            loaded: true,
+            loading: false,
+          }),
+        },
         statuses: {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
@@ -79,8 +116,6 @@ describe("machine reducer", () => {
     });
     const initialState = machineStateFactory({
       items: [existingMachine],
-      loading: true,
-      loaded: false,
       statuses: {
         abc123: machineStatusFactory(),
       },
@@ -93,13 +128,40 @@ describe("machine reducer", () => {
     expect(
       reducers(
         initialState,
-        actions.fetchSuccess({ groups: [{ items: fetchedMachines }] })
+        actions.fetchSuccess("123456", {
+          count: 1,
+          cur_page: 2,
+          groups: [
+            {
+              collapsed: true,
+              count: 4,
+              items: fetchedMachines,
+              name: "admin",
+            },
+          ],
+          num_pages: 3,
+        })
       )
     ).toEqual(
       machineStateFactory({
         items: [existingMachine, fetchedMachines[1]],
-        loading: false,
-        loaded: true,
+        lists: {
+          "123456": machineStateListFactory({
+            count: 1,
+            cur_page: 2,
+            groups: [
+              machineStateListGroupFactory({
+                collapsed: true,
+                count: 4,
+                items: ["abc123", "def456"],
+                name: "admin",
+              }),
+            ],
+            num_pages: 3,
+            loaded: true,
+            loading: false,
+          }),
+        },
         statuses: {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
@@ -110,16 +172,26 @@ describe("machine reducer", () => {
 
   it("reduces fetchError", () => {
     const initialState = machineStateFactory({
-      errors: null,
-      loaded: false,
-      loading: true,
+      lists: {
+        "123456": machineStateListFactory({
+          loading: true,
+        }),
+      },
     });
 
     expect(
-      reducers(initialState, actions.fetchError("Could not fetch machines"))
+      reducers(
+        initialState,
+        actions.fetchError("123456", "Could not fetch machines")
+      )
     ).toEqual(
       machineStateFactory({
-        errors: "Could not fetch machines",
+        lists: {
+          "123456": machineStateListFactory({
+            errors: "Could not fetch machines",
+            loading: false,
+          }),
+        },
         eventErrors: [
           machineEventErrorFactory({
             error: "Could not fetch machines",
@@ -127,8 +199,6 @@ describe("machine reducer", () => {
             id: null,
           }),
         ],
-        loaded: false,
-        loading: false,
       })
     );
   });

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -231,6 +231,135 @@ export type DeployParams = BaseNodeActionParams & {
   user_data?: string;
 };
 
+export enum FetchSortDirection {
+  Ascending = "ascending",
+  Descending = "descending",
+}
+
+// TODO: Define the specific filters that the API supports:
+// https://github.com/canonical-web-and-design/app-tribe/issues/1149
+export type FetchFilters = {
+  [x: string]: string | number | boolean | (string | number)[];
+};
+
+export enum FetchGroupKey {
+  AddressTtl = "address_ttl",
+  AgentName = "agent_name",
+  Architecture = "architecture",
+  BiosBootMethod = "bios_boot_method",
+  Bmc = "bmc",
+  BmcId = "bmc_id",
+  BootClusterIp = "boot_cluster_ip",
+  BootDisk = "boot_disk",
+  BootDiskId = "boot_disk_id",
+  BootInterface = "boot_interface",
+  BootInterfaceId = "boot_interface_id",
+  Children = "children",
+  Connections = "connections",
+  Controllerinfo = "controllerinfo",
+  CpuCount = "cpu_count",
+  CpuSpeed = "cpu_speed",
+  Created = "created",
+  CurrentCommissioningScriptSet = "current_commissioning_script_set",
+  CurrentCommissioningScriptSetId = "current_commissioning_script_set_id",
+  CurrentConfig = "current_config",
+  CurrentConfigId = "current_config_id",
+  CurrentInstallationScriptSet = "current_installation_script_set",
+  CurrentInstallationScriptSetId = "current_installation_script_set_id",
+  CurrentTestingScriptSet = "current_testing_script_set",
+  CurrentTestingScriptSetId = "current_testing_script_set_id",
+  DefaultUser = "default_user",
+  Description = "description",
+  Dhcpsnippet = "dhcpsnippet",
+  Discovery = "discovery",
+  DistroSeries = "distro_series",
+  DnsProcess = "dns_process",
+  DnsProcessId = "dns_process_id",
+  Domain = "domain",
+  DomainId = "domain_id",
+  Dynamic = "dynamic",
+  EnableHwSync = "enable_hw_sync",
+  EnableSsh = "enable_ssh",
+  EphemeralDeploy = "ephemeral_deploy",
+  Error = "error",
+  ErrorDescription = "error_description",
+  Event = "event",
+  GatewayLinkIpv4 = "gateway_link_ipv4",
+  GatewayLinkIpv4Id = "gateway_link_ipv4_id",
+  GatewayLinkIpv6 = "gateway_link_ipv6",
+  GatewayLinkIpv6Id = "gateway_link_ipv6_id",
+  HardwareUuid = "hardware_uuid",
+  Hostname = "hostname",
+  HweKernel = "hwe_kernel",
+  Id = "id",
+  InstallKvm = "install_kvm",
+  InstallRackd = "install_rackd",
+  InstancePowerParameters = "instance_power_parameters",
+  LastAppliedStorageLayout = "last_applied_storage_layout",
+  LastImageSync = "last_image_sync",
+  LastSync = "last_sync",
+  LicenseKey = "license_key",
+  Locked = "locked",
+  ManagingProcess = "managing_process",
+  ManagingProcessId = "managing_process_id",
+  Memory = "memory",
+  MinHweKernel = "min_hwe_kernel",
+  Netboot = "netboot",
+  NodeType = "node_type",
+  Nodeconfig = "nodeconfig",
+  Nodekey = "nodekey",
+  Nodemetadata = "nodemetadata",
+  Nodeuserdata = "nodeuserdata",
+  NumaNodesCount = "numa_nodes_count",
+  Numanode = "numanode",
+  Osystem = "osystem",
+  Owner = "owner",
+  OwnerId = "owner_id",
+  Ownerdata = "ownerdata",
+  Parent = "parent",
+  ParentId = "parent_id",
+  Podhints = "podhints",
+  Pool = "pool",
+  PoolId = "pool_id",
+  PowerState = "power_state",
+  PowerStateQueried = "power_state_queried",
+  PowerStateUpdated = "power_state_updated",
+  PreviousStatus = "previous_status",
+  Processes = "processes",
+  Rdns = "rdns",
+  RegisterVmhost = "register_vmhost",
+  RoutableBmcRelationships = "routable_bmc_relationships",
+  RoutableBmcs = "routable_bmcs",
+  Scriptset = "scriptset",
+  Service = "service",
+  SkipNetworking = "skip_networking",
+  SkipStorage = "skip_storage",
+  SriovSupport = "sriov_support",
+  Status = "status",
+  StatusEventDescription = "status_event_description",
+  StatusEventTypeDescription = "status_event_type_description",
+  StatusExpires = "status_expires",
+  SwapSize = "swap_size",
+  SyncInterval = "sync_interval",
+  SystemId = "system_id",
+  Tags = "tags",
+  Updated = "updated",
+  Url = "url",
+  Virtualmachine = "virtualmachine",
+  Zone = "zone",
+  ZoneId = "zone_id",
+}
+
+export type FetchParams = {
+  filter?: FetchFilters;
+  group_key?: FetchGroupKey | null;
+  group_collapsed?: string[];
+  page_size?: number;
+  page_number?: number;
+  sort_key?: string | null;
+  sort_direction?: FetchSortDirection;
+};
+
 export type GetSummaryXmlParams = {
   systemId: Machine[MachineMeta.PK];
   fileId: string;

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -194,127 +194,21 @@ export type MachineStateDetailsItem = {
 
 export type MachineStateDetails = Record<string, MachineStateDetailsItem>;
 
-export type MachinesGroupName =
-  | "address_ttl"
-  | "agent_name"
-  | "architecture"
-  | "bios_boot_method"
-  | "bmc"
-  | "bmc_id"
-  | "boot_cluster_ip"
-  | "boot_disk"
-  | "boot_disk_id"
-  | "boot_interface"
-  | "boot_interface_id"
-  | "children"
-  | "connections"
-  | "controllerinfo"
-  | "cpu_count"
-  | "cpu_speed"
-  | "created"
-  | "current_commissioning_script_set"
-  | "current_commissioning_script_set_id"
-  | "current_config"
-  | "current_config_id"
-  | "current_installation_script_set"
-  | "current_installation_script_set_id"
-  | "current_testing_script_set"
-  | "current_testing_script_set_id"
-  | "default_user"
-  | "description"
-  | "dhcpsnippet"
-  | "discovery"
-  | "distro_series"
-  | "dns_process"
-  | "dns_process_id"
-  | "domain"
-  | "domain_id"
-  | "dynamic"
-  | "enable_hw_sync"
-  | "enable_ssh"
-  | "ephemeral_deploy"
-  | "error"
-  | "error_description"
-  | "event"
-  | "gateway_link_ipv4"
-  | "gateway_link_ipv4_id"
-  | "gateway_link_ipv6"
-  | "gateway_link_ipv6_id"
-  | "hardware_uuid"
-  | "hostname"
-  | "hwe_kernel"
-  | "id"
-  | "install_kvm"
-  | "install_rackd"
-  | "instance_power_parameters"
-  | "last_applied_storage_layout"
-  | "last_image_sync"
-  | "last_sync"
-  | "license_key"
-  | "locked"
-  | "managing_process"
-  | "managing_process_id"
-  | "memory"
-  | "min_hwe_kernel"
-  | "netboot"
-  | "node_type"
-  | "nodeconfig"
-  | "nodekey"
-  | "nodemetadata"
-  | "nodeuserdata"
-  | "numa_nodes_count"
-  | "numanode"
-  | "osystem"
-  | "owner"
-  | "owner_id"
-  | "ownerdata"
-  | "parent"
-  | "parent_id"
-  | "podhints"
-  | "pool"
-  | "pool_id"
-  | "power_state"
-  | "power_state_queried"
-  | "power_state_updated"
-  | "previous_status"
-  | "processes"
-  | "rdns"
-  | "register_vmhost"
-  | "routable_bmc_relationships"
-  | "routable_bmcs"
-  | "scriptset"
-  | "service"
-  | "skip_networking"
-  | "skip_storage"
-  | "sriov_support"
-  | "status"
-  | "status_event_description"
-  | "status_event_type_description"
-  | "status_expires"
-  | "swap_size"
-  | "sync_interval"
-  | "system_id"
-  | "tags"
-  | "updated"
-  | "url"
-  | "virtualmachine"
-  | "zone"
-  | "zone_id";
-
 export type MachineStateListGroup = {
+  collapsed: boolean;
   count: number;
-  items: Machine[MachineMeta.PK];
-  name: MachinesGroupName;
+  items: Machine[MachineMeta.PK][];
+  name: string | null;
 };
 
 export type MachineStateList = {
-  count: number;
-  cur_page: number;
+  count: number | null;
+  cur_page: number | null;
   errors: APIError;
-  groups: MachineStateListGroup[];
+  groups: MachineStateListGroup[] | null;
   loaded: boolean;
   loading: boolean;
-  num_pages: number;
+  num_pages: number | null;
 };
 
 export type MachineStateLists = Record<string, MachineStateList>;

--- a/src/app/store/machine/types/index.ts
+++ b/src/app/store/machine/types/index.ts
@@ -22,6 +22,8 @@ export type {
   DeletePartitionParams,
   DeleteVolumeGroupParams,
   DeployParams,
+  FetchFilters,
+  FetchParams,
   GetSummaryXmlParams,
   GetSummaryYamlParams,
   LinkSubnetParams,
@@ -40,13 +42,14 @@ export type {
   UpdateVmfsDatastoreParams,
 } from "./actions";
 
+export { FetchGroupKey, FetchSortDirection } from "./actions";
+
 export type {
   BaseMachine,
   Machine,
   MachineActions,
   MachineDetails,
   MachineEventErrors,
-  MachinesGroupName,
   MachineState,
   MachineStateDetails,
   MachineStateDetailsItem,
@@ -58,4 +61,9 @@ export type {
 } from "./base";
 
 export { BcacheModes, MachineMeta } from "./enum";
-export type { FilterGroupResponse } from "./responses";
+
+export type {
+  FilterGroupResponse,
+  FetchResponse,
+  FetchResponseGroup,
+} from "./responses";

--- a/src/app/store/machine/types/responses.ts
+++ b/src/app/store/machine/types/responses.ts
@@ -1,3 +1,17 @@
-import type { FilterGroup } from "./base";
+import type { FilterGroup, Machine } from "./base";
 
 export type FilterGroupResponse = Omit<FilterGroup, "options">;
+
+export type FetchResponseGroup = {
+  collapsed: boolean;
+  count: number;
+  items: Machine[];
+  name: string | null;
+};
+
+export type FetchResponse = {
+  count: number;
+  cur_page: number;
+  num_pages: number;
+  groups: FetchResponseGroup[];
+};

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -27,6 +27,9 @@ import { objectHasKey } from "app/utils";
 
 export type GenericItemMeta<I> = {
   item: I;
+} & GenericMeta;
+
+export type GenericMeta = {
   requestId?: string;
   identifier?: number | string;
 };

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -248,19 +248,20 @@ export const licenseKeysState = define<LicenseKeysState>({
 });
 
 export const machineStateListGroup = define<MachineStateListGroup>({
+  collapsed: false,
   count: 15,
   items: () => [],
-  name: "owner",
+  name: null,
 });
 
 export const machineStateList = define<MachineStateList>({
-  count: 40,
-  cur_page: 1,
+  count: null,
+  cur_page: null,
   errors: null,
-  groups: () => [],
+  groups: null,
   loaded: false,
   loading: false,
-  num_pages: 1,
+  num_pages: null,
 });
 
 export const machineStateLists = define<MachineStateLists>({


### PR DESCRIPTION
## Done

- Update the slice to handle calls to machine.list to use the new API.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list. The machines should load.
- Open the redux dev tools and inside the `machines` store you should see `lists` populated with the requests. Note: a number of those requests will get replaced with calls to `machine.count`.

## Fixes

Fixes: canonical-web-and-design/app-tribe#1138.