### PR TITLE
feat(machines): reorder group by options to match filters

### DIFF
--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.tsx
@@ -14,24 +14,24 @@ const groupOptions = [
     label: "No grouping",
   },
   {
-    value: FetchGroupKey.Owner,
-    label: "Group by owner",
+    value: FetchGroupKey.Status,
+    label: "Group by status",
   },
   {
-    value: FetchGroupKey.Parent,
-    label: "Group by parent",
+    value: FetchGroupKey.Owner,
+    label: "Group by owner",
   },
   {
     value: FetchGroupKey.Pool,
     label: "Group by pool",
   },
   {
-    value: FetchGroupKey.PowerState,
-    label: "Group by power state",
+    value: FetchGroupKey.Parent,
+    label: "Group by parent",
   },
   {
-    value: FetchGroupKey.Status,
-    label: "Group by status",
+    value: FetchGroupKey.PowerState,
+    label: "Group by power state",
   },
   {
     value: FetchGroupKey.Zone,


### PR DESCRIPTION
## Done

- reorder group by options to match filters 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open group by select and verify that the options order matches the order of machine filters (and first 3 items are: status, owner, pool)

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4510

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
