### PR TITLE
fix(base): prevent side nav from overlapping main content

### DIFF
--- a/src/app/base/components/AppSideNavigation/_index.scss
+++ b/src/app/base/components/AppSideNavigation/_index.scss
@@ -35,4 +35,7 @@
       );
     }
   }
+  .l-navigation-bar {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Done

Added `display: block` to `l-navigation-bar` to keep element in DOM and prevent layout shift at vanilla nav collapse breakpoint.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Make sure your browser window is wider than 1036px
- [ ] Open MAAS UI 
- [ ] Ensure the side nav does not overlap the main page content

<!-- Steps for QA. -->

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/a52df5cb-7218-4d00-bf22-74dc80e888dc)

### After
![image](https://github.com/user-attachments/assets/3b232c7c-ea86-44d7-91c9-f4f667e3cfdf)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->