### PR TITLE
fix: use underscores in bundle name and .tgz extension 3.7 backport

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -9,7 +9,7 @@ jobs:
     name: Upload build artifacts
     runs-on: ubuntu-24.04
     env:
-      PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
+      PACKAGE_NAME: maas_ui_${{ github.sha }}.tgz
       VITE_APP_GIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Done

- changed extension for bundle to `.tgz`
- swapped `-` with `_` in file name

<!--
- Itemised list of what was changed by this PR.
-->