### PR TITLE
docs: create standards for tables, forms, api and testing

### DIFF
--- a/docs/component-standards/api-hooks.md
+++ b/docs/component-standards/api-hooks.md
@@ -25,7 +25,6 @@ Our API layer follows a three-tier architecture:
 Use `useWebsocketAwareQuery` to automatically invalidate when websocket updates occur:
 
 ```typescript
-
 export const useUsers = (options?: Options<ListUsersWithSummaryData>) => {
   return useWebsocketAwareQuery(
     listUsersWithSummaryOptions(options) as UseQueryOptions<
@@ -75,18 +74,6 @@ export const useUserCount = (options?: Options<ListUsersWithSummaryData>) => {
 Always invalidate related queries in `onSuccess`:
 
 ```typescript
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type {
-  CreateUserData,
-  CreateUserError,
-  CreateUserResponse,
-  Options,
-} from "@/app/apiclient";
-import {
-  createUserMutation,
-  listUsersWithSummaryQueryKey,
-} from "@/app/apiclient/@tanstack/react-query.gen";
-
 export const useCreateUser = (mutationOptions?: Options<CreateUserData>) => {
   const queryClient = useQueryClient();
   return useMutation<
@@ -167,18 +154,6 @@ Each resolver file should follow this structure:
 ### Complete Example
 
 ```typescript
-import { http, HttpResponse } from "msw";
-import { BASE_URL } from "../utils";
-import type {
-  CreateUserError,
-  DeleteUserError,
-  GetUserError,
-  ListUsersError,
-  ListUsersWithSummaryResponse,
-  UpdateUserError,
-} from "@/app/apiclient";
-import { user as userFactory } from "@/testing/factories";
-
 // 1. Define default mock data using factories
 const mockUsers: ListUsersWithSummaryResponse = {
   items: [
@@ -333,14 +308,6 @@ await waitFor(() => {
 ### Test Structure
 
 ```typescript
-import { useUsers, useCreateUser } from "@/app/api/query/users";
-import { usersResolvers, mockUsers } from "@/testing/resolvers/users";
-import {
-  renderHookWithProviders,
-  setupMockServer,
-  waitFor,
-} from "@/testing/utils";
-
 const mockServer = setupMockServer(
   usersResolvers.listUsers.handler(),
   usersResolvers.createUser.handler()

--- a/docs/component-standards/forms.md
+++ b/docs/component-standards/forms.md
@@ -5,9 +5,8 @@
 - Use `FormikForm` for all forms, and extract field definitions into separate components or hooks for maintainability
 - Use `ModelActionForm` for simple confirmation forms (e.g., delete, archive)
 - Use Yup for validation schemas
-- Keep business logic (API calls, mutation hooks) outside the form component when possible
 - Always provide clear error, loading, and success states
-- Write tests in separate `describe` blocks for display, validation, permissions, and actions
+- Write tests in separate `describe` blocks for display, validation, and actions
 
 ## Overview
 
@@ -20,11 +19,6 @@ We use [FormikForm](/src/app/base/components/FormikForm/FormikForm.tsx) for all 
 Extract field definitions into their own components or hooks. Use Yup for validation. Example:
 
 ```tsx
-import * as Yup from "yup";
-import FormikForm from "@/app/base/components/FormikForm";
-import FormikField from "@/app/base/components/FormikField";
-import { useCreateUser } from "@/app/api/query/users";
-
 const UserSchema = Yup.object().shape({
   email: Yup.string().email().required(),
   username: Yup.string().required(),
@@ -56,14 +50,20 @@ const AddUserForm = () => {
 Use `ModelActionForm` for simple confirmation dialogs:
 
 ```tsx
-import ModelActionForm from "@/app/base/components/ModelActionForm";
-
 <ModelActionForm
+  aria-label="Confirm user deletion"
+  errors={deleteUser.error}
   modelType="user"
   initialValues={{}}
+  onCancel={closeSidePanel}
   onSubmit={handleDelete}
-  submitLabel="Delete"
-/>;
+  onSuccess={() =>
+    queryClient.invalidateQueries({ queryKey: listUsersQueryKey() })
+  }
+  saved={deleteUser.isSuccess}
+  saving={deleteUser.isPending}
+  submitLabel="Delete user"
+/>
 ```
 
 ### Validation
@@ -80,7 +80,6 @@ import ModelActionForm from "@/app/base/components/ModelActionForm";
 ### Business Logic
 
 - Use mutation/query hooks (e.g., `useCreateUser`, `useUpdateUser`) for API calls
-- Keep API logic outside the form component when possible
 - Pass mutation functions to `onSubmit`
 
 ## Testing Standards
@@ -97,9 +96,6 @@ describe("AddUserForm", () => {
   describe("validation", () => {
     // Validation tests
   });
-  describe("permissions", () => {
-    // Permission tests
-  });
   describe("actions", () => {
     // Action/interaction tests
   });
@@ -115,10 +111,6 @@ describe("AddUserForm", () => {
 
 - Test required fields and validation errors
 - Test that invalid input shows correct error messages
-
-### Permission Tests
-
-- Test that fields/buttons are disabled or hidden based on permissions
 
 ### Action Tests
 

--- a/docs/component-standards/tables.md
+++ b/docs/component-standards/tables.md
@@ -23,10 +23,6 @@ Column definitions should be extracted into a custom hook in a separate file for
 ### Example: useMyTableColumns.tsx
 
 ```tsx
-import { useMemo } from "react";
-import type { ColumnDef } from "@tanstack/react-table";
-import { Link } from "react-router";
-
 // Only define custom data types if the API type is not a direct match with table columns
 type MyDataType = {
   id: number;
@@ -107,8 +103,6 @@ import TableActions from "@/app/base/components/TableActions";
 For more complex actions, use `TableActionsDropdown`:
 
 ```tsx
-import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
-
 {
   id: "actions",
   accessorKey: "id",
@@ -133,11 +127,6 @@ import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
 ### Basic Structure
 
 ```tsx
-import { GenericTable } from "@canonical/maas-react-components";
-import useMyTableColumns from "./useMyTableColumns/useMyTableColumns";
-import { useMyData } from "@/app/api/query/mydata";
-import usePagination from "@/app/base/hooks/usePagination/usePagination";
-
 const MyTable = () => {
   const columns = useMyTableColumns();
   const { data, isPending } = useMyData();
@@ -218,10 +207,6 @@ Every table component should have comprehensive tests organized into separate `d
 ### Test Structure
 
 ```tsx
-import { describe, it, expect } from "vitest";
-import { screen, waitFor, within, renderWithProviders } from "@/testing/utils";
-import MyTable from "./MyTable";
-
 describe("MyTable", () => {
   describe("display", () => {
     // Display-related tests

--- a/docs/component-standards/testing.md
+++ b/docs/component-standards/testing.md
@@ -26,9 +26,6 @@ We use [Vitest](https://vitest.dev/) as our test runner and [React Testing Libra
 `renderWithProviders` is the standard way to render components in tests. It provides all necessary context providers (React Query, Redux, Router, WebSocket, Side Panel), eliminating the need to manually wrap components in providers. This ensures your tests run in an environment that closely mirrors your application's runtime context.
 
 ```typescript
-import { renderWithProviders, screen, waitFor } from "@/testing/utils";
-import MyComponent from "./MyComponent";
-
 describe("MyComponent", () => {
   it("renders correctly", async () => {
     renderWithProviders(<MyComponent />);
@@ -45,10 +42,6 @@ describe("MyComponent", () => {
 Use `setupMockServer` at the top of your test file to configure MSW handlers. This function handles the complete lifecycle of the mock server.
 
 ```typescript
-import { setupMockServer, renderWithProviders } from "@/testing/utils";
-import { usersResolvers } from "@/testing/resolvers/users";
-import MyComponent from "./MyComponent";
-
 const mockServer = setupMockServer(
   usersResolvers.listUsers.handler(),
   usersResolvers.createUser.handler()
@@ -103,8 +96,6 @@ it("handles errors", async () => {
 Pass custom Redux state to `renderWithProviders` to test components in specific application states. This is useful for testing permission-based UI, user-specific content, or any component behavior that depends on Redux state.
 
 ```typescript
-import * as factory from "@/testing/factories";
-
 it("displays user-specific content", () => {
   renderWithProviders(<MyComponent />, {
     state: {
@@ -125,10 +116,6 @@ it("displays user-specific content", () => {
 Use `renderHookWithProviders` to test custom hooks in isolation. This wrapper provides all necessary context (React Query, Redux, WebSocket) that your hooks might depend on, allowing you to test hook logic independently from components.
 
 ```typescript
-import { renderHookWithProviders, waitFor } from "@/testing/utils";
-import { useUsers } from "@/app/api/query/users";
-import { usersResolvers, mockUsers } from "@/testing/resolvers/users";
-
 const mockServer = setupMockServer(usersResolvers.listUsers.handler());
 
 describe("useUsers", () => {
@@ -149,8 +136,6 @@ describe("useUsers", () => {
 Use `mockIsPending` to test loading states without waiting for actual API calls. This utility mocks React Query's `useQuery` to return a pending state, allowing you to verify that your loading UI renders correctly.
 
 ```typescript
-import { mockIsPending, renderWithProviders, screen, waitFor } from "@/testing/utils";
-
 it("displays loading state", async () => {
   mockIsPending();
   renderWithProviders(<MyComponent />);
@@ -166,8 +151,6 @@ it("displays loading state", async () => {
 Use `mockSidePanel` to mock side panel interactions and verify that your components correctly open and close side panels with the expected content and properties.
 
 ```typescript
-import { mockSidePanel, renderWithProviders, screen, userEvent } from "@/testing/utils";
-
 const { mockOpen, mockClose } = await mockSidePanel();
 
 describe("MyComponent", () => {
@@ -231,8 +214,6 @@ describe("MyComponent", () => {
 Use `userEvent` for simulating user actions. This library provides more realistic user interactions than the legacy `fireEvent` API, including proper focus management and keyboard event sequences.
 
 ```typescript
-import { userEvent, screen } from "@/testing/utils";
-
 // Clicking buttons
 await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
@@ -283,8 +264,6 @@ screen.findByRole("button"); // Returns promise, waits for element
 Always use `waitFor` for async assertions to handle asynchronous state updates, API calls, and DOM changes. Never use arbitrary timeouts or delays in tests.
 
 ```typescript
-import { waitFor } from "@/testing/utils";
-
 // Wait for element to appear
 await waitFor(() => {
   expect(screen.getByText("Success")).toBeInTheDocument();
@@ -306,8 +285,6 @@ await waitFor(() => {
 Use `within` to query inside a specific element, which is particularly useful for testing table rows, list items, or any nested content where you need to scope your queries.
 
 ```typescript
-import { within } from "@/testing/utils";
-
 const row = screen.getByRole("row", { name: /john doe/i });
 expect(within(row).getByText("admin")).toBeInTheDocument();
 expect(within(row).getByRole("button", { name: /edit/i })).toBeInTheDocument();
@@ -333,9 +310,6 @@ Legacy tests may create Redux stores manually using `configureStore()` from `red
 
 ```typescript
 // ❌ Legacy pattern - avoid in new code
-import configureStore from "redux-mock-store";
-import * as factory from "@/testing/factories";
-
 const mockStore = configureStore();
 const store = mockStore(factory.rootState());
 
@@ -372,8 +346,6 @@ These utilities exist for legacy tests but should not be used in new code:
 Use `screen.debug()` to print the current DOM structure when debugging test failures. This helps you understand what's actually rendered versus what you expect.
 
 ```typescript
-import { screen } from "@/testing/utils";
-
 // Print the current DOM
 screen.debug();
 


### PR DESCRIPTION
## Done

- Created standards documentation for:
  - Writing tables with GenericTable
  - Creating forms using FormikForm
  - API query hooks for v3
  - General testing best practices

<!--
- Itemised list of what was changed by this PR.
-->

## :robot: GitHub Copilot was used to help generate this documentation - I asked it to scan each of the documented aspects, find usage patterns, and document best practices with examples. I gave it context for what we use for modern tooling (e.g. `GenericTable` for tables, `useWebsocketAwareQuery` for writing queries).