### PR TITLE
fix(networkDiscovery): Remove nested PageContent in network discovery configuration

### DIFF
--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.tsx
@@ -9,7 +9,6 @@ import NetworkDiscoveryFormFields from "./NetworkDiscoveryFormFields";
 import type { NetworkDiscoveryValues } from "./types";
 
 import FormikForm from "@/app/base/components/FormikForm";
-import PageContent from "@/app/base/components/PageContent";
 import { useWindowTitle } from "@/app/base/hooks";
 import { configActions } from "@/app/store/config";
 import configSelectors from "@/app/store/config/selectors";
@@ -44,44 +43,39 @@ const NetworkDiscoveryForm = (): React.ReactElement => {
   }, [dispatch, loaded]);
 
   return (
-    <PageContent sidePanelContent={null} sidePanelTitle={null}>
-      <ContentSection variant="narrow">
-        <ContentSection.Title className="section-header__title">
-          Network discovery
-        </ContentSection.Title>
-        <ContentSection.Content>
-          {loading && <Spinner text="Loading..." />}
-          {loaded && (
-            <FormikForm<NetworkDiscoveryValues>
-              cleanup={configActions.cleanup}
-              errors={errors}
-              initialValues={{
-                active_discovery_interval: activeDiscoveryInterval || "",
-                network_discovery: networkDiscovery || "",
-              }}
-              onSaveAnalytics={{
-                action: "Saved",
-                category: "Network settings",
-                label: "Network discovery form",
-              }}
-              onSubmit={(values, { resetForm }) => {
-                if (values.network_discovery === NetworkDiscovery.DISABLED) {
-                  // Don't update the interval when the discovery is being disabled.
-                  delete values.active_discovery_interval;
-                }
-                dispatch(updateConfig(values));
-                resetForm({ values });
-              }}
-              saved={saved}
-              saving={saving}
-              validationSchema={NetworkDiscoverySchema}
-            >
-              <NetworkDiscoveryFormFields />
-            </FormikForm>
-          )}
-        </ContentSection.Content>
-      </ContentSection>
-    </PageContent>
+    <ContentSection variant="narrow">
+      <ContentSection.Content>
+        {loading && <Spinner text="Loading..." />}
+        {loaded && (
+          <FormikForm<NetworkDiscoveryValues>
+            cleanup={configActions.cleanup}
+            errors={errors}
+            initialValues={{
+              active_discovery_interval: activeDiscoveryInterval || "",
+              network_discovery: networkDiscovery || "",
+            }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Network settings",
+              label: "Network discovery form",
+            }}
+            onSubmit={(values, { resetForm }) => {
+              if (values.network_discovery === NetworkDiscovery.DISABLED) {
+                // Don't update the interval when the discovery is being disabled.
+                delete values.active_discovery_interval;
+              }
+              dispatch(updateConfig(values));
+              resetForm({ values });
+            }}
+            saved={saved}
+            saving={saving}
+            validationSchema={NetworkDiscoverySchema}
+          >
+            <NetworkDiscoveryFormFields />
+          </FormikForm>
+        )}
+      </ContentSection.Content>
+    </ContentSection>
   );
 };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { lazy } from "react";
 
+import { MainToolbar } from "@canonical/maas-react-components";
 import { createBrowserRouter, Navigate } from "react-router";
 
 import TagDetails from "./app/tags/views/TagDetails";
@@ -590,7 +591,17 @@ export const router = createBrowserRouter(
               ),
               element: (
                 <ErrorBoundary>
-                  <NetworkDiscoveryForm />
+                  <PageContent
+                    header={
+                      <MainToolbar>
+                        <MainToolbar.Title>Network discovery</MainToolbar.Title>
+                      </MainToolbar>
+                    }
+                    sidePanelContent={null}
+                    sidePanelTitle={null}
+                  >
+                    <NetworkDiscoveryForm />
+                  </PageContent>
                 </ErrorBoundary>
               ),
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5439,7 +5439,7 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chance@^1.1.13:
+chance@1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.13.tgz#d4ecfd20c5e6799aaf5c2270d7653b32385cd6e3"
   integrity sha512-V6lQCljcLznE7tUYUM9EOAnnKXbctE6j/rdQkYOHIWbfGQbrzTsAXNW9CdU5XCo4ArXQCj/rb6HgxPlmGJcaUg==
@@ -11737,7 +11737,16 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11819,7 +11828,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13043,7 +13059,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13056,6 +13072,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Done

- Removed `PageContent` from `NetworkDiscoveryForm`
- Added `PageContent` in router where form is rendered
- (driveby) updated yarn lock

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to /network-discovery/configuration
- [ ] Ensure you cannot scroll to the right

<!-- Steps for QA. -->

## Screenshots

### Before
<img width="1920" height="1014" alt="image" src="https://github.com/user-attachments/assets/e6c5e76b-d985-406a-a969-5bb30dc33f24" />

### After
<img width="1920" height="1014" alt="image" src="https://github.com/user-attachments/assets/519231e2-6934-4bbf-b941-92bdc5bca5af" />


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
