### PR TITLE
refactor(base): use GenericTable for displaying node test details MAASENG-5671

### DIFF
--- a/src/app/base/components/node/NodeTestDetails/NodeTestDetails.test.tsx
+++ b/src/app/base/components/node/NodeTestDetails/NodeTestDetails.test.tsx
@@ -27,6 +27,32 @@ describe("NodeTestDetails", () => {
     });
   });
 
+  it("shows the right columns", () => {
+    const scriptResult = factory.scriptResult({ id: 1 });
+    const scriptResults = [scriptResult];
+    state.nodescriptresult.items = { abc123: [1] };
+    state.scriptresult.items = scriptResults;
+    renderWithProviders(<NodeTestDetails getReturnPath={getReturnPath} />, {
+      initialEntries: ["/machine/abc123/testing/1/details"],
+      pattern: "/machine/:id/testing/:scriptResultId/details",
+      state,
+    });
+    [
+      "Status",
+      "Exit Status",
+      "Tags",
+      "Start time",
+      "End time",
+      "Runtime",
+    ].forEach((column) => {
+      expect(
+        screen.getByRole("columnheader", {
+          name: new RegExp(`^${column}`, "i"),
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
   it("displays a spinner when loading", () => {
     state.scriptresult.loading = true;
     renderWithProviders(<NodeTestDetails getReturnPath={getReturnPath} />, {

--- a/src/app/base/components/node/NodeTestDetails/NodeTestDetails.tsx
+++ b/src/app/base/components/node/NodeTestDetails/NodeTestDetails.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 
+import { GenericTable } from "@canonical/maas-react-components";
 import { Col, Row, Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router";
 
 import NodeTestDetailsLogs from "./NodeTestDetailsLogs";
+import useNodeTestDetailsTableColumns from "./useNodeTestDetailsTableColumns/useNodeTestDetailsTableColumns";
 
-import ScriptStatus from "@/app/base/components/ScriptStatus";
 import { useGetURLId } from "@/app/base/hooks/urls";
 import type { RootState } from "@/app/store/root/types";
 import { scriptResultActions } from "@/app/store/scriptresult";
@@ -35,6 +36,7 @@ const NodeTestDetails = ({
   const logs = useSelector(scriptResultSelectors.logs);
   const loading = useSelector(scriptResultSelectors.loading);
   const log = logs && isId(scriptResultId) ? logs[scriptResultId] : null;
+  const columns = useNodeTestDetailsTableColumns();
 
   useEffect(() => {
     if (!fetched && isId(scriptResultId)) {
@@ -64,6 +66,19 @@ const NodeTestDetails = ({
 
   const hasMetrics = result.results.length > 0;
   const returnPath = getReturnPath(id);
+  const data = [
+    {
+      ...result,
+      id: result.id,
+      status: result.status,
+      status_name: result.status_name,
+      exit_status: result.exit_status,
+      tags: result.tags,
+      started: result.started,
+      ended: result.ended,
+      runtime: result.runtime,
+    },
+  ];
   return (
     <>
       <Row className="u-sv2">
@@ -76,40 +91,12 @@ const NodeTestDetails = ({
           </Link>
         </Col>
       </Row>
-      <Row className="u-sv2">
-        <Col size={6}>
-          <Row>
-            <Col size={2}>Status</Col>
-            <Col size={4}>
-              <ScriptStatus status={result.status}>
-                {result.status_name}
-              </ScriptStatus>
-            </Col>
-          </Row>
-          <Row>
-            <Col size={2}>Exit status</Col>
-            <Col size={4}>{result.exit_status}</Col>
-          </Row>
-          <Row>
-            <Col size={2}>Tags</Col>
-            <Col size={4}>{result.tags}</Col>
-          </Row>
-        </Col>
-        <Col size={6}>
-          <Row>
-            <Col size={2}>Start time</Col>
-            <Col size={4}>{result.started}</Col>
-          </Row>
-          <Row>
-            <Col size={2}>End time</Col>
-            <Col size={4}>{result.ended}</Col>
-          </Row>
-          <Row>
-            <Col size={2}>Runtime</Col>
-            <Col size={4}>{result.runtime}</Col>
-          </Row>
-        </Col>
-      </Row>
+      <GenericTable
+        columns={columns}
+        data={data}
+        isLoading={false}
+        noData="No details available."
+      />
       {hasMetrics ? (
         <Row>
           <Col size={12}>

--- a/src/app/base/components/node/NodeTestDetails/useNodeTestDetailsTableColumns/useNodeTestDetailsTableColumns.tsx
+++ b/src/app/base/components/node/NodeTestDetails/useNodeTestDetailsTableColumns/useNodeTestDetailsTableColumns.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import ScriptStatus from "../../../ScriptStatus";
+
+import type { ScriptResult } from "@/app/store/scriptresult/types";
+
+type NodeTestDetailsColumnData = ScriptResult & {
+  id: number;
+};
+
+export type NodeTestDetailsColumnDef = ColumnDef<
+  NodeTestDetailsColumnData,
+  Partial<NodeTestDetailsColumnData>
+>;
+
+const useNodeTestDetailsTableColumns = (): NodeTestDetailsColumnDef[] => {
+  return useMemo(
+    (): NodeTestDetailsColumnDef[] => [
+      {
+        accessorKey: "status",
+        enableSorting: false,
+        id: "status",
+        cell: ({
+          row: {
+            original: { status, status_name },
+          },
+        }) => <ScriptStatus status={status}>{status_name}</ScriptStatus>,
+      },
+      {
+        accessorKey: "exit_status",
+        enableSorting: false,
+        id: "exit_status",
+        header: "Exit status",
+      },
+      {
+        accessorKey: "tags",
+        enableSorting: false,
+        id: "tags",
+      },
+      {
+        accessorKey: "started",
+        enableSorting: false,
+        id: "started",
+        header: "Start time",
+      },
+      {
+        accessorKey: "ended",
+        enableSorting: false,
+        id: "ended",
+        header: "End time",
+      },
+      {
+        accessorKey: "runtime",
+        enableSorting: false,
+        id: "runtime",
+      },
+    ],
+    []
+  );
+};
+
+export default useNodeTestDetailsTableColumns;

--- a/src/app/base/components/node/NodeTestDetails/useNodeTestDetailsTableColumns/useNodeTestDetailsTableColumns.tsx
+++ b/src/app/base/components/node/NodeTestDetails/useNodeTestDetailsTableColumns/useNodeTestDetailsTableColumns.tsx
@@ -33,6 +33,11 @@ const useNodeTestDetailsTableColumns = (): NodeTestDetailsColumnDef[] => {
         enableSorting: false,
         id: "exit_status",
         header: "Exit status",
+        cell: ({
+          row: {
+            original: { exit_status },
+          },
+        }) => exit_status ?? "—",
       },
       {
         accessorKey: "tags",
@@ -44,17 +49,33 @@ const useNodeTestDetailsTableColumns = (): NodeTestDetailsColumnDef[] => {
         enableSorting: false,
         id: "started",
         header: "Start time",
+        cell: ({
+          row: {
+            original: { started },
+          },
+        }) => (started ? started : "—"),
       },
       {
         accessorKey: "ended",
         enableSorting: false,
         id: "ended",
         header: "End time",
+        cell: ({
+          row: {
+            original: { ended },
+          },
+        }) => (ended ? ended : "—"),
       },
       {
         accessorKey: "runtime",
         enableSorting: false,
         id: "runtime",
+        header: "Runtime",
+        cell: ({
+          row: {
+            original: { runtime },
+          },
+        }) => (runtime ? runtime : "—"),
       },
     ],
     []


### PR DESCRIPTION
## Done

- Refactored the node test details page to use `<GenericTable />`

## QA steps

- [x] Go to the scripts tab for any machine (e.g. /machine/qxxwxb/scripts)
- [x] Visit a script/test that has passed (e.g. `50-maas-01-commissioning`)
- [x] Observe a table is visible with 6 columns (status, exit status, tags, start time, end time and runtime)
- [x] Go back to scripts and choose a script/test that has a status of Pending
- [x] Observe that only 2 columns in the table are populated (status and tags)

## Fixes

Resolves [MAASENG-5671](https://warthogs.atlassian.net/browse/MAASENG-5671)

[MAASENG-5671]: https://warthogs.atlassian.net/browse/MAASENG-5671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ