### PR TITLE
feat(kvm): Add 'Copy' button for certificate to LXD authentication form

### DIFF
--- a/src/app/base/components/CertificateDownload/CertificateDownload.tsx
+++ b/src/app/base/components/CertificateDownload/CertificateDownload.tsx
@@ -63,7 +63,7 @@ const CertificateDownload = ({
         </span>
       </Button>
       <CopyButton
-        value={`lxc config trust add - <<EOF\n\n${certificate}\nEOF`}
+        value={`lxc config trust add - <<EOF \n\n${certificate}\n EOF`}
       />
     </>
   );

--- a/src/app/base/components/CertificateDownload/CertificateDownload.tsx
+++ b/src/app/base/components/CertificateDownload/CertificateDownload.tsx
@@ -6,6 +6,7 @@ import {
 } from "@canonical/react-components";
 import fileDownload from "js-file-download";
 
+import CopyButton from "@/app/base/components/CopyButton";
 import type { CertificateData } from "@/app/store/general/types";
 
 type Props = {
@@ -61,6 +62,9 @@ const CertificateDownload = ({
           <Icon name="begin-downloading" />
         </span>
       </Button>
+      <CopyButton
+        value={`lxc config trust add - <<EOF\n\n${certificate}\nEOF`}
+      />
     </>
   );
 };

--- a/src/app/base/components/CopyButton/CopyButton.tsx
+++ b/src/app/base/components/CopyButton/CopyButton.tsx
@@ -42,6 +42,7 @@ const CopyButton = ({ value }: Props): React.ReactElement => {
         className="is-dense u-table-cell-padding-overlap u-no-margin--right"
         hasIcon
         onClick={handleClick}
+        type="button"
       >
         <i className={`p-icon--${icon}`}>Copy</i>
       </Button>

--- a/src/app/kvm/components/AddLxd/AddLxd.tsx
+++ b/src/app/kvm/components/AddLxd/AddLxd.tsx
@@ -12,6 +12,7 @@ import type { AddLxdStepValues, NewPodValues } from "./types";
 
 import { usePools } from "@/app/api/query/pools";
 import { useZones } from "@/app/api/query/zones";
+import { generalActions } from "@/app/store/general";
 import { podActions } from "@/app/store/pod";
 
 export const AddLxdSteps = {
@@ -42,10 +43,12 @@ export const AddLxd = (): ReactElement => {
   // We run the cleanup function here rather than in each form component
   // because we want the errors to be able to persist across forms. We also
   // clear projects, so the user has to "re-authenticate" every time.
+  // Clear the generated certificate when the entire AddLxd flow ends.
   useEffect(() => {
     return () => {
       dispatch(podActions.cleanup());
       dispatch(podActions.clearProjects());
+      dispatch(generalActions.clearGeneratedCertificate());
     };
   }, [dispatch]);
 

--- a/src/app/kvm/components/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/src/app/kvm/components/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -13,7 +13,6 @@ import AuthenticationFormFields from "./AuthenticationFormFields";
 
 import FormikForm from "@/app/base/components/FormikForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
-import { generalActions } from "@/app/store/general";
 import { generatedCertificate as generatedCertificateSelectors } from "@/app/store/general/selectors";
 import { podActions } from "@/app/store/pod";
 import { PodType } from "@/app/store/pod/constants";
@@ -74,12 +73,9 @@ export const AuthenticationForm = ({
     }
   }, [setStep, shouldGoToProjectStep]);
 
-  // The generated certificate is cleared as we only store one in state at a
-  // time. This will prepare the form for the next added KVM host. We also make
-  // sure to stop polling the LXD server for projects.
+  // Stop polling the LXD server when the component unmounts.
   useEffect(() => {
     return () => {
-      dispatch(generalActions.clearGeneratedCertificate());
       dispatch(podActions.pollLxdServerStop());
     };
   }, [dispatch]);


### PR DESCRIPTION
## Done

- Added "Copy to clipboard" button for the command to add a certificate to the LXC trust config
- Fixed case where generated certificate could be immediately removed from the store after receiving over the websocket

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to LXD
- [ ] Click "Add host"
- [ ] Fill in the fields, selecting "Generate new certificate"
- [ ] Click "Next"
- [ ] Ensure the command to add a certificate appears
- [ ] Click the "Copy" button (small clipboard icon"
- [ ] Ensure the command is copied to the clipboard

<!-- Steps for QA. -->

## Screenshots

<img width="509" height="450" alt="image" src="https://github.com/user-attachments/assets/9473dc37-0345-4323-9a64-4831c80fd6b4" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

Copilot (backed by Claude Sonnet 4.5) was used to generate the majority of this code. Seemed to do quite well at implementing a small feature and fixing this bug. As per policy, I take full responsibility for the PR and the code which it contains.