### PR TITLE
feat(racks): Racks with summary MAASENG-5529

### DIFF
--- a/src/app/api/query/racks.ts
+++ b/src/app/api/query/racks.ts
@@ -19,34 +19,34 @@ import type {
   GetRackData,
   GetRackErrors,
   GetRackResponses,
-  ListRacksData,
-  ListRacksErrors,
-  ListRacksResponses,
+  ListRacksWithSummaryData,
+  ListRacksWithSummaryErrors,
+  ListRacksWithSummaryResponses,
   Options,
   UpdateRackData,
   UpdateRackErrors,
   UpdateRackResponses,
 } from "@/app/apiclient";
 import {
+  listRacksWithSummary,
   createRack,
   deleteRacks,
   generateRackBootstrapToken,
   updateRack,
   getRack,
-  listRacks,
 } from "@/app/apiclient";
 import {
   getRackQueryKey,
-  listRacksQueryKey,
+  listRacksWithSummaryQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 
-export const useRacks = (options?: Options<ListRacksData>) => {
+export const useRacks = (options?: Options<ListRacksWithSummaryData>) => {
   return useWebsocketAwareQuery(
-    queryOptionsWithHeaders<ListRacksResponses, ListRacksErrors, ListRacksData>(
-      options,
-      listRacks,
-      listRacksQueryKey(options)
-    )
+    queryOptionsWithHeaders<
+      ListRacksWithSummaryResponses,
+      ListRacksWithSummaryErrors,
+      ListRacksWithSummaryData
+    >(options, listRacksWithSummary, listRacksWithSummaryQueryKey(options))
   );
 };
 
@@ -70,7 +70,7 @@ export const useCreateRack = (mutationOptions?: Options<CreateRackData>) => {
     >(mutationOptions, createRack),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listRacksQueryKey(),
+        queryKey: listRacksWithSummaryQueryKey(),
       });
     },
   });
@@ -86,7 +86,7 @@ export const useUpdateRack = (mutationOptions?: Options<UpdateRackData>) => {
     >(mutationOptions, updateRack),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listRacksQueryKey(),
+        queryKey: listRacksWithSummaryQueryKey(),
       });
     },
   });
@@ -102,7 +102,7 @@ export const useDeleteRack = (mutationOptions?: Options<DeleteRacksData>) => {
     >(mutationOptions, deleteRacks),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listRacksQueryKey(),
+        queryKey: listRacksWithSummaryQueryKey(),
       });
     },
   });

--- a/src/app/racks/components/RacksTable/RacksTable.tsx
+++ b/src/app/racks/components/RacksTable/RacksTable.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { GenericTable } from "@canonical/maas-react-components";
 
 import useRacksTableColumns from "./useRacksTableColumns/useRacksTableColumns";
@@ -14,21 +12,13 @@ const RacksTable = () => {
   const racks = useRacks({
     query: { page: debouncedPage, size },
   });
+
   const columns = useRacksTableColumns();
-  const fakeData = useMemo(() => {
-    if (racks.data && racks.data.items.length > 0) {
-      return racks.data?.items.map((rack) => ({
-        ...rack,
-        registered: [`controller-${rack.id}`],
-      }));
-    } else {
-      return [];
-    }
-  }, [racks.data]);
+
   return (
     <GenericTable
       columns={columns}
-      data={fakeData}
+      data={racks.data?.items ?? []}
       isLoading={racks.isPending}
       noData="No racks found."
       pagination={{

--- a/src/app/racks/components/RacksTable/useRacksTableColumns/useRacksTableColumns.tsx
+++ b/src/app/racks/components/RacksTable/useRacksTableColumns/useRacksTableColumns.tsx
@@ -9,26 +9,24 @@ import EditRack from "../../EditRack";
 import RegisterController from "../../RegisterController";
 import RemoveControllers from "../../RemoveControllers";
 
-import type { RackResponse } from "@/app/apiclient";
+import type { RackWithSummaryResponse } from "@/app/apiclient";
 import TableMenu from "@/app/base/components/TableMenu";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import urls from "@/app/base/urls";
 import { FilterControllers } from "@/app/store/controller/utils";
 
-type RackWithSummaryResponse = RackResponse & { registered: string[] };
-
 type RacksColumnDef = ColumnDef<RackWithSummaryResponse>;
 
 const getControllersLabel = (row: Row<RackWithSummaryResponse>) => {
-  if (row.original.registered.length === 0) {
+  if (row.original.registered_agents_system_ids.length === 0) {
     return "0 controllers";
   }
   const filters = FilterControllers.filtersToQueryString({
-    system_id: [`=${row.original.registered.join(",")}`],
+    system_id: [`=${row.original.registered_agents_system_ids.join(",")}`],
   });
   return (
     <Link to={`${urls.controllers.index}${filters}`}>
-      {`${row.original.registered.length} ${pluralize("controller", row.original.registered.length)}`}
+      {`${row.original.registered_agents_system_ids.length} ${pluralize("controller", row.original.registered_agents_system_ids.length)}`}
     </Link>
   );
 };
@@ -45,7 +43,7 @@ const useRacksTableColumns = (): RacksColumnDef[] => {
       },
       {
         id: "registered",
-        accessorKey: "registered",
+        accessorKey: "registered_agents_system_ids",
         enableSorting: true,
         header: "Registered",
         cell: ({ row }) => {

--- a/src/testing/factories/racks.ts
+++ b/src/testing/factories/racks.ts
@@ -5,17 +5,20 @@ import {
   uniqueNamesGenerator,
 } from "unique-names-generator";
 
-import type { RackResponse } from "@/app/apiclient";
+import type { RackWithSummaryResponse } from "@/app/apiclient";
 
-export const rackFactory = Factory.define<RackResponse>(({ sequence }) => {
-  const name = uniqueNamesGenerator({
-    dictionaries: [adjectives, animals],
-    separator: "_",
-    style: "lowerCase",
-    seed: sequence,
-  });
-  return {
-    id: sequence,
-    name,
-  };
-});
+export const rackFactory = Factory.define<RackWithSummaryResponse>(
+  ({ sequence }) => {
+    const name = uniqueNamesGenerator({
+      dictionaries: [adjectives, animals],
+      separator: "_",
+      style: "lowerCase",
+      seed: sequence,
+    });
+    return {
+      id: sequence,
+      name,
+      registered_agents_system_ids: [`controller-${sequence}`],
+    };
+  }
+);

--- a/src/testing/resolvers/racks.ts
+++ b/src/testing/resolvers/racks.ts
@@ -9,7 +9,8 @@ import type {
   GenerateRackBootstrapTokenError,
   GetRackError,
   ListRacksError,
-  ListRacksResponse,
+  ListRacksWithSummaryError,
+  ListRacksWithSummaryResponse,
   UpdateRackError,
 } from "@/app/apiclient";
 
@@ -48,13 +49,13 @@ const mockGenerateRackBootstrapTokenError: GenerateRackBootstrapTokenError = {
 const rackResolvers = {
   listRacks: {
     resolved: false,
-    handler: (data: ListRacksResponse = mockRacks) =>
-      http.get(`${BASE_URL}MAAS/a/v3/racks`, () => {
+    handler: (data: ListRacksWithSummaryResponse = mockRacks) =>
+      http.get(`${BASE_URL}MAAS/a/v3/racks_with_summary`, () => {
         rackResolvers.listRacks.resolved = true;
         return HttpResponse.json(data);
       }),
-    error: (error: ListRacksError = mockListRacksError) =>
-      http.get(`${BASE_URL}MAAS/a/v3/racks`, () => {
+    error: (error: ListRacksWithSummaryError = mockListRacksError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/racks_with_summary`, () => {
         rackResolvers.listRacks.resolved = true;
         return HttpResponse.json(error, { status: error.code });
       }),


### PR DESCRIPTION
## Done

- Replaced listRacks with listRacksWithSummary
- Removed fake data, fixed rack type used for column definitions
- Fixed rack resolver and factory to use the WithSummary type/endpoint

## QA steps

- [x] Set VITE_APP_AGENT_ENROLLMENT to true in your .env
- [x] Navigate to /racks
- [x] Verify the table loads properly
- [x] Add a rack
- [x] Verify the table is correctly updated
- [x] Edit the rack
- [x] Verify the table is correctly updated
- [x] Delete the rack
- [x] Verify the table is correctly updated

## Fixes

Resolves [MAASENG-5529](https://warthogs.atlassian.net/browse/MAASENG-5529)

## Note

The demo instance currently throws a 500 for the racks_with_summary endpoint, so you might want to review with a local latest/edge instance.


[MAASENG-5529]: https://warthogs.atlassian.net/browse/MAASENG-5529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ