### PR TITLE
chore(networks): migrate DHCPReservedRanges to GenericTable MAASENG-5694

### DIFF
--- a/docs/component-standards/testing.md
+++ b/docs/component-standards/testing.md
@@ -2,6 +2,7 @@
 
 ## TL;DR
 
+- Run tests using `yarn test path/to/file.test.tsx`, add `--run` to only run once instead of watching
 - Import all test utilities from `@/testing/utils` (includes `renderWithProviders`, `screen`, `waitFor`, `userEvent`, `within`, etc.)
 - Use `renderWithProviders` for all modern component tests
 - Use `setupMockServer` to configure MSW for API mocking

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/ConfigureDHCP.test.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/ConfigureDHCP.test.tsx
@@ -4,10 +4,10 @@ import { getSubnetDisplay } from "@/app/store/subnet/utils";
 import { vlanActions } from "@/app/store/vlan";
 import * as factory from "@/testing/factories";
 import {
-  userEvent,
-  screen,
-  waitFor,
   renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
 } from "@/testing/utils";
 
 describe("ConfigureDHCP", () => {

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -8,6 +8,7 @@ import DHCPReservedRanges, { Headers } from "./DHCPReservedRanges";
 import urls from "@/app/base/urls";
 import * as factory from "@/testing/factories";
 import {
+  mockIsPending,
   renderWithProviders,
   screen,
   userEvent,
@@ -31,130 +32,268 @@ beforeEach(() => {
   };
 });
 
-it("renders a table of IP ranges if the VLAN has any defined", () => {
-  const vlan = factory.vlan();
-  const subnet = factory.subnet({ gateway_ip: "192.168.1.11", vlan: vlan.id });
-  const ipRange = factory.ipRange({
-    start_ip: "192.168.1.1",
-    end_ip: "192.168.1.10",
-    subnet: subnet.id,
-    vlan: vlan.id,
-  });
-  const state = factory.rootState({
-    iprange: factory.ipRangeState({ items: [ipRange] }),
-    subnet: factory.subnetState({ items: [subnet] }),
-    vlan: factory.vlanState({ items: [vlan] }),
-  });
-  renderWithProviders(
-    <Formik initialValues={initialValues} onSubmit={vi.fn()}>
-      <DHCPReservedRanges id={vlan.id} />
-    </Formik>,
-    { state }
-  );
+describe("DHCPReservedRanges", () => {
+  describe("display", () => {
+    it("does not render when DHCP is disabled", () => {
+      const vlan = factory.vlan();
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [] }),
+        subnet: factory.subnetState({ items: [] }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
 
-  expect(
-    within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
-      "link"
-    )
-  ).toHaveAttribute("href", urls.networks.subnet.index({ id: subnet.id }));
-  expect(
-    screen.getByRole("gridcell", { name: Headers.StartIP }).textContent
-  ).toBe(ipRange.start_ip);
-  expect(
-    screen.getByRole("gridcell", { name: Headers.EndIP }).textContent
-  ).toBe(ipRange.end_ip);
-  expect(
-    screen.getByRole("gridcell", { name: Headers.GatewayIP }).textContent
-  ).toBe(subnet.gateway_ip);
-});
+      renderWithProviders(
+        <Formik
+          initialValues={{ ...initialValues, enableDHCP: false }}
+          onSubmit={vi.fn()}
+        >
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
 
-it(`renders only a subnet select field if no IP ranges exist and no subnet is
-    selected`, () => {
-  const vlan = factory.vlan();
-  const subnet = factory.subnet({ gateway_ip: "192.168.1.11", vlan: vlan.id });
-  const state = factory.rootState({
-    iprange: factory.ipRangeState({ items: [] }),
-    subnet: factory.subnetState({ items: [subnet], loaded: true }),
-    vlan: factory.vlanState({ items: [vlan] }),
+      expect(
+        screen.queryByText("Reserved dynamic range")
+      ).not.toBeInTheDocument();
+    });
+
+    it("displays a loading component when data is loading", async () => {
+      mockIsPending();
+      const vlan = factory.vlan();
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({
+          items: [factory.ipRange({ vlan: vlan.id })],
+          loading: true,
+        }),
+        subnet: factory.subnetState({ items: [] }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Loading...")).toBeInTheDocument();
+      });
+    });
+
+    it("displays a message when rendering an empty list with no ranges", async () => {
+      const vlan = factory.vlan();
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [] }),
+        subnet: factory.subnetState({ items: [], loaded: true }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      // In form mode with no subnet selected, the table shows form fields but no data message
+      expect(screen.getByText("Reserved dynamic range")).toBeInTheDocument();
+      expect(
+        screen.getByRole("combobox", { name: "Subnet" })
+      ).toBeInTheDocument();
+    });
+
+    it("displays the columns correctly for existing IP ranges", () => {
+      const vlan = factory.vlan();
+      const subnet = factory.subnet({
+        gateway_ip: "192.168.1.11",
+        vlan: vlan.id,
+      });
+      const ipRange = factory.ipRange({
+        start_ip: "192.168.1.1",
+        end_ip: "192.168.1.10",
+        subnet: subnet.id,
+        vlan: vlan.id,
+      });
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [ipRange] }),
+        subnet: factory.subnetState({ items: [subnet] }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      [
+        "Subnet",
+        Headers.StartIP,
+        Headers.EndIP,
+        Headers.GatewayIP,
+        Headers.Comment,
+      ].forEach((column) => {
+        expect(
+          screen.getByRole("columnheader", {
+            name: new RegExp(`^${column}`, "i"),
+          })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("displays the columns correctly for form mode (no existing ranges)", () => {
+      const vlan = factory.vlan();
+      const subnet = factory.subnet({ vlan: vlan.id });
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [] }),
+        subnet: factory.subnetState({ items: [subnet], loaded: true }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      // Form mode should not show Comment column
+      ["Subnet", Headers.StartIP, Headers.EndIP, Headers.GatewayIP].forEach(
+        (column) => {
+          expect(
+            screen.getByRole("columnheader", {
+              name: new RegExp(`^${column}`, "i"),
+            })
+          ).toBeInTheDocument();
+        }
+      );
+
+      // Comment column should not be present
+      expect(
+        screen.queryByRole("columnheader", {
+          name: new RegExp(`^${Headers.Comment}`, "i"),
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a table of IP ranges if the VLAN has any defined", () => {
+      const vlan = factory.vlan();
+      const subnet = factory.subnet({
+        gateway_ip: "192.168.1.11",
+        vlan: vlan.id,
+      });
+      const ipRange = factory.ipRange({
+        start_ip: "192.168.1.1",
+        end_ip: "192.168.1.10",
+        subnet: subnet.id,
+        vlan: vlan.id,
+      });
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [ipRange] }),
+        subnet: factory.subnetState({ items: [subnet] }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      const subnetCell = screen.getByRole("cell", {
+        name: new RegExp(subnet.name),
+      });
+      expect(within(subnetCell).getByRole("link")).toHaveAttribute(
+        "href",
+        urls.networks.subnet.index({ id: subnet.id })
+      );
+
+      expect(
+        screen.getByRole("cell", { name: ipRange.start_ip })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("cell", { name: ipRange.end_ip })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("cell", { name: `${subnet.gateway_ip}` })
+      ).toBeInTheDocument();
+    });
+
+    it("renders only a subnet select field if no IP ranges exist and no subnet is selected", () => {
+      const vlan = factory.vlan();
+      const subnet = factory.subnet({
+        gateway_ip: "192.168.1.11",
+        vlan: vlan.id,
+      });
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [] }),
+        subnet: factory.subnetState({ items: [subnet], loaded: true }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      expect(
+        within(screen.getByRole("cell", { name: /Select subnet/i })).getByRole(
+          "combobox",
+          { name: "Subnet" }
+        )
+      ).toBeInTheDocument();
+
+      // all the other cells should be empty
+      expect(screen.getAllByRole("cell", { name: "" })).toHaveLength(3);
+    });
+
+    it("renders a subnet select field and prepopulated fields for a reserved range if no IP ranges exist and a subnet is selected", async () => {
+      const vlan = factory.vlan();
+      const subnet = factory.subnet({
+        gateway_ip: "192.168.1.11",
+        statistics: factory.subnetStatistics({
+          suggested_dynamic_range: factory.subnetStatisticsRange({
+            start: "192.168.1.1",
+            end: "192.168.1.5",
+          }),
+        }),
+        vlan: vlan.id,
+      });
+      const state = factory.rootState({
+        iprange: factory.ipRangeState({ items: [] }),
+        subnet: factory.subnetState({ items: [subnet], loaded: true }),
+        vlan: factory.vlanState({ items: [vlan] }),
+      });
+
+      renderWithProviders(
+        <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+          <DHCPReservedRanges id={vlan.id} />
+        </Formik>,
+        { state }
+      );
+
+      await userEvent.selectOptions(
+        screen.getByRole("combobox", { name: "Subnet" }),
+        subnet.id.toString()
+      );
+
+      expect(
+        screen.getByRole("textbox", { name: Headers.StartIP })
+      ).toHaveAttribute(
+        "value",
+        subnet.statistics.suggested_dynamic_range.start
+      );
+      expect(
+        screen.getByRole("textbox", { name: Headers.EndIP })
+      ).toHaveAttribute("value", subnet.statistics.suggested_dynamic_range.end);
+      expect(
+        screen.getByRole("textbox", { name: Headers.GatewayIP })
+      ).toHaveAttribute("value", subnet.gateway_ip);
+    });
   });
-  renderWithProviders(
-    <Formik initialValues={initialValues} onSubmit={vi.fn()}>
-      <DHCPReservedRanges id={vlan.id} />
-    </Formik>,
-    { state }
-  );
-
-  expect(
-    within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
-      "combobox",
-      { name: "Subnet" }
-    )
-  ).toBeInTheDocument();
-  expect(
-    screen.getByRole("gridcell", { name: Headers.StartIP })
-  ).toBeEmptyDOMElement();
-  expect(
-    screen.getByRole("gridcell", { name: Headers.EndIP })
-  ).toBeEmptyDOMElement();
-  expect(
-    screen.getByRole("gridcell", { name: Headers.GatewayIP })
-  ).toBeEmptyDOMElement();
-});
-
-it(`renders a subnet select field and prepopulated fields for a reserved range
-    if no IP ranges exist and a subnet is selected`, async () => {
-  const vlan = factory.vlan();
-  const subnet = factory.subnet({
-    gateway_ip: "192.168.1.11",
-    statistics: factory.subnetStatistics({
-      suggested_dynamic_range: factory.subnetStatisticsRange({
-        start: "192.168.1.1",
-        end: "192.168.1.5",
-      }),
-    }),
-    vlan: vlan.id,
-  });
-  const state = factory.rootState({
-    iprange: factory.ipRangeState({ items: [] }),
-    subnet: factory.subnetState({ items: [subnet], loaded: true }),
-    vlan: factory.vlanState({ items: [vlan] }),
-  });
-  renderWithProviders(
-    <Formik initialValues={initialValues} onSubmit={vi.fn()}>
-      <DHCPReservedRanges id={vlan.id} />
-    </Formik>,
-    { state }
-  );
-
-  await userEvent.selectOptions(
-    screen.getByRole("combobox", { name: "Subnet" }),
-    subnet.id.toString()
-  );
-
-  await waitFor(() => {
-    expect(
-      within(screen.getByRole("gridcell", { name: Headers.Subnet })).getByRole(
-        "combobox",
-        { name: "Subnet" }
-      )
-    ).toBeInTheDocument();
-  });
-  expect(
-    within(screen.getByRole("gridcell", { name: Headers.StartIP })).getByRole(
-      "textbox",
-      { name: Headers.StartIP }
-    )
-  ).toHaveAttribute("value", subnet.statistics.suggested_dynamic_range.start);
-  expect(
-    within(screen.getByRole("gridcell", { name: Headers.EndIP })).getByRole(
-      "textbox",
-      { name: Headers.EndIP }
-    )
-  ).toHaveAttribute("value", subnet.statistics.suggested_dynamic_range.end);
-  expect(
-    within(screen.getByRole("gridcell", { name: Headers.GatewayIP })).getByRole(
-      "textbox",
-      { name: Headers.GatewayIP }
-    )
-  ).toHaveAttribute("value", subnet.gateway_ip);
 });

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -96,7 +96,6 @@ describe("DHCPReservedRanges", () => {
         { state }
       );
 
-      // In form mode with no subnet selected, the table shows form fields but no data message
       expect(screen.getByText("Reserved dynamic range")).toBeInTheDocument();
       expect(
         screen.getByRole("combobox", { name: "Subnet" })
@@ -159,7 +158,6 @@ describe("DHCPReservedRanges", () => {
         { state }
       );
 
-      // Form mode should not show Comment column
       ["Subnet", Headers.StartIP, Headers.EndIP, Headers.GatewayIP].forEach(
         (column) => {
           expect(
@@ -170,7 +168,6 @@ describe("DHCPReservedRanges", () => {
         }
       );
 
-      // Comment column should not be present
       expect(
         screen.queryByRole("columnheader", {
           name: new RegExp(`^${Headers.Comment}`, "i"),

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEventHandler } from "react";
+import { useEffect } from "react";
 
 import { GenericTable } from "@canonical/maas-react-components";
 import { useFormikContext } from "formik";
@@ -34,7 +34,7 @@ export enum Headers {
 }
 
 const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
-  const { handleChange, setFieldValue, validateForm, values } =
+  const { setFieldTouched, setFieldValue, validateForm, values } =
     useFormikContext<ConfigureDHCPValues>();
 
   const ipRanges = useSelector((state: RootState) =>
@@ -48,18 +48,11 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
   const hasIPRanges = ipRanges.length > 0;
   const subnetSelected = isId(values.subnet);
 
-  const handleSubnetChange: ChangeEventHandler<HTMLInputElement> = async (
-    e
-  ) => {
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-    await handleChange(e);
-    // We set reserved range defaults based on the selected subnet if they exist
-    // otherwise leave the field empty.
-    const subnet = subnets.find(
-      (subnet) => Number(e.target.value) === subnet.id
-    );
-
-    await setFieldValue(
+  // When the selected subnet changes, populate the reserved range defaults
+  // based on the subnet's suggested dynamic range, or clear the fields.
+  useEffect(() => {
+    const subnet = subnets.find((s) => s.id === Number(values.subnet));
+    setFieldValue(
       "endIP",
       subnet?.statistics.suggested_dynamic_range?.end || ""
     ).catch((reason: unknown) => {
@@ -69,8 +62,7 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
         reason as string
       );
     });
-
-    await setFieldValue(
+    setFieldValue(
       "gatewayIP",
       subnet?.gateway_ip || subnet?.statistics.suggested_gateway || ""
     ).catch((reason: unknown) => {
@@ -80,8 +72,7 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
         reason as string
       );
     });
-
-    await setFieldValue(
+    setFieldValue(
       "startIP",
       subnet?.statistics.suggested_dynamic_range?.start || ""
     ).catch((reason: unknown) => {
@@ -91,15 +82,16 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
         reason as string
       );
     });
-
+    if (isId(values.subnet)) {
+      setFieldTouched("subnet", true, false);
+    }
     // need to manually call this as Yup does not automatically re-trigger the validation schema
     validateForm();
-  };
+  }, [setFieldTouched, setFieldValue, subnets, validateForm, values.subnet]);
 
   const columns = useDHCPReservedRangesColumns({
     hasIPRanges,
     subnetSelected,
-    handleSubnetChange,
     vlanId: id,
   });
 

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
@@ -1,25 +1,23 @@
 import type { ChangeEventHandler } from "react";
 
-import { MainTable } from "@canonical/react-components";
+import { GenericTable } from "@canonical/maas-react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import type { ConfigureDHCPValues } from "../ConfigureDHCP";
 
-import FormikField from "@/app/base/components/FormikField";
+import type { DHCPReservedRangeData } from "./useDHCPReservedRangesColumns";
+import useDHCPReservedRangesColumns from "./useDHCPReservedRangesColumns";
+
 import { FormikFieldChangeError } from "@/app/base/components/FormikField/FormikField";
-import SubnetLink from "@/app/base/components/SubnetLink";
-import SubnetSelect from "@/app/base/components/SubnetSelect";
 import TitledSection from "@/app/base/components/TitledSection";
 import { useFetchActions } from "@/app/base/hooks";
 import { ipRangeActions } from "@/app/store/iprange";
 import ipRangeSelectors from "@/app/store/iprange/selectors";
-import type { IPRange } from "@/app/store/iprange/types";
 import { getCommentDisplay } from "@/app/store/iprange/utils";
 import type { RootState } from "@/app/store/root/types";
 import { subnetActions } from "@/app/store/subnet";
 import subnetSelectors from "@/app/store/subnet/selectors";
-import type { Subnet } from "@/app/store/subnet/types";
 import type { VLAN, VLANMeta } from "@/app/store/vlan/types";
 import { isId } from "@/app/utils";
 
@@ -35,124 +33,22 @@ export enum Headers {
   Subnet = "Subnet",
 }
 
-const generateIPRangeRows = (ipRanges: IPRange[], subnets: Subnet[]) =>
-  ipRanges.map((ipRange) => {
-    const subnet = subnets.find((subnet) => subnet.id === ipRange.subnet);
-    const comment = getCommentDisplay(ipRange);
-    const gatewayIP = subnet?.gateway_ip || "—";
-
-    return {
-      columns: [
-        {
-          "aria-label": Headers.Subnet,
-          content: <SubnetLink id={ipRange.subnet} />,
-        },
-        {
-          "aria-label": Headers.StartIP,
-          content: ipRange.start_ip,
-        },
-        {
-          "aria-label": Headers.EndIP,
-          content: ipRange.end_ip,
-        },
-        {
-          "aria-label": Headers.GatewayIP,
-          content: gatewayIP,
-        },
-        {
-          "aria-label": Headers.Comment,
-          content: comment,
-        },
-      ],
-      key: ipRange.id,
-      sortData: {
-        comment,
-        endIP: ipRange.end_ip,
-        gatewayIP,
-        subnet: subnet?.cidr || "",
-        startIP: ipRange.start_ip,
-      },
-    };
-  });
-
-const generateFormRow = (
-  vlanId: VLAN[VLANMeta.PK],
-  subnetSelected: boolean,
-  handleSubnetChange: ChangeEventHandler
-) => {
-  return [
-    {
-      columns: [
-        {
-          "aria-label": Headers.Subnet,
-          content: (
-            <SubnetSelect
-              labelClassName="u-visually-hidden"
-              name="subnet"
-              onChange={handleSubnetChange}
-              vlan={vlanId}
-            />
-          ),
-        },
-        {
-          "aria-label": Headers.StartIP,
-          content: subnetSelected ? (
-            <FormikField
-              label={Headers.StartIP}
-              labelClassName="u-visually-hidden"
-              name="startIP"
-              type="text"
-            />
-          ) : null,
-        },
-        {
-          "aria-label": Headers.EndIP,
-          content: subnetSelected ? (
-            <FormikField
-              label={Headers.EndIP}
-              labelClassName="u-visually-hidden"
-              name="endIP"
-              type="text"
-            />
-          ) : null,
-        },
-        {
-          "aria-label": Headers.GatewayIP,
-          content: subnetSelected ? (
-            <FormikField
-              label={Headers.GatewayIP}
-              labelClassName="u-visually-hidden"
-              name="gatewayIP"
-              type="text"
-            />
-          ) : null,
-        },
-      ],
-    },
-  ];
-};
-
 const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
-  const { handleChange, setFieldValue, values } =
+  const { handleChange, setFieldValue, validateForm, values } =
     useFormikContext<ConfigureDHCPValues>();
 
   const ipRanges = useSelector((state: RootState) =>
     ipRangeSelectors.getByVLAN(state, id)
   );
   const subnets = useSelector(subnetSelectors.all);
+  const ipRangeLoading = useSelector(ipRangeSelectors.loading);
 
   useFetchActions([ipRangeActions.fetch, subnetActions.fetch]);
 
-  if (!values.enableDHCP) {
-    return null;
-  }
-
-  // If the VLAN already has IP ranges defined in its subnets we only display
-  // a table of that IP range data. Otherwise, we allow the user to define a
-  // range of IP addresses to be used for DHCP.
   const hasIPRanges = ipRanges.length > 0;
   const subnetSelected = isId(values.subnet);
-  const handleSubnetChange: ChangeEventHandler<HTMLSelectElement> = async (
+
+  const handleSubnetChange: ChangeEventHandler<HTMLInputElement> = async (
     e
   ) => {
     // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
@@ -162,7 +58,9 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
     const subnet = subnets.find(
       (subnet) => Number(e.target.value) === subnet.id
     );
-    setFieldValue(
+
+    // Set all field values without validating individually
+    await setFieldValue(
       "endIP",
       subnet?.statistics.suggested_dynamic_range?.end || ""
     ).catch((reason: unknown) => {
@@ -172,7 +70,8 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
         reason as string
       );
     });
-    setFieldValue(
+
+    await setFieldValue(
       "gatewayIP",
       subnet?.gateway_ip || subnet?.statistics.suggested_gateway || ""
     ).catch((reason: unknown) => {
@@ -182,7 +81,8 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
         reason as string
       );
     });
-    setFieldValue(
+
+    await setFieldValue(
       "startIP",
       subnet?.statistics.suggested_dynamic_range?.start || ""
     ).catch((reason: unknown) => {
@@ -192,37 +92,55 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
         reason as string
       );
     });
+
+    // Validate the entire form after all values are set
+    validateForm();
   };
+
+  const columns = useDHCPReservedRangesColumns({
+    hasIPRanges,
+    subnetSelected,
+    handleSubnetChange,
+    vlanId: id,
+  });
+
+  if (!values.enableDHCP) {
+    return null;
+  }
+
+  const data: DHCPReservedRangeData[] = hasIPRanges
+    ? ipRanges.map((ipRange) => {
+        const subnet = subnets.find((subnet) => subnet.id === ipRange.subnet);
+        return {
+          id: ipRange.id,
+          subnet: ipRange.subnet,
+          startIp: ipRange.start_ip,
+          endIp: ipRange.end_ip,
+          gatewayIp: subnet?.gateway_ip || "—",
+          comment: getCommentDisplay(ipRange),
+        };
+      })
+    : [
+        {
+          id: 0,
+          subnet: values.subnet || 0,
+          startIp: values.startIP,
+          endIp: values.endIP,
+          gatewayIp: values.gatewayIP,
+          comment: "",
+        },
+      ];
 
   return (
     <TitledSection title="Reserved dynamic range">
-      {hasIPRanges ? (
-        <MainTable
-          defaultSort="startIP"
-          defaultSortDirection="ascending"
-          headers={[
-            { content: Headers.Subnet, sortKey: "subnet" },
-            { content: Headers.StartIP, sortKey: "startIP" },
-            { content: Headers.EndIP, sortKey: "endIP" },
-            { content: Headers.GatewayIP, sortKey: "gatewayIP" },
-            { content: Headers.Comment, sortKey: "comment" },
-          ]}
-          responsive
-          rows={generateIPRangeRows(ipRanges, subnets)}
-          sortable
-        />
-      ) : (
-        <MainTable
-          headers={[
-            { content: Headers.Subnet },
-            { content: Headers.StartIP },
-            { content: Headers.EndIP },
-            { content: Headers.GatewayIP },
-          ]}
-          responsive
-          rows={generateFormRow(id, subnetSelected, handleSubnetChange)}
-        />
-      )}
+      <GenericTable
+        columns={columns}
+        data={data}
+        isLoading={hasIPRanges ? ipRangeLoading : false}
+        noData={hasIPRanges ? "No IP ranges have been reserved." : ""}
+        sorting={hasIPRanges ? [{ id: "startIp", desc: false }] : undefined}
+        variant="regular"
+      />
     </TitledSection>
   );
 };

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
@@ -59,7 +59,6 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
       (subnet) => Number(e.target.value) === subnet.id
     );
 
-    // Set all field values without validating individually
     await setFieldValue(
       "endIP",
       subnet?.statistics.suggested_dynamic_range?.end || ""
@@ -93,7 +92,7 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
       );
     });
 
-    // Validate the entire form after all values are set
+    // need to manually call this as Yup does not automatically re-trigger the validation schema
     validateForm();
   };
 

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/useDHCPReservedRangesColumns/index.ts
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/useDHCPReservedRangesColumns/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./useDHCPReservedRangesColumns";
+export type { DHCPReservedRangeData } from "./useDHCPReservedRangesColumns";

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/useDHCPReservedRangesColumns/useDHCPReservedRangesColumns.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/useDHCPReservedRangesColumns/useDHCPReservedRangesColumns.tsx
@@ -1,4 +1,3 @@
-import type { ChangeEventHandler } from "react";
 import { useMemo } from "react";
 
 import type { ColumnDef } from "@tanstack/react-table";
@@ -27,14 +26,12 @@ type DHCPReservedRangesColumnDef = ColumnDef<
 type UseDHCPReservedRangesColumnsProps = {
   hasIPRanges: boolean;
   subnetSelected: boolean;
-  handleSubnetChange: ChangeEventHandler<HTMLInputElement>;
   vlanId: VLAN[VLANMeta.PK];
 };
 
 const useDHCPReservedRangesColumns = ({
   hasIPRanges,
   subnetSelected = false,
-  handleSubnetChange,
   vlanId,
 }: UseDHCPReservedRangesColumnsProps): DHCPReservedRangesColumnDef[] => {
   return useMemo(
@@ -51,7 +48,6 @@ const useDHCPReservedRangesColumns = ({
             <SubnetSelect
               labelClassName="u-visually-hidden"
               name="subnet"
-              onChange={handleSubnetChange}
               vlan={vlanId}
             />
           ),
@@ -120,7 +116,7 @@ const useDHCPReservedRangesColumns = ({
           ]
         : []),
     ],
-    [hasIPRanges, subnetSelected, handleSubnetChange, vlanId]
+    [hasIPRanges, subnetSelected, vlanId]
   );
 };
 

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/useDHCPReservedRangesColumns/useDHCPReservedRangesColumns.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/useDHCPReservedRangesColumns/useDHCPReservedRangesColumns.tsx
@@ -1,0 +1,127 @@
+import type { ChangeEventHandler } from "react";
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import FormikField from "@/app/base/components/FormikField";
+import SubnetLink from "@/app/base/components/SubnetLink";
+import SubnetSelect from "@/app/base/components/SubnetSelect";
+import type { IPRange } from "@/app/store/iprange/types";
+import type { Subnet } from "@/app/store/subnet/types";
+import type { VLAN, VLANMeta } from "@/app/store/vlan/types";
+
+export type DHCPReservedRangeData = {
+  id: IPRange["id"];
+  subnet: IPRange["subnet"];
+  startIp: IPRange["start_ip"];
+  endIp: IPRange["end_ip"];
+  gatewayIp: Subnet["gateway_ip"] | "—";
+  comment: string;
+};
+
+type DHCPReservedRangesColumnDef = ColumnDef<
+  DHCPReservedRangeData,
+  Partial<DHCPReservedRangeData>
+>;
+
+type UseDHCPReservedRangesColumnsProps = {
+  hasIPRanges: boolean;
+  subnetSelected: boolean;
+  handleSubnetChange: ChangeEventHandler<HTMLInputElement>;
+  vlanId: VLAN[VLANMeta.PK];
+};
+
+const useDHCPReservedRangesColumns = ({
+  hasIPRanges,
+  subnetSelected = false,
+  handleSubnetChange,
+  vlanId,
+}: UseDHCPReservedRangesColumnsProps): DHCPReservedRangesColumnDef[] => {
+  return useMemo(
+    () => [
+      {
+        id: "subnet",
+        accessorKey: "subnet",
+        enableSorting: hasIPRanges,
+        header: "Subnet",
+        cell: ({ row }: { row: { original: DHCPReservedRangeData } }) =>
+          hasIPRanges ? (
+            <SubnetLink id={row.original.subnet} />
+          ) : (
+            <SubnetSelect
+              labelClassName="u-visually-hidden"
+              name="subnet"
+              onChange={handleSubnetChange}
+              vlan={vlanId}
+            />
+          ),
+      },
+      {
+        id: "startIp",
+        accessorKey: "startIp",
+        enableSorting: hasIPRanges,
+        header: "Start IP address",
+        cell: ({ row }: { row: { original: DHCPReservedRangeData } }) =>
+          hasIPRanges ? (
+            row.original.startIp
+          ) : subnetSelected ? (
+            <FormikField
+              label="Start IP address"
+              labelClassName="u-visually-hidden"
+              name="startIP"
+              type="text"
+            />
+          ) : null,
+      },
+      {
+        id: "endIp",
+        accessorKey: "endIp",
+        enableSorting: hasIPRanges,
+        header: "End IP address",
+        cell: ({ row }: { row: { original: DHCPReservedRangeData } }) =>
+          hasIPRanges ? (
+            row.original.endIp
+          ) : subnetSelected ? (
+            <FormikField
+              label="End IP address"
+              labelClassName="u-visually-hidden"
+              name="endIP"
+              type="text"
+            />
+          ) : null,
+      },
+      {
+        id: "gatewayIp",
+        accessorKey: "gatewayIp",
+        enableSorting: hasIPRanges,
+        header: "Gateway IP",
+        cell: ({ row }: { row: { original: DHCPReservedRangeData } }) =>
+          hasIPRanges ? (
+            row.original.gatewayIp
+          ) : subnetSelected ? (
+            <FormikField
+              label="Gateway IP"
+              labelClassName="u-visually-hidden"
+              name="gatewayIP"
+              type="text"
+            />
+          ) : null,
+      },
+      ...(hasIPRanges
+        ? [
+            {
+              id: "comment",
+              accessorKey: "comment",
+              enableSorting: hasIPRanges,
+              header: "Comment",
+              cell: ({ row }: { row: { original: DHCPReservedRangeData } }) =>
+                hasIPRanges ? row.original.comment : null,
+            },
+          ]
+        : []),
+    ],
+    [hasIPRanges, subnetSelected, handleSubnetChange, vlanId]
+  );
+};
+
+export default useDHCPReservedRangesColumns;


### PR DESCRIPTION
## Done

- Migrated DHCPReservedRanges to GenericTable

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

On `maas-ui-demo.internal`:
- [x] Go to `/vlan/5001`
- [x] Click "Configure DHCP"
- [x] Select a controller
- [x] Select a subnet from the dropdown (ensure list of subnets is valid)
- [x] Ensure form fields are populated correctly
- [x] Close the form
- [x] Go to `/vlan/5002`
- [x] Click "Configure DHCP"
- [x] Ensure the table is pre-filled with the existing dynamic range

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5694](https://warthogs.atlassian.net/browse/MAASENG-5694)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Notes

Used Copilot (Claude Sonnet 4.5) to do most of the grunt work here - it seemed mostly competent, although it took a few tries to get it to do the column definitions in a clean way, it really wanted to re-map the whole definition for the form-fields variant of the table instead of just passing an argument to the hook. 

[MAASENG-5694]: https://warthogs.atlassian.net/browse/MAASENG-5694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ