### PR TITLE
fix: manually remove unknown types when generating the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cypress-run-a11y": "yarn cypress run --config specPattern=cypress/e2e/accessibility/**/*.ts",
     "cypress-run-docs": "yarn cypress run --config specPattern=cypress/e2e/docs-links/**/*.ts ",
     "cypress-run": "yarn cypress run",
-    "generate-api-client": "export NODE_TLS_REJECT_UNAUTHORIZED=0 && openapi-ts",
+    "generate-api-client": "export NODE_TLS_REJECT_UNAUTHORIZED=0 && openapi-ts && sed -i 's/ | unknown//g' src/app/apiclient/types.gen.ts",
     "lint": "npmPkgJsonLint . && eslint src cypress && tsc --project tsconfig.json --noEmit && tsc --project cypress/tsconfig.json --noEmit && npx tsx scripts/check-cucumber-steps.ts",
     "lint-fix": "npmPkgJsonLint . && eslint src cypress --fix && tsc --project tsconfig.json --noEmit && tsc --project cypress/tsconfig.json --noEmit && npx tsx scripts/check-cucumber-steps.ts",
     "link-components": "yarn link \"@canonical/react-components\" && yarn link \"react\" && yarn install",


### PR DESCRIPTION
## Done

Following the recent Pydantic upgrade, hey-api seems to map fields like the following to `last_name?: string | unknown`  types, leading to several failing tests and linting errors:
```json
 "last_name": {
            "anyOf": [
              {
                "type": "string"
              },
              {
                "type": "null"
              }
            ],
            "title": "Last Name"
          },
```
The obvious fix was to upgrade `hey-api` to a newer version (which I tried), but unfortunately this problem still occurs. While we find a better workaround, it might be safe to manually handle this issue, so we can continue working with the latest API changes. 
- This PR manually handles "null" types coming from the OpenAPI spec so that they are not mapped to `unknown` types
