### PR TITLE
chore(machines): refactor InterfaceFormTable to use GenericTable MAASENG-5691

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
@@ -80,11 +80,21 @@ const InterfaceSchema = Yup.object().shape({
 
 // TODO: better prop typing, these are sometimes undefined
 const AddBondForm = ({
-  selected,
-  setSelected,
+  selected: initialSelected,
+  setSelected: setParentSelected,
   systemId,
 }: AddBondProps): ReactElement => {
   const { closeSidePanel } = useSidePanel();
+
+  // Local state is required because `selected` is frozen in the side panel context when the panel opens and won't reflect parent updates.
+  const [selected, setLocalSelected] = useState<Selected[]>(initialSelected);
+  const setSelected: SetSelected = useCallback(
+    (newSelected) => {
+      setLocalSelected(newSelected);
+      setParentSelected(newSelected);
+    },
+    [setParentSelected]
+  );
   const [editingMembers, setEditingMembers] = useState(false);
   const [bondVLAN, setBondVLAN] = useState<NetworkInterface["vlan_id"] | null>(
     null

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
@@ -74,11 +74,11 @@ describe("EditBondForm", () => {
         interfaces,
       }),
     ];
-    const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
+    nic.parents = [interfaces[0].id, interfaces[1].id];
     renderWithProviders(
       <EditBondForm
         nic={nic}
-        selected={selected}
+        selected={[]}
         setSelected={vi.fn()}
         systemId="abc123"
       />,
@@ -107,6 +107,7 @@ describe("EditBondForm", () => {
       }),
     ];
     const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
+    nic.parents = [interfaces[0].id, interfaces[1].id];
     renderWithProviders(
       <EditBondForm
         nic={nic}
@@ -179,7 +180,9 @@ describe("EditBondForm", () => {
       />,
       { state }
     );
-    await userEvent.click(screen.getByTestId("edit-members"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit bond members" })
+    );
 
     const rows = screen.getAllByRole("row");
     expect(within(rows[1]).getByTestId("name")).toHaveTextContent("valid0");
@@ -195,14 +198,17 @@ describe("EditBondForm", () => {
   it("disables the submit button if two interfaces aren't selected", async () => {
     const interfaces = [
       factory.machineInterface({
+        name: "eth0",
         type: NetworkInterfaceTypes.PHYSICAL,
         vlan_id: 1,
       }),
       factory.machineInterface({
+        name: "eth1",
         type: NetworkInterfaceTypes.PHYSICAL,
         vlan_id: 1,
       }),
       factory.machineInterface({
+        name: "eth2",
         type: NetworkInterfaceTypes.PHYSICAL,
         vlan_id: 1,
       }),
@@ -213,26 +219,32 @@ describe("EditBondForm", () => {
         interfaces,
       }),
     ];
-    const { rerender } = renderWithProviders(
-      <EditBondForm
-        nic={nic}
-        selected={[{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }]}
-        setSelected={vi.fn()}
-        systemId="abc123"
-      />,
-      { state }
-    );
-    expect(
-      screen.getByRole("button", { name: "Save interface" })
-    ).not.toBeDisabled();
-    await userEvent.click(screen.getByTestId("edit-members"));
-    rerender(
+    nic.parents = [interfaces[0].id, interfaces[1].id];
+    renderWithProviders(
       <EditBondForm
         nic={nic}
         selected={[]}
         setSelected={vi.fn()}
         systemId="abc123"
-      />
+      />,
+      { state }
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit bond members" })
+    );
+    // Select eth2 to make membersHaveChanged=true → submit becomes enabled.
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "select eth2" })
+    );
+    expect(
+      screen.getByRole("button", { name: "Save interface" })
+    ).not.toBeDisabled();
+    // Deselect eth0 and eth1, leaving only eth2 → fewer than two selected → disabled.
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "select eth0" })
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "select eth1" })
     );
     expect(
       screen.getByRole("button", { name: "Save interface" })
@@ -250,6 +262,7 @@ describe("EditBondForm", () => {
         vlan_id: 1,
       }),
       factory.machineInterface({
+        name: "eth2",
         type: NetworkInterfaceTypes.PHYSICAL,
         vlan_id: 1,
       }),
@@ -261,10 +274,10 @@ describe("EditBondForm", () => {
       }),
     ];
     nic.parents = [interfaces[0].id, interfaces[1].id];
-    const { rerender } = renderWithProviders(
+    renderWithProviders(
       <EditBondForm
         nic={nic}
-        selected={[{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }]}
+        selected={[]}
         setSelected={vi.fn()}
         systemId="abc123"
       />,
@@ -273,19 +286,12 @@ describe("EditBondForm", () => {
     expect(
       screen.getByRole("button", { name: "Save interface" })
     ).toBeDisabled();
-    await userEvent.click(screen.getByTestId("edit-members"));
-    // Select an extra interface.
-    rerender(
-      <EditBondForm
-        nic={nic}
-        selected={[
-          { nicId: interfaces[0].id },
-          { nicId: interfaces[1].id },
-          { nicId: interfaces[2].id },
-        ]}
-        setSelected={vi.fn()}
-        systemId="abc123"
-      />
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit bond members" })
+    );
+    // Select an extra interface — membersHaveChanged becomes true → submit enabled.
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "select eth2" })
     );
     expect(
       screen.getByRole("button", { name: "Save interface" })
@@ -327,6 +333,7 @@ describe("EditBondForm", () => {
     const bond = factory.machineInterface({
       id: 3,
       name: "bond1",
+      parents: [9, 10],
       type: NetworkInterfaceTypes.BOND,
       vlan_id: 1,
       params: {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -81,11 +81,23 @@ const InterfaceSchema = Yup.object().shape({
 const EditBondForm = ({
   link,
   nic,
-  selected,
-  setSelected,
+  selected: _selected,
+  setSelected: setParentSelected,
   systemId,
 }: EditBondProps): ReactElement | null => {
   const [editingMembers, setEditingMembers] = useState(false);
+  // Local state is required because `selected` is frozen in the side panel context when the panel opens and won't reflect parent updates.
+  // Initialise directly from the bond's parents so the table is populated regardless of the network table selection.
+  const [selected, setLocalSelected] = useState<Selected[]>(
+    () => nic?.parents.map((id) => ({ nicId: id })) ?? []
+  );
+  const setSelected: SetSelected = useCallback(
+    (newSelected) => {
+      setLocalSelected(newSelected);
+      setParentSelected(newSelected);
+    },
+    [setParentSelected]
+  );
   const dispatch = useDispatch();
   const { closeSidePanel } = useSidePanel();
   const machine = useSelector((state: RootState) =>
@@ -121,18 +133,6 @@ const EditBondForm = ({
     subnetActions.fetch,
     vlanActions.fetch,
   ]);
-
-  useEffect(() => {
-    // Set the bond parents as selected so that they appear in the table and the
-    // parents can be edited.
-    if (nic) {
-      setSelected(
-        nic.parents.map((id) => ({
-          nicId: id,
-        }))
-      );
-    }
-  }, [setSelected, nic]);
 
   if (
     !nic ||

--- a/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -81,29 +81,7 @@ describe("InterfaceFormTable", () => {
     );
 
     expect(
-      screen.getByRole("checkbox", { name: nic.name })
+      screen.getByRole("checkbox", { name: `select ${nic.name}` })
     ).toBeInTheDocument();
-  });
-
-  it("mutes a row if its not selected", () => {
-    const nic = factory.machineInterface();
-    state.machine.items = [
-      factory.machineDetails({
-        interfaces: [nic],
-        system_id: "abc123",
-      }),
-    ];
-    renderWithProviders(
-      <InterfaceFormTable
-        interfaces={[{ nicId: nic.id }]}
-        selected={[]}
-        selectedEditable
-        setSelected={vi.fn()}
-        systemId="abc123"
-      />,
-      { state }
-    );
-
-    expect(screen.getAllByRole("row")[1]).toHaveClass("p-table__row--muted");
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
@@ -1,17 +1,11 @@
-import { MainTable, Spinner } from "@canonical/react-components";
-import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { useEffect, useMemo, useState } from "react";
+
+import { GenericTable } from "@canonical/maas-react-components";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { useSelector } from "react-redux";
 
-import TableHeader from "@/app/base/components/TableHeader";
-import DHCPColumn from "@/app/base/components/node/networking/DHCPColumn";
-import FabricColumn from "@/app/base/components/node/networking/FabricColumn";
-import NameColumn from "@/app/base/components/node/networking/NameColumn";
-import IPColumn from "@/app/base/components/node/networking/NetworkTable/IPColumn";
-import { generateUniqueId } from "@/app/base/components/node/networking/NetworkTable/NetworkTable";
-import PXEColumn from "@/app/base/components/node/networking/NetworkTable/PXEColumn";
-import SpeedColumn from "@/app/base/components/node/networking/NetworkTable/SpeedColumn";
-import SubnetColumn from "@/app/base/components/node/networking/SubnetColumn";
-import TypeColumn from "@/app/base/components/node/networking/TypeColumn";
+import useInterfaceFormTableColumns from "./useInterfaceFormTableColumns/useInterfaceFormTableColumns";
+
 import type {
   Selected,
   SetSelected,
@@ -26,70 +20,34 @@ import {
   getInterfaceName,
   getLinkFromNic,
 } from "@/app/store/utils";
-import { generateCheckboxHandlers, simpleSortByKey } from "@/app/utils";
-import type { CheckboxHandlers } from "@/app/utils/generateCheckboxHandlers";
+import { simpleSortByKey } from "@/app/utils";
+
+import "./_index.scss";
 
 export type InterfaceRow = {
   linkId?: NetworkLink["id"] | null;
   nicId?: NetworkInterface["id"] | null;
 };
 
-const generateRow = (
-  machine: MachineDetails,
-  interfaceRow: InterfaceRow,
-  selected: Selected[] = [],
-  handleRowCheckbox?: CheckboxHandlers<Selected>["handleRowCheckbox"] | null,
-  checkSelected?: CheckboxHandlers<Selected>["checkSelected"] | null,
-  selectedEditable?: boolean
-): MainTableRow => {
-  const { linkId, nicId } = interfaceRow;
-  const nic = getInterfaceById(machine, nicId, linkId);
-  const link = getLinkFromNic(nic, linkId);
-  const isSelected = checkSelected
-    ? checkSelected({ nicId, linkId }, selected)
-    : false;
-  return {
-    className: isSelected || !selectedEditable ? null : "p-table__row--muted",
-    columns: [
-      {
-        content: (
-          <NameColumn
-            checkSelected={checkSelected}
-            handleRowCheckbox={handleRowCheckbox}
-            link={link}
-            nic={nic}
-            node={machine}
-            selected={selected}
-            showCheckbox={selectedEditable}
-          />
-        ),
-      },
-      {
-        content: <PXEColumn link={link} nic={nic} node={machine} />,
-        className: "u-align--center",
-      },
-      {
-        content: <SpeedColumn link={link} nic={nic} node={machine} />,
-      },
-      {
-        content: <TypeColumn link={link} nic={nic} node={machine} />,
-      },
-      {
-        content: <FabricColumn link={link} nic={nic} node={machine} />,
-      },
-      {
-        content: <SubnetColumn link={link} nic={nic} node={machine} />,
-      },
-      {
-        content: <IPColumn link={link} nic={nic} node={machine} />,
-      },
-      {
-        content: <DHCPColumn nic={nic} />,
-      },
-    ],
-    key: getInterfaceName(machine, nic, link),
-  };
+export type InterfaceTableRow = {
+  id: number;
+  name: string;
+  nic: NetworkInterface | null;
+  link: NetworkLink | null;
+  machine: MachineDetails;
+  nicId: NetworkInterface["id"] | null | undefined;
+  linkId: NetworkLink["id"] | null | undefined;
 };
+
+const selectedToRowSelection = (
+  selectedItems: Selected[],
+  rows: InterfaceTableRow[]
+): RowSelectionState =>
+  rows.reduce<RowSelectionState>((acc, row) => {
+    const isSelected = selectedItems.some((s) => s.nicId === row.id);
+    if (isSelected) acc[row.id] = true;
+    return acc;
+  }, {});
 
 type Props = {
   interfaces: InterfaceRow[];
@@ -109,104 +67,77 @@ const InterfaceFormTable = ({
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
-  let handleRowCheckbox: CheckboxHandlers<Selected>["handleRowCheckbox"] | null;
-  let checkSelected: CheckboxHandlers<Selected>["checkSelected"] | null;
-  if (setSelected) {
-    const handlers = generateCheckboxHandlers<Selected>(
-      setSelected,
-      generateUniqueId
-    );
-    checkSelected = handlers.checkSelected;
-    handleRowCheckbox = handlers.handleRowCheckbox;
-  }
+  const columns = useInterfaceFormTableColumns();
 
-  if (!isMachineDetails(machine) || interfaces.length === 0) {
-    return <Spinner />;
-  }
+  const isLoading = !isMachineDetails(machine);
 
-  const rows = interfaces
-    .map((interfaceRow) =>
-      generateRow(
-        machine,
-        interfaceRow,
-        selected,
-        handleRowCheckbox,
-        checkSelected,
-        selectedEditable
-      )
-    )
-    .sort(simpleSortByKey("key"));
+  const rows = useMemo<InterfaceTableRow[]>(
+    () =>
+      isLoading
+        ? []
+        : interfaces
+            .map(({ nicId, linkId }) => {
+              const nic = getInterfaceById(
+                machine as MachineDetails,
+                nicId,
+                linkId
+              );
+              const link = getLinkFromNic(nic, linkId);
+              const id = getInterfaceName(machine as MachineDetails, nic, link);
+              return {
+                id: nic!.id,
+                name: id,
+                nic,
+                link,
+                machine: machine as MachineDetails,
+                nicId,
+                linkId,
+              };
+            })
+            .sort(simpleSortByKey("id")),
+    [interfaces, isLoading, machine]
+  );
+
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>(() =>
+    selectedToRowSelection(selected, rows)
+  );
+
+  useEffect(() => {
+    if (!setSelected) return;
+    const selectedKeys = Object.keys(
+      selectedToRowSelection(selected, rows)
+    ).sort();
+    const rowSelectionKeys = Object.keys(rowSelection)
+      .filter((key) => rowSelection[key])
+      .sort();
+    if (selectedKeys.join(",") !== rowSelectionKeys.join(",")) {
+      const newSelected = rows
+        .filter((row) => rowSelection[row.id])
+        .map((row) => ({ nicId: row.nicId, linkId: row.linkId }));
+      setSelected(newSelected);
+    }
+  }, [rowSelection, selected, setSelected, rows]);
+
   return (
-    <MainTable
-      headers={[
-        {
-          content: (
-            <>
-              <TableHeader>Name</TableHeader>
-              <TableHeader>MAC</TableHeader>
-            </>
-          ),
-        },
-        {
-          content: (
-            <>
-              <TableHeader className="u-align--center">PXE</TableHeader>
-            </>
-          ),
-        },
-        {
-          content: (
-            <TableHeader className="p-double-row__header-spacer">
-              Link/interface speed
-            </TableHeader>
-          ),
-        },
-        {
-          content: (
-            <div>
-              <TableHeader className="p-double-row__header-spacer">
-                Type
-              </TableHeader>
-              <TableHeader className="p-double-row__header-spacer">
-                NUMA node
-              </TableHeader>
-            </div>
-          ),
-        },
-        {
-          content: (
-            <div>
-              <TableHeader>Fabric</TableHeader>
-              <TableHeader>VLAN</TableHeader>
-            </div>
-          ),
-        },
-        {
-          content: (
-            <div>
-              <TableHeader>Subnet</TableHeader>
-              <TableHeader>Name</TableHeader>
-            </div>
-          ),
-        },
-        {
-          content: (
-            <div>
-              <TableHeader>IP Address</TableHeader>
-              <TableHeader>Status</TableHeader>
-            </div>
-          ),
-        },
-        {
-          content: (
-            <TableHeader className="p-double-row__header-spacer">
-              DHCP
-            </TableHeader>
-          ),
-        },
-      ]}
-      rows={rows}
-    />
+    <>
+      <GenericTable
+        className="interface-form-table"
+        columns={columns}
+        data={rows}
+        isLoading={isLoading}
+        noData="No interfaces available."
+        selection={
+          selectedEditable && setSelected
+            ? {
+                rowSelection,
+                setRowSelection,
+                rowSelectionLabelKey: "name",
+              }
+            : undefined
+        }
+        variant="regular"
+      />
+    </>
   );
 };
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/_index.scss
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/_index.scss
@@ -1,0 +1,13 @@
+.interface-form-table.p-generic-table {
+  .p-generic-table__table {
+    th.p-column-header.dhcp {
+      text-align: left;
+    }
+
+    tbody {
+      td.dhcp:last-child {
+        text-align: left;
+      }
+    }
+  }
+}

--- a/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/useInterfaceFormTableColumns/useInterfaceFormTableColumns.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/useInterfaceFormTableColumns/useInterfaceFormTableColumns.tsx
@@ -1,0 +1,162 @@
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import TableHeader from "@/app/base/components/TableHeader";
+import DHCPColumn from "@/app/base/components/node/networking/DHCPColumn";
+import FabricColumn from "@/app/base/components/node/networking/FabricColumn";
+import NameColumn from "@/app/base/components/node/networking/NameColumn";
+import IPColumn from "@/app/base/components/node/networking/NetworkTable/IPColumn";
+import PXEColumn from "@/app/base/components/node/networking/NetworkTable/PXEColumn";
+import SpeedColumn from "@/app/base/components/node/networking/NetworkTable/SpeedColumn";
+import SubnetColumn from "@/app/base/components/node/networking/SubnetColumn";
+import TypeColumn from "@/app/base/components/node/networking/TypeColumn";
+import type { InterfaceTableRow } from "@/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable";
+
+export type InterfaceFormTableColumnDef = ColumnDef<
+  InterfaceTableRow,
+  Partial<InterfaceTableRow>
+>;
+
+const useInterfaceFormTableColumns = (): InterfaceFormTableColumnDef[] => {
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        enableSorting: false,
+        header: () => (
+          <>
+            <span>Name</span>
+            <br />
+            <span>MAC</span>
+          </>
+        ),
+        cell: ({ row: { original } }) => (
+          <NameColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "pxe",
+        enableSorting: false,
+        header: () => (
+          <TableHeader className="p-double-row__header-spacer">PXE</TableHeader>
+        ),
+        cell: ({ row: { original } }) => (
+          <PXEColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "speed",
+        enableSorting: false,
+        header: () => (
+          <TableHeader className="p-double-row__header-spacer">
+            Link/interface speed
+          </TableHeader>
+        ),
+        cell: ({ row: { original } }) => (
+          <SpeedColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "type",
+        enableSorting: false,
+        header: () => (
+          <>
+            <TableHeader className="p-double-row__header-spacer">
+              Type
+            </TableHeader>
+            <TableHeader className="p-double-row__header-spacer">
+              NUMA node
+            </TableHeader>
+          </>
+        ),
+        cell: ({ row: { original } }) => (
+          <TypeColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "fabric",
+        enableSorting: false,
+        header: () => (
+          <>
+            <span>Fabric</span>
+            <br />
+            <span>VLAN</span>
+          </>
+        ),
+        cell: ({ row: { original } }) => (
+          <FabricColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "subnet",
+        enableSorting: false,
+        header: () => (
+          <>
+            <span>Subnet</span>
+            <br />
+            <span>Name</span>
+          </>
+        ),
+        cell: ({ row: { original } }) => (
+          <SubnetColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "ip",
+        enableSorting: false,
+        header: () => (
+          <>
+            <span>IP Address</span>
+            <br />
+            <span>Status</span>
+          </>
+        ),
+        cell: ({ row: { original } }) => (
+          <IPColumn
+            link={original.link}
+            nic={original.nic}
+            node={original.machine}
+          />
+        ),
+      },
+      {
+        id: "dhcp",
+        enableSorting: false,
+        header: () => (
+          <TableHeader className="p-double-row__header-spacer">
+            DHCP
+          </TableHeader>
+        ),
+        cell: ({ row: { original } }) => <DHCPColumn nic={original.nic} />,
+      },
+    ],
+    []
+  );
+};
+
+export default useInterfaceFormTableColumns;


### PR DESCRIPTION
## Done

- Migrated InterfaceFormTable to GenericTable
- Fixed bug where not selecting a bond would result in an empty table in the "Edit bond" form
- Fixed bug where the bond itself would be displayed in the interface form table when selected in the network table
- Fixed bug where additional bond members could not be selected from within the form
- Fixed background of extra rows when updating bond members to be correct for dark mode

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

With maas-ui-demo.internal as your backend:
- [x] Go to `/machine/qxxwxb/network`
- [x] Select two interfaces
- [x] Click "Add bond"
- [x] Ensure the table appears normal (compared to maas-ui-demo) and the interfaces are shown
- [x] Click "Edit bond members"
- [x] Ensure any other valid interfaces (same fabric + vlan) are shown
- [x] Select another bond member and click "Update bond members"
- [x] Ensure table is no longer selectable and new members are shown
- [x] Close the form
- [x] Edit an existing bond
- [x] Ensure all bond members are present in the table
- [x] Ensure the bond itself is *not* present in the table
- [x] Repeat steps to check updating bond members

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5691](https://warthogs.atlassian.net/browse/MAASENG-5691)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Notes

Partially generated using Copilot + Claude Sonnet 4.6. It was quite helpful in debugging the react state updates around selection and fixing the mentioned bugs.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-5691]: https://warthogs.atlassian.net/browse/MAASENG-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ