### PR TITLE
fix: install snapd and core snaps locally before calling setup-maas

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/checkout@main
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
+      - name: Install snapd and core snaps
+        run: |
+          sudo snap install snapd
+          sudo snap install core26 --edge
       - name: Setup MAAS
         uses: canonical/setup-maas@main
         with:

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install snapd and core snaps
         run: |
           sudo snap install snapd
-          sudo snap install core26 --edge
+          sudo snap install core26 --candidate
       - name: Setup MAAS
         uses: canonical/setup-maas@main
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/checkout@main
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
+      - name: Install snapd and core snaps
+        run: |
+          sudo snap install snapd
+          sudo snap install core26 --edge
       - name: Setup MAAS
         uses: canonical/setup-maas@main
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install snapd and core snaps
         run: |
           sudo snap install snapd
-          sudo snap install core26 --edge
+          sudo snap install core26 --candidate
       - name: Setup MAAS
         uses: canonical/setup-maas@main
         with:

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -15,6 +15,10 @@ jobs:
       MAAS_URL: http://localhost:5240
     steps:
       - uses: actions/checkout@main
+      - name: Install snapd and core snaps
+        run: |
+          sudo snap install snapd
+          sudo snap install core26 --edge
       - name: Setup MAAS
         uses: canonical/setup-maas@main
         with:

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install snapd and core snaps
         run: |
           sudo snap install snapd
-          sudo snap install core26 --edge
+          sudo snap install core26 --candidate
       - name: Setup MAAS
         uses: canonical/setup-maas@main
         with:


### PR DESCRIPTION
## Done

- Cypress, accessibility and sitespeed.io tests are currently failing due to missing dependency requirements
- This PR adds in the required snaps before calling `setup-maas`

## QA steps

- [x] Verify that all tests are now working (some cypress tests may fail for `machines_actions.feature` and related, but all others should work; this will be fixed in a following PR)

## Notes
- We may want to revert this change once GitHub has a runner for Resolute Raccoon, as right now we are running Resolute dependencies on Noble runners
