### PR TITLE
chore(machines): refactor MachineDetails routes to centralised routes in router.tsx MAASENG-6079

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,13 +1,18 @@
 import { waitFor } from "@testing-library/react";
-import { Route, Routes } from "react-router";
 import type { Mock } from "vitest";
 
 import MachineDetails from "./MachineDetails";
 
 import urls from "@/app/base/urls";
+import { useFetchMachine } from "@/app/store/machine/utils/hooks";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
 import { renderWithProviders, screen, userEvent } from "@/testing/utils";
+
+vi.mock("@/app/store/machine/utils/hooks", async () => ({
+  ...(await vi.importActual("@/app/store/machine/utils/hooks")),
+  useFetchMachine: vi.fn(),
+}));
 
 describe("MachineDetails", () => {
   let state: RootState;
@@ -28,106 +33,24 @@ describe("MachineDetails", () => {
         loaded: true,
       }),
     });
+    vi.mocked(useFetchMachine).mockReturnValue({
+      machine: factory.machineDetails({
+        fqdn: "test-machine",
+        system_id: "abc123",
+      }),
+      loaded: true,
+      loading: false,
+    });
   });
 
   afterAll(() => {
     vi.restoreAllMocks();
   });
 
-  [
-    {
-      component: "MachineSummary",
-      path: urls.machines.machine.summary({ id: "abc123" }),
-      title: "details",
-    },
-    {
-      component: "MachineInstances",
-      path: urls.machines.machine.instances({ id: "abc123" }),
-      title: "instances",
-    },
-    {
-      component: "MachineNetwork",
-      path: urls.machines.machine.network({ id: "abc123" }),
-      title: "network",
-    },
-    {
-      component: "MachineStorage",
-      path: urls.machines.machine.storage({ id: "abc123" }),
-      title: "storage",
-    },
-    {
-      component: "MachinePCIDevices",
-      path: urls.machines.machine.pciDevices({ id: "abc123" }),
-      title: "PCI devices",
-    },
-    {
-      component: "MachineUSBDevices",
-      path: urls.machines.machine.usbDevices({ id: "abc123" }),
-      title: "USB devices",
-    },
-    {
-      component: "NodeScripts",
-      path: urls.machines.machine.scriptsResults.index({ id: "abc123" }),
-      title: "scripts",
-    },
-    {
-      component: "NodeLogs",
-      path: urls.machines.machine.logs.index({ id: "abc123" }),
-      title: "logs",
-    },
-    {
-      component: "MachineConfiguration",
-      path: urls.machines.machine.configuration({ id: "abc123" }),
-      title: "configuration",
-    },
-  ].forEach(({ component, path, title }) => {
-    it(`Displays: ${component} at: ${path}`, async () => {
-      const { router } = renderWithProviders(
-        <Routes>
-          <Route
-            element={<MachineDetails />}
-            path={`${urls.machines.machine.index(null)}/*`}
-          />
-        </Routes>,
-        {
-          state,
-          initialEntries: [
-            `${urls.machines.machine.index({ id: "abc123" })}/*`,
-          ],
-        }
-      );
-      await router.navigate(path);
-      await waitFor(() => {
-        expect(document.title).toBe(
-          `${state.machine.items[0].fqdn} ${title} | MAAS`
-        );
-      });
-    });
-  });
-
-  it("redirects to summary", () => {
-    const { router } = renderWithProviders(
-      <Routes>
-        <Route
-          element={<MachineDetails />}
-          path={`${urls.machines.machine.index(null)}/*`}
-        />
-      </Routes>,
-      {
-        state,
-        initialEntries: [`${urls.machines.machine.index({ id: "abc123" })}`],
-      }
-    );
-
-    expect(router.state.location.pathname).toBe(
-      urls.machines.machine.summary({ id: "abc123" })
-    );
-  });
-
   it("dispatches an action to set the machine as active", () => {
     const { store } = renderWithProviders(<MachineDetails />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [urls.machines.machine.summary({ id: "abc123" })],
       pattern: `${urls.machines.machine.index(null)}/*`,
     });
 
@@ -148,9 +71,14 @@ describe("MachineDetails", () => {
   });
 
   it("displays a message if the machine does not exist", () => {
-    state.machine.loading = false;
+    vi.mocked(useFetchMachine).mockReturnValue({
+      machine: null,
+      loaded: true,
+      loading: false,
+    });
     renderWithProviders(<MachineDetails />, {
-      initialEntries: ["/machine/not-valid-id"],
+      initialEntries: [urls.machines.machine.summary({ id: "not-valid-id" })],
+      pattern: `${urls.machines.machine.index(null)}/*`,
       state,
     });
     expect(screen.getByTestId("not-found")).toBeInTheDocument();
@@ -162,7 +90,7 @@ describe("MachineDetails", () => {
       store,
     } = renderWithProviders(<MachineDetails />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [urls.machines.machine.summary({ id: "abc123" })],
       pattern: `${urls.machines.machine.index(null)}/*`,
     });
     unmount();
@@ -174,7 +102,7 @@ describe("MachineDetails", () => {
   it("scrolls to the top when changing tabs", async () => {
     renderWithProviders(<MachineDetails />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [urls.machines.machine.summary({ id: "abc123" })],
       pattern: `${urls.machines.machine.index(null)}/*`,
     });
 

--- a/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -40,6 +40,7 @@ describe("MachineDetails", () => {
       }),
       loaded: true,
       loading: false,
+      error: null,
     });
   });
 
@@ -73,8 +74,9 @@ describe("MachineDetails", () => {
   it("displays a message if the machine does not exist", () => {
     vi.mocked(useFetchMachine).mockReturnValue({
       machine: null,
-      loaded: true,
+      loaded: false,
       loading: false,
+      error: "Uh oh!",
     });
     renderWithProviders(<MachineDetails />, {
       initialEntries: [urls.machines.machine.summary({ id: "not-valid-id" })],

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -1,21 +1,9 @@
 import { useEffect } from "react";
 
 import { useDispatch } from "react-redux";
-import { Navigate, Route, Routes, useLocation } from "react-router";
+import { Outlet, useLocation } from "react-router";
 
-import MachineConfiguration from "./MachineConfiguration";
 import MachineHeader from "./MachineHeader";
-import MachineInstances from "./MachineInstances";
-import MachineLogs from "./MachineLogs";
-import MachineNetwork from "./MachineNetwork";
-import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
-import MachinePCIDevices from "./MachinePCIDevices";
-import MachineScript from "./MachineScripts";
-import MachineStorage from "./MachineStorage";
-import StorageNotifications from "./MachineStorage/StorageNotifications";
-import MachineSummary from "./MachineSummary";
-import SummaryNotifications from "./MachineSummary/SummaryNotifications";
-import MachineUSBDevices from "./MachineUSBDevices";
 
 import ModelNotFound from "@/app/base/components/ModelNotFound";
 import PageContent from "@/app/base/components/PageContent";
@@ -25,7 +13,7 @@ import { machineActions } from "@/app/store/machine";
 import { MachineMeta } from "@/app/store/machine/types";
 import { useFetchMachine } from "@/app/store/machine/utils/hooks";
 import { tagActions } from "@/app/store/tag";
-import { getRelativeRoute, isId } from "@/app/utils";
+import { isId } from "@/app/utils";
 
 const MachineDetails = (): React.ReactElement => {
   const dispatch = useDispatch();
@@ -53,123 +41,21 @@ const MachineDetails = (): React.ReactElement => {
 
   if (!isId(id) || (detailsLoaded && !machine)) {
     return (
-      <ModelNotFound
-        id={id}
-        linkURL={urls.machines.index}
-        modelName="machine"
-      />
+      <>
+        <ModelNotFound
+          id={id}
+          linkURL={urls.machines.index}
+          modelName="machine"
+        />
+        pathname: {pathname}
+        id: {id}
+      </>
     );
   }
 
-  const base = urls.machines.machine.index(null);
-
   return (
     <PageContent header={<MachineHeader systemId={id} />}>
-      {machine && (
-        <Routes>
-          <Route
-            element={
-              <Navigate replace to={urls.machines.machine.summary({ id })} />
-            }
-            index
-          />
-          <Route
-            element={
-              <>
-                <SummaryNotifications id={id} />
-                <MachineSummary />
-              </>
-            }
-            path={getRelativeRoute(urls.machines.machine.summary(null), base)}
-          />
-          <Route
-            element={<MachineInstances />}
-            path={getRelativeRoute(urls.machines.machine.instances(null), base)}
-          />
-          <Route
-            element={
-              <>
-                <NetworkNotifications id={id} />
-                <MachineNetwork id={id} />
-              </>
-            }
-            path={getRelativeRoute(urls.machines.machine.network(null), base)}
-          />
-          <Route
-            element={
-              <>
-                <StorageNotifications id={id} />
-                <MachineStorage />
-              </>
-            }
-            path={getRelativeRoute(urls.machines.machine.storage(null), base)}
-          />
-          <Route
-            element={<MachinePCIDevices />}
-            path={getRelativeRoute(
-              urls.machines.machine.pciDevices(null),
-              base
-            )}
-          />
-          <Route
-            element={<MachineUSBDevices />}
-            path={getRelativeRoute(
-              urls.machines.machine.usbDevices(null),
-              base
-            )}
-          />
-          <Route
-            element={<MachineScript systemId={id} />}
-            path={getRelativeRoute(
-              `${urls.machines.machine.scriptsResults.index(null)}/*`,
-              base
-            )}
-          />
-          <Route
-            element={
-              <Navigate
-                replace
-                to={urls.machines.machine.scriptsResults.commissioning.index({
-                  id,
-                })}
-              />
-            }
-            path={getRelativeRoute(
-              urls.machines.machine.commissioning.index(null),
-              base
-            )}
-          />
-          <Route
-            element={<MachineLogs systemId={id} />}
-            path={getRelativeRoute(
-              `${urls.machines.machine.logs.index(null)}/*`,
-              base
-            )}
-          />
-          <Route
-            element={
-              <Navigate
-                replace
-                to={urls.machines.machine.logs.events({ id })}
-              />
-            }
-            path={getRelativeRoute(urls.machines.machine.events(null), base)}
-          />
-          <Route
-            element={<MachineConfiguration />}
-            path={getRelativeRoute(
-              urls.machines.machine.configuration(null),
-              base
-            )}
-          />
-          <Route
-            element={
-              <Navigate replace to={urls.machines.machine.summary({ id })} />
-            }
-            path={base}
-          />
-        </Routes>
-      )}
+      <Outlet />
     </PageContent>
   );
 };

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -19,7 +19,7 @@ const MachineDetails = (): React.ReactElement => {
   const dispatch = useDispatch();
   const id = useGetURLId(MachineMeta.PK);
   const { pathname } = useLocation();
-  const { machine, loaded: detailsLoaded } = useFetchMachine(id);
+  const { machine, loaded: detailsLoaded, error } = useFetchMachine(id);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -39,17 +39,13 @@ const MachineDetails = (): React.ReactElement => {
     };
   }, [dispatch, id]);
 
-  if (!isId(id) || (detailsLoaded && !machine)) {
+  if (!isId(id) || (detailsLoaded && !machine) || error) {
     return (
-      <>
-        <ModelNotFound
-          id={id}
-          linkURL={urls.machines.index}
-          modelName="machine"
-        />
-        pathname: {pathname}
-        id: {id}
-      </>
+      <ModelNotFound
+        id={id}
+        linkURL={urls.machines.index}
+        modelName="machine"
+      />
     );
   }
 

--- a/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
@@ -24,7 +24,7 @@ describe("MachineLogs", () => {
         items: [],
       }),
     });
-    renderWithProviders(<MachineLogs systemId="abc123" />, {
+    renderWithProviders(<MachineLogs />, {
       state,
     });
     expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe("MachineLogs", () => {
     },
   ].forEach(({ label, path }) => {
     it(`Displays: ${label} at: ${path}`, () => {
-      renderWithProviders(<MachineLogs systemId="abc123" />, {
+      renderWithProviders(<MachineLogs />, {
         initialEntries: [path],
         state,
         pattern: `${urls.machines.machine.logs.index(null)}/*`,

--- a/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -3,19 +3,19 @@ import { useSelector } from "react-redux";
 
 import NodeLogs from "@/app/base/components/node/NodeLogs";
 import { useWindowTitle } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import urls from "@/app/base/urls";
 import machineSelectors from "@/app/store/machine/selectors";
-import type { Machine } from "@/app/store/machine/types";
+import { MachineMeta } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
 import type { RootState } from "@/app/store/root/types";
-
-type Props = { systemId: Machine["system_id"] };
 
 export enum Label {
   Loading = "Loading logs",
 }
 
-const MachineLogs = ({ systemId }: Props): React.ReactElement => {
+const MachineLogs = (): React.ReactElement => {
+  const systemId = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -1,7 +1,11 @@
 import MachineNetwork from "./MachineNetwork";
 
+import urls from "@/app/base/urls";
 import * as factory from "@/testing/factories";
 import { screen, renderWithProviders } from "@/testing/utils";
+
+const machineRoutePattern = `${urls.machines.machine.index(null)}/*`;
+const networkUrl = urls.machines.machine.network({ id: "abc123" });
 
 it("displays a spinner if machine is loading", () => {
   const state = factory.rootState({
@@ -9,7 +13,11 @@ it("displays a spinner if machine is loading", () => {
       items: [],
     }),
   });
-  renderWithProviders(<MachineNetwork id="abc123" />, { state });
+  renderWithProviders(<MachineNetwork />, {
+    state,
+    initialEntries: [networkUrl],
+    pattern: machineRoutePattern,
+  });
   expect(screen.getByLabelText("Loading machine")).toBeInTheDocument();
   expect(screen.queryByLabelText("Machine network")).not.toBeInTheDocument();
 });
@@ -20,7 +28,11 @@ it("displays the network tab when loaded", () => {
       items: [factory.machineDetails({ system_id: "abc123" })],
     }),
   });
-  renderWithProviders(<MachineNetwork id="abc123" />, { state });
+  renderWithProviders(<MachineNetwork />, {
+    state,
+    initialEntries: [networkUrl],
+    pattern: machineRoutePattern,
+  });
   expect(screen.queryByLabelText("Loading machine")).not.toBeInTheDocument();
   expect(screen.getByLabelText("Machine network")).toBeInTheDocument();
 });

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -11,17 +11,14 @@ import NodeNetworkTab from "@/app/base/components/NodeNetworkTab";
 import NetworkTable from "@/app/base/components/node/networking/NetworkTable";
 import type { Selected } from "@/app/base/components/node/networking/types";
 import { useWindowTitle } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import machineSelectors from "@/app/store/machine/selectors";
-import type { Machine } from "@/app/store/machine/types";
 import { MachineMeta } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
 import type { RootState } from "@/app/store/root/types";
 
-type MachineNetworkProps = {
-  id: Machine[MachineMeta.PK];
-};
-
-const MachineNetwork = ({ id }: MachineNetworkProps): ReactElement => {
+const MachineNetwork = (): ReactElement => {
+  const id = useGetURLId(MachineMeta.PK);
   const [selected, setSelected] = useState<Selected[]>([]);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
@@ -40,7 +37,7 @@ const MachineNetwork = ({ id }: MachineNetworkProps): ReactElement => {
           expanded={expanded}
           selected={selected}
           setSelected={setSelected}
-          systemId={id}
+          systemId={id!}
         />
       )}
       aria-label="Machine network"

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
@@ -1,9 +1,12 @@
 import NetworkNotifications from "./NetworkNotifications";
 
+import urls from "@/app/base/urls";
 import type { RootState } from "@/app/store/root/types";
 import { NodeStatus } from "@/app/store/types/node";
 import * as factory from "@/testing/factories";
 import { renderWithProviders, screen } from "@/testing/utils";
+
+const machineRoutePattern = `${urls.machines.machine.index(null)}/*`;
 
 describe("NetworkNotifications", () => {
   let state: RootState;
@@ -39,8 +42,10 @@ describe("NetworkNotifications", () => {
         system_id: "abc123",
       }),
     ];
-    renderWithProviders(<NetworkNotifications id="abc123" />, {
+    renderWithProviders(<NetworkNotifications />, {
       state,
+      initialEntries: [urls.machines.machine.network({ id: "abc123" })],
+      pattern: machineRoutePattern,
     });
     expect(screen.queryByRole("notification")).not.toBeInTheDocument();
   });
@@ -52,8 +57,10 @@ describe("NetworkNotifications", () => {
         system_id: "abc123",
       }),
     ];
-    renderWithProviders(<NetworkNotifications id="abc123" />, {
+    renderWithProviders(<NetworkNotifications />, {
       state,
+      initialEntries: [urls.machines.machine.network({ id: "abc123" })],
+      pattern: machineRoutePattern,
     });
     expect(
       screen.getByText(/Machine must be connected to a network./i)
@@ -62,8 +69,10 @@ describe("NetworkNotifications", () => {
 
   it("can show a permissions message", () => {
     state.machine.items[0].status = NodeStatus.DEPLOYING;
-    renderWithProviders(<NetworkNotifications id="abc123" />, {
+    renderWithProviders(<NetworkNotifications />, {
       state,
+      initialEntries: [urls.machines.machine.network({ id: "abc123" })],
+      pattern: machineRoutePattern,
     });
     expect(
       screen.getByText(/Interface configuration cannot be modified/i)
@@ -72,8 +81,10 @@ describe("NetworkNotifications", () => {
 
   it("can display a custom image message", () => {
     state.machine.items[0].osystem = "custom";
-    renderWithProviders(<NetworkNotifications id="abc123" />, {
+    renderWithProviders(<NetworkNotifications />, {
       state,
+      initialEntries: [urls.machines.machine.network({ id: "abc123" })],
+      pattern: machineRoutePattern,
     });
     expect(
       screen.getByText(/Custom images may require special preparation/i)

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
@@ -1,17 +1,15 @@
 import { useSelector } from "react-redux";
 
 import { useIsAllNetworkingDisabled } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import MachineNotifications from "@/app/machines/views/MachineDetails/MachineNotifications";
 import machineSelectors from "@/app/store/machine/selectors";
-import type { Machine } from "@/app/store/machine/types";
+import { MachineMeta } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
 import type { RootState } from "@/app/store/root/types";
 
-type Props = {
-  id: Machine["system_id"];
-};
-
-const NetworkNotifications = ({ id }: Props): React.ReactElement | null => {
+const NetworkNotifications = (): React.ReactElement | null => {
+  const id = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );

--- a/src/app/machines/views/MachineDetails/MachineScripts/MachineScripts.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineScripts/MachineScripts.test.tsx
@@ -27,7 +27,7 @@ describe("MachineScripts", () => {
       }),
     });
 
-    renderWithProviders(<MachineScripts systemId="abc123" />, {
+    renderWithProviders(<MachineScripts />, {
       state,
     });
 
@@ -59,7 +59,7 @@ describe("MachineScripts", () => {
     },
   ].forEach(({ label, path }) => {
     it(`displays: ${label} at: ${path}`, () => {
-      renderWithProviders(<MachineScripts systemId="abc123" />, {
+      renderWithProviders(<MachineScripts />, {
         initialEntries: [path],
         state,
         pattern: `${urls.machines.machine.scriptsResults.index(null)}/*`,

--- a/src/app/machines/views/MachineDetails/MachineScripts/MachineScripts.tsx
+++ b/src/app/machines/views/MachineDetails/MachineScripts/MachineScripts.tsx
@@ -3,18 +3,19 @@ import { useSelector } from "react-redux";
 
 import NodeScripts from "@/app/base/components/node/NodeScripts/NodeScripts";
 import { useWindowTitle } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import urls from "@/app/base/urls";
 import machineSelectors from "@/app/store/machine/selectors";
-import type { Machine } from "@/app/store/machine/types";
+import { MachineMeta } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
 import type { RootState } from "@/app/store/root/types";
 
-type Props = { systemId: Machine["system_id"] };
 export enum Label {
   Loading = "Loading scripts",
 }
 
-const MachineScript = ({ systemId }: Props): React.ReactElement => {
+const MachineScript = (): React.ReactElement => {
+  const systemId = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );

--- a/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
@@ -1,10 +1,14 @@
 import StorageNotifications from "./StorageNotifications";
 
+import urls from "@/app/base/urls";
 import type { MachineDetails } from "@/app/store/machine/types";
 import type { RootState } from "@/app/store/root/types";
 import { NodeStatusCode } from "@/app/store/types/node";
 import * as factory from "@/testing/factories";
 import { renderWithProviders, screen } from "@/testing/utils";
+
+const machineRoutePattern = `${urls.machines.machine.index(null)}/*`;
+const storageUrl = urls.machines.machine.storage({ id: "abc123" });
 
 describe("StorageNotifications", () => {
   let state: RootState;
@@ -28,7 +32,9 @@ describe("StorageNotifications", () => {
   });
 
   it("handles no notifications", () => {
-    renderWithProviders(<StorageNotifications id="abc123" />, {
+    renderWithProviders(<StorageNotifications />, {
+      initialEntries: [storageUrl],
+      pattern: machineRoutePattern,
       state,
     });
 
@@ -39,7 +45,9 @@ describe("StorageNotifications", () => {
 
   it("can display a commissioning error", () => {
     machine.disks = [];
-    renderWithProviders(<StorageNotifications id="abc123" />, {
+    renderWithProviders(<StorageNotifications />, {
+      initialEntries: [storageUrl],
+      pattern: machineRoutePattern,
       state,
     });
 
@@ -52,7 +60,9 @@ describe("StorageNotifications", () => {
 
   it("can display a machine state error", () => {
     machine.status_code = NodeStatusCode.NEW;
-    renderWithProviders(<StorageNotifications id="abc123" />, {
+    renderWithProviders(<StorageNotifications />, {
+      initialEntries: [storageUrl],
+      pattern: machineRoutePattern,
       state,
     });
 
@@ -65,7 +75,9 @@ describe("StorageNotifications", () => {
 
   it("can display an OS storage configuration notification", () => {
     machine.osystem = "windows";
-    renderWithProviders(<StorageNotifications id="abc123" />, {
+    renderWithProviders(<StorageNotifications />, {
+      initialEntries: [storageUrl],
+      pattern: machineRoutePattern,
       state,
     });
 
@@ -78,7 +90,9 @@ describe("StorageNotifications", () => {
 
   it("can display a bcache ZFS error", () => {
     machine.osystem = "centos";
-    renderWithProviders(<StorageNotifications id="abc123" />, {
+    renderWithProviders(<StorageNotifications />, {
+      initialEntries: [storageUrl],
+      pattern: machineRoutePattern,
       state,
     });
 
@@ -89,7 +103,9 @@ describe("StorageNotifications", () => {
 
   it("can display a list of storage layout issues", () => {
     machine.storage_layout_issues = ["it's bad", "it won't work"];
-    renderWithProviders(<StorageNotifications id="abc123" />, {
+    renderWithProviders(<StorageNotifications />, {
+      initialEntries: [storageUrl],
+      pattern: machineRoutePattern,
       state,
     });
 

--- a/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
@@ -2,9 +2,10 @@ import { NotificationSeverity } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import { useCanEdit } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import MachineNotifications from "@/app/machines/views/MachineDetails/MachineNotifications";
 import machineSelectors from "@/app/store/machine/selectors";
-import type { Machine } from "@/app/store/machine/types";
+import { MachineMeta } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
 import type { RootState } from "@/app/store/root/types";
 import {
@@ -13,11 +14,8 @@ import {
   isNodeStorageConfigurable,
 } from "@/app/store/utils";
 
-type Props = {
-  id: Machine["system_id"];
-};
-
-const StorageNotifications = ({ id }: Props): React.ReactElement | null => {
+const StorageNotifications = (): React.ReactElement | null => {
+  const id = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );

--- a/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -1,10 +1,14 @@
 import SummaryNotifications from "./SummaryNotifications";
 
+import urls from "@/app/base/urls";
 import type { RootState } from "@/app/store/root/types";
 import { PowerState } from "@/app/store/types/enum";
 import { NodeStatus } from "@/app/store/types/node";
 import * as factory from "@/testing/factories";
 import { screen, within, renderWithProviders } from "@/testing/utils";
+
+const machineRoutePattern = `${urls.machines.machine.index(null)}/*`;
+const summaryUrl = urls.machines.machine.summary({ id: "abc123" });
 
 describe("SummaryNotifications", () => {
   let state: RootState;
@@ -32,9 +36,10 @@ describe("SummaryNotifications", () => {
   });
 
   it("handles no notifications", () => {
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -57,9 +62,10 @@ describe("SummaryNotifications", () => {
       }),
     ];
 
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
     expect(screen.getByRole("alert")).toHaveTextContent(
       /Script - machine timed out/i
@@ -69,9 +75,10 @@ describe("SummaryNotifications", () => {
   it("can display a rack connection error", () => {
     state.general.powerTypes.data = [];
 
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
 
     expect(screen.getByRole("alert")).toHaveTextContent(
@@ -82,9 +89,10 @@ describe("SummaryNotifications", () => {
   it("can display an architecture error", () => {
     state.machine.items[0].architecture = "";
 
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
     expect(screen.getByRole("alert")).toHaveTextContent(
       /This machine currently has an invalid architecture/i
@@ -97,9 +105,10 @@ describe("SummaryNotifications", () => {
       loaded: true,
     });
 
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
 
     expect(screen.getByRole("alert")).toHaveTextContent(
@@ -110,9 +119,10 @@ describe("SummaryNotifications", () => {
   it("can display a hardware status", () => {
     state.machine.items[0].cpu_count = 0;
 
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
     expect(screen.getByRole("status")).toHaveTextContent(
       /Commission this machine to get CPU/i
@@ -129,9 +139,10 @@ describe("SummaryNotifications", () => {
       }),
     ];
 
-    renderWithProviders(<SummaryNotifications id="abc123" />, {
+    renderWithProviders(<SummaryNotifications />, {
       state,
-      initialEntries: ["/machine/abc123"],
+      initialEntries: [summaryUrl],
+      pattern: machineRoutePattern,
     });
     expect(screen.getByRole("status")).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent(

--- a/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -6,12 +6,13 @@ import {
   useCanEdit,
   useIsRackControllerConnected,
 } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import urls from "@/app/base/urls";
 import MachineNotifications from "@/app/machines/views/MachineDetails/MachineNotifications";
 import { generalActions } from "@/app/store/general";
 import { architectures as architecturesSelectors } from "@/app/store/general/selectors";
 import machineSelectors from "@/app/store/machine/selectors";
-import type { Machine } from "@/app/store/machine/types";
+import { MachineMeta } from "@/app/store/machine/types";
 import {
   isMachineDetails,
   useHasInvalidArchitecture,
@@ -23,10 +24,6 @@ import {
 import type { RootState } from "@/app/store/root/types";
 import { PowerState } from "@/app/store/types/enum";
 import type { NodeEvent } from "@/app/store/types/node";
-
-type Props = {
-  id: Machine["system_id"];
-};
 
 const formatEventText = (event: NodeEvent) => {
   if (!event) {
@@ -42,7 +39,8 @@ const formatEventText = (event: NodeEvent) => {
   return text.join(" - ");
 };
 
-const SummaryNotifications = ({ id }: Props): React.ReactElement | null => {
+const SummaryNotifications = (): React.ReactElement | null => {
+  const id = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );

--- a/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -24,6 +24,7 @@ import {
 import type { RootState } from "@/app/store/root/types";
 import { PowerState } from "@/app/store/types/enum";
 import type { NodeEvent } from "@/app/store/types/node";
+import { isId } from "@/app/utils";
 
 const formatEventText = (event: NodeEvent) => {
   if (!event) {
@@ -58,7 +59,7 @@ const SummaryNotifications = (): React.ReactElement | null => {
   // Confirm that the full machine details have been fetched. This also allows
   // TypeScript know we're using the right union type (otherwise it will
   // complain that events don't exist on the base machine type).
-  if (!isMachineDetails(machine) || !architecturesLoaded) {
+  if (!isMachineDetails(machine) || !architecturesLoaded || !isId(id)) {
     return null;
   }
 

--- a/src/app/store/machine/utils/hooks.tsx
+++ b/src/app/store/machine/utils/hooks.tsx
@@ -662,7 +662,12 @@ export const useFetchMachines = (
  */
 export const useFetchMachine = (
   id?: Machine[MachineMeta.PK] | null
-): { machine: Machine | null; loading?: boolean; loaded?: boolean } => {
+): {
+  machine: Machine | null;
+  loading?: boolean;
+  loaded?: boolean;
+  error: APIError;
+} => {
   const [callId, setCallId] = useState<string | null>(null);
   const previousId = usePrevious(id, false);
   const previousCallId = usePrevious(callId);
@@ -675,6 +680,9 @@ export const useFetchMachine = (
   );
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
+  );
+  const error = useSelector((state: RootState) =>
+    machineSelectors.errors(state)
   );
   useCleanup(callId);
 
@@ -695,6 +703,7 @@ export const useFetchMachine = (
     machine,
     loading,
     loaded,
+    error,
   };
 };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -11,8 +11,10 @@ import TagList from "./app/tags/views/TagList";
 import App from "@/app/App";
 import ErrorBoundary from "@/app/base/components/ErrorBoundary";
 import PageContent from "@/app/base/components/PageContent";
+import { useGetURLId } from "@/app/base/hooks/urls";
 import urls from "@/app/base/urls";
 import NotFound from "@/app/base/views/NotFound";
+import machineUrls from "@/app/machines/urls";
 import APIKeyList from "@/app/preferences/views/APIKeys/views";
 import Details from "@/app/preferences/views/Details";
 import SSHKeysList from "@/app/preferences/views/SSHKeys/views";
@@ -40,6 +42,7 @@ import SessionTimeout from "@/app/settings/views/Security/SessionTimeout";
 import StorageForm from "@/app/settings/views/Storage/StorageForm";
 import SingleSignOn from "@/app/settings/views/UserManagement/views/SingleSignOn";
 import UsersList from "@/app/settings/views/UserManagement/views/UsersList/UsersList";
+import { MachineMeta } from "@/app/store/machine/types";
 import { getRelativeRoute } from "@/app/utils";
 
 const ControllerDetails = lazy(
@@ -62,6 +65,51 @@ const LXDSingleDetails = lazy(() => import("@/app/kvm/views/LXDSingleDetails"));
 const VirshDetails = lazy(() => import("@/app/kvm/views/VirshDetails"));
 const MachineDetails = lazy(
   () => import("@/app/machines/views/MachineDetails")
+);
+const MachineConfiguration = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineConfiguration")
+);
+const MachineInstances = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineInstances")
+);
+const MachineLogs = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineLogs")
+);
+const MachineNetwork = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineNetwork")
+);
+const NetworkNotifications = lazy(
+  () =>
+    import(
+      "@/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications"
+    )
+);
+const MachinePCIDevices = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachinePCIDevices")
+);
+const MachineScript = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineScripts")
+);
+const MachineStorage = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineStorage")
+);
+const StorageNotifications = lazy(
+  () =>
+    import(
+      "@/app/machines/views/MachineDetails/MachineStorage/StorageNotifications"
+    )
+);
+const MachineSummary = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineSummary")
+);
+const SummaryNotifications = lazy(
+  () =>
+    import(
+      "@/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications"
+    )
+);
+const MachineUSBDevices = lazy(
+  () => import("@/app/machines/views/MachineDetails/MachineUSBDevices")
 );
 const Machines = lazy(() => import("@/app/machines/views/Machines"));
 const DiscoveriesList = lazy(
@@ -100,6 +148,16 @@ const VLANsList = lazy(
   () => import("@/app/networks/views/VLANs/views/VLANsList")
 );
 const ZonesList = lazy(() => import("@/app/zones/views"));
+
+const MachineRedirect = ({
+  to,
+}: {
+  to: (params: { id: string }) => string;
+}): React.ReactElement | null => {
+  const id = useGetURLId(MachineMeta.PK);
+  if (!id) return null;
+  return <Navigate replace to={to({ id })} />;
+};
 
 export const router = createBrowserRouter(
   [
@@ -296,12 +354,118 @@ export const router = createBrowserRouter(
               ],
             },
             {
-              path: `${urls.machines.machine.index(null)}/*`,
+              path: urls.machines.machine.index(null),
               element: (
                 <ErrorBoundary>
                   <MachineDetails />
                 </ErrorBoundary>
               ),
+              children: [
+                {
+                  index: true,
+                  element: <MachineRedirect to={machineUrls.machine.summary} />,
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.summary(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: (
+                    <>
+                      <SummaryNotifications />
+                      <MachineSummary />
+                    </>
+                  ),
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.instances(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: <MachineInstances />,
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.network(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: (
+                    <>
+                      <NetworkNotifications />
+                      <MachineNetwork />
+                    </>
+                  ),
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.storage(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: (
+                    <>
+                      <StorageNotifications />
+                      <MachineStorage />
+                    </>
+                  ),
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.pciDevices(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: <MachinePCIDevices />,
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.usbDevices(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: <MachineUSBDevices />,
+                },
+                {
+                  path: `${getRelativeRoute(
+                    machineUrls.machine.scriptsResults.index(null),
+                    machineUrls.machine.index(null)
+                  )}/*`,
+                  element: <MachineScript />,
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.commissioning.index(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: (
+                    <MachineRedirect
+                      to={
+                        machineUrls.machine.scriptsResults.commissioning.index
+                      }
+                    />
+                  ),
+                },
+                {
+                  path: `${getRelativeRoute(
+                    machineUrls.machine.logs.index(null),
+                    machineUrls.machine.index(null)
+                  )}/*`,
+                  element: <MachineLogs />,
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.events(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: (
+                    <MachineRedirect to={machineUrls.machine.logs.events} />
+                  ),
+                },
+                {
+                  path: getRelativeRoute(
+                    machineUrls.machine.configuration(null),
+                    machineUrls.machine.index(null)
+                  ),
+                  element: <MachineConfiguration />,
+                },
+              ],
             },
             {
               path: `${urls.networks.fabric.index(null)}/*`,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
   resolve: {
     alias: { "@": path.resolve(__dirname, "src") },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        silenceDeprecations: ["legacy-js-api"],
+      },
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Done

- Moved element routes from MachineDetails to object routes in router
- Updated sub-components to pull ID from URL instead of prop
- Removed unnecessary test for checking each route within MachineDetails itself

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to a machine's details page
- [x] Ensure it loads on the summary page
- [x] Click all the other tabs and ensure they load correctly
- [x] Poke around for any edge cases

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6079](https://warthogs.atlassian.net/browse/MAASENG-6079)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->


[MAASENG-6079]: https://warthogs.atlassian.net/browse/MAASENG-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ