### PR TITLE
chore: refactor zones_with_summary to zones:statistics MAASENG-6470

### DIFF
--- a/src/app/api/query/base.ts
+++ b/src/app/api/query/base.ts
@@ -7,7 +7,7 @@ import { useSelector } from "react-redux";
 
 import {
   listUserSshkeysQueryKey,
-  listZonesWithSummaryQueryKey,
+  listZonesWithStatisticsQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 import { WebSocketContext } from "@/app/base/websocket-context";
 import statusSelectors from "@/app/store/status/selectors";
@@ -15,7 +15,7 @@ import type { WebSocketEndpointModel } from "@/websocket-client";
 import { WebSocketMessageType } from "@/websocket-client";
 
 const wsToQueryKeyMapping: Partial<Record<WebSocketEndpointModel, unknown>> = {
-  zone: listZonesWithSummaryQueryKey(),
+  zone: listZonesWithStatisticsQueryKey(),
   sshkey: listUserSshkeysQueryKey(),
 };
 

--- a/src/app/api/query/zones.ts
+++ b/src/app/api/query/zones.ts
@@ -15,9 +15,9 @@ import type {
   GetZoneData,
   GetZoneErrors,
   GetZoneResponses,
-  ListZonesWithSummaryData,
-  ListZonesWithSummaryErrors,
-  ListZonesWithSummaryResponses,
+  ListZonesWithStatisticsData,
+  ListZonesWithStatisticsErrors,
+  ListZonesWithStatisticsResponses,
   Options,
   UpdateZoneData,
   UpdateZoneErrors,
@@ -28,30 +28,40 @@ import {
   updateZone,
   createZone,
   getZone,
-  listZonesWithSummary,
+  listZonesWithStatistics,
 } from "@/app/apiclient";
 import {
   getZoneQueryKey,
-  listZonesWithSummaryQueryKey,
+  listZonesWithStatisticsQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 
-export const useZones = (options?: Options<ListZonesWithSummaryData>) => {
+export const useZones = (options?: Options<ListZonesWithStatisticsData>) => {
   return useWebsocketAwareQuery(
     queryOptionsWithHeaders<
-      ListZonesWithSummaryResponses,
-      ListZonesWithSummaryErrors,
-      ListZonesWithSummaryData
-    >(options, listZonesWithSummary, listZonesWithSummaryQueryKey(options))
+      ListZonesWithStatisticsResponses,
+      ListZonesWithStatisticsErrors,
+      ListZonesWithStatisticsData
+    >(
+      options,
+      listZonesWithStatistics,
+      listZonesWithStatisticsQueryKey(options)
+    )
   );
 };
 
-export const useZoneCount = (options?: Options<ListZonesWithSummaryData>) => {
+export const useZoneCount = (
+  options?: Options<ListZonesWithStatisticsData>
+) => {
   return useWebsocketAwareQuery({
     ...queryOptionsWithHeaders<
-      ListZonesWithSummaryResponses,
-      ListZonesWithSummaryErrors,
-      ListZonesWithSummaryData
-    >(options, listZonesWithSummary, listZonesWithSummaryQueryKey(options)),
+      ListZonesWithStatisticsResponses,
+      ListZonesWithStatisticsErrors,
+      ListZonesWithStatisticsData
+    >(
+      options,
+      listZonesWithStatistics,
+      listZonesWithStatisticsQueryKey(options)
+    ),
     select: (data) => data?.total ?? 0,
   });
 };
@@ -76,7 +86,7 @@ export const useCreateZone = (mutationOptions?: Options<CreateZoneData>) => {
     >(mutationOptions, createZone),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithSummaryQueryKey(),
+        queryKey: listZonesWithStatisticsQueryKey(),
       });
     },
   });
@@ -92,7 +102,7 @@ export const useUpdateZone = (mutationOptions?: Options<UpdateZoneData>) => {
     >(mutationOptions, updateZone),
     onSuccess: async () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithSummaryQueryKey(),
+        queryKey: listZonesWithStatisticsQueryKey(),
       });
     },
   });
@@ -108,7 +118,7 @@ export const useDeleteZone = (mutationOptions?: Options<DeleteZoneData>) => {
     >(mutationOptions, deleteZone),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithSummaryQueryKey(),
+        queryKey: listZonesWithStatisticsQueryKey(),
       });
     },
   });

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -119,7 +119,6 @@ import {
   getUserSshkey,
   getUserSslkey,
   getUserSslkeys,
-  getUserSslkeysWithSummary,
   getZone,
   handleOauthCallback,
   importUserSshkeys,
@@ -166,9 +165,10 @@ import {
   listTags,
   listUsers,
   listUserSshkeys,
+  listUserSslkeysStatistics,
   listUsersWithSummary,
   listZones,
-  listZonesWithSummary,
+  listZonesWithStatistics,
   login,
   logout,
   type Options,
@@ -543,9 +543,6 @@ import type {
   GetUserSslkeysData,
   GetUserSslkeysError,
   GetUserSslkeysResponse,
-  GetUserSslkeysWithSummaryData,
-  GetUserSslkeysWithSummaryError,
-  GetUserSslkeysWithSummaryResponse,
   GetZoneData,
   GetZoneError,
   GetZoneResponse,
@@ -684,15 +681,18 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
+  ListUserSslkeysStatisticsData,
+  ListUserSslkeysStatisticsError,
+  ListUserSslkeysStatisticsResponse,
   ListUsersWithSummaryData,
   ListUsersWithSummaryError,
   ListUsersWithSummaryResponse,
   ListZonesData,
   ListZonesError,
   ListZonesResponse,
-  ListZonesWithSummaryData,
-  ListZonesWithSummaryError,
-  ListZonesWithSummaryResponse,
+  ListZonesWithStatisticsData,
+  ListZonesWithStatisticsError,
+  ListZonesWithStatisticsResponse,
   LoginData,
   LoginError,
   LoginResponse,
@@ -4568,26 +4568,24 @@ export const getUserSslkeyOptions = (options: Options<GetUserSslkeyData>) =>
     queryKey: getUserSslkeyQueryKey(options),
   });
 
-export const getUserSslkeysWithSummaryQueryKey = (
-  options?: Options<GetUserSslkeysWithSummaryData>
-) => createQueryKey("getUserSslkeysWithSummary", options);
+export const listUserSslkeysStatisticsQueryKey = (
+  options?: Options<ListUserSslkeysStatisticsData>
+) => createQueryKey("listUserSslkeysStatistics", options);
 
 /**
- * List sslkeys with a summary. ONLY FOR INTERNAL USAGE.
- *
- * List sslkeys with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List User Sslkeys Statistics
  */
-export const getUserSslkeysWithSummaryOptions = (
-  options?: Options<GetUserSslkeysWithSummaryData>
+export const listUserSslkeysStatisticsOptions = (
+  options?: Options<ListUserSslkeysStatisticsData>
 ) =>
   queryOptions<
-    GetUserSslkeysWithSummaryResponse,
-    GetUserSslkeysWithSummaryError,
-    GetUserSslkeysWithSummaryResponse,
-    ReturnType<typeof getUserSslkeysWithSummaryQueryKey>
+    ListUserSslkeysStatisticsResponse,
+    ListUserSslkeysStatisticsError,
+    ListUserSslkeysStatisticsResponse,
+    ReturnType<typeof listUserSslkeysStatisticsQueryKey>
   >({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await getUserSslkeysWithSummary({
+      const { data } = await listUserSslkeysStatistics({
         ...options,
         ...queryKey[0],
         signal,
@@ -4595,7 +4593,7 @@ export const getUserSslkeysWithSummaryOptions = (
       });
       return data;
     },
-    queryKey: getUserSslkeysWithSummaryQueryKey(options),
+    queryKey: listUserSslkeysStatisticsQueryKey(options),
   });
 
 export const listFabricVlanSubnetsQueryKey = (
@@ -5996,26 +5994,26 @@ export const updateZoneMutation = (
   return mutationOptions;
 };
 
-export const listZonesWithSummaryQueryKey = (
-  options?: Options<ListZonesWithSummaryData>
-) => createQueryKey("listZonesWithSummary", options);
+export const listZonesWithStatisticsQueryKey = (
+  options?: Options<ListZonesWithStatisticsData>
+) => createQueryKey("listZonesWithStatistics", options);
 
 /**
- * List zones with a summary. ONLY FOR INTERNAL USAGE.
+ * List zones with statistics. ONLY FOR INTERNAL USAGE.
  *
- * List zones with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List zones with statistics. This endpoint is only for internal usage and might be changed or removed without notice.
  */
-export const listZonesWithSummaryOptions = (
-  options?: Options<ListZonesWithSummaryData>
+export const listZonesWithStatisticsOptions = (
+  options?: Options<ListZonesWithStatisticsData>
 ) =>
   queryOptions<
-    ListZonesWithSummaryResponse,
-    ListZonesWithSummaryError,
-    ListZonesWithSummaryResponse,
-    ReturnType<typeof listZonesWithSummaryQueryKey>
+    ListZonesWithStatisticsResponse,
+    ListZonesWithStatisticsError,
+    ListZonesWithStatisticsResponse,
+    ReturnType<typeof listZonesWithStatisticsQueryKey>
   >({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await listZonesWithSummary({
+      const { data } = await listZonesWithStatistics({
         ...options,
         ...queryKey[0],
         signal,
@@ -6023,7 +6021,7 @@ export const listZonesWithSummaryOptions = (
       });
       return data;
     },
-    queryKey: listZonesWithSummaryQueryKey(options),
+    queryKey: listZonesWithStatisticsQueryKey(options),
   });
 
 export const getSubnetQueryKey = (options: Options<GetSubnetData>) =>

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -354,9 +354,6 @@ import type {
   GetUserSslkeysData,
   GetUserSslkeysErrors,
   GetUserSslkeysResponses,
-  GetUserSslkeysWithSummaryData,
-  GetUserSslkeysWithSummaryErrors,
-  GetUserSslkeysWithSummaryResponses,
   GetZoneData,
   GetZoneErrors,
   GetZoneResponses,
@@ -495,15 +492,18 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysErrors,
   ListUserSshkeysResponses,
+  ListUserSslkeysStatisticsData,
+  ListUserSslkeysStatisticsErrors,
+  ListUserSslkeysStatisticsResponses,
   ListUsersWithSummaryData,
   ListUsersWithSummaryErrors,
   ListUsersWithSummaryResponses,
   ListZonesData,
   ListZonesErrors,
   ListZonesResponses,
-  ListZonesWithSummaryData,
-  ListZonesWithSummaryErrors,
-  ListZonesWithSummaryResponses,
+  ListZonesWithStatisticsData,
+  ListZonesWithStatisticsErrors,
+  ListZonesWithStatisticsResponses,
   LoginData,
   LoginErrors,
   LoginResponses,
@@ -3733,19 +3733,17 @@ export const getUserSslkey = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * List sslkeys with a summary. ONLY FOR INTERNAL USAGE.
- *
- * List sslkeys with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List User Sslkeys Statistics
  */
-export const getUserSslkeysWithSummary = <ThrowOnError extends boolean = false>(
-  options?: Options<GetUserSslkeysWithSummaryData, ThrowOnError>
+export const listUserSslkeysStatistics = <ThrowOnError extends boolean = false>(
+  options?: Options<ListUserSslkeysStatisticsData, ThrowOnError>
 ) => {
   return (options?.client ?? client).get<
-    GetUserSslkeysWithSummaryResponses,
-    GetUserSslkeysWithSummaryErrors,
+    ListUserSslkeysStatisticsResponses,
+    ListUserSslkeysStatisticsErrors,
     ThrowOnError
   >({
-    url: "/MAAS/a/v3/users/me/sslkeys_with_summary",
+    url: "/MAAS/a/v3/users/me/sslkeys:statistics",
     ...options,
   });
 };
@@ -4969,16 +4967,16 @@ export const updateZone = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * List zones with a summary. ONLY FOR INTERNAL USAGE.
+ * List zones with statistics. ONLY FOR INTERNAL USAGE.
  *
- * List zones with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List zones with statistics. This endpoint is only for internal usage and might be changed or removed without notice.
  */
-export const listZonesWithSummary = <ThrowOnError extends boolean = false>(
-  options?: Options<ListZonesWithSummaryData, ThrowOnError>
+export const listZonesWithStatistics = <ThrowOnError extends boolean = false>(
+  options?: Options<ListZonesWithStatisticsData, ThrowOnError>
 ) => {
   return (options?.client ?? client).get<
-    ListZonesWithSummaryResponses,
-    ListZonesWithSummaryErrors,
+    ListZonesWithStatisticsResponses,
+    ListZonesWithStatisticsErrors,
     ThrowOnError
   >({
     security: [
@@ -4987,7 +4985,7 @@ export const listZonesWithSummary = <ThrowOnError extends boolean = false>(
         type: "http",
       },
     ],
-    url: "/MAAS/a/v3/zones_with_summary",
+    url: "/MAAS/a/v3/zones:statistics",
     ...options,
   });
 };

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -425,6 +425,12 @@ export type BootSourceCreateRequest = {
    */
   skip_keyring_verification?: boolean;
   /**
+   * Name
+   *
+   * Name of this boot source.
+   */
+  name: string;
+  /**
    * Priority
    *
    * Priority value. Higher values mean higher priority. Must be non-negative.
@@ -436,6 +442,12 @@ export type BootSourceCreateRequest = {
    * URL of SimpleStreams server providing boot source information.
    */
   url: string;
+  /**
+   * Enabled
+   *
+   * Whether to enable downloads from this source or not.
+   */
+  enabled: boolean;
 };
 
 /**
@@ -486,6 +498,10 @@ export type BootSourceResponse = {
    */
   id: number;
   /**
+   * Name
+   */
+  name: string;
+  /**
    * Url
    */
   url: string;
@@ -505,6 +521,10 @@ export type BootSourceResponse = {
    * Skip Keyring Verification
    */
   skip_keyring_verification: boolean;
+  /**
+   * Enabled
+   */
+  enabled: boolean;
 };
 
 /**
@@ -568,11 +588,29 @@ export type BootSourceUpdateRequest = {
    */
   skip_keyring_verification?: boolean;
   /**
+   * Name
+   *
+   * Name of this boot source.
+   */
+  name: string;
+  /**
    * Priority
    *
    * Priority value. Higher values mean higher priority. Must be non-negative.
    */
   priority: number;
+  /**
+   * Url
+   *
+   * URL of SimpleStreams server providing boot source information.
+   */
+  url: string;
+  /**
+   * Enabled
+   *
+   * Whether to enable downloads from this source or not.
+   */
+  enabled: boolean;
 };
 
 /**
@@ -3409,9 +3447,9 @@ export type SslKeyResponse = {
 };
 
 /**
- * SSLKeyWithSummaryResponse
+ * SSLKeyStatisticsResponse
  */
-export type SslKeyWithSummaryResponse = {
+export type SslKeyStatisticsResponse = {
   _links?: BaseHal;
   /**
    * Embedded
@@ -3436,13 +3474,13 @@ export type SslKeyWithSummaryResponse = {
 };
 
 /**
- * SSLKeysWithSummaryListResponse
+ * SSLKeysStatisticsListResponse
  */
-export type SslKeysWithSummaryListResponse = {
+export type SslKeysStatisticsListResponse = {
   /**
    * Items
    */
-  items: SslKeyWithSummaryResponse[];
+  items: SslKeyStatisticsResponse[];
   /**
    * Total
    */
@@ -5127,9 +5165,9 @@ export type ZoneResponse = {
 };
 
 /**
- * ZoneWithSummaryResponse
+ * ZoneWithStatisticsResponse
  */
-export type ZoneWithSummaryResponse = {
+export type ZoneWithStatisticsResponse = {
   _links?: BaseHal;
   /**
    * Embedded
@@ -5188,13 +5226,13 @@ export type ZonesListResponse = {
 };
 
 /**
- * ZonesWithSummaryListResponse
+ * ZonesWithStatisticsListResponse
  */
-export type ZonesWithSummaryListResponse = {
+export type ZonesWithStatisticsListResponse = {
   /**
    * Items
    */
-  items: ZoneWithSummaryResponse[];
+  items: ZoneWithStatisticsResponse[];
   /**
    * Total
    */
@@ -5906,6 +5944,10 @@ export type DeleteBootsourceData = {
 
 export type DeleteBootsourceErrors = {
   /**
+   * Bad Request
+   */
+  400: BadRequestBodyResponse;
+  /**
    * Not Found
    */
   404: NotFoundBodyResponse;
@@ -5976,6 +6018,10 @@ export type UpdateBootsourceData = {
 };
 
 export type UpdateBootsourceErrors = {
+  /**
+   * Bad Request
+   */
+  400: BadRequestBodyResponse;
   /**
    * Not Found
    */
@@ -10555,7 +10601,7 @@ export type GetUserSslkeyResponses = {
 export type GetUserSslkeyResponse =
   GetUserSslkeyResponses[keyof GetUserSslkeyResponses];
 
-export type GetUserSslkeysWithSummaryData = {
+export type ListUserSslkeysStatisticsData = {
   body?: never;
   path?: never;
   query?: {
@@ -10568,10 +10614,10 @@ export type GetUserSslkeysWithSummaryData = {
      */
     size?: number;
   };
-  url: "/MAAS/a/v3/users/me/sslkeys_with_summary";
+  url: "/MAAS/a/v3/users/me/sslkeys:statistics";
 };
 
-export type GetUserSslkeysWithSummaryErrors = {
+export type ListUserSslkeysStatisticsErrors = {
   /**
    * Unauthorized
    */
@@ -10582,18 +10628,18 @@ export type GetUserSslkeysWithSummaryErrors = {
   422: ValidationErrorBodyResponse;
 };
 
-export type GetUserSslkeysWithSummaryError =
-  GetUserSslkeysWithSummaryErrors[keyof GetUserSslkeysWithSummaryErrors];
+export type ListUserSslkeysStatisticsError =
+  ListUserSslkeysStatisticsErrors[keyof ListUserSslkeysStatisticsErrors];
 
-export type GetUserSslkeysWithSummaryResponses = {
+export type ListUserSslkeysStatisticsResponses = {
   /**
    * Successful Response
    */
-  200: SslKeysWithSummaryListResponse;
+  200: SslKeysStatisticsListResponse;
 };
 
-export type GetUserSslkeysWithSummaryResponse =
-  GetUserSslkeysWithSummaryResponses[keyof GetUserSslkeysWithSummaryResponses];
+export type ListUserSslkeysStatisticsResponse =
+  ListUserSslkeysStatisticsResponses[keyof ListUserSslkeysStatisticsResponses];
 
 export type ListFabricVlanSubnetsData = {
   body?: never;
@@ -12443,10 +12489,6 @@ export type ListZonesData = {
      * Size
      */
     size?: number;
-    /**
-     * Filter by zone id
-     */
-    id?: number[];
   };
   url: "/MAAS/a/v3/zones";
 };
@@ -12610,10 +12652,14 @@ export type UpdateZoneResponses = {
 
 export type UpdateZoneResponse = UpdateZoneResponses[keyof UpdateZoneResponses];
 
-export type ListZonesWithSummaryData = {
+export type ListZonesWithStatisticsData = {
   body?: never;
   path?: never;
   query?: {
+    /**
+     * Filter by zone id
+     */
+    id?: number[];
     /**
      * Page
      */
@@ -12623,28 +12669,28 @@ export type ListZonesWithSummaryData = {
      */
     size?: number;
   };
-  url: "/MAAS/a/v3/zones_with_summary";
+  url: "/MAAS/a/v3/zones:statistics";
 };
 
-export type ListZonesWithSummaryErrors = {
+export type ListZonesWithStatisticsErrors = {
   /**
    * Unprocessable Content
    */
   422: ValidationErrorBodyResponse;
 };
 
-export type ListZonesWithSummaryError =
-  ListZonesWithSummaryErrors[keyof ListZonesWithSummaryErrors];
+export type ListZonesWithStatisticsError =
+  ListZonesWithStatisticsErrors[keyof ListZonesWithStatisticsErrors];
 
-export type ListZonesWithSummaryResponses = {
+export type ListZonesWithStatisticsResponses = {
   /**
    * Successful Response
    */
-  200: ZonesWithSummaryListResponse;
+  200: ZonesWithStatisticsListResponse;
 };
 
-export type ListZonesWithSummaryResponse =
-  ListZonesWithSummaryResponses[keyof ListZonesWithSummaryResponses];
+export type ListZonesWithStatisticsResponse =
+  ListZonesWithStatisticsResponses[keyof ListZonesWithStatisticsResponses];
 
 export type GetSubnetData = {
   body?: never;

--- a/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
+++ b/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
@@ -2,7 +2,7 @@ import { GenericTable } from "@canonical/maas-react-components";
 import { useSelector } from "react-redux";
 
 import { useZones } from "@/app/api/query/zones";
-import type { ZoneWithSummaryResponse } from "@/app/apiclient";
+import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
 import urls from "@/app/base/urls";
 import type { Props as RAMColumnProps } from "@/app/kvm/components/RAMColumn/RAMColumn";
 import type { KVMResource, KVMStoragePoolResources } from "@/app/kvm/types";
@@ -46,7 +46,7 @@ export type LXDKVMHost = {
 
 export const generateSingleHostRows = (
   pods: Pod[],
-  zones: ZoneWithSummaryResponse[] | undefined
+  zones: ZoneWithStatisticsResponse[] | undefined
 ): LXDKVMHost[] =>
   pods.map((pod): LXDKVMHost => {
     const zone = zones?.find((zone) => pod.zone === zone.id);

--- a/src/app/zones/components/DeleteZone/DeleteZone.tsx
+++ b/src/app/zones/components/DeleteZone/DeleteZone.tsx
@@ -7,7 +7,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useDeleteZone, useGetZone } from "@/app/api/query/zones";
-import { listZonesWithSummaryQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
+import { listZonesWithStatisticsQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
 
@@ -47,7 +47,7 @@ const DeleteZone: React.FC<DeleteZoneProps> = ({ id }) => {
           onSuccess={() => {
             return queryClient
               .invalidateQueries({
-                queryKey: listZonesWithSummaryQueryKey(),
+                queryKey: listZonesWithStatisticsQueryKey(),
               })
               .then(closeSidePanel);
           }}

--- a/src/app/zones/components/ZonesTable/useZonesTableColumns/useZonesTableColumns.tsx
+++ b/src/app/zones/components/ZonesTable/useZonesTableColumns/useZonesTableColumns.tsx
@@ -4,7 +4,7 @@ import type { ColumnDef, Row } from "@tanstack/react-table";
 import { Link } from "react-router";
 
 import { useGetIsSuperUser } from "@/app/api/query/auth";
-import type { ZoneWithSummaryResponse } from "@/app/apiclient";
+import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import urls from "@/app/base/urls";
@@ -13,8 +13,8 @@ import { FilterMachines } from "@/app/store/machine/utils";
 import { DeleteZone, EditZone } from "@/app/zones/components";
 
 export type ZoneColumnDef = ColumnDef<
-  ZoneWithSummaryResponse,
-  Partial<ZoneWithSummaryResponse>
+  ZoneWithStatisticsResponse,
+  Partial<ZoneWithStatisticsResponse>
 >;
 
 const filterDevices = (name: string) =>
@@ -94,7 +94,7 @@ const useZonesTableColumns = (): ZoneColumnDef[] => {
         accessorKey: "id",
         enableSorting: false,
         header: "Actions",
-        cell: ({ row }: { row: Row<ZoneWithSummaryResponse> }) => {
+        cell: ({ row }: { row: Row<ZoneWithStatisticsResponse> }) => {
           const canBeDeleted = isSuperUser.data && row.original.id !== 1;
           return (
             <TableActions

--- a/src/testing/factories/zone.ts
+++ b/src/testing/factories/zone.ts
@@ -1,8 +1,8 @@
 import { define, random } from "cooky-cutter";
 
-import type { ZoneWithSummaryResponse } from "@/app/apiclient";
+import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
 
-export const zone = define<ZoneWithSummaryResponse>({
+export const zone = define<ZoneWithStatisticsResponse>({
   controllers_count: random,
   description: "test description",
   devices_count: random,

--- a/src/testing/resolvers/zones.ts
+++ b/src/testing/resolvers/zones.ts
@@ -4,14 +4,14 @@ import type {
   CreateZoneError,
   DeleteZoneError,
   GetZoneError,
-  ListZonesWithSummaryError,
+  ListZonesWithStatisticsError,
   UpdateZoneError,
-  ZonesWithSummaryListResponse,
+  ZonesWithStatisticsListResponse,
 } from "@/app/apiclient";
 import { zone as zoneFactory } from "@/testing/factories";
 import { BASE_URL } from "@/testing/utils";
 
-const mockZones: ZonesWithSummaryListResponse = {
+const mockZones: ZonesWithStatisticsListResponse = {
   items: [
     zoneFactory({
       id: 1,
@@ -41,7 +41,7 @@ const mockZones: ZonesWithSummaryListResponse = {
   total: 3,
 };
 
-const mockListZonesError: ListZonesWithSummaryError = {
+const mockListZonesError: ListZonesWithStatisticsError = {
   message: "Unauthorized",
   code: 401,
   kind: "Error", // This will always be 'Error' for every error response
@@ -68,13 +68,13 @@ const mockUpdateZoneError: UpdateZoneError = {
 const zoneResolvers = {
   listZones: {
     resolved: false,
-    handler: (data: ZonesWithSummaryListResponse = mockZones) =>
-      http.get(`${BASE_URL}MAAS/a/v3/zones_with_summary`, () => {
+    handler: (data: ZonesWithStatisticsListResponse = mockZones) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
         zoneResolvers.listZones.resolved = true;
         return HttpResponse.json(data);
       }),
-    error: (error: ListZonesWithSummaryError = mockListZonesError) =>
-      http.get(`${BASE_URL}MAAS/a/v3/zones_with_summary`, () => {
+    error: (error: ListZonesWithStatisticsError = mockListZonesError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
         zoneResolvers.listZones.resolved = true;
         return HttpResponse.json(error, { status: error.code });
       }),


### PR DESCRIPTION
## Done

- Regenerated API client and updated zones_with_summary to zones:statistics
- (Closing off [this](https://github.com/canonical/maas-ui/pull/6012) PR as it will have failing tests unless the changes are made together)

## QA steps

- [ ] Navigate to `/MAAS/r/zones` and ensure the page works as expected

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6470](https://warthogs.atlassian.net/browse/MAASENG-6470)


[MAASENG-6470]: https://warthogs.atlassian.net/browse/MAASENG-6470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ