### PR TITLE
chore: update zones_with_summary to zones:statistics MAASENG-6470

### DIFF
--- a/src/app/api/query/base.ts
+++ b/src/app/api/query/base.ts
@@ -7,7 +7,7 @@ import { useSelector } from "react-redux";
 
 import {
   listUserSshkeysQueryKey,
-  listZonesWithSummaryQueryKey,
+  listZonesWithStatisticsQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 import { WebSocketContext } from "@/app/base/websocket-context";
 import statusSelectors from "@/app/store/status/selectors";
@@ -15,7 +15,7 @@ import type { WebSocketEndpointModel } from "@/websocket-client";
 import { WebSocketMessageType } from "@/websocket-client";
 
 const wsToQueryKeyMapping: Partial<Record<WebSocketEndpointModel, unknown>> = {
-  zone: listZonesWithSummaryQueryKey(),
+  zone: listZonesWithStatisticsQueryKey(),
   sshkey: listUserSshkeysQueryKey(),
 };
 

--- a/src/app/api/query/zones.test.ts
+++ b/src/app/api/query/zones.test.ts
@@ -5,9 +5,14 @@ import {
   useCreateZone,
   useUpdateZone,
   useDeleteZone,
+  useZonesStatistics,
 } from "@/app/api/query/zones";
 import type { ZoneRequest } from "@/app/apiclient";
-import { mockZones, zoneResolvers } from "@/testing/resolvers/zones";
+import {
+  mockZones,
+  zoneResolvers,
+  mockZonesWithStatistics,
+} from "@/testing/resolvers/zones";
 import {
   renderHookWithProviders,
   setupMockServer,
@@ -16,6 +21,7 @@ import {
 
 const mockServer = setupMockServer(
   zoneResolvers.listZones.handler(),
+  zoneResolvers.listZonesWithStatistics.handler(),
   zoneResolvers.getZone.handler(),
   zoneResolvers.createZone.handler(),
   zoneResolvers.updateZone.handler(),
@@ -29,6 +35,18 @@ describe("useZones", () => {
       expect(result.current.isSuccess).toBe(true);
     });
     expect(result.current.data).toMatchObject(mockZones);
+  });
+});
+
+describe("useZonesStatistics", () => {
+  it("should return zones statistics data", async () => {
+    const { result } = renderHookWithProviders(() => useZonesStatistics());
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.items[0]).toMatchObject(
+      mockZonesWithStatistics.items[0]
+    );
   });
 });
 

--- a/src/app/api/query/zones.ts
+++ b/src/app/api/query/zones.ts
@@ -1,3 +1,4 @@
+import type { UseQueryResult } from "@tanstack/react-query";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 
 import { useWebsocketAwareQuery } from "@/app/api/query/base";
@@ -15,6 +16,9 @@ import type {
   GetZoneData,
   GetZoneErrors,
   GetZoneResponses,
+  ListZonesData,
+  ListZonesErrors,
+  ListZonesResponses,
   ListZonesWithStatisticsData,
   ListZonesWithStatisticsErrors,
   ListZonesWithStatisticsResponses,
@@ -22,6 +26,7 @@ import type {
   UpdateZoneData,
   UpdateZoneErrors,
   UpdateZoneResponses,
+  ZoneWithStatisticsResponse,
 } from "@/app/apiclient";
 import {
   deleteZone,
@@ -29,28 +34,63 @@ import {
   createZone,
   getZone,
   listZonesWithStatistics,
+  listZones,
 } from "@/app/apiclient";
 import {
   getZoneQueryKey,
+  listZonesQueryKey,
   listZonesWithStatisticsQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 
-export const useZones = (options?: Options<ListZonesWithStatisticsData>) => {
-  return useWebsocketAwareQuery(
-    queryOptionsWithHeaders<
-      ListZonesWithStatisticsResponses,
-      ListZonesWithStatisticsErrors,
-      ListZonesWithStatisticsData
-    >(
-      options,
-      listZonesWithStatistics,
-      listZonesWithStatisticsQueryKey(options)
-    )
-  );
+type UseZonesResult = {
+  data:
+    | {
+        items: {
+          statistics: ZoneWithStatisticsResponse | undefined;
+          id: number;
+          name: string;
+          description: string;
+        }[];
+        total: number;
+      }
+    | undefined;
+  isPending: UseQueryResult["isPending"];
+  isSuccess: UseQueryResult["isSuccess"];
+  isError: UseQueryResult["isError"];
 };
 
-export const useZoneCount = (
-  options?: Options<ListZonesWithStatisticsData>
+export const useZones = (options?: Options<ListZonesData>): UseZonesResult => {
+  const zones = useWebsocketAwareQuery(
+    queryOptionsWithHeaders<ListZonesResponses, ListZonesErrors, ListZonesData>(
+      options,
+      listZones,
+      listZonesQueryKey(options)
+    )
+  );
+  const zoneIds = zones.data?.items.map((zone) => zone.id) ?? [];
+  const statistics = useZonesStatistics({
+    query: { id: zoneIds },
+  });
+
+  return {
+    ...zones,
+    data: zones.data
+      ? {
+          ...zones.data,
+          items: zones.data.items.map((zone) => ({
+            ...zone,
+            statistics: statistics.data?.items.find(
+              (stat) => stat.id === zone.id
+            ),
+          })),
+        }
+      : undefined,
+  };
+};
+
+export const useZonesStatistics = (
+  options?: Options<ListZonesWithStatisticsData>,
+  enabled?: boolean
 ) => {
   return useWebsocketAwareQuery({
     ...queryOptionsWithHeaders<
@@ -62,6 +102,17 @@ export const useZoneCount = (
       listZonesWithStatistics,
       listZonesWithStatisticsQueryKey(options)
     ),
+    enabled,
+  });
+};
+
+export const useZoneCount = (options?: Options<ListZonesData>) => {
+  return useWebsocketAwareQuery({
+    ...queryOptionsWithHeaders<
+      ListZonesResponses,
+      ListZonesErrors,
+      ListZonesData
+    >(options, listZones, listZonesQueryKey(options)),
     select: (data) => data?.total ?? 0,
   });
 };
@@ -86,7 +137,7 @@ export const useCreateZone = (mutationOptions?: Options<CreateZoneData>) => {
     >(mutationOptions, createZone),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithStatisticsQueryKey(),
+        queryKey: listZonesQueryKey(),
       });
     },
   });
@@ -102,7 +153,7 @@ export const useUpdateZone = (mutationOptions?: Options<UpdateZoneData>) => {
     >(mutationOptions, updateZone),
     onSuccess: async () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithStatisticsQueryKey(),
+        queryKey: listZonesQueryKey(),
       });
     },
   });
@@ -118,7 +169,7 @@ export const useDeleteZone = (mutationOptions?: Options<DeleteZoneData>) => {
     >(mutationOptions, deleteZone),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithStatisticsQueryKey(),
+        queryKey: listZonesQueryKey(),
       });
     },
   });

--- a/src/app/api/query/zones.ts
+++ b/src/app/api/query/zones.ts
@@ -15,9 +15,9 @@ import type {
   GetZoneData,
   GetZoneErrors,
   GetZoneResponses,
-  ListZonesWithSummaryData,
-  ListZonesWithSummaryErrors,
-  ListZonesWithSummaryResponses,
+  ListZonesWithStatisticsData,
+  ListZonesWithStatisticsErrors,
+  ListZonesWithStatisticsResponses,
   Options,
   UpdateZoneData,
   UpdateZoneErrors,
@@ -28,30 +28,40 @@ import {
   updateZone,
   createZone,
   getZone,
-  listZonesWithSummary,
+  listZonesWithStatistics,
 } from "@/app/apiclient";
 import {
   getZoneQueryKey,
-  listZonesWithSummaryQueryKey,
+  listZonesWithStatisticsQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 
-export const useZones = (options?: Options<ListZonesWithSummaryData>) => {
+export const useZones = (options?: Options<ListZonesWithStatisticsData>) => {
   return useWebsocketAwareQuery(
     queryOptionsWithHeaders<
-      ListZonesWithSummaryResponses,
-      ListZonesWithSummaryErrors,
-      ListZonesWithSummaryData
-    >(options, listZonesWithSummary, listZonesWithSummaryQueryKey(options))
+      ListZonesWithStatisticsResponses,
+      ListZonesWithStatisticsErrors,
+      ListZonesWithStatisticsData
+    >(
+      options,
+      listZonesWithStatistics,
+      listZonesWithStatisticsQueryKey(options)
+    )
   );
 };
 
-export const useZoneCount = (options?: Options<ListZonesWithSummaryData>) => {
+export const useZoneCount = (
+  options?: Options<ListZonesWithStatisticsData>
+) => {
   return useWebsocketAwareQuery({
     ...queryOptionsWithHeaders<
-      ListZonesWithSummaryResponses,
-      ListZonesWithSummaryErrors,
-      ListZonesWithSummaryData
-    >(options, listZonesWithSummary, listZonesWithSummaryQueryKey(options)),
+      ListZonesWithStatisticsResponses,
+      ListZonesWithStatisticsErrors,
+      ListZonesWithStatisticsData
+    >(
+      options,
+      listZonesWithStatistics,
+      listZonesWithStatisticsQueryKey(options)
+    ),
     select: (data) => data?.total ?? 0,
   });
 };
@@ -76,7 +86,7 @@ export const useCreateZone = (mutationOptions?: Options<CreateZoneData>) => {
     >(mutationOptions, createZone),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithSummaryQueryKey(),
+        queryKey: listZonesWithStatisticsQueryKey(),
       });
     },
   });
@@ -92,7 +102,7 @@ export const useUpdateZone = (mutationOptions?: Options<UpdateZoneData>) => {
     >(mutationOptions, updateZone),
     onSuccess: async () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithSummaryQueryKey(),
+        queryKey: listZonesWithStatisticsQueryKey(),
       });
     },
   });
@@ -108,7 +118,7 @@ export const useDeleteZone = (mutationOptions?: Options<DeleteZoneData>) => {
     >(mutationOptions, deleteZone),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listZonesWithSummaryQueryKey(),
+        queryKey: listZonesWithStatisticsQueryKey(),
       });
     },
   });

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -119,7 +119,6 @@ import {
   getUserSshkey,
   getUserSslkey,
   getUserSslkeys,
-  getUserSslkeysWithSummary,
   getZone,
   handleOauthCallback,
   importUserSshkeys,
@@ -166,9 +165,10 @@ import {
   listTags,
   listUsers,
   listUserSshkeys,
+  listUserSslkeysStatistics,
   listUsersWithSummary,
   listZones,
-  listZonesWithSummary,
+  listZonesWithStatistics,
   login,
   logout,
   type Options,
@@ -543,9 +543,6 @@ import type {
   GetUserSslkeysData,
   GetUserSslkeysError,
   GetUserSslkeysResponse,
-  GetUserSslkeysWithSummaryData,
-  GetUserSslkeysWithSummaryError,
-  GetUserSslkeysWithSummaryResponse,
   GetZoneData,
   GetZoneError,
   GetZoneResponse,
@@ -684,15 +681,18 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
+  ListUserSslkeysStatisticsData,
+  ListUserSslkeysStatisticsError,
+  ListUserSslkeysStatisticsResponse,
   ListUsersWithSummaryData,
   ListUsersWithSummaryError,
   ListUsersWithSummaryResponse,
   ListZonesData,
   ListZonesError,
   ListZonesResponse,
-  ListZonesWithSummaryData,
-  ListZonesWithSummaryError,
-  ListZonesWithSummaryResponse,
+  ListZonesWithStatisticsData,
+  ListZonesWithStatisticsError,
+  ListZonesWithStatisticsResponse,
   LoginData,
   LoginError,
   LoginResponse,
@@ -4568,26 +4568,24 @@ export const getUserSslkeyOptions = (options: Options<GetUserSslkeyData>) =>
     queryKey: getUserSslkeyQueryKey(options),
   });
 
-export const getUserSslkeysWithSummaryQueryKey = (
-  options?: Options<GetUserSslkeysWithSummaryData>
-) => createQueryKey("getUserSslkeysWithSummary", options);
+export const listUserSslkeysStatisticsQueryKey = (
+  options?: Options<ListUserSslkeysStatisticsData>
+) => createQueryKey("listUserSslkeysStatistics", options);
 
 /**
- * List sslkeys with a summary. ONLY FOR INTERNAL USAGE.
- *
- * List sslkeys with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List User Sslkeys Statistics
  */
-export const getUserSslkeysWithSummaryOptions = (
-  options?: Options<GetUserSslkeysWithSummaryData>
+export const listUserSslkeysStatisticsOptions = (
+  options?: Options<ListUserSslkeysStatisticsData>
 ) =>
   queryOptions<
-    GetUserSslkeysWithSummaryResponse,
-    GetUserSslkeysWithSummaryError,
-    GetUserSslkeysWithSummaryResponse,
-    ReturnType<typeof getUserSslkeysWithSummaryQueryKey>
+    ListUserSslkeysStatisticsResponse,
+    ListUserSslkeysStatisticsError,
+    ListUserSslkeysStatisticsResponse,
+    ReturnType<typeof listUserSslkeysStatisticsQueryKey>
   >({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await getUserSslkeysWithSummary({
+      const { data } = await listUserSslkeysStatistics({
         ...options,
         ...queryKey[0],
         signal,
@@ -4595,7 +4593,7 @@ export const getUserSslkeysWithSummaryOptions = (
       });
       return data;
     },
-    queryKey: getUserSslkeysWithSummaryQueryKey(options),
+    queryKey: listUserSslkeysStatisticsQueryKey(options),
   });
 
 export const listFabricVlanSubnetsQueryKey = (
@@ -5996,26 +5994,26 @@ export const updateZoneMutation = (
   return mutationOptions;
 };
 
-export const listZonesWithSummaryQueryKey = (
-  options?: Options<ListZonesWithSummaryData>
-) => createQueryKey("listZonesWithSummary", options);
+export const listZonesWithStatisticsQueryKey = (
+  options?: Options<ListZonesWithStatisticsData>
+) => createQueryKey("listZonesWithStatistics", options);
 
 /**
- * List zones with a summary. ONLY FOR INTERNAL USAGE.
+ * List zones with statistics. ONLY FOR INTERNAL USAGE.
  *
- * List zones with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List zones with statistics. This endpoint is only for internal usage and might be changed or removed without notice.
  */
-export const listZonesWithSummaryOptions = (
-  options?: Options<ListZonesWithSummaryData>
+export const listZonesWithStatisticsOptions = (
+  options?: Options<ListZonesWithStatisticsData>
 ) =>
   queryOptions<
-    ListZonesWithSummaryResponse,
-    ListZonesWithSummaryError,
-    ListZonesWithSummaryResponse,
-    ReturnType<typeof listZonesWithSummaryQueryKey>
+    ListZonesWithStatisticsResponse,
+    ListZonesWithStatisticsError,
+    ListZonesWithStatisticsResponse,
+    ReturnType<typeof listZonesWithStatisticsQueryKey>
   >({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await listZonesWithSummary({
+      const { data } = await listZonesWithStatistics({
         ...options,
         ...queryKey[0],
         signal,
@@ -6023,7 +6021,7 @@ export const listZonesWithSummaryOptions = (
       });
       return data;
     },
-    queryKey: listZonesWithSummaryQueryKey(options),
+    queryKey: listZonesWithStatisticsQueryKey(options),
   });
 
 export const getSubnetQueryKey = (options: Options<GetSubnetData>) =>

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -180,7 +180,6 @@ import {
   stopSyncBootsourceBootsourceselection,
   syncBootsourceBootsourceselection,
   updateBootsource,
-  updateBootsourceBootsourceselection,
   updateFabric,
   updateFabricVlan,
   updateFabricVlanSubnet,
@@ -719,9 +718,6 @@ import type {
   SyncBootsourceBootsourceselectionData,
   SyncBootsourceBootsourceselectionError,
   SyncBootsourceBootsourceselectionResponse,
-  UpdateBootsourceBootsourceselectionData,
-  UpdateBootsourceBootsourceselectionError,
-  UpdateBootsourceBootsourceselectionResponse,
   UpdateBootsourceData,
   UpdateBootsourceError,
   UpdateBootsourceResponse,
@@ -1495,33 +1491,6 @@ export const getBootsourceBootsourceselectionOptions = (
     },
     queryKey: getBootsourceBootsourceselectionQueryKey(options),
   });
-
-/**
- * Update Bootsource Bootsourceselection
- */
-export const updateBootsourceBootsourceselectionMutation = (
-  options?: Partial<Options<UpdateBootsourceBootsourceselectionData>>
-): UseMutationOptions<
-  UpdateBootsourceBootsourceselectionResponse,
-  UpdateBootsourceBootsourceselectionError,
-  Options<UpdateBootsourceBootsourceselectionData>
-> => {
-  const mutationOptions: UseMutationOptions<
-    UpdateBootsourceBootsourceselectionResponse,
-    UpdateBootsourceBootsourceselectionError,
-    Options<UpdateBootsourceBootsourceselectionData>
-  > = {
-    mutationFn: async (fnOptions) => {
-      const { data } = await updateBootsourceBootsourceselection({
-        ...options,
-        ...fnOptions,
-        throwOnError: true,
-      });
-      return data;
-    },
-  };
-  return mutationOptions;
-};
 
 /**
  * Fetch Bootsources Available Images

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -354,9 +354,6 @@ import type {
   GetUserSslkeysData,
   GetUserSslkeysErrors,
   GetUserSslkeysResponses,
-  GetUserSslkeysWithSummaryData,
-  GetUserSslkeysWithSummaryErrors,
-  GetUserSslkeysWithSummaryResponses,
   GetZoneData,
   GetZoneErrors,
   GetZoneResponses,
@@ -495,15 +492,18 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysErrors,
   ListUserSshkeysResponses,
+  ListUserSslkeysStatisticsData,
+  ListUserSslkeysStatisticsErrors,
+  ListUserSslkeysStatisticsResponses,
   ListUsersWithSummaryData,
   ListUsersWithSummaryErrors,
   ListUsersWithSummaryResponses,
   ListZonesData,
   ListZonesErrors,
   ListZonesResponses,
-  ListZonesWithSummaryData,
-  ListZonesWithSummaryErrors,
-  ListZonesWithSummaryResponses,
+  ListZonesWithStatisticsData,
+  ListZonesWithStatisticsErrors,
+  ListZonesWithStatisticsResponses,
   LoginData,
   LoginErrors,
   LoginResponses,
@@ -3733,19 +3733,17 @@ export const getUserSslkey = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * List sslkeys with a summary. ONLY FOR INTERNAL USAGE.
- *
- * List sslkeys with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List User Sslkeys Statistics
  */
-export const getUserSslkeysWithSummary = <ThrowOnError extends boolean = false>(
-  options?: Options<GetUserSslkeysWithSummaryData, ThrowOnError>
+export const listUserSslkeysStatistics = <ThrowOnError extends boolean = false>(
+  options?: Options<ListUserSslkeysStatisticsData, ThrowOnError>
 ) => {
   return (options?.client ?? client).get<
-    GetUserSslkeysWithSummaryResponses,
-    GetUserSslkeysWithSummaryErrors,
+    ListUserSslkeysStatisticsResponses,
+    ListUserSslkeysStatisticsErrors,
     ThrowOnError
   >({
-    url: "/MAAS/a/v3/users/me/sslkeys_with_summary",
+    url: "/MAAS/a/v3/users/me/sslkeys:statistics",
     ...options,
   });
 };
@@ -4969,16 +4967,16 @@ export const updateZone = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * List zones with a summary. ONLY FOR INTERNAL USAGE.
+ * List zones with statistics. ONLY FOR INTERNAL USAGE.
  *
- * List zones with a summary. This endpoint is only for internal usage and might be changed or removed without notice.
+ * List zones with statistics. This endpoint is only for internal usage and might be changed or removed without notice.
  */
-export const listZonesWithSummary = <ThrowOnError extends boolean = false>(
-  options?: Options<ListZonesWithSummaryData, ThrowOnError>
+export const listZonesWithStatistics = <ThrowOnError extends boolean = false>(
+  options?: Options<ListZonesWithStatisticsData, ThrowOnError>
 ) => {
   return (options?.client ?? client).get<
-    ListZonesWithSummaryResponses,
-    ListZonesWithSummaryErrors,
+    ListZonesWithStatisticsResponses,
+    ListZonesWithStatisticsErrors,
     ThrowOnError
   >({
     security: [
@@ -4987,7 +4985,7 @@ export const listZonesWithSummary = <ThrowOnError extends boolean = false>(
         type: "http",
       },
     ],
-    url: "/MAAS/a/v3/zones_with_summary",
+    url: "/MAAS/a/v3/zones:statistics",
     ...options,
   });
 };

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -3409,9 +3409,9 @@ export type SslKeyResponse = {
 };
 
 /**
- * SSLKeyWithSummaryResponse
+ * SSLKeyStatisticsResponse
  */
-export type SslKeyWithSummaryResponse = {
+export type SslKeyStatisticsResponse = {
   _links?: BaseHal;
   /**
    * Embedded
@@ -3436,13 +3436,13 @@ export type SslKeyWithSummaryResponse = {
 };
 
 /**
- * SSLKeysWithSummaryListResponse
+ * SSLKeysStatisticsListResponse
  */
-export type SslKeysWithSummaryListResponse = {
+export type SslKeysStatisticsListResponse = {
   /**
    * Items
    */
-  items: SslKeyWithSummaryResponse[];
+  items: SslKeyStatisticsResponse[];
   /**
    * Total
    */
@@ -5127,9 +5127,9 @@ export type ZoneResponse = {
 };
 
 /**
- * ZoneWithSummaryResponse
+ * ZoneWithStatisticsResponse
  */
-export type ZoneWithSummaryResponse = {
+export type ZoneWithStatisticsResponse = {
   _links?: BaseHal;
   /**
    * Embedded
@@ -5188,13 +5188,13 @@ export type ZonesListResponse = {
 };
 
 /**
- * ZonesWithSummaryListResponse
+ * ZonesWithStatisticsListResponse
  */
-export type ZonesWithSummaryListResponse = {
+export type ZonesWithStatisticsListResponse = {
   /**
    * Items
    */
-  items: ZoneWithSummaryResponse[];
+  items: ZoneWithStatisticsResponse[];
   /**
    * Total
    */
@@ -5906,6 +5906,10 @@ export type DeleteBootsourceData = {
 
 export type DeleteBootsourceErrors = {
   /**
+   * Bad Request
+   */
+  400: BadRequestBodyResponse;
+  /**
    * Not Found
    */
   404: NotFoundBodyResponse;
@@ -5976,6 +5980,10 @@ export type UpdateBootsourceData = {
 };
 
 export type UpdateBootsourceErrors = {
+  /**
+   * Bad Request
+   */
+  400: BadRequestBodyResponse;
   /**
    * Not Found
    */
@@ -10555,7 +10563,7 @@ export type GetUserSslkeyResponses = {
 export type GetUserSslkeyResponse =
   GetUserSslkeyResponses[keyof GetUserSslkeyResponses];
 
-export type GetUserSslkeysWithSummaryData = {
+export type ListUserSslkeysStatisticsData = {
   body?: never;
   path?: never;
   query?: {
@@ -10568,10 +10576,10 @@ export type GetUserSslkeysWithSummaryData = {
      */
     size?: number;
   };
-  url: "/MAAS/a/v3/users/me/sslkeys_with_summary";
+  url: "/MAAS/a/v3/users/me/sslkeys:statistics";
 };
 
-export type GetUserSslkeysWithSummaryErrors = {
+export type ListUserSslkeysStatisticsErrors = {
   /**
    * Unauthorized
    */
@@ -10582,18 +10590,18 @@ export type GetUserSslkeysWithSummaryErrors = {
   422: ValidationErrorBodyResponse;
 };
 
-export type GetUserSslkeysWithSummaryError =
-  GetUserSslkeysWithSummaryErrors[keyof GetUserSslkeysWithSummaryErrors];
+export type ListUserSslkeysStatisticsError =
+  ListUserSslkeysStatisticsErrors[keyof ListUserSslkeysStatisticsErrors];
 
-export type GetUserSslkeysWithSummaryResponses = {
+export type ListUserSslkeysStatisticsResponses = {
   /**
    * Successful Response
    */
-  200: SslKeysWithSummaryListResponse;
+  200: SslKeysStatisticsListResponse;
 };
 
-export type GetUserSslkeysWithSummaryResponse =
-  GetUserSslkeysWithSummaryResponses[keyof GetUserSslkeysWithSummaryResponses];
+export type ListUserSslkeysStatisticsResponse =
+  ListUserSslkeysStatisticsResponses[keyof ListUserSslkeysStatisticsResponses];
 
 export type ListFabricVlanSubnetsData = {
   body?: never;
@@ -12443,10 +12451,6 @@ export type ListZonesData = {
      * Size
      */
     size?: number;
-    /**
-     * Filter by zone id
-     */
-    id?: number[];
   };
   url: "/MAAS/a/v3/zones";
 };
@@ -12610,10 +12614,14 @@ export type UpdateZoneResponses = {
 
 export type UpdateZoneResponse = UpdateZoneResponses[keyof UpdateZoneResponses];
 
-export type ListZonesWithSummaryData = {
+export type ListZonesWithStatisticsData = {
   body?: never;
   path?: never;
   query?: {
+    /**
+     * Filter by zone id
+     */
+    id?: number[];
     /**
      * Page
      */
@@ -12623,28 +12631,28 @@ export type ListZonesWithSummaryData = {
      */
     size?: number;
   };
-  url: "/MAAS/a/v3/zones_with_summary";
+  url: "/MAAS/a/v3/zones:statistics";
 };
 
-export type ListZonesWithSummaryErrors = {
+export type ListZonesWithStatisticsErrors = {
   /**
    * Unprocessable Content
    */
   422: ValidationErrorBodyResponse;
 };
 
-export type ListZonesWithSummaryError =
-  ListZonesWithSummaryErrors[keyof ListZonesWithSummaryErrors];
+export type ListZonesWithStatisticsError =
+  ListZonesWithStatisticsErrors[keyof ListZonesWithStatisticsErrors];
 
-export type ListZonesWithSummaryResponses = {
+export type ListZonesWithStatisticsResponses = {
   /**
    * Successful Response
    */
-  200: ZonesWithSummaryListResponse;
+  200: ZonesWithStatisticsListResponse;
 };
 
-export type ListZonesWithSummaryResponse =
-  ListZonesWithSummaryResponses[keyof ListZonesWithSummaryResponses];
+export type ListZonesWithStatisticsResponse =
+  ListZonesWithStatisticsResponses[keyof ListZonesWithStatisticsResponses];
 
 export type GetSubnetData = {
   body?: never;

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -5144,14 +5144,6 @@ export type ZoneWithStatisticsResponse = {
    */
   id: number;
   /**
-   * Name
-   */
-  name: string;
-  /**
-   * Description
-   */
-  description: string;
-  /**
    * Devices Count
    */
   devices_count: number;
@@ -12451,6 +12443,10 @@ export type ListZonesData = {
      * Size
      */
     size?: number;
+    /**
+     * Filter by zone id
+     */
+    id?: number[];
   };
   url: "/MAAS/a/v3/zones";
 };

--- a/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.test.tsx
+++ b/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.test.tsx
@@ -14,6 +14,7 @@ import {
 
 setupMockServer(
   zoneResolvers.listZones.handler(),
+  zoneResolvers.listZonesWithStatistics.handler(),
   zoneResolvers.getZone.handler(),
   poolsResolvers.getPool.handler()
 );

--- a/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
+++ b/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
@@ -2,7 +2,7 @@ import { GenericTable } from "@canonical/maas-react-components";
 import { useSelector } from "react-redux";
 
 import { useZones } from "@/app/api/query/zones";
-import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
+import type { ZoneResponse } from "@/app/apiclient";
 import urls from "@/app/base/urls";
 import type { Props as RAMColumnProps } from "@/app/kvm/components/RAMColumn/RAMColumn";
 import type { KVMResource, KVMStoragePoolResources } from "@/app/kvm/types";
@@ -46,7 +46,7 @@ export type LXDKVMHost = {
 
 export const generateSingleHostRows = (
   pods: Pod[],
-  zones: Pick<ZoneWithStatisticsResponse, "id" | "name">[] | undefined
+  zones?: ZoneResponse[]
 ): LXDKVMHost[] =>
   pods.map((pod): LXDKVMHost => {
     const zone = zones?.find((zone) => pod.zone === zone.id);

--- a/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
+++ b/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
@@ -46,7 +46,7 @@ export type LXDKVMHost = {
 
 export const generateSingleHostRows = (
   pods: Pod[],
-  zones: ZoneWithStatisticsResponse[] | undefined
+  zones: Pick<ZoneWithStatisticsResponse, "id" | "name">[] | undefined
 ): LXDKVMHost[] =>
   pods.map((pod): LXDKVMHost => {
     const zone = zones?.find((zone) => pod.zone === zone.id);

--- a/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
+++ b/src/app/kvm/views/KVMList/LXDHostsTable/LXDHostsTable.tsx
@@ -2,7 +2,7 @@ import { GenericTable } from "@canonical/maas-react-components";
 import { useSelector } from "react-redux";
 
 import { useZones } from "@/app/api/query/zones";
-import type { ZoneWithSummaryResponse } from "@/app/apiclient";
+import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
 import urls from "@/app/base/urls";
 import type { Props as RAMColumnProps } from "@/app/kvm/components/RAMColumn/RAMColumn";
 import type { KVMResource, KVMStoragePoolResources } from "@/app/kvm/types";
@@ -46,7 +46,7 @@ export type LXDKVMHost = {
 
 export const generateSingleHostRows = (
   pods: Pod[],
-  zones: ZoneWithSummaryResponse[] | undefined
+  zones: ZoneWithStatisticsResponse[] | undefined
 ): LXDKVMHost[] =>
   pods.map((pod): LXDKVMHost => {
     const zone = zones?.find((zone) => pod.zone === zone.id);

--- a/src/app/zones/components/DeleteZone/DeleteZone.tsx
+++ b/src/app/zones/components/DeleteZone/DeleteZone.tsx
@@ -7,7 +7,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useDeleteZone, useGetZone } from "@/app/api/query/zones";
-import { listZonesWithSummaryQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
+import { listZonesWithStatisticsQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
 
@@ -47,7 +47,7 @@ const DeleteZone: React.FC<DeleteZoneProps> = ({ id }) => {
           onSuccess={() => {
             return queryClient
               .invalidateQueries({
-                queryKey: listZonesWithSummaryQueryKey(),
+                queryKey: listZonesWithStatisticsQueryKey(),
               })
               .then(closeSidePanel);
           }}

--- a/src/app/zones/components/DeleteZone/DeleteZone.tsx
+++ b/src/app/zones/components/DeleteZone/DeleteZone.tsx
@@ -7,7 +7,10 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useDeleteZone, useGetZone } from "@/app/api/query/zones";
-import { listZonesWithStatisticsQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
+import {
+  listZonesQueryKey,
+  listZonesWithStatisticsQueryKey,
+} from "@/app/apiclient/@tanstack/react-query.gen";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
 
@@ -44,12 +47,14 @@ const DeleteZone: React.FC<DeleteZoneProps> = ({ id }) => {
               path: { zone_id: id },
             });
           }}
-          onSuccess={() => {
-            return queryClient
-              .invalidateQueries({
-                queryKey: listZonesWithStatisticsQueryKey(),
-              })
-              .then(closeSidePanel);
+          onSuccess={async () => {
+            await queryClient.invalidateQueries({
+              queryKey: listZonesWithStatisticsQueryKey(),
+            });
+            await queryClient.invalidateQueries({
+              queryKey: listZonesQueryKey(),
+            });
+            closeSidePanel();
           }}
           saved={deleteZone.isSuccess}
           saving={deleteZone.isPending}

--- a/src/app/zones/components/ZonesTable/ZonesTable.test.tsx
+++ b/src/app/zones/components/ZonesTable/ZonesTable.test.tsx
@@ -80,7 +80,6 @@ describe("ZonesTable", () => {
         zoneResolvers.listZonesWithStatistics.handler({
           items: [
             factory.zoneWithStatistics({
-              name: "default",
               machines_count: 5,
             }),
           ],
@@ -117,7 +116,6 @@ describe("ZonesTable", () => {
         zoneResolvers.listZonesWithStatistics.handler({
           items: [
             factory.zoneWithStatistics({
-              name: "default",
               devices_count: 2,
             }),
           ],
@@ -154,7 +152,6 @@ describe("ZonesTable", () => {
         zoneResolvers.listZonesWithStatistics.handler({
           items: [
             factory.zoneWithStatistics({
-              name: "default",
               controllers_count: 1,
             }),
           ],

--- a/src/app/zones/components/ZonesTable/ZonesTable.test.tsx
+++ b/src/app/zones/components/ZonesTable/ZonesTable.test.tsx
@@ -19,6 +19,7 @@ import {
 
 const mockServer = setupMockServer(
   zoneResolvers.listZones.handler(),
+  zoneResolvers.listZonesWithStatistics.handler(),
   zoneResolvers.getZone.handler(),
   authResolvers.getCurrentUser.handler()
 );
@@ -69,9 +70,18 @@ describe("ZonesTable", () => {
           items: [
             factory.zone({
               name: "default",
+            }),
+          ],
+          total: 1,
+        })
+      );
+
+      mockServer.use(
+        zoneResolvers.listZonesWithStatistics.handler({
+          items: [
+            factory.zoneWithStatistics({
+              name: "default",
               machines_count: 5,
-              devices_count: 2,
-              controllers_count: 1,
             }),
           ],
           total: 1,
@@ -97,9 +107,18 @@ describe("ZonesTable", () => {
           items: [
             factory.zone({
               name: "default",
-              machines_count: 5,
+            }),
+          ],
+          total: 1,
+        })
+      );
+
+      mockServer.use(
+        zoneResolvers.listZonesWithStatistics.handler({
+          items: [
+            factory.zoneWithStatistics({
+              name: "default",
               devices_count: 2,
-              controllers_count: 1,
             }),
           ],
           total: 1,
@@ -125,8 +144,17 @@ describe("ZonesTable", () => {
           items: [
             factory.zone({
               name: "default",
-              machines_count: 5,
-              devices_count: 2,
+            }),
+          ],
+          total: 1,
+        })
+      );
+
+      mockServer.use(
+        zoneResolvers.listZonesWithStatistics.handler({
+          items: [
+            factory.zoneWithStatistics({
+              name: "default",
               controllers_count: 1,
             }),
           ],

--- a/src/app/zones/components/ZonesTable/useZonesTableColumns/useZonesTableColumns.tsx
+++ b/src/app/zones/components/ZonesTable/useZonesTableColumns/useZonesTableColumns.tsx
@@ -4,7 +4,7 @@ import type { ColumnDef, Row } from "@tanstack/react-table";
 import { Link } from "react-router";
 
 import { useGetIsSuperUser } from "@/app/api/query/auth";
-import type { ZoneWithSummaryResponse } from "@/app/apiclient";
+import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import urls from "@/app/base/urls";
@@ -13,8 +13,8 @@ import { FilterMachines } from "@/app/store/machine/utils";
 import { DeleteZone, EditZone } from "@/app/zones/components";
 
 export type ZoneColumnDef = ColumnDef<
-  ZoneWithSummaryResponse,
-  Partial<ZoneWithSummaryResponse>
+  ZoneWithStatisticsResponse,
+  Partial<ZoneWithStatisticsResponse>
 >;
 
 const filterDevices = (name: string) =>
@@ -94,7 +94,7 @@ const useZonesTableColumns = (): ZoneColumnDef[] => {
         accessorKey: "id",
         enableSorting: false,
         header: "Actions",
-        cell: ({ row }: { row: Row<ZoneWithSummaryResponse> }) => {
+        cell: ({ row }: { row: Row<ZoneWithStatisticsResponse> }) => {
           const canBeDeleted = isSuperUser.data && row.original.id !== 1;
           return (
             <TableActions

--- a/src/app/zones/components/ZonesTable/useZonesTableColumns/useZonesTableColumns.tsx
+++ b/src/app/zones/components/ZonesTable/useZonesTableColumns/useZonesTableColumns.tsx
@@ -4,7 +4,7 @@ import type { ColumnDef, Row } from "@tanstack/react-table";
 import { Link } from "react-router";
 
 import { useGetIsSuperUser } from "@/app/api/query/auth";
-import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
+import type { ZoneResponse, ZoneWithStatisticsResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import urls from "@/app/base/urls";
@@ -12,9 +12,13 @@ import { FilterDevices } from "@/app/store/device/utils";
 import { FilterMachines } from "@/app/store/machine/utils";
 import { DeleteZone, EditZone } from "@/app/zones/components";
 
+type ZonesColumnData = ZoneResponse & {
+  statistics?: ZoneWithStatisticsResponse;
+};
+
 export type ZoneColumnDef = ColumnDef<
-  ZoneWithStatisticsResponse,
-  Partial<ZoneWithStatisticsResponse>
+  ZonesColumnData,
+  Partial<ZonesColumnData>
 >;
 
 const filterDevices = (name: string) =>
@@ -49,13 +53,17 @@ const useZonesTableColumns = (): ZoneColumnDef[] => {
         accessorKey: "machines_count",
         enableSorting: true,
         header: "Machines",
-        cell: ({ row }) => {
+        cell: ({
+          row: {
+            original: { statistics, name },
+          },
+        }) => {
           return (
             <Link
               className="u-align--right"
-              to={`${urls.machines.index}${machinesFilter(row.original.name)}`}
+              to={`${urls.machines.index}${machinesFilter(name)}`}
             >
-              {row.original.machines_count}
+              {statistics?.machines_count}
             </Link>
           );
         },
@@ -65,13 +73,17 @@ const useZonesTableColumns = (): ZoneColumnDef[] => {
         accessorKey: "devices_count",
         enableSorting: true,
         header: "Devices",
-        cell: ({ row }) => {
+        cell: ({
+          row: {
+            original: { statistics, name },
+          },
+        }) => {
           return (
             <Link
               className="u-align--right"
-              to={`${urls.devices.index}${filterDevices(row.original.name)}`}
+              to={`${urls.devices.index}${filterDevices(name)}`}
             >
-              {row.original.devices_count}
+              {statistics?.devices_count}
             </Link>
           );
         },
@@ -81,10 +93,14 @@ const useZonesTableColumns = (): ZoneColumnDef[] => {
         accessorKey: "controllers_count",
         enableSorting: true,
         header: "Controllers",
-        cell: ({ row }) => {
+        cell: ({
+          row: {
+            original: { statistics },
+          },
+        }) => {
           return (
             <Link className="u-align--right" to={`${urls.controllers.index}`}>
-              {row.original.controllers_count}
+              {statistics?.controllers_count}
             </Link>
           );
         },
@@ -94,7 +110,7 @@ const useZonesTableColumns = (): ZoneColumnDef[] => {
         accessorKey: "id",
         enableSorting: false,
         header: "Actions",
-        cell: ({ row }: { row: Row<ZoneWithStatisticsResponse> }) => {
+        cell: ({ row }: { row: Row<ZonesColumnData> }) => {
           const canBeDeleted = isSuperUser.data && row.original.id !== 1;
           return (
             <TableActions

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -205,5 +205,5 @@ export {
   vmClusterStoragePoolResource,
   vmHost,
 } from "./vmcluster";
-export { zone } from "./zone";
+export { zone, zoneWithStatistics } from "./zone";
 export { zonesGet } from "./response";

--- a/src/testing/factories/zone.ts
+++ b/src/testing/factories/zone.ts
@@ -1,8 +1,8 @@
 import { define, random } from "cooky-cutter";
 
-import type { ZoneWithSummaryResponse } from "@/app/apiclient";
+import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
 
-export const zone = define<ZoneWithSummaryResponse>({
+export const zone = define<ZoneWithStatisticsResponse>({
   controllers_count: random,
   description: "test description",
   devices_count: random,

--- a/src/testing/factories/zone.ts
+++ b/src/testing/factories/zone.ts
@@ -1,12 +1,18 @@
 import { define, random } from "cooky-cutter";
 
-import type { ZoneWithStatisticsResponse } from "@/app/apiclient";
+import type { ZoneResponse, ZoneWithStatisticsResponse } from "@/app/apiclient";
 
-export const zone = define<ZoneWithStatisticsResponse>({
-  controllers_count: random,
+export const zone = define<ZoneResponse>({
   description: "test description",
-  devices_count: random,
-  machines_count: random,
   name: (i: number) => `zone-${i}`,
   id: (i: number) => i,
+});
+
+export const zoneWithStatistics = define<ZoneWithStatisticsResponse>({
+  id: (i: number) => i,
+  name: (i: number) => `zone-${i}`,
+  description: "test description",
+  controllers_count: random,
+  devices_count: random,
+  machines_count: random,
 });

--- a/src/testing/factories/zone.ts
+++ b/src/testing/factories/zone.ts
@@ -10,8 +10,6 @@ export const zone = define<ZoneResponse>({
 
 export const zoneWithStatistics = define<ZoneWithStatisticsResponse>({
   id: (i: number) => i,
-  name: (i: number) => `zone-${i}`,
-  description: "test description",
   controllers_count: random,
   devices_count: random,
   machines_count: random,

--- a/src/testing/resolvers/zones.ts
+++ b/src/testing/resolvers/zones.ts
@@ -41,24 +41,18 @@ const mockZonesWithStatistics: ZonesWithStatisticsListResponse = {
   items: [
     zoneStatsFactory({
       id: 1,
-      name: "zone-1",
-      description: "",
       controllers_count: 2,
       devices_count: 5,
       machines_count: 10,
     }),
     zoneStatsFactory({
       id: 2,
-      name: "zone-2",
-      description: "",
       controllers_count: 1,
       devices_count: 3,
       machines_count: 6,
     }),
     zoneStatsFactory({
       id: 3,
-      name: "zone-3",
-      description: "",
       controllers_count: 0,
       devices_count: 2,
       machines_count: 4,

--- a/src/testing/resolvers/zones.ts
+++ b/src/testing/resolvers/zones.ts
@@ -4,14 +4,14 @@ import type {
   CreateZoneError,
   DeleteZoneError,
   GetZoneError,
-  ListZonesWithSummaryError,
+  ListZonesWithStatisticsError,
   UpdateZoneError,
-  ZonesWithSummaryListResponse,
+  ZonesWithStatisticsListResponse,
 } from "@/app/apiclient";
 import { zone as zoneFactory } from "@/testing/factories";
 import { BASE_URL } from "@/testing/utils";
 
-const mockZones: ZonesWithSummaryListResponse = {
+const mockZones: ZonesWithStatisticsListResponse = {
   items: [
     zoneFactory({
       id: 1,
@@ -41,7 +41,7 @@ const mockZones: ZonesWithSummaryListResponse = {
   total: 3,
 };
 
-const mockListZonesError: ListZonesWithSummaryError = {
+const mockListZonesError: ListZonesWithStatisticsError = {
   message: "Unauthorized",
   code: 401,
   kind: "Error", // This will always be 'Error' for every error response
@@ -68,13 +68,13 @@ const mockUpdateZoneError: UpdateZoneError = {
 const zoneResolvers = {
   listZones: {
     resolved: false,
-    handler: (data: ZonesWithSummaryListResponse = mockZones) =>
-      http.get(`${BASE_URL}MAAS/a/v3/zones_with_summary`, () => {
+    handler: (data: ZonesWithStatisticsListResponse = mockZones) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
         zoneResolvers.listZones.resolved = true;
         return HttpResponse.json(data);
       }),
-    error: (error: ListZonesWithSummaryError = mockListZonesError) =>
-      http.get(`${BASE_URL}MAAS/a/v3/zones_with_summary`, () => {
+    error: (error: ListZonesWithStatisticsError = mockListZonesError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
         zoneResolvers.listZones.resolved = true;
         return HttpResponse.json(error, { status: error.code });
       }),

--- a/src/testing/resolvers/zones.ts
+++ b/src/testing/resolvers/zones.ts
@@ -4,44 +4,76 @@ import type {
   CreateZoneError,
   DeleteZoneError,
   GetZoneError,
+  ListZonesError,
+  ListZonesResponse,
   ListZonesWithStatisticsError,
   UpdateZoneError,
   ZonesWithStatisticsListResponse,
 } from "@/app/apiclient";
-import { zone as zoneFactory } from "@/testing/factories";
+import {
+  zone as zoneFactory,
+  zoneWithStatistics as zoneStatsFactory,
+} from "@/testing/factories";
 import { BASE_URL } from "@/testing/utils";
 
-const mockZones: ZonesWithStatisticsListResponse = {
+const mockZones: ListZonesResponse = {
   items: [
     zoneFactory({
       id: 1,
       name: "zone-1",
       description: "",
-      controllers_count: 0,
-      devices_count: 0,
-      machines_count: 0,
     }),
     zoneFactory({
       id: 2,
       name: "zone-2",
       description: "",
-      controllers_count: 0,
-      devices_count: 0,
-      machines_count: 0,
     }),
     zoneFactory({
       id: 3,
       name: "zone-3",
       description: "",
-      controllers_count: 0,
-      devices_count: 0,
-      machines_count: 0,
     }),
   ],
   total: 3,
 };
 
-const mockListZonesError: ListZonesWithStatisticsError = {
+const mockZonesWithStatistics: ZonesWithStatisticsListResponse = {
+  items: [
+    zoneStatsFactory({
+      id: 1,
+      name: "zone-1",
+      description: "",
+      controllers_count: 2,
+      devices_count: 5,
+      machines_count: 10,
+    }),
+    zoneStatsFactory({
+      id: 2,
+      name: "zone-2",
+      description: "",
+      controllers_count: 1,
+      devices_count: 3,
+      machines_count: 6,
+    }),
+    zoneStatsFactory({
+      id: 3,
+      name: "zone-3",
+      description: "",
+      controllers_count: 0,
+      devices_count: 2,
+      machines_count: 4,
+    }),
+  ],
+  total: 3,
+};
+
+const mockListZonesError: ListZonesError = {
+  message: "Unauthorized",
+  code: 401,
+  kind: "Error", // This will always be 'Error' for every error response
+};
+
+const mockListZonesWithStatisticsError: ListZonesWithStatisticsError = {
   message: "Unauthorized",
   code: 401,
   kind: "Error", // This will always be 'Error' for every error response
@@ -68,14 +100,31 @@ const mockUpdateZoneError: UpdateZoneError = {
 const zoneResolvers = {
   listZones: {
     resolved: false,
-    handler: (data: ZonesWithStatisticsListResponse = mockZones) =>
-      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
+    handler: (data: ListZonesResponse = mockZones) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones`, () => {
         zoneResolvers.listZones.resolved = true;
         return HttpResponse.json(data);
       }),
-    error: (error: ListZonesWithStatisticsError = mockListZonesError) =>
-      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
+    error: (error: ListZonesError = mockListZonesError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones`, () => {
         zoneResolvers.listZones.resolved = true;
+        return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+  listZonesWithStatistics: {
+    resolved: false,
+    handler: (
+      data: ZonesWithStatisticsListResponse = mockZonesWithStatistics
+    ) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
+        zoneResolvers.listZonesWithStatistics.resolved = true;
+        return HttpResponse.json(data);
+      }),
+    error: (
+      error: ListZonesWithStatisticsError = mockListZonesWithStatisticsError
+    ) =>
+      http.get(`${BASE_URL}MAAS/a/v3/zones:statistics`, () => {
+        zoneResolvers.listZonesWithStatistics.resolved = true;
         return HttpResponse.json(error, { status: error.code });
       }),
   },
@@ -137,4 +186,4 @@ const zoneResolvers = {
   },
 };
 
-export { zoneResolvers, mockZones };
+export { zoneResolvers, mockZones, mockZonesWithStatistics };


### PR DESCRIPTION
## Done

- Updated `/zones_with_summary` to `/zones:statistics`
- Updated tests, resolvers and factories

## QA steps
Note: `maas-ui-demo` still uses `/zones_with_summary`. Use a local MAAS instance with the latest changes to verify.
- [ ] Go to `/MAAS/r/zones` and verify the table is populated as expected

## Fixes

Resolves [MAASENG-6470](https://warthogs.atlassian.net/browse/MAASENG-6470)



[MAASENG-6470]: https://warthogs.atlassian.net/browse/MAASENG-6470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ