### PR TITLE
feat(settings): Source name and default source enabling/disabling MAASENG-6314

### DIFF
--- a/src/app/api/query/imageSources.test.ts
+++ b/src/app/api/query/imageSources.test.ts
@@ -77,11 +77,13 @@ describe("useGetImageSource", () => {
 
 describe("useChangeImageSource", () => {
   const newImageSource: BootSourceCreateRequest = {
+    name: "Custom",
     url: "http://updated.images.io/",
     keyring_filename: "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg",
     keyring_data: "newdata",
     priority: 5,
     skip_keyring_verification: false,
+    enabled: true,
   };
 
   afterEach(() => {
@@ -129,12 +131,15 @@ describe("useChangeImageSource", () => {
 });
 
 describe("useUpdateImageSource", () => {
-  it("should update a pool", async () => {
+  it("should update a source", async () => {
     const updatedImageSource: BootSourceUpdateRequest = {
+      name: "Custom",
+      url: "http://updated.images.io/",
       keyring_filename: "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg",
       keyring_data: "newdata",
       priority: 5,
       skip_keyring_verification: false,
+      enabled: true,
     };
     const { result } = renderHookWithProviders(() => useUpdateImageSource());
     result.current.mutate({

--- a/src/app/api/query/imageSources.ts
+++ b/src/app/api/query/imageSources.ts
@@ -168,23 +168,3 @@ export const useFetchImageSource = (
     >(mutationOptions, fetchBootsourcesAvailableImages),
   });
 };
-
-// TODO: implement default source enabling when v3 is ready
-export const useEnableImageSource = () => {
-  return {
-    error: {},
-    mutate: (_args: object) => {},
-    isPending: false,
-    isSuccess: true,
-  };
-};
-
-// TODO: implement default source disabling when v3 is ready
-export const useDisableImageSource = () => {
-  return {
-    error: {},
-    mutate: (_args: object) => {},
-    isPending: false,
-    isSuccess: true,
-  };
-};

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -531,9 +531,6 @@ import type {
   SyncBootsourceBootsourceselectionData,
   SyncBootsourceBootsourceselectionErrors,
   SyncBootsourceBootsourceselectionResponses,
-  UpdateBootsourceBootsourceselectionData,
-  UpdateBootsourceBootsourceselectionErrors,
-  UpdateBootsourceBootsourceselectionResponses,
   UpdateBootsourceData,
   UpdateBootsourceErrors,
   UpdateBootsourceResponses,
@@ -1150,34 +1147,6 @@ export const getBootsourceBootsourceselection = <
     ],
     url: "/MAAS/a/v3/boot_sources/{boot_source_id}/selections/{id}",
     ...options,
-  });
-};
-
-/**
- * Update Bootsource Bootsourceselection
- */
-export const updateBootsourceBootsourceselection = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<UpdateBootsourceBootsourceselectionData, ThrowOnError>
-) => {
-  return (options.client ?? client).put<
-    UpdateBootsourceBootsourceselectionResponses,
-    UpdateBootsourceBootsourceselectionErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/MAAS/a/v3/boot_sources/{boot_source_id}/selections/{id}",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
   });
 };
 

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -425,6 +425,12 @@ export type BootSourceCreateRequest = {
    */
   skip_keyring_verification?: boolean;
   /**
+   * Name
+   *
+   * Name of this boot source.
+   */
+  name: string;
+  /**
    * Priority
    *
    * Priority value. Higher values mean higher priority. Must be non-negative.
@@ -436,6 +442,12 @@ export type BootSourceCreateRequest = {
    * URL of SimpleStreams server providing boot source information.
    */
   url: string;
+  /**
+   * Enabled
+   *
+   * Whether to enable downloads from this source or not.
+   */
+  enabled: boolean;
 };
 
 /**
@@ -486,6 +498,10 @@ export type BootSourceResponse = {
    */
   id: number;
   /**
+   * Name
+   */
+  name: string;
+  /**
    * Url
    */
   url: string;
@@ -505,6 +521,10 @@ export type BootSourceResponse = {
    * Skip Keyring Verification
    */
   skip_keyring_verification: boolean;
+  /**
+   * Enabled
+   */
+  enabled: boolean;
 };
 
 /**
@@ -568,11 +588,29 @@ export type BootSourceUpdateRequest = {
    */
   skip_keyring_verification?: boolean;
   /**
+   * Name
+   *
+   * Name of this boot source.
+   */
+  name: string;
+  /**
    * Priority
    *
    * Priority value. Higher values mean higher priority. Must be non-negative.
    */
   priority: number;
+  /**
+   * Url
+   *
+   * URL of SimpleStreams server providing boot source information.
+   */
+  url: string;
+  /**
+   * Enabled
+   *
+   * Whether to enable downloads from this source or not.
+   */
+  enabled: boolean;
 };
 
 /**
@@ -6084,46 +6122,6 @@ export type GetBootsourceBootsourceselectionResponses = {
 
 export type GetBootsourceBootsourceselectionResponse =
   GetBootsourceBootsourceselectionResponses[keyof GetBootsourceBootsourceselectionResponses];
-
-export type UpdateBootsourceBootsourceselectionData = {
-  body: BootSourceSelectionRequest;
-  path: {
-    /**
-     * Boot Source Id
-     */
-    boot_source_id: number;
-    /**
-     * Id
-     */
-    id: number;
-  };
-  query?: never;
-  url: "/MAAS/a/v3/boot_sources/{boot_source_id}/selections/{id}";
-};
-
-export type UpdateBootsourceBootsourceselectionErrors = {
-  /**
-   * Not Found
-   */
-  404: NotFoundBodyResponse;
-  /**
-   * Unprocessable Content
-   */
-  422: ValidationErrorBodyResponse;
-};
-
-export type UpdateBootsourceBootsourceselectionError =
-  UpdateBootsourceBootsourceselectionErrors[keyof UpdateBootsourceBootsourceselectionErrors];
-
-export type UpdateBootsourceBootsourceselectionResponses = {
-  /**
-   * Successful Response
-   */
-  200: BootSourceResponse;
-};
-
-export type UpdateBootsourceBootsourceselectionResponse =
-  UpdateBootsourceBootsourceselectionResponses[keyof UpdateBootsourceBootsourceselectionResponses];
 
 export type FetchBootsourcesAvailableImagesData = {
   body: BootSourceFetchRequest;

--- a/src/app/images/constants.ts
+++ b/src/app/images/constants.ts
@@ -1,8 +1,8 @@
 import type { Accept } from "react-dropzone";
 
 export const MAAS_IO_URLS = {
-  stable: "http://images.maas.io/ephemeral-v3/stable/",
-  candidate: "http://images.maas.io/ephemeral-v3/candidate/",
+  stable: "http://images.maas.io/ephemeral-v3/stable",
+  candidate: "http://images.maas.io/ephemeral-v3/candidate",
 } as const;
 
 export const MAAS_IO_DEFAULT_KEYRING_FILE_PATHS = {

--- a/src/app/settings/views/Images/Sources/Sources.tsx
+++ b/src/app/settings/views/Images/Sources/Sources.tsx
@@ -12,8 +12,6 @@ import SourcesTable from "@/app/settings/views/Images/Sources/components/Sources
 
 export type ImageSource = BootSourceResponse & {
   type: BootResourceSourceType;
-  // TODO: implement v3 enabled state
-  enabled?: boolean;
 };
 
 const Sources = (): ReactElement => {

--- a/src/app/settings/views/Images/Sources/components/AddSource/AddSource.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/AddSource/AddSource.test.tsx
@@ -197,6 +197,8 @@ describe("AddSource", () => {
   it("calls create source on save click", async () => {
     renderWithProviders(<AddSource />);
     await waitForLoading();
+    const nameInput = screen.getByRole("textbox", { name: Labels.Name });
+    await userEvent.type(nameInput, "Custom Source");
     const urlInput = screen.getByRole("textbox", { name: Labels.Url });
     await userEvent.clear(urlInput);
     await userEvent.type(urlInput, "http://invalid.example.com/");
@@ -225,6 +227,8 @@ describe("AddSource", () => {
     );
     renderWithProviders(<AddSource />);
     await waitForLoading();
+    const nameInput = screen.getByRole("textbox", { name: Labels.Name });
+    await userEvent.type(nameInput, "Custom Source");
     const urlInput = screen.getByRole("textbox", { name: Labels.Url });
     await userEvent.clear(urlInput);
     await userEvent.type(urlInput, "http://invalid.example.com/");

--- a/src/app/settings/views/Images/Sources/components/AddSource/AddSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/AddSource/AddSource.tsx
@@ -124,6 +124,7 @@ const AddSource = (): ReactElement => {
       buttonsBehavior="independent"
       errors={errors}
       initialValues={{
+        name: "",
         url: "",
         keyring_type: "keyring_filename",
         keyring_filename:
@@ -133,12 +134,14 @@ const AddSource = (): ReactElement => {
         keyring_data: "",
         skip_keyring_verification: undefined,
         priority: 10,
+        enabled: true,
       }}
       onCancel={closeSidePanel}
       onSubmit={(values) => {
         createSource.mutate(
           {
             body: {
+              name: values.name,
               url: values.url,
               keyring_filename:
                 values.keyring_type === "keyring_filename"
@@ -151,6 +154,7 @@ const AddSource = (): ReactElement => {
               skip_keyring_verification:
                 values.keyring_type === "keyring_unsigned" ? true : undefined,
               priority: values.priority,
+              enabled: true,
             },
           },
           { onSuccess: closeSidePanel }
@@ -174,8 +178,7 @@ const AddSource = (): ReactElement => {
       }: FormikContextType<SourceValues>) => {
         return (
           <>
-            {/*TODO: uncomment when name field is available*/}
-            {/*<FormikField label={Labels.Name} name="name" required type="text" />*/}
+            <FormikField label={Labels.Name} name="name" required type="text" />
             <FormikField
               label={Labels.Url}
               name="url"

--- a/src/app/settings/views/Images/Sources/components/DeleteSource/DeleteSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/DeleteSource/DeleteSource.tsx
@@ -47,10 +47,9 @@ const DeleteSource = ({ id }: DeleteSourceProps): ReactElement => {
             errors={deleteSource.error}
             initialValues={{}}
             message={
-              // TODO: add actual source name
               <>
-                Are you sure you want to remove <strong>Source</strong> (
-                {source.data.url})?
+                Are you sure you want to remove{" "}
+                <strong>{source.data.name}</strong> ({source.data.url})?
               </>
             }
             modelType="custom source"

--- a/src/app/settings/views/Images/Sources/components/DisableSource/DisableSource.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/DisableSource/DisableSource.test.tsx
@@ -1,0 +1,65 @@
+import { expect, it } from "vitest";
+
+import DisableSource from "@/app/settings/views/Images/Sources/components/DisableSource/DisableSource";
+import { imageSourceFactory } from "@/testing/factories";
+import { imageSourceResolvers } from "@/testing/resolvers/imageSources";
+import {
+  userEvent,
+  renderWithProviders,
+  screen,
+  waitForLoading,
+  waitFor,
+  setupMockServer,
+  mockSidePanel,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  imageSourceResolvers.fetchImageSource.handler(),
+  imageSourceResolvers.getImageSource.handler(
+    imageSourceFactory.build({
+      id: 1,
+      enabled: true,
+    })
+  ),
+  imageSourceResolvers.updateImageSource.handler()
+);
+const { mockClose } = await mockSidePanel();
+
+describe("DisableSource", () => {
+  it("calls closeForm on cancel click", async () => {
+    renderWithProviders(<DisableSource id={1} />);
+    await waitForLoading();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("calls update source on save click", async () => {
+    renderWithProviders(<DisableSource id={1} />);
+    await waitForLoading();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Disable source" })
+    );
+    await waitFor(() => {
+      expect(imageSourceResolvers.updateImageSource.resolved).toBeTruthy();
+    });
+  });
+
+  it("displays error messages when update source fails", async () => {
+    mockServer.use(
+      imageSourceResolvers.updateImageSource.error({
+        code: 400,
+        message: "Uh oh!",
+      })
+    );
+    renderWithProviders(<DisableSource id={1} />);
+    await waitForLoading();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Disable source" })
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Uh oh!/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/settings/views/Images/Sources/components/DisableSource/DisableSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/DisableSource/DisableSource.tsx
@@ -38,10 +38,9 @@ const DisableSource = ({ id }: DisableSourceProps): ReactElement => {
           errors={disableSource.error}
           initialValues={{}}
           message={
-            // TODO: add actual source name
             <>
-              Are you sure you want to disable <strong>Source</strong> (
-              {source.data.url})?
+              Are you sure you want to disable{" "}
+              <strong>{source.data.name}</strong> ({source.data.url})?
             </>
           }
           modelType="default source"

--- a/src/app/settings/views/Images/Sources/components/DisableSource/DisableSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/DisableSource/DisableSource.tsx
@@ -6,8 +6,8 @@ import {
 } from "@canonical/react-components";
 
 import {
-  useDisableImageSource,
   useGetImageSource,
+  useUpdateImageSource,
 } from "@/app/api/query/imageSources";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
@@ -22,7 +22,7 @@ const DisableSource = ({ id }: DisableSourceProps): ReactElement => {
   const source = useGetImageSource({ path: { boot_source_id: id } }, true);
 
   const eTag = source.data?.headers?.get("ETag");
-  const disableSource = useDisableImageSource();
+  const disableSource = useUpdateImageSource();
 
   return (
     <>
@@ -49,6 +49,16 @@ const DisableSource = ({ id }: DisableSourceProps): ReactElement => {
             disableSource.mutate({
               headers: { ETag: eTag },
               path: { boot_source_id: id },
+              body: {
+                name: source.data.name,
+                url: source.data.url,
+                keyring_filename: source.data.keyring_filename,
+                keyring_data: source.data.keyring_data,
+                skip_keyring_verification:
+                  source.data.skip_keyring_verification,
+                priority: source.data.priority,
+                enabled: false,
+              },
             });
           }}
           onSuccess={closeSidePanel}

--- a/src/app/settings/views/Images/Sources/components/EditSource/EditSource.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/EditSource/EditSource.test.tsx
@@ -19,6 +19,7 @@ const mockServer = setupMockServer(
   imageSourceResolvers.getImageSource.handler(
     imageSourceFactory.build({
       id: 1,
+      name: "Custom",
       url: "http://custom.image.source/stable/",
       keyring_filename: "/custom/keyring/file.gpg",
       keyring_data: "aabbccdd",

--- a/src/app/settings/views/Images/Sources/components/EditSource/EditSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/EditSource/EditSource.tsx
@@ -51,6 +51,7 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
 
   const initialValues = useMemo<SourceValues>(
     () => ({
+      name: source.data?.name ?? "",
       url: source.data?.url ?? "",
       keyring_type: source.data
         ? getInitialKeyringType(source.data)
@@ -59,6 +60,7 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
       keyring_data: source.data?.keyring_data ?? "",
       skip_keyring_verification: source.data?.skip_keyring_verification,
       priority: source.data?.priority ?? 10,
+      enabled: source.data?.enabled ?? true,
     }),
     [source.data]
   );
@@ -146,6 +148,8 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
                 headers: { ETag: eTag },
                 path: { boot_source_id: id },
                 body: {
+                  name: values.name,
+                  url: values.url,
                   keyring_filename:
                     values.keyring_type === "keyring_filename"
                       ? values.keyring_filename
@@ -159,6 +163,7 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
                       ? true
                       : undefined,
                   priority: values.priority,
+                  enabled: values.enabled,
                 },
               },
               { onSuccess: closeSidePanel }
@@ -186,13 +191,12 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
               <>
                 {!isDefault && (
                   <>
-                    {/*TODO: uncomment when name field is available*/}
-                    {/*<FormikField*/}
-                    {/*  label={Labels.Name}*/}
-                    {/*  name="name"*/}
-                    {/*  required*/}
-                    {/*  type="text"*/}
-                    {/*/>*/}
+                    <FormikField
+                      label={Labels.Name}
+                      name="name"
+                      required
+                      type="text"
+                    />
                     <FormikField
                       aria-label={Labels.Url}
                       disabled

--- a/src/app/settings/views/Images/Sources/components/EnableSource/EnableSource.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/EnableSource/EnableSource.test.tsx
@@ -1,0 +1,65 @@
+import { expect, it } from "vitest";
+
+import EnableSource from "@/app/settings/views/Images/Sources/components/EnableSource/EnableSource";
+import { imageSourceFactory } from "@/testing/factories";
+import { imageSourceResolvers } from "@/testing/resolvers/imageSources";
+import {
+  userEvent,
+  renderWithProviders,
+  screen,
+  waitForLoading,
+  waitFor,
+  setupMockServer,
+  mockSidePanel,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  imageSourceResolvers.fetchImageSource.handler(),
+  imageSourceResolvers.getImageSource.handler(
+    imageSourceFactory.build({
+      id: 1,
+      enabled: false,
+    })
+  ),
+  imageSourceResolvers.updateImageSource.handler()
+);
+const { mockClose } = await mockSidePanel();
+
+describe("EnableSource", () => {
+  it("calls closeForm on cancel click", async () => {
+    renderWithProviders(<EnableSource id={1} />);
+    await waitForLoading();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("calls update source on save click", async () => {
+    renderWithProviders(<EnableSource id={1} />);
+    await waitForLoading();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Enable source" })
+    );
+    await waitFor(() => {
+      expect(imageSourceResolvers.updateImageSource.resolved).toBeTruthy();
+    });
+  });
+
+  it("displays error messages when update source fails", async () => {
+    mockServer.use(
+      imageSourceResolvers.updateImageSource.error({
+        code: 400,
+        message: "Uh oh!",
+      })
+    );
+    renderWithProviders(<EnableSource id={1} />);
+    await waitForLoading();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Enable source" })
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Uh oh!/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/settings/views/Images/Sources/components/EnableSource/EnableSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/EnableSource/EnableSource.tsx
@@ -6,8 +6,8 @@ import {
 } from "@canonical/react-components";
 
 import {
-  useEnableImageSource,
   useGetImageSource,
+  useUpdateImageSource,
 } from "@/app/api/query/imageSources";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
@@ -22,7 +22,7 @@ const EnableSource = ({ id }: EnableSourceProps): ReactElement => {
   const source = useGetImageSource({ path: { boot_source_id: id } }, true);
 
   const eTag = source.data?.headers?.get("ETag");
-  const enableSource = useEnableImageSource();
+  const enableSource = useUpdateImageSource();
 
   return (
     <>
@@ -49,6 +49,16 @@ const EnableSource = ({ id }: EnableSourceProps): ReactElement => {
             enableSource.mutate({
               headers: { ETag: eTag },
               path: { boot_source_id: id },
+              body: {
+                name: source.data.name,
+                url: source.data.url,
+                keyring_filename: source.data.keyring_filename,
+                keyring_data: source.data.keyring_data,
+                skip_keyring_verification:
+                  source.data.skip_keyring_verification,
+                priority: source.data.priority,
+                enabled: true,
+              },
             });
           }}
           onSuccess={closeSidePanel}

--- a/src/app/settings/views/Images/Sources/components/EnableSource/EnableSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/EnableSource/EnableSource.tsx
@@ -38,9 +38,9 @@ const EnableSource = ({ id }: EnableSourceProps): ReactElement => {
           errors={enableSource.error}
           initialValues={{}}
           message={
-            // TODO: add actual source name
             <>
-              <strong>Source</strong> will now be used to download images.
+              <strong>{source.data.name}</strong> will now be used to download
+              images.
             </>
           }
           modelType="default source"

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
@@ -81,9 +81,10 @@ describe("SourcesTable", () => {
       mockServer.use(
         imageSourceResolvers.listImageSources.handler({
           items: [
-            factory.imageSourceFactory.build({ id: 1 }),
+            factory.imageSourceFactory.build({ id: 1, enabled: true }),
+            factory.imageSourceFactory.build({ id: 2, enabled: false }),
             factory.imageSourceFactory.build({
-              id: 2,
+              id: 3,
               url: "http://custom.image.source/stable/",
             }),
           ],
@@ -97,9 +98,9 @@ describe("SourcesTable", () => {
       const rowActions = screen.getAllByRole("button", {
         name: "Toggle menu",
       });
-      expect(rowActions.length).toBe(2);
+      expect(rowActions.length).toBe(3);
 
-      // Default source
+      // Default source (enabled)
       await userEvent.click(rowActions[0]);
       expect(
         screen.getByRole("button", { name: "Edit source..." })
@@ -107,17 +108,44 @@ describe("SourcesTable", () => {
       expect(
         screen.queryByRole("button", { name: "Delete source..." })
       ).not.toBeInTheDocument();
-      // TODO: add enable/disable checks when backend is ready
+      expect(
+        screen.queryByRole("button", { name: "Enable source..." })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Disable source..." })
+      ).toBeInTheDocument();
       await userEvent.click(rowActions[0]);
 
-      // Custom source
+      // Default source (disabled)
       await userEvent.click(rowActions[1]);
+      expect(
+        screen.getByRole("button", { name: "Edit source..." })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Delete source..." })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Enable source..." })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Disable source..." })
+      ).not.toBeInTheDocument();
+      await userEvent.click(rowActions[1]);
+
+      // Custom source
+      await userEvent.click(rowActions[2]);
       expect(
         screen.getByRole("button", { name: "Edit source..." })
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Delete source..." })
       ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Enable source..." })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Disable source..." })
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/_index.scss
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/_index.scss
@@ -1,3 +1,9 @@
+@import 'vanilla-framework';
+
+@include vf-base;
+
+@include vf-p-icons;
+
 .p-generic-table.sources-table {
   tr {
     .name {
@@ -18,4 +24,33 @@
       width: 20%;
     }
   }
+
+  tr:has(.disabled-source-tooltip) {
+    td {
+      color: var(--vf-color-text-muted);
+
+      &:has(.disabled-source-tooltip) {
+        position: relative;
+        overflow: visible;
+      }
+    }
+
+    .disabled-source-tooltip {
+      position: absolute;
+      left: -23px;
+    }
+
+    .p-icon--help {
+      @include vf-themed-icon($light-value: vf-icon-help-url($colors--light-theme--text-muted), $dark-value: vf-icon-help-url($colors--dark-theme--text-muted));
+    }
+
+    .p-icon--success-grey {
+      @include vf-themed-icon($light-value: vf-icon-success-grey-url($colors--light-theme--text-muted), $dark-value: vf-icon-success-grey-url($colors--dark-theme--text-muted));
+    }
+
+    .p-icon--error-grey {
+      @include vf-themed-icon($light-value: vf-icon-error-grey-url($colors--light-theme--text-muted), $dark-value: vf-icon-error-grey-url($colors--dark-theme--text-muted));
+    }
+  }
 }
+

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -65,7 +65,7 @@ const useSourcesTableColumns = ({
           header: "Name",
           cell: ({
             row: {
-              original: { type, url },
+              original: { type, url, name },
             },
           }: {
             row: Row<ImageSource>;
@@ -75,8 +75,7 @@ const useSourcesTableColumns = ({
                 ? "MAAS Stable"
                 : "MAAS Candidate";
             }
-            // TODO: implement the proper name return when available
-            return "—";
+            return name;
           },
         },
         {

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -9,7 +9,9 @@ import { MAAS_IO_URLS } from "@/app/images/constants";
 import { BootResourceSourceType } from "@/app/images/types";
 import type { ImageSource } from "@/app/settings/views/Images/Sources/Sources";
 import DeleteSource from "@/app/settings/views/Images/Sources/components/DeleteSource";
+import DisableSource from "@/app/settings/views/Images/Sources/components/DisableSource";
 import EditSource from "@/app/settings/views/Images/Sources/components/EditSource";
+import EnableSource from "@/app/settings/views/Images/Sources/components/EnableSource";
 
 type SourcesColumnDef = ColumnDef<ImageSource, Partial<ImageSource>>;
 
@@ -57,7 +59,6 @@ const useSourcesTableColumns = ({
             );
           },
         },
-        // TODO: add the disabled source styling and tooltip
         {
           id: "name",
           accessorKey: "name",
@@ -65,15 +66,28 @@ const useSourcesTableColumns = ({
           header: "Name",
           cell: ({
             row: {
-              original: { type, url, name },
+              original: { type, url, name, enabled },
             },
           }: {
             row: Row<ImageSource>;
           }) => {
             if (type === BootResourceSourceType.MAAS_IO) {
-              return new RegExp(MAAS_IO_URLS.stable).test(url)
+              const label = new RegExp(MAAS_IO_URLS.stable).test(url)
                 ? "MAAS Stable"
                 : "MAAS Candidate";
+              return (
+                <>
+                  {!enabled && (
+                    <Tooltip
+                      className="disabled-source-tooltip"
+                      message="This default source is disabled."
+                    >
+                      <Icon name="help" />
+                    </Tooltip>
+                  )}
+                  {label}
+                </>
+              );
             }
             return name;
           },
@@ -143,38 +157,38 @@ const useSourcesTableColumns = ({
                       });
                     },
                   },
-                  original.type === BootResourceSourceType.CUSTOM && {
-                    children: "Delete source...",
-                    onClick: () => {
-                      openSidePanel({
-                        component: DeleteSource,
-                        title: "Delete custom source",
-                        props: { id: original.id },
-                      });
-                    },
-                  },
-                  // TODO: insert enable/disable items for type === MAAS_IO when backend is ready
-                  // original.enabled
-                  //   ? {
-                  //       children: "Disable source...",
-                  //       onClick: () => {
-                  //         openSidePanel({
-                  //           component: DisableSource,
-                  //           title: "Disable default source",
-                  //           props: { id: original.id },
-                  //         });
-                  //       },
-                  //     }
-                  //   : {
-                  //       children: "Enable source...",
-                  //       onClick: () => {
-                  //         openSidePanel({
-                  //           component: EnableSource,
-                  //           title: "Enable default source",
-                  //           props: { id: original.id },
-                  //         });
-                  //       },
-                  //     },
+                  original.type === BootResourceSourceType.CUSTOM
+                    ? {
+                        children: "Delete source...",
+                        onClick: () => {
+                          openSidePanel({
+                            component: DeleteSource,
+                            title: "Delete custom source",
+                            props: { id: original.id },
+                          });
+                        },
+                      }
+                    : original.enabled
+                      ? {
+                          children: "Disable source...",
+                          onClick: () => {
+                            openSidePanel({
+                              component: DisableSource,
+                              title: "Disable default source",
+                              props: { id: original.id },
+                            });
+                          },
+                        }
+                      : {
+                          children: "Enable source...",
+                          onClick: () => {
+                            openSidePanel({
+                              component: EnableSource,
+                              title: "Enable default source",
+                              props: { id: original.id },
+                            });
+                          },
+                        },
                 ]}
                 toggleAppearance="base"
                 toggleClassName="row-menu-toggle u-no-margin--bottom"

--- a/src/testing/factories/imageSource.ts
+++ b/src/testing/factories/imageSource.ts
@@ -5,10 +5,12 @@ import type { BootSourceResponse } from "@/app/apiclient";
 export const imageSourceFactory = Factory.define<BootSourceResponse>(
   ({ sequence }) => ({
     id: sequence,
+    name: "MAAS Stable",
     url: "http://images.maas.io/ephemeral-v3/stable/",
     keyring_filename: "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg",
     keyring_data: "aabbccdd",
     priority: sequence,
     skip_keyring_verification: false,
+    enabled: true,
   })
 );


### PR DESCRIPTION
## Done

- Added source name fields and table column
- Added source enable/disable row action
- Added disabled defalult source styling
- Added enable/disable tests
- Removed TODOs and placeholders

## QA steps

- [x] [Create a new MAAS instance](https://github.com/canonical/maas-ui/blob/main/docs/RUNNING_MAAS.md)
- [x] Navigate to /settings
- [x] Verify there is a "Sources" view
- [x] Verify there are 2 default sources available (MAAS Candidate & MAAS Stable)
- [x] Verify MAAS Candidate is disabled, and the styling matches the [designs](https://www.figma.com/design/jgJ5gRgYVkmigZDoXTRhhB/Multiple-image-sources---MAAS?node-id=0-1)
- [x] Verify the disabled row has "Enable source..." as a row action, and no "Delete source"...
- [x] Click the action
- [x] Verify the correct form opens and matches the designs
- [x] Submit the form
- [x] Verify MAAS Candidate is now enabled
- [x] Verify the enabled sources have "Disable source..." as a row action
- [x] Click the action
- [x] Verify the correct form opens and matches the designs
- [x] Submit the form
- [x] Verify MAAS Candidate is now disabled
- [x] Add a custom source
NOTE: if you don't have a custom source available, use the API directly to create one in order to bypass the validation requirement
- [x] Verify the custom source is grouped correctly
- [x] Verify it has "Edit source..." and "Delete source..." as its row actions, and no enable/disable

## Fixes

Resolves [MAASENG-6314](https://warthogs.atlassian.net/browse/MAASENG-6314)

[MAASENG-6314]: https://warthogs.atlassian.net/browse/MAASENG-6314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ