### PR TITLE
fix(login): invalidate me:statistics query key when finishing intro

### DIFF
--- a/src/app/api/query/auth.ts
+++ b/src/app/api/query/auth.ts
@@ -308,9 +308,14 @@ export const useCompleteIntro = (
       CompleteIntroData
     >(mutationOptions, completeIntro),
     onSuccess: () => {
-      return queryClient.invalidateQueries({
-        queryKey: getUserInfoQueryKey(),
-      });
+      return Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: getUserInfoQueryKey(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: getMeStatisticsQueryKey(),
+        }),
+      ]);
     },
   });
 };


### PR DESCRIPTION
## Done

- Fixes the user-intro screen bug where, after clicking "Finish setup", users would still be the stuck on the intro screen

## QA steps
Use a local MAAS instance, because the demo instance hasn't been updated recently
### Preconditions
- Log in as an admin user
- From the settings page, create a new user, say `user1`
- From the groups settings, add `user1` to the `Administrators` group (just to prevent any permission issues later on)
- Log out and perform a hard refresh (`Shift` + Refresh or open an incognito tab)

- [x] Log in as `user1`
- [x] You should see the user intro screen, asking you to add SSH keys. Choose one of the providers and enter your username (e.g. Launchpad > `nehjoshi5`)
- [x] Import the key
- [x] Click the "Finish Setup" button on the bottom right
- [x] Observe that you are redirected to the machines page or any other protected MAAS route, and you're **not** stuck on the intro page
