### PR TITLE
fix: candid/rbac integration for 3.8

### DIFF
--- a/src/app/api/auth-interceptor.test.ts
+++ b/src/app/api/auth-interceptor.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { COOKIE_NAMES } from "../utils/cookies";
 
-import { configureAuthInterceptor } from "./auth-interceptor";
+import {
+  checkExternalSessionExpired,
+  configureAuthInterceptor,
+} from "./auth-interceptor";
 
 import { client } from "@/app/apiclient/client.gen";
+import { statusActions } from "@/app/store/status";
 import { getCookie } from "@/app/utils";
+import { store } from "@/redux-store";
 
 vi.mock("@/app/apiclient/client.gen", () => ({
   client: {
@@ -13,7 +18,17 @@ vi.mock("@/app/apiclient/client.gen", () => ({
       request: {
         use: vi.fn(),
       },
+      response: {
+        use: vi.fn(),
+      },
     },
+  },
+}));
+
+vi.mock("@/redux-store", () => ({
+  store: {
+    dispatch: vi.fn(),
+    getState: vi.fn(),
   },
 }));
 
@@ -58,5 +73,88 @@ describe("configureAuthInterceptor", () => {
     const result = await interceptor(request, { url: "" });
 
     expect(result.headers.get("Authorization")).toBeNull();
+  });
+});
+
+describe("checkExternalSessionExpired", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("expires the external session on a discharge required 401 when authenticated", async () => {
+    vi.mocked(store.getState).mockReturnValue({
+      status: { authenticated: true },
+    } as ReturnType<typeof store.getState>);
+
+    checkExternalSessionExpired();
+
+    const interceptor = vi.mocked(client.interceptors.response.use).mock
+      .calls[0][0];
+    const response = new Response(
+      JSON.stringify({ Code: "macaroon discharge required" }),
+      { status: 401 }
+    );
+
+    const result = await interceptor(
+      response,
+      new Request("http://example.com/MAAS/a/v3/users/me"),
+      { url: "/MAAS/a/v3/users/me" }
+    );
+
+    expect(result).toBe(response);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      statusActions.externalSessionExpired()
+    );
+  });
+
+  it("ignores discharge required startup 401 responses when unauthenticated", async () => {
+    vi.mocked(store.getState).mockReturnValue({
+      status: { authenticated: false },
+    } as ReturnType<typeof store.getState>);
+
+    checkExternalSessionExpired();
+
+    const interceptor = vi.mocked(client.interceptors.response.use).mock
+      .calls[0][0];
+    const response = new Response(
+      JSON.stringify({ Code: "macaroon discharge required" }),
+      { status: 401 }
+    );
+
+    const result = await interceptor(
+      response,
+      new Request("http://example.com/MAAS/a/v3/users/me"),
+      { url: "/MAAS/a/v3/users/me" }
+    );
+
+    expect(result).toBe(response);
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      statusActions.externalSessionExpired()
+    );
+  });
+
+  it("ignores non-discharge 401 responses when authenticated", async () => {
+    vi.mocked(store.getState).mockReturnValue({
+      status: { authenticated: true },
+    } as ReturnType<typeof store.getState>);
+
+    checkExternalSessionExpired();
+
+    const interceptor = vi.mocked(client.interceptors.response.use).mock
+      .calls[0][0];
+    const response = new Response(JSON.stringify({ kind: "Error" }), {
+      status: 401,
+    });
+
+    const result = await interceptor(
+      response,
+      new Request("http://example.com/MAAS/a/v3/users/me"),
+      { url: "/MAAS/a/v3/users/me" }
+    );
+
+    expect(result).toBe(response);
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      statusActions.externalSessionExpired()
+    );
   });
 });

--- a/src/app/api/auth-interceptor.ts
+++ b/src/app/api/auth-interceptor.ts
@@ -1,7 +1,11 @@
 import { COOKIE_NAMES } from "../utils/cookies";
 
 import { client } from "@/app/apiclient/client.gen";
+import { statusActions } from "@/app/store/status";
 import { getCookie } from "@/app/utils";
+import { store } from "@/redux-store";
+
+const MACAROON_DISCHARGE_REQUIRED = "macaroon discharge required";
 
 /**
  * Configures the API client to automatically include Authorization header
@@ -16,5 +20,28 @@ export const configureAuthInterceptor = () => {
     }
 
     return request;
+  });
+};
+
+/**
+ * Checks if the response for an API call is a discharge required 401 and, if
+ * the user is authenticated, dispatches an externalSessionExpired.
+ * TODO [candid/rbac] Delete this when we remove support for candid/rbac
+ */
+export const checkExternalSessionExpired = () => {
+  client.interceptors.response.use(async (response) => {
+    const authenticated = store.getState().status.authenticated;
+    const responseBody = await response
+      .clone()
+      .json()
+      .catch(() => null);
+    const dischargeRequired =
+      responseBody?.Code === MACAROON_DISCHARGE_REQUIRED;
+
+    if (response.status === 401 && dischargeRequired && authenticated) {
+      store.dispatch(statusActions.externalSessionExpired());
+    }
+
+    return response;
   });
 };

--- a/src/app/login/Login/Login.test.tsx
+++ b/src/app/login/Login/Login.test.tsx
@@ -53,6 +53,26 @@ describe("Login", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not restart external login when already authenticated", async () => {
+    state.status.authenticated = true;
+    state.status.externalAuthURL = "http://login.example.com";
+
+    const { router, store } = renderWithProviders(<Login />, {
+      initialEntries: ["/login"],
+      state,
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/machines");
+    });
+
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === statusActions.externalLogin().type)
+    ).toBe(false);
+  });
+
   it("hides the password field when a username has not been entered", async () => {
     renderWithProviders(<Login />, { initialEntries: ["/login"], state });
 

--- a/src/app/login/Login/Login.test.tsx
+++ b/src/app/login/Login/Login.test.tsx
@@ -1,6 +1,7 @@
 import Login, { Labels } from "./Login";
 
 import type { RootState } from "@/app/store/root/types";
+import { statusActions } from "@/app/store/status";
 import * as factory from "@/testing/factories";
 import { authResolvers } from "@/testing/resolvers/auth";
 import {

--- a/src/app/login/Login/Login.tsx
+++ b/src/app/login/Login/Login.tsx
@@ -59,6 +59,7 @@ export const Login = (): ReactElement => {
   const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const externalLoginURL = useSelector(statusSelectors.externalLoginURL);
   const authenticationError = useSelector(statusSelectors.authenticationError);
+  const authenticated = useSelector(statusSelectors.authenticated);
   const noUsers = useSelector(statusSelectors.noUsers);
 
   const [searchParams] = useSearchParams();
@@ -94,18 +95,18 @@ export const Login = (): ReactElement => {
   }, [navigate, redirect]);
 
   useEffect(() => {
-    if (authenticate.isSuccess) {
+    if (authenticate.isSuccess || authenticated) {
       handleRedirect();
     }
-  }, [authenticate.isSuccess, handleRedirect]);
+  }, [authenticate.isSuccess, authenticated, handleRedirect]);
 
   useWindowTitle("Login");
 
   useEffect(() => {
-    if (externalAuthURL) {
+    if (externalAuthURL && !authenticated) {
       dispatch(statusActions.externalLogin());
     }
-  }, [dispatch, externalAuthURL]);
+  }, [authenticated, dispatch, externalAuthURL]);
 
   const handleSubmit = (values: LoginValues) => {
     authenticate.mutate({

--- a/src/app/store/status/reducers.test.ts
+++ b/src/app/store/status/reducers.test.ts
@@ -307,6 +307,31 @@ describe("status", () => {
     );
   });
 
+  it("should correctly reduce status/externalSessionExpired", () => {
+    expect(
+      reducers(
+        factory.statusState({
+          authenticated: true,
+          authenticating: true,
+          authenticationError: null,
+          connected: true,
+          connecting: true,
+        }),
+        {
+          type: "status/externalSessionExpired",
+        }
+      )
+    ).toStrictEqual(
+      factory.statusState({
+        authenticated: false,
+        authenticating: false,
+        authenticationError: "Session expired",
+        connected: false,
+        connecting: false,
+      })
+    );
+  });
+
   it("should correctly reduce status/checkAuthenticatedError", () => {
     expect(
       reducers(

--- a/src/app/store/status/slice.ts
+++ b/src/app/store/status/slice.ts
@@ -84,6 +84,14 @@ const statusSlice = createSlice({
       state.authenticationError = action.payload;
       state.authenticating = false;
     },
+    // TODO [candid/rbac] Delete this when we remove support for candid/rbac
+    externalSessionExpired: (state: StatusState) => {
+      state.authenticated = false;
+      state.authenticating = false;
+      state.authenticationError = "Session expired";
+      state.connected = false;
+      state.connecting = false;
+    },
     logout: {
       prepare: () => ({
         payload: null,

--- a/src/bakery.ts
+++ b/src/bakery.ts
@@ -8,7 +8,6 @@ import { statusActions } from "@/app/store/status";
 const visit = (error: { Info: { VisitURL: string } }) => {
   const url = error.Info.VisitURL;
   store.dispatch(statusActions.externalLoginURL({ url }));
-  window.open(url, "_blank");
 };
 
 const bakery = new Bakery({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,10 @@ import { RouterProvider } from "react-router";
 
 import packageInfo from "../package.json";
 
-import { configureAuthInterceptor } from "./app/api/auth-interceptor";
+import {
+  checkExternalSessionExpired,
+  configureAuthInterceptor,
+} from "./app/api/auth-interceptor";
 import { createQueryClient } from "./app/api/query-client";
 import useDarkMode from "./app/base/hooks/useDarkMode/useDarkMode";
 import { store } from "./redux-store";
@@ -19,6 +22,8 @@ import { router } from "@/router";
 import "./scss/index.scss";
 
 configureAuthInterceptor();
+// TODO [candid/rbac] Delete this when we remove support for candid/rbac
+checkExternalSessionExpired();
 
 export const Root = () => {
   const queryClient = createQueryClient();


### PR DESCRIPTION
Candid/RBAC integration for 3.8 in the UI was broken: logging in resulted in an endless loop.
Furthermore, we cannot rely anymore on the sessionid for the v3 API calls, so we have to use the macaroons (which are set server-side by MAAS, see https://github.com/canonical/maas/pull/279). When this expires, we have to make sure the user is logged out and it is redirected to the login page.

## Done

- The login page uses the `authenticated` redux state
- The external login flow is now only started when `externalAuthURL` exists AND the user is not already authenticated
- Added a dedicated `externalSessionExpired` status action for expired/invalid Candid/RBAC macaroon sessions.
- Added a separate response interceptor `checkExternalSessionExpired`, that logs the user out whenever the macaroon is not valid anymore and the redux state says the user is authenticated

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- Setup a MAAS environment with candid/rbac integration enabled (I can provide you a script)
- Go to the login page
- Login through Candid
- Make sure you're redirected and no loop happen

To test the session expired:
- Change the `MACAROON_LIFESPAN` variable in MAAS, set it to 1-2 minutes
- Login through Candid
- Open the dev tools to see the network requests
- Wait until a 401 request to the v3 API is made (This will happen as we constantly fetch the notifications for example)
- See that you are redirected to the login page
- NOTE: in this case you will be automatically re-logged in as the Candid's session is still valid (has a lifespan of 1 day). Just make sure to see that the redirect happens, or
- Once you are logged in, clear the local storage for:
  - CANDID url, usually http://IP:8081
  - identity (Candid Identity)
  - RBAC url, usually http://IP:5000/auth (should not be necessary, but just in case)

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6532](https://warthogs.atlassian.net/browse/MAASENG-6532)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-6532]: https://warthogs.atlassian.net/browse/MAASENG-6532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ