### PR TITLE
fix(images): fallback image label in case release title is empty

### DIFF
--- a/src/app/store/general/selectors/osInfo.test.ts
+++ b/src/app/store/general/selectors/osInfo.test.ts
@@ -209,6 +209,21 @@ describe("osInfo selectors", () => {
       state.general.osInfo.data = null;
       expect(osInfo.getOsReleases(state, "ubuntu")).toEqual([]);
     });
+
+    it("falls back to the release key when the label is an empty string", () => {
+      const stateWithEmptyLabel = factory.rootState({
+        general: factory.generalState({
+          osInfo: factory.osInfoState({
+            data: factory.osInfo({
+              releases: [["ubuntu/jammy", ""]],
+            }),
+          }),
+        }),
+      });
+      expect(osInfo.getOsReleases(stateWithEmptyLabel, "ubuntu")).toEqual([
+        { value: "jammy", label: "ubuntu/jammy" },
+      ]);
+    });
   });
 
   describe("getAllOsReleases", () => {
@@ -254,6 +269,33 @@ describe("osInfo selectors", () => {
     it("handles no data", () => {
       state.general.osInfo.data = null;
       expect(osInfo.getAllOsReleases(state)).toEqual({});
+    });
+
+    it("falls back to the release key when a label is an empty string", () => {
+      const stateWithEmptyLabel = factory.rootState({
+        general: factory.generalState({
+          osInfo: factory.osInfoState({
+            loading: false,
+            loaded: true,
+            data: factory.osInfo({
+              osystems: [["ubuntu", "Ubuntu"]],
+              releases: [
+                ["ubuntu/focal", ""],
+                ["ubuntu/jammy", "Ubuntu 22.04 LTS 'Jammy Jellyfish'"],
+              ],
+            }),
+          }),
+        }),
+      });
+      expect(osInfo.getAllOsReleases(stateWithEmptyLabel)).toEqual({
+        ubuntu: [
+          { value: "focal", label: "ubuntu/focal" },
+          {
+            value: "jammy",
+            label: "Ubuntu 22.04 LTS 'Jammy Jellyfish'",
+          },
+        ],
+      });
     });
   });
 

--- a/src/app/store/general/selectors/osInfo.ts
+++ b/src/app/store/general/selectors/osInfo.ts
@@ -79,7 +79,7 @@ const getAllUbuntuKernelOptions = createSelector(
 
 /**
  * Returns OS releases
- * @param {OSInfo} data - The osinfo data.
+ * @param {OSInfo} allOsInfo - The osinfo data.
  * @param {String} os - the OS to get releases of
  * @returns {OSInfoOption[]} - the available OS releases
  */
@@ -96,10 +96,12 @@ const _getOsReleases = (
         release[0].includes(os)
       );
     }
-    osReleases = releases.map((release: OSInfoRelease) => ({
-      value: release[0].split("/")[1],
-      label: release[1],
-    }));
+    osReleases = releases.map((release: OSInfoRelease) => {
+      const releaseKey = release[0]; // e.g. "ubuntu/precise"
+      const value = releaseKey.split("/")[1];
+      const label = release[1] || releaseKey;
+      return { value, label };
+    });
   }
 
   return osReleases;


### PR DESCRIPTION
## Done

- Added fallback image release label for the machine deploy form
- Added fallback tests

## QA steps
- [x] Set up a 3.5 MAAS following the [LXD setup instructions](https://github.com/canonical/maas-ui/blob/main/docs/RUNNING_MAAS.md)
- [x] Create a dummy custom image
```bash
sudo bash -c 'dd if=/dev/zero bs=1M count=1 | gzip > /root/dummy.img.gz'
```
- [x] Then make it readable by your user
```bash
sudo cp /root/dummy.img.gz /home/ubuntu/dummy.img.gz
sudo chown ubuntu:ubuntu /home/ubuntu/dummy.img.gz
```
- [x] Get your API key
```bash
sudo maas apikey --username <profile-name>
```
- [x] Log in to the MAAS CLI
```bash
maas login <profile-name> http://localhost:5240/MAAS/api/2.0 <api-key>
```
- [x] Upload a custom image with no release title
```bash
maas <profile-name> boot-resources create \
  architecture=amd64/generic \
  name=custom/dummy-no-title \
  content@=/home/ubuntu/dummy.img.gz
```
- [x] Verify the image is uploaded
```bash
maas <profile-name> boot-resources read | python3 -m json.tool | grep -A 10 "dummy-no-title"
```
- [x] Navigate to /machines
- [x] Select a machine
- [x] Open the "Deploy" form from the actions menu
- [x] Select the proper OS for your uploaded titleless image
- [x] Verify the release field select options all have labels
- [x] Verify the titleless image you uploaded is displaying a fallback label

## Fixes

Resolves [MAASENG-6500](https://warthogs.atlassian.net/browse/MAASENG-6500)
Fixes [LP#2044378](https://bugs.launchpad.net/maas/+bug/2044378) 

[MAASENG-6500]: https://warthogs.atlassian.net/browse/MAASENG-6500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ