### PR TITLE
refactor(machines): MachineInstances to GenericTable MAASENG-5690

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
@@ -82,12 +82,12 @@ describe("MachineInstances", () => {
       pattern: "/machine/:id/instances",
     });
 
-    expect(screen.getByTestId("name")).toHaveTextContent("foo");
-    expect(screen.getByTestId("mac")).toHaveTextContent("00:00:9b:7c:1b:85");
-    expect(screen.getByTestId("ip")).toHaveTextContent("100.100.3.99");
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByText("00:00:9b:7c:1b:85")).toBeInTheDocument();
+    expect(screen.getByText("100.100.3.99")).toBeInTheDocument();
   });
 
-  it("displays instance with mac address correctly", () => {
+  it("displays instance with mac address correctly when there are no links", () => {
     state.machine.items = [
       factory.machineDetails({
         system_id: "abc123",
@@ -110,9 +110,8 @@ describe("MachineInstances", () => {
       pattern: "/machine/:id/instances",
     });
 
-    expect(screen.getByTestId("name")).toHaveTextContent("foo");
-    expect(screen.getByTestId("mac")).toHaveTextContent("00:00:9b:7c:1b:85");
-    expect(screen.getByTestId("ip")).toHaveTextContent("");
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByText("00:00:9b:7c:1b:85")).toBeInTheDocument();
   });
 
   it("displays multiple instances", () => {
@@ -122,27 +121,15 @@ describe("MachineInstances", () => {
         devices: [
           factory.machineDevice({
             fqdn: "foo",
-            interfaces: [
-              factory.machineInterface({
-                mac_address: "00:00:9b:7c:1b:85",
-              }),
-            ],
+            interfaces: [factory.machineInterface()],
           }),
           factory.machineDevice({
             fqdn: "bar",
-            interfaces: [
-              factory.machineInterface({
-                mac_address: "00:00:9b:7c:1b:85",
-              }),
-            ],
+            interfaces: [factory.machineInterface()],
           }),
           factory.machineDevice({
             fqdn: "baz",
-            interfaces: [
-              factory.machineInterface({
-                mac_address: "00:00:9b:7c:1b:85",
-              }),
-            ],
+            interfaces: [factory.machineInterface()],
           }),
         ],
       }),
@@ -154,7 +141,9 @@ describe("MachineInstances", () => {
       pattern: "/machine/:id/instances",
     });
 
-    expect(screen.getAllByTestId("name")).toHaveLength(3);
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByText("bar")).toBeInTheDocument();
+    expect(screen.getByText("baz")).toBeInTheDocument();
   });
 
   it("displays instances with multiple mac addresses", () => {
@@ -183,17 +172,9 @@ describe("MachineInstances", () => {
       pattern: "/machine/:id/instances",
     });
 
-    expect(screen.getAllByTestId("mac")).toHaveLength(2);
-    expect(screen.getAllByTestId("name").at(0)).toHaveTextContent("foo");
-    expect(screen.getAllByTestId("mac").at(0)).toHaveTextContent(
-      "00:00:9b:7c:1b:85"
-    );
-    expect(screen.getAllByTestId("ip").at(0)).toHaveTextContent("");
-    expect(screen.getAllByTestId("name").at(1)).toHaveTextContent("");
-    expect(screen.getAllByTestId("mac").at(1)).toHaveTextContent(
-      "00:00:9b:7c:1b:01"
-    );
-    expect(screen.getAllByTestId("ip").at(1)).toHaveTextContent("");
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByText("00:00:9b:7c:1b:85")).toBeInTheDocument();
+    expect(screen.getByText("00:00:9b:7c:1b:01")).toBeInTheDocument();
   });
 
   it("displays instances with multiple ip addresses", () => {
@@ -227,14 +208,11 @@ describe("MachineInstances", () => {
       pattern: "/machine/:id/instances",
     });
 
-    expect(screen.getAllByTestId("mac")).toHaveLength(2);
-    expect(screen.getAllByTestId("name").at(0)).toHaveTextContent("foo");
-    expect(screen.getAllByTestId("mac").at(0)).toHaveTextContent(
-      "00:00:9b:7c:1b:85"
-    );
-    expect(screen.getAllByTestId("ip").at(0)).toHaveTextContent("1.2.3.4");
-    expect(screen.getAllByTestId("name").at(1)).toHaveTextContent("");
-    expect(screen.getAllByTestId("mac").at(1)).toHaveTextContent("");
-    expect(screen.getAllByTestId("ip").at(1)).toHaveTextContent("1.2.3.5");
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    // interface row shows mac and first link's ip
+    expect(screen.getByText("00:00:9b:7c:1b:85")).toBeInTheDocument();
+    expect(screen.getByText("1.2.3.4")).toBeInTheDocument();
+    // sibling row for the second link: ip visible, mac cell empty
+    expect(screen.getByText("1.2.3.5")).toBeInTheDocument();
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
+++ b/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
@@ -1,6 +1,8 @@
+import type { ReactElement } from "react";
 import { useEffect } from "react";
 
-import { Spinner, Row, Col, MainTable } from "@canonical/react-components";
+import { GenericTable } from "@canonical/maas-react-components";
+import { Row, Col } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 
@@ -8,6 +10,9 @@ import { useWindowTitle } from "@/app/base/hooks";
 import { useGetURLId } from "@/app/base/hooks/urls";
 import type { SyncNavigateFunction } from "@/app/base/types";
 import urls from "@/app/base/urls";
+import useMachineInstancesColumns, {
+  filterCells,
+} from "@/app/machines/views/MachineDetails/MachineInstances/useMachineInstancesColumns/useMachineInstancesColumns";
 import machineSelectors from "@/app/store/machine/selectors";
 import { MachineMeta } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
@@ -18,73 +23,43 @@ import type {
   NodeDeviceRef,
 } from "@/app/store/types/node";
 
-type InterfaceRow = {
-  key: string;
-  columns: { content: React.ReactElement }[];
+import "./_index.scss";
+
+export type MachineInstance = {
+  id: string;
+  name: NodeDeviceRef["fqdn"];
+  mac: NetworkInterface["mac_address"];
+  ip: NetworkLink["ip_address"];
+  interfaceCount: number;
 };
 
-const formatRowData = (
-  name: NodeDeviceRef["fqdn"],
-  macAddress: NetworkInterface["mac_address"],
-  ipAddress: NetworkLink["ip_address"]
-): InterfaceRow => {
-  return {
-    key: name + macAddress + ipAddress,
-    columns: [
-      { content: <span data-testid="name">{name}</span> },
-      { content: <span data-testid="mac">{macAddress}</span> },
-      { content: <span data-testid="ip">{ipAddress}</span> },
-    ],
-  };
-};
-
-const generateRows = (devices: NodeDeviceRef[]) => {
-  const formattedDevices: InterfaceRow[] = [];
-
-  devices.forEach((device) => {
-    let deviceName = device.fqdn;
-    if (device.interfaces && device.interfaces.length > 0) {
-      device.interfaces.forEach((deviceInterface, deviceIndex) => {
-        // Remove device name so it is not duplicated in the table since this
-        // is another MAC address on this device.
-        if (deviceIndex > 0) {
-          deviceName = "";
-        }
-
-        let interfaceMacAddress = deviceInterface.mac_address;
-
-        if (deviceInterface.links && deviceInterface.links.length > 0) {
-          deviceInterface.links.forEach((interfaceLink, interfaceIndex) => {
-            // Remove the MAC address so it is not duplicated in the table
-            // since this is another link on this interface.
-            if (interfaceIndex > 0) {
-              interfaceMacAddress = "";
-              deviceName = "";
-            }
-
-            formattedDevices.push(
-              formatRowData(
-                deviceName,
-                interfaceMacAddress,
-                interfaceLink.ip_address
-              )
-            );
-          });
-        } else {
-          formattedDevices.push(
-            formatRowData(deviceName, interfaceMacAddress, "")
-          );
-        }
-      });
-    } else {
-      formattedDevices.push(formatRowData(deviceName, "", ""));
+const generateTableData = (devices: NodeDeviceRef[]): MachineInstance[] =>
+  devices.flatMap((device): MachineInstance[] => {
+    const interfaceCount = device.interfaces?.length ?? 0;
+    if (!interfaceCount) {
+      return [
+        { id: device.fqdn, name: device.fqdn, mac: "", ip: "", interfaceCount },
+      ];
     }
+    return device.interfaces.flatMap((iface, ifaceIndex) => [
+      {
+        id: `${device.fqdn}-${ifaceIndex}`,
+        name: device.fqdn,
+        mac: iface.mac_address,
+        ip: iface.links?.[0]?.ip_address ?? "",
+        interfaceCount,
+      },
+      ...(iface.links?.slice(1).map((link, linkIndex) => ({
+        id: `${device.fqdn}-${ifaceIndex}-${linkIndex + 1}`,
+        name: device.fqdn,
+        mac: "",
+        ip: link.ip_address ?? "",
+        interfaceCount,
+      })) ?? []),
+    ]);
   });
 
-  return formattedDevices;
-};
-
-const MachineInstances = (): React.ReactElement => {
+const MachineInstances = (): ReactElement => {
   const navigate: SyncNavigateFunction = useNavigate();
   const id = useGetURLId(MachineMeta.PK);
   const machine = useSelector((state: RootState) =>
@@ -104,28 +79,25 @@ const MachineInstances = (): React.ReactElement => {
     }
   }, [navigate, machine]);
 
-  if (!machine || !isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
-  }
+  const data =
+    machine && isMachineDetails(machine) && machine.devices.length > 0
+      ? generateTableData(machine.devices)
+      : [];
+  const columns = useMachineInstancesColumns();
 
   return (
     <Row>
       <Col size={12}>
-        <MainTable
-          aria-label="machine instances"
-          headers={[
-            {
-              content: "Name",
-            },
-            {
-              content: "MAC",
-            },
-            {
-              content: "IP Address",
-            },
-          ]}
-          paginate={50}
-          rows={generateRows(machine.devices)}
+        <GenericTable
+          aria-label="Machine instances table"
+          className="machine-instances-table"
+          columns={columns}
+          data={data}
+          filterCells={filterCells}
+          groupBy={["name"]}
+          isLoading={!machine || !isMachineDetails(machine)}
+          showChevron
+          variant="full-height"
         />
       </Col>
     </Row>

--- a/src/app/machines/views/MachineDetails/MachineInstances/_index.scss
+++ b/src/app/machines/views/MachineDetails/MachineInstances/_index.scss
@@ -1,0 +1,5 @@
+.p-generic-table.machine-instances-table {
+  .ip {
+    text-align: left !important;
+  }
+}

--- a/src/app/machines/views/MachineDetails/MachineInstances/useMachineInstancesColumns/useMachineInstancesColumns.tsx
+++ b/src/app/machines/views/MachineDetails/MachineInstances/useMachineInstancesColumns/useMachineInstancesColumns.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import type { Column, ColumnDef, Row } from "@tanstack/react-table";
+import pluralize from "pluralize";
+
+import type { MachineInstance } from "@/app/machines/views/MachineDetails/MachineInstances/MachineInstances";
+
+export type MachineInstanceColumnDef = ColumnDef<
+  MachineInstance,
+  Partial<MachineInstance>
+>;
+
+export const filterCells = (
+  row: Row<MachineInstance>,
+  column: Column<MachineInstance>
+): boolean => {
+  if (row.getIsGrouped()) return column.id === "name";
+  return row.original.interfaceCount > 0;
+};
+
+const useMachineInstancesColumns = (): MachineInstanceColumnDef[] => {
+  return useMemo(
+    () =>
+      [
+        {
+          id: "name",
+          accessorKey: "name",
+          header: "",
+          cell: ({ row }: { row: Row<MachineInstance> }) => {
+            if (!row.getIsGrouped()) {
+              return null;
+            }
+            const interfaceCount =
+              row.getLeafRows()[0]?.original.interfaceCount ?? 0;
+            return (
+              <div>
+                <strong>{row.original.name}</strong>
+                <br />
+                <small className="u-text--muted">
+                  {pluralize("interface", interfaceCount, true)}
+                </small>
+              </div>
+            );
+          },
+        },
+        {
+          id: "mac",
+          accessorKey: "mac",
+          enableSorting: false,
+          header: "MAC Address",
+        },
+        {
+          id: "ip",
+          accessorKey: "ip",
+          enableSorting: false,
+          header: "IP Address",
+        },
+      ] as MachineInstanceColumnDef[],
+    []
+  );
+};
+
+export default useMachineInstancesColumns;


### PR DESCRIPTION
## Done

- Migrate MachineInstances to GenericTable
- Replaced getByTestId tests with getByText

## QA steps

- [x] Refer to the "Notes" if you do not have access to a machine with devices
- [x] Navigate to the machine
- [x] Go to the "Instances" tab
- [x] Verify the table is readable
- [x] Verify the device interfaces are grouped by device name
- [x] Verify the interface count under device name is correct
- [x] Verify links are "subrowed" by interfaces (same MAC links are listed consecutively, and only the first one displays the MAC)

## Fixes

Resolves [MAASENG-5690](https://warthogs.atlassian.net/browse/MAASENG-5690)

## Notes

If you do not have access to a machine with interfaces, do the following:
- [x] Go to MachineHeader.tsx
- [x] Make the render of the "Instances" tab unconditional
```ts
...(isDetails && machine.devices?.length >= 1
          ? [
              {
                active: pathname.startsWith(`${urlBase}/instances`),
                component: Link,
                label: "Instances",
                to: `${urlBase}/instances`,
              },
            ]
          : []),
```
- [x] Go to MachineInstances.tsx
- [x] Add the following dummy data set
```ts
import * as factory from "@/testing/factories";

const DEV_DUMMY_DEVICES: NodeDeviceRef[] = [
  factory.machineDevice({
    fqdn: "device-alpha.maas",
    interfaces: [
      factory.machineInterface({
        mac_address: "aa:bb:cc:dd:ee:01",
        links: [factory.networkLink({ ip_address: "192.168.1.10" })],
      }),
      factory.machineInterface({
        mac_address: "aa:bb:cc:dd:ee:02",
        links: [
          factory.networkLink({ ip_address: "192.168.1.11" }),
          factory.networkLink({ ip_address: "192.168.1.12" }),
        ],
      }),
    ],
  }),
  factory.machineDevice({
    fqdn: "device-beta.maas",
    interfaces: [
      factory.machineInterface({ mac_address: "bb:cc:dd:ee:ff:01", links: [] }),
    ],
  }),
  factory.machineInterface({ fqdn: "device-gamma.maas", interfaces: [] }),
];
```
- [x] Replace the redirect and data parsing with the following:
```ts
useEffect(() => {
    if (
      machine &&
      (!isMachineDetails(machine) || machine.devices.length === -1)
    ) {
      navigate(urls.machines.machine.summary({ id: machine.system_id }), {
        replace: true,
      });
    }
  }, [navigate, machine]);

  const data =
    machine && isMachineDetails(machine) && machine.devices.length > -1
      ? generateTableData(DEV_DUMMY_DEVICES)
      : [];
```
These changes inject the dummy data for the table, and disable the forced redirect away from /instances.

[MAASENG-5690]: https://warthogs.atlassian.net/browse/MAASENG-5690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ