### PR TITLE
fix(machines): machine list loading and commissioning page failures

### DIFF
--- a/src/app/base/sagas/websockets/websockets.test.ts
+++ b/src/app/base/sagas/websockets/websockets.test.ts
@@ -560,9 +560,9 @@ describe("websocket sagas", () => {
   it("can handle a WebSocket open message", () => {
     const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
-    expect(saga.next({ type: "open" }).value).toEqual(
-      put({ type: "status/websocketConnect" })
-    );
+    // On open, resetLoaded() runs synchronously (no yield), so the saga
+    // continues to the next yield which is take(socketChannel) again.
+    expect(saga.next({ type: "open" }).value).toEqual(take(socketChannel));
   });
 
   it("can store a file context action when sending a WebSocket message", () => {

--- a/src/app/base/sagas/websockets/websockets.ts
+++ b/src/app/base/sagas/websockets/websockets.ts
@@ -213,7 +213,7 @@ export function* handleWebsocketEvent(
       }
 
       case "open": {
-        yield* put({ type: "status/websocketConnect" });
+        // Only reset the loaded cache here so the saga can re-fetch stale data.
         resetLoaded();
         break;
       }
@@ -423,7 +423,7 @@ export function* setupWebSocket({
     resetLoaded();
     const socketChannel = yield* call(watchWebsocketEvents, socketClient);
     while (true) {
-      const { cancel } = yield* race({
+      const { cancel, reopen } = yield* race({
         task: all(
           [
             call(handleWebsocketEvent, socketChannel, socketClient),
@@ -452,7 +452,16 @@ export function* setupWebSocket({
           )
         ),
         cancel: take("status/websocketDisconnect"),
+        // Handle reconnection within the saga instead of letting takeLatest
+        // cancel this instance, which would kill in-flight requests.
+        reopen: take("status/websocketConnect"),
       });
+      if (reopen) {
+        // Reconnection detected -> reset cache and loop to re-register takeEvery.
+        resetLoaded();
+        yield* put({ type: "status/websocketConnected" });
+        continue;
+      }
       if (cancel) {
         yield* put({ type: "status/websocketDisconnected" });
       }

--- a/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
@@ -41,6 +41,8 @@ describe("MachineCommissioning", () => {
     });
   });
   it("renders the spinner while script results are loading.", () => {
+    state.scriptresult.loading = true;
+    state.scriptresult.loaded = false;
     const store = mockStore(state);
     render(
       <Provider store={store}>
@@ -150,5 +152,24 @@ describe("MachineCommissioning", () => {
         .getActions()
         .filter((action) => action.type === "scriptresult/getByNodeId").length
     ).toBe(1);
+  });
+  it("renders content (not spinner) when script results are loaded but empty", () => {
+    state.nodescriptresult.items = { abc123: [] };
+    state.scriptresult.items = [];
+    state.scriptresult.loaded = true;
+    state.scriptresult.loading = false;
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Routes>
+            <Route element={<MachineCommissioning />} path="/machine/:id" />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.tsx
+++ b/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.tsx
@@ -31,6 +31,9 @@ const MachineCommissioning = (): React.ReactElement => {
   const loading = useSelector((state: RootState) =>
     scriptResultSelectors.loading(state)
   );
+  const loaded = useSelector((state: RootState) =>
+    scriptResultSelectors.loaded(state)
+  );
   const isDetails = isMachineDetails(machine);
   const previousCommissioningStatus = usePrevious(
     isDetails ? machine.commissioning_status.status : null,
@@ -62,7 +65,7 @@ const MachineCommissioning = (): React.ReactElement => {
     isDetails,
   ]);
 
-  if (isId(id) && isDetails && scriptResults?.length) {
+  if (isId(id) && isDetails && loaded) {
     return (
       <div>
         {commissioningResults?.length && commissioningResults.length > 0 ? (

--- a/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -299,4 +299,25 @@ describe("MachineTests", () => {
         .filter((action) => action.type === "scriptresult/getByNodeId").length
     ).toBe(2);
   });
+
+  it("renders content (not spinner) when script results are loaded but empty", () => {
+    state.nodescriptresult.items = { abc123: [] };
+    state.scriptresult.items = [];
+    state.scriptresult.loaded = true;
+    state.scriptresult.loading = false;
+    const store = mockStore(state);
+    renderWithMockStore(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Routes>
+            <Route element={<MachineTests />} path="/machine/:id" />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+      { store }
+    );
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -38,9 +38,6 @@ const MachineTests = (): React.ReactElement => {
     machineSelectors.getById(state, id)
   );
   const previousTestingStatus = usePrevious(machine?.testing_status, true);
-  const scriptResults = useSelector((state: RootState) =>
-    scriptResultSelectors.getByNodeId(state, id)
-  );
   const hardwareResults = useSelector((state: RootState) =>
     scriptResultSelectors.getHardwareTestingByNodeId(state, id)
   );
@@ -51,6 +48,7 @@ const MachineTests = (): React.ReactElement => {
     scriptResultSelectors.getOtherTestingByNodeId(state, id)
   );
   const loading = useSelector(scriptResultSelectors.loading);
+  const loaded = useSelector(scriptResultSelectors.loaded);
   useWindowTitle(`${machine?.fqdn || "Machine"} tests`);
   const isDetails = isMachineDetails(machine);
 
@@ -75,7 +73,7 @@ const MachineTests = (): React.ReactElement => {
     }
   }, [dispatch, previousTestingStatus, loading, machine, id]);
 
-  if (isId(id) && isDetails && scriptResults?.length) {
+  if (isId(id) && isDetails && loaded) {
     return (
       <div>
         {hardwareResults?.length && hardwareResults.length > 0

--- a/src/app/store/scriptresult/selectors.test.tsx
+++ b/src/app/store/scriptresult/selectors.test.tsx
@@ -96,7 +96,33 @@ describe("scriptResult selectors", () => {
       }),
       nodescriptresult: factory.nodeScriptResultState(),
     });
-    expect(selectors.getByNodeId(state, "abc123")).toStrictEqual(null);
+    expect(selectors.getByNodeId(state, "abc123")).toStrictEqual([]);
+  });
+
+  it("returns empty array for a node with empty result IDs", () => {
+    const state = factory.rootState({
+      scriptresult: factory.scriptResultState({
+        items: [],
+      }),
+      nodescriptresult: factory.nodeScriptResultState({
+        items: { abc123: [] },
+      }),
+    });
+    expect(selectors.getByNodeId(state, "abc123")).toStrictEqual([]);
+  });
+
+  it("returns empty array for commissioning results when node has empty result IDs", () => {
+    const state = factory.rootState({
+      scriptresult: factory.scriptResultState({
+        items: [],
+      }),
+      nodescriptresult: factory.nodeScriptResultState({
+        items: { abc123: [] },
+      }),
+    });
+    expect(selectors.getCommissioningByNodeId(state, "abc123")).toStrictEqual(
+      []
+    );
   });
 
   it("returns hardware testing script results by node id", () => {

--- a/src/app/store/scriptresult/selectors.ts
+++ b/src/app/store/scriptresult/selectors.ts
@@ -112,7 +112,7 @@ const getResult = (
   const nodeResultIds =
     nodeId in nodeScriptResult ? nodeScriptResult[nodeId] : [];
   if (!nodeResultIds.length) {
-    return null;
+    return [];
   }
   return scriptResults.filter((scriptResult) => {
     const matchesId = nodeResultIds.includes(scriptResult.id);
@@ -399,7 +399,7 @@ const getInstallationLogsByNodeId = createSelector(
     const results = getResult(nodeScriptResult, scriptResults, nodeId, [
       ScriptResultType.INSTALLATION,
     ]);
-    if (!results) {
+    if (!results?.length) {
       return null;
     }
     return results.reduce<ScriptResultData[]>((resultData, result) => {


### PR DESCRIPTION
## Done

- Fixed some potential websocket connection race conditions (they don't usually occur, but they could be problematic in an already overloaded MAAS)
- Check that script results are fully loaded before returning commissioning results
- Unable to cherry-pick commit [`dc0ff02`](https://github.com/canonical/maas-ui/commit/dc0ff02833ff1f1bf77f4a50d9208bcdbb04210c) since many things did not exist in 3.7 (like `renderWithProviders()`) 


## QA Steps
Follow the steps in the next section to set up a 3.7 instance first. Then, point your UI to the container running MAAS 3.7.
- [x] Log in to MAAS
- [x] Go to the machines page, and ensure everything loads normally
- [x] Go to any machine
- [x] Navigate through the various tabs, and ensure they load normally
- [x] Ensure you're not running into any infinite loading spinners


## Set up a 3.7 instance

- Use `lxc launch ubuntu:24.04 maas-3-7` to create a container
- Inside the container, run `sudo snap install maas --channel=3.7/stable`
- Inside the container, run `sudo snap install maas-test-db --channel=3.7`
- Run `sudo maas init region+rack --database-uri maas-test-db:///`
- Download some test data on your host machine (you can get test data from Jenkins using the `maas-sampledata-24.04-3.7-1000` job)
- Push it to the container where MAAS-3.7 is running using: 
```bash
lxc file push ./data.dump maas-3-7/home/ubuntu/maasdb.dump
```
- Run the following inside the container:
```bash
sudo cp maasdb.dump /var/snap/maas-test-db/common
sudo snap run --shell maas-test-db.psql \
     -c 'db-dump restore $SNAP_COMMON/maasdb.dump maassampledata'
```
- Edit `/var/snap/maas/current/regiond.conf` using vim/nano and change the DB name (i.e. change `maasdb` to `maassampledata`.
- Restart the maas snap
- Create an admin user using `sudo maas createadmin`
