### PR TITLE
revert(settings): Reverted default source immutability MAASENG-6566

### DIFF
--- a/src/app/settings/views/Images/Sources/components/EditSource/EditSource.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/EditSource/EditSource.test.tsx
@@ -33,16 +33,14 @@ const { mockClose } = await mockSidePanel();
 
 describe("EditSource", () => {
   it("calls closeForm on cancel click", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockClose).toHaveBeenCalled();
   });
 
   it("correctly renders edit fields for custom and default sources", async () => {
-    const { rerender } = renderWithProviders(
-      <EditSource id={1} isDefault={false} />
-    );
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     expect(
@@ -64,25 +62,26 @@ describe("EditSource", () => {
       screen.getByRole("spinbutton", { name: Labels.Priority })
     ).toHaveValue(0);
 
-    rerender(<EditSource id={1} isDefault={true} />);
-    await waitForLoading();
-
-    expect(
-      screen.queryByRole("textbox", { name: Labels.Url })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("textbox", { name: Labels.KeyringFilename })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("spinbutton", { name: Labels.Priority })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("spinbutton", { name: Labels.Priority })
-    ).toHaveValue(0);
+    // TODO: re-introduce default variance to the edit form
+    // rerender(<EditSource id={1} isDefault={true} />);
+    // await waitForLoading();
+    //
+    // expect(
+    //   screen.queryByRole("textbox", { name: Labels.Url })
+    // ).not.toBeInTheDocument();
+    // expect(
+    //   screen.queryByRole("textbox", { name: Labels.KeyringFilename })
+    // ).not.toBeInTheDocument();
+    // expect(
+    //   screen.getByRole("spinbutton", { name: Labels.Priority })
+    // ).toBeInTheDocument();
+    // expect(
+    //   screen.getByRole("spinbutton", { name: Labels.Priority })
+    // ).toHaveValue(0);
   });
 
   it("switches between keyring filename and keyring data fields when selecting different options", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
     expect(
       screen.getByRole("textbox", { name: Labels.KeyringFilename })
@@ -104,7 +103,7 @@ describe("EditSource", () => {
   });
 
   it("clears the other field when switching between keyring types", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
     // The default keyring filename is the editing source filename
     expect(
@@ -130,7 +129,7 @@ describe("EditSource", () => {
   });
 
   it("does not display keyring fields when unsigned keyring type is selected", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     const select = screen.getByRole("combobox");
@@ -151,7 +150,7 @@ describe("EditSource", () => {
   });
 
   it("shows error when keyring_filename is empty and keyring_type is keyring_filename", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     const select = screen.getByRole("combobox");
@@ -173,7 +172,7 @@ describe("EditSource", () => {
   });
 
   it("shows error when keyring_data is empty and keyring_type is keyring_data", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     const select = screen.getByRole("combobox");
@@ -200,7 +199,7 @@ describe("EditSource", () => {
       })
     );
 
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     const select = screen.getByRole("combobox");
@@ -220,7 +219,7 @@ describe("EditSource", () => {
   });
 
   it("calls update source on save click", async () => {
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     const select = screen.getByRole("combobox");
@@ -245,7 +244,7 @@ describe("EditSource", () => {
         message: "Uh oh!",
       })
     );
-    renderWithProviders(<EditSource id={1} isDefault={false} />);
+    renderWithProviders(<EditSource id={1} />);
     await waitForLoading();
 
     const select = screen.getByRole("combobox");

--- a/src/app/settings/views/Images/Sources/components/EditSource/EditSource.tsx
+++ b/src/app/settings/views/Images/Sources/components/EditSource/EditSource.tsx
@@ -31,7 +31,6 @@ import { Labels } from "@/app/settings/views/Images/Sources/constants";
 
 type EditSourceProps = {
   id: number;
-  isDefault: boolean;
 };
 
 const getInitialKeyringType = (
@@ -42,7 +41,7 @@ const getInitialKeyringType = (
   return "keyring_unsigned";
 };
 
-const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
+const EditSource = ({ id }: EditSourceProps): ReactElement => {
   const { closeSidePanel } = useSidePanel();
 
   const source = useGetImageSource({ path: { boot_source_id: id } }, true);
@@ -172,13 +171,11 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
           onValuesChanged={onValuesChanged}
           saved={updateSource.isSuccess}
           saving={updateSource.isPending}
-          secondarySubmit={!isDefault ? onValidate : undefined}
-          secondarySubmitLabel={
-            !isValidated && !isDefault ? "Validate" : undefined
-          }
+          secondarySubmit={onValidate}
+          secondarySubmitLabel={!isValidated ? "Validate" : undefined}
           secondarySubmitSaved={isValidated}
           secondarySubmitSaving={fetchImageSource.isPending}
-          submitDisabled={!isValidated && !isDefault}
+          submitDisabled={!isValidated}
           submitLabel="Save source"
           validationSchema={SourceSchema}
         >
@@ -189,106 +186,100 @@ const EditSource = ({ id, isDefault }: EditSourceProps): ReactElement => {
           }: FormikContextType<SourceValues>) => {
             return (
               <>
-                {!isDefault && (
-                  <>
-                    <FormikField
-                      label={Labels.Name}
-                      name="name"
-                      required
-                      type="text"
-                    />
-                    <FormikField
-                      aria-label={Labels.Url}
-                      disabled
-                      label={
-                        <>
-                          {Labels.Url}
-                          <Tooltip
-                            className="u-nudge-right--small"
-                            message="Source URL is immutable. You must delete this source, and create a new one to change the URL."
-                          >
-                            <Icon name="help" />
-                          </Tooltip>
-                        </>
-                      }
-                      name="url"
-                      type="text"
-                    />
-                    <Select
-                      label="Keyring"
-                      name="keyring_type"
-                      onChange={async (
-                        e: React.ChangeEvent<HTMLSelectElement>
-                      ) => {
-                        const newType = e.target.value as
-                          | "keyring_data"
-                          | "keyring_filename"
-                          | "keyring_unsigned";
-                        await setFieldValue("keyring_type", newType).catch(
-                          (reason: unknown) => {
-                            throw new FormikFieldChangeError(
-                              "keyring_type",
-                              "setFieldValue",
-                              reason as string
-                            );
-                          }
+                <FormikField
+                  label={Labels.Name}
+                  name="name"
+                  required
+                  type="text"
+                />
+                <FormikField
+                  aria-label={Labels.Url}
+                  disabled
+                  label={
+                    <>
+                      {Labels.Url}
+                      <Tooltip
+                        className="u-nudge-right--small"
+                        message="Source URL is immutable. You must delete this source, and create a new one to change the URL."
+                      >
+                        <Icon name="help" />
+                      </Tooltip>
+                    </>
+                  }
+                  name="url"
+                  type="text"
+                />
+                <Select
+                  label="Keyring"
+                  name="keyring_type"
+                  onChange={async (e: React.ChangeEvent<HTMLSelectElement>) => {
+                    const newType = e.target.value as
+                      | "keyring_data"
+                      | "keyring_filename"
+                      | "keyring_unsigned";
+                    await setFieldValue("keyring_type", newType).catch(
+                      (reason: unknown) => {
+                        throw new FormikFieldChangeError(
+                          "keyring_type",
+                          "setFieldValue",
+                          reason as string
                         );
-                        // Clear the other field when switching types
-                        if (newType === "keyring_filename") {
-                          await setFieldValue("keyring_data", "").catch(
-                            (reason: unknown) => {
-                              throw new FormikFieldChangeError(
-                                "keyring_data",
-                                "setFieldValue",
-                                reason as string
-                              );
-                            }
-                          );
-                        } else if (newType === "keyring_data") {
-                          await setFieldValue("keyring_filename", "").catch(
-                            (reason: unknown) => {
-                              throw new FormikFieldChangeError(
-                                "keyring_filename",
-                                "setFieldValue",
-                                reason as string
-                              );
-                            }
+                      }
+                    );
+                    // Clear the other field when switching types
+                    if (newType === "keyring_filename") {
+                      await setFieldValue("keyring_data", "").catch(
+                        (reason: unknown) => {
+                          throw new FormikFieldChangeError(
+                            "keyring_data",
+                            "setFieldValue",
+                            reason as string
                           );
                         }
-                        await validateForm();
-                      }}
-                      options={[
-                        {
-                          label: "Keyring filename",
-                          value: "keyring_filename",
-                        },
-                        { label: "Keyring data", value: "keyring_data" },
-                        { label: "Unsigned", value: "keyring_unsigned" },
-                      ]}
-                      required
-                      value={values.keyring_type}
-                    />
-                    {values.keyring_type === "keyring_filename" ? (
-                      <FormikField
-                        aria-label={Labels.KeyringFilename}
-                        help="Path to the keyring to validate the mirror path."
-                        name="keyring_filename"
-                        placeholder="e.g. /usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"
-                        required
-                        type="text"
-                      />
-                    ) : values.keyring_type === "keyring_data" ? (
-                      <FormikField
-                        aria-label={Labels.KeyringData}
-                        component={Textarea}
-                        help="Contents on the keyring to validate the mirror path."
-                        name="keyring_data"
-                        placeholder="Contents of GPG key (base64 encoded)"
-                        required
-                      />
-                    ) : null}
-                  </>
-                )}
+                      );
+                    } else if (newType === "keyring_data") {
+                      await setFieldValue("keyring_filename", "").catch(
+                        (reason: unknown) => {
+                          throw new FormikFieldChangeError(
+                            "keyring_filename",
+                            "setFieldValue",
+                            reason as string
+                          );
+                        }
+                      );
+                    }
+                    await validateForm();
+                  }}
+                  options={[
+                    {
+                      label: "Keyring filename",
+                      value: "keyring_filename",
+                    },
+                    { label: "Keyring data", value: "keyring_data" },
+                    { label: "Unsigned", value: "keyring_unsigned" },
+                  ]}
+                  required
+                  value={values.keyring_type}
+                />
+                {values.keyring_type === "keyring_filename" ? (
+                  <FormikField
+                    aria-label={Labels.KeyringFilename}
+                    help="Path to the keyring to validate the mirror path."
+                    name="keyring_filename"
+                    placeholder="e.g. /usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"
+                    required
+                    type="text"
+                  />
+                ) : values.keyring_type === "keyring_data" ? (
+                  <FormikField
+                    aria-label={Labels.KeyringData}
+                    component={Textarea}
+                    help="Contents on the keyring to validate the mirror path."
+                    name="keyring_data"
+                    placeholder="Contents of GPG key (base64 encoded)"
+                    required
+                  />
+                ) : null}
                 <FormikField
                   help="If the same image is available from several sources, the image from the higher priority takes precedence. 1 is the lowest priority."
                   label={Labels.Priority}

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
@@ -100,20 +100,48 @@ describe("SourcesTable", () => {
       });
       expect(rowActions.length).toBe(3);
 
-      // Default source
+      // Default source (enabled)
       await userEvent.click(rowActions[0]);
       expect(
         screen.getByRole("menuitem", { name: "Edit source..." })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: "Enable source..." })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: "Disable source..." })
       ).toBeInTheDocument();
       expect(
         screen.getByRole("menuitem", { name: "Delete source..." })
       ).toBeInTheDocument();
       await userEvent.click(rowActions[0]);
 
+      // Default source (disabled)
+      await userEvent.click(rowActions[1]);
+      expect(
+        screen.getByRole("menuitem", { name: "Edit source..." })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: "Enable source..." })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: "Disable source..." })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: "Delete source..." })
+      ).toBeInTheDocument();
+      await userEvent.click(rowActions[1]);
+
       // Custom source
       await userEvent.click(rowActions[2]);
       expect(
         screen.getByRole("menuitem", { name: "Edit source..." })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: "Enable source..." })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: "Disable source..." })
       ).toBeInTheDocument();
       expect(
         screen.getByRole("menuitem", { name: "Delete source..." })

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
@@ -100,37 +100,15 @@ describe("SourcesTable", () => {
       });
       expect(rowActions.length).toBe(3);
 
-      // Default source (enabled)
+      // Default source
       await userEvent.click(rowActions[0]);
       expect(
         screen.getByRole("menuitem", { name: "Edit source..." })
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole("menuitem", { name: "Delete source..." })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: "Enable source..." })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByRole("menuitem", { name: "Disable source..." })
+        screen.getByRole("menuitem", { name: "Delete source..." })
       ).toBeInTheDocument();
       await userEvent.click(rowActions[0]);
-
-      // Default source (disabled)
-      await userEvent.click(rowActions[1]);
-      expect(
-        screen.getByRole("menuitem", { name: "Edit source..." })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: "Delete source..." })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByRole("menuitem", { name: "Enable source..." })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: "Disable source..." })
-      ).not.toBeInTheDocument();
-      await userEvent.click(rowActions[1]);
 
       // Custom source
       await userEvent.click(rowActions[2]);
@@ -140,12 +118,6 @@ describe("SourcesTable", () => {
       expect(
         screen.getByRole("menuitem", { name: "Delete source..." })
       ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: "Enable source..." })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: "Disable source..." })
-      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/SourcesTable.test.tsx
@@ -153,7 +153,7 @@ describe("SourcesTable", () => {
       expect(mockOpen).toHaveBeenCalledWith({
         component: EditSource,
         title: "Edit default source",
-        props: { id: 1, isDefault: true },
+        props: { id: 1 },
       });
     });
 

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/_index.scss
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/_index.scss
@@ -8,6 +8,17 @@
   tr {
     .name {
       width: 20%;
+
+      div {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .url {
+      width: 25%;
+      word-break: break-all;
+      white-space: normal;
     }
 
     .priority {
@@ -18,11 +29,6 @@
     .signed {
       width: 20%;
       text-align: center;
-    }
-
-    .url {
-      word-break: break-all;
-      white-space: normal;
     }
 
     .actions {

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/_index.scss
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/_index.scss
@@ -20,6 +20,11 @@
       text-align: center;
     }
 
+    .url {
+      word-break: break-all;
+      white-space: normal;
+    }
+
     .actions {
       width: 20%;
     }

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -71,25 +71,25 @@ const useSourcesTableColumns = ({
           }: {
             row: Row<ImageSource>;
           }) => {
-            if (type === BootResourceSourceType.MAAS_IO) {
-              const label = new RegExp(MAAS_IO_URLS.stable).test(url)
-                ? "MAAS Stable"
-                : "MAAS Candidate";
-              return (
-                <>
-                  {!enabled && (
-                    <Tooltip
-                      className="disabled-source-tooltip"
-                      message={`This ${type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source is disabled.`}
-                    >
-                      <Icon name="help" />
-                    </Tooltip>
-                  )}
-                  <div>{label}</div>
-                </>
-              );
-            }
-            return name;
+            return (
+              <>
+                {!enabled && (
+                  <Tooltip
+                    className="disabled-source-tooltip"
+                    message={`This ${type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source is disabled.`}
+                  >
+                    <Icon name="help" />
+                  </Tooltip>
+                )}
+                <div>
+                  {type === BootResourceSourceType.CUSTOM
+                    ? name
+                    : new RegExp(MAAS_IO_URLS.stable).test(url)
+                      ? "MAAS Stable"
+                      : "MAAS Candidate"}
+                </div>
+              </>
+            );
           },
         },
         {

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -9,9 +9,7 @@ import { MAAS_IO_URLS } from "@/app/images/constants";
 import { BootResourceSourceType } from "@/app/images/types";
 import type { ImageSource } from "@/app/settings/views/Images/Sources/Sources";
 import DeleteSource from "@/app/settings/views/Images/Sources/components/DeleteSource";
-import DisableSource from "@/app/settings/views/Images/Sources/components/DisableSource";
 import EditSource from "@/app/settings/views/Images/Sources/components/EditSource";
-import EnableSource from "@/app/settings/views/Images/Sources/components/EnableSource";
 
 type SourcesColumnDef = ColumnDef<ImageSource, Partial<ImageSource>>;
 
@@ -157,38 +155,19 @@ const useSourcesTableColumns = ({
                       });
                     },
                   },
-                  original.type === BootResourceSourceType.CUSTOM
-                    ? {
-                        children: "Delete source...",
-                        onClick: () => {
-                          openSidePanel({
-                            component: DeleteSource,
-                            title: "Delete custom source",
-                            props: { id: original.id },
-                          });
-                        },
-                      }
-                    : original.enabled
-                      ? {
-                          children: "Disable source...",
-                          onClick: () => {
-                            openSidePanel({
-                              component: DisableSource,
-                              title: "Disable default source",
-                              props: { id: original.id },
-                            });
-                          },
-                        }
-                      : {
-                          children: "Enable source...",
-                          onClick: () => {
-                            openSidePanel({
-                              component: EnableSource,
-                              title: "Enable default source",
-                              props: { id: original.id },
-                            });
-                          },
-                        },
+                  // TODO: When the backend re-introduces the immutable default source
+                  //  feature, restore the type-conditional disable/enable action and remove
+                  //  the unconditional "Delete source..." entry.
+                  {
+                    children: "Delete source...",
+                    onClick: () => {
+                      openSidePanel({
+                        component: DeleteSource,
+                        title: `Delete ${original.type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source`,
+                        props: { id: original.id },
+                      });
+                    },
+                  },
                 ]}
                 toggleAppearance="base"
                 toggleClassName="row-menu-toggle u-no-margin--bottom"

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -85,7 +85,7 @@ const useSourcesTableColumns = ({
                       <Icon name="help" />
                     </Tooltip>
                   )}
-                  {label}
+                  <div>{label}</div>
                 </>
               );
             }

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -149,8 +149,9 @@ const useSourcesTableColumns = ({
                         title: `Edit ${original.type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source`,
                         props: {
                           id: original.id,
-                          isDefault:
-                            original.type === BootResourceSourceType.MAAS_IO,
+                          // TODO: Re-introduce default variant when immutable default sources are re-implemented
+                          // isDefault:
+                          //   original.type === BootResourceSourceType.MAAS_IO,
                         },
                       });
                     },

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -9,7 +9,9 @@ import { MAAS_IO_URLS } from "@/app/images/constants";
 import { BootResourceSourceType } from "@/app/images/types";
 import type { ImageSource } from "@/app/settings/views/Images/Sources/Sources";
 import DeleteSource from "@/app/settings/views/Images/Sources/components/DeleteSource";
+import DisableSource from "@/app/settings/views/Images/Sources/components/DisableSource";
 import EditSource from "@/app/settings/views/Images/Sources/components/EditSource";
+import EnableSource from "@/app/settings/views/Images/Sources/components/EnableSource";
 
 type SourcesColumnDef = ColumnDef<ImageSource, Partial<ImageSource>>;
 
@@ -64,7 +66,7 @@ const useSourcesTableColumns = ({
           header: "Name",
           cell: ({
             row: {
-              original: { type, url, name },
+              original: { type, url, name, enabled },
             },
           }: {
             row: Row<ImageSource>;
@@ -75,15 +77,14 @@ const useSourcesTableColumns = ({
                 : "MAAS Candidate";
               return (
                 <>
-                  {/*TODO: re-introduce disabled styling with immutable defaults*/}
-                  {/*{!enabled && (*/}
-                  {/*  <Tooltip*/}
-                  {/*    className="disabled-source-tooltip"*/}
-                  {/*    message="This default source is disabled."*/}
-                  {/*  >*/}
-                  {/*    <Icon name="help" />*/}
-                  {/*  </Tooltip>*/}
-                  {/*)}*/}
+                  {!enabled && (
+                    <Tooltip
+                      className="disabled-source-tooltip"
+                      message={`This ${type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source is disabled.`}
+                    >
+                      <Icon name="help" />
+                    </Tooltip>
+                  )}
                   {label}
                 </>
               );
@@ -157,9 +158,27 @@ const useSourcesTableColumns = ({
                       });
                     },
                   },
-                  // TODO: When the backend re-introduces the immutable default source
-                  //  feature, restore the type-conditional disable/enable action and remove
-                  //  the unconditional "Delete source..." entry.
+                  original.enabled
+                    ? {
+                        children: "Disable source...",
+                        onClick: () => {
+                          openSidePanel({
+                            component: DisableSource,
+                            title: `Disable ${original.type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source`,
+                            props: { id: original.id },
+                          });
+                        },
+                      }
+                    : {
+                        children: "Enable source...",
+                        onClick: () => {
+                          openSidePanel({
+                            component: EnableSource,
+                            title: `Enable ${original.type === BootResourceSourceType.MAAS_IO ? "default" : "custom"} source`,
+                            props: { id: original.id },
+                          });
+                        },
+                      },
                   {
                     children: "Delete source...",
                     onClick: () => {

--- a/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
+++ b/src/app/settings/views/Images/Sources/components/SourcesTable/useSourcesTableColumns/useSourcesTableColumns.tsx
@@ -64,7 +64,7 @@ const useSourcesTableColumns = ({
           header: "Name",
           cell: ({
             row: {
-              original: { type, url, name, enabled },
+              original: { type, url, name },
             },
           }: {
             row: Row<ImageSource>;
@@ -75,14 +75,15 @@ const useSourcesTableColumns = ({
                 : "MAAS Candidate";
               return (
                 <>
-                  {!enabled && (
-                    <Tooltip
-                      className="disabled-source-tooltip"
-                      message="This default source is disabled."
-                    >
-                      <Icon name="help" />
-                    </Tooltip>
-                  )}
+                  {/*TODO: re-introduce disabled styling with immutable defaults*/}
+                  {/*{!enabled && (*/}
+                  {/*  <Tooltip*/}
+                  {/*    className="disabled-source-tooltip"*/}
+                  {/*    message="This default source is disabled."*/}
+                  {/*  >*/}
+                  {/*    <Icon name="help" />*/}
+                  {/*  </Tooltip>*/}
+                  {/*)}*/}
                   {label}
                 </>
               );


### PR DESCRIPTION
## Done

- Removed enable/disable default source forms from the context menu
- Removed default variation from the edit source form
- Removed row styling for disabled sources

## QA steps

- [x] Navigate to "Sources" settings
- [x] Verify you have default and custom sources (maas-ui-demo is broken right now, so you can use a local latest/edge instance and use the CLI to bypass the custom source validation to add a custom source)
- [x] Verify there is no "disabled" sources (tooltip with muted colored row)
- [x] Verify the context menu items are identical for default and custom sources
- [x] Verify the forms are the same for default and custom sources
- [x] Verify the forms work

## Fixes

Resolves [MAASENG-6566](https://warthogs.atlassian.net/browse/MAASENG-6566)


[MAASENG-6566]: https://warthogs.atlassian.net/browse/MAASENG-6566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ