### PR TITLE
fix(kvm): dark mode background for NumaResourcesCard.tsx

### DIFF
--- a/src/app/base/components/DoughnutChart/DoughnutChart.tsx
+++ b/src/app/base/components/DoughnutChart/DoughnutChart.tsx
@@ -4,8 +4,6 @@ import { Tooltip } from "@canonical/react-components";
 import { nanoid } from "@reduxjs/toolkit";
 import classNames from "classnames";
 
-import useDarkMode from "../../hooks/useDarkMode/useDarkMode";
-
 type Segment = {
   /**
    * The colour of the segment.
@@ -64,8 +62,6 @@ export const DoughnutChart = ({
   const [tooltipMessage, setTooltipMessage] = useState<
     Segment["tooltip"] | null
   >(null);
-
-  const [isDarkMode] = useDarkMode();
 
   const id = useRef(`doughnut-chart-${nanoid()}`);
   const hoverIncrease = segmentHoverWidth - segmentWidth;
@@ -186,7 +182,6 @@ export const DoughnutChart = ({
           </g>
           {label ? (
             <text
-              fill={isDarkMode ? "white" : "black"}
               x={radius + adjustedHoverWidth / 2}
               y={radius + adjustedHoverWidth / 2}
             >

--- a/src/app/base/components/DoughnutChart/_index.scss
+++ b/src/app/base/components/DoughnutChart/_index.scss
@@ -17,6 +17,13 @@
     // Center the text in the circle.
     dominant-baseline: middle;
     text-anchor: middle;
+    // Inherit color so that .is-dark class changes cascade through to the SVG
+    // text without relying on React state, which is only set once at mount.
+    fill: $color-dark;
+
+    .is-dark & {
+      fill: $color-light;
+    }
   }
 
   .doughnut-chart__segment {

--- a/src/app/base/components/Popover/_index.scss
+++ b/src/app/base/components/Popover/_index.scss
@@ -1,6 +1,5 @@
 @mixin Popover {
   .p-popover {
-    @extend %vf-bg--x-light;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
     z-index: 10;

--- a/src/app/base/components/Popover/_index.scss
+++ b/src/app/base/components/Popover/_index.scss
@@ -1,5 +1,6 @@
 @mixin Popover {
   .p-popover {
+    @extend %vf-bg-themed;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
     z-index: 10;

--- a/src/app/kvm/components/CPUColumn/CPUPopover/_index.scss
+++ b/src/app/kvm/components/CPUColumn/CPUPopover/_index.scss
@@ -20,7 +20,7 @@
 
   .cpu-popover__secondary {
     @extend %cpu-popover-grid;
-    background: $color-light;
+    background: $colors--theme--background-alt;
   }
 
   .cpu-popover__separator {

--- a/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/_index.scss
+++ b/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/_index.scss
@@ -1,7 +1,6 @@
 @mixin NumaResourcesCard {
   .numa-resources-card {
     @extend %vf-is-bordered;
-    @extend %vf-bg--x-light;
     margin-bottom: $spv--x-large;
   }
 

--- a/src/app/kvm/components/RAMColumn/RAMPopover/_index.scss
+++ b/src/app/kvm/components/RAMColumn/RAMPopover/_index.scss
@@ -20,7 +20,7 @@
 
   .ram-popover__secondary {
     @extend %ram-popover-grid;
-    background: $color-light;
+    background: $colors--theme--background-alt;
   }
 
   .ram-popover__separator {


### PR DESCRIPTION
## Done

- Removed the light theme background extension from NUMA summary card and LXD column popovers

## QA steps

- [x] Navigate to LXD list
- [x] Hover over the RAM and CPU Cores cells in both dark and light modes
- [x] Verify the popovers are correctly themed
- [x] Navigate to the details of a KVM with NUMA nodes
- [x] Toggle the "View by NUMA node" switch
- [ ] Verify the NUMA cards are correctly themed across light and dark modes

## Screenshots
<img width="2672" height="1455" alt="Screenshot 2026-06-10 at 16 02 58" src="https://github.com/user-attachments/assets/1259cf1a-cf57-4136-baed-d64049b3119d" />
<img width="2672" height="1455" alt="Screenshot 2026-06-10 at 16 02 51" src="https://github.com/user-attachments/assets/fb8db82c-de84-4b9c-859b-68b27f07a6da" />
<img width="2672" height="1455" alt="Screenshot 2026-06-10 at 15 41 58" src="https://github.com/user-attachments/assets/aec24a91-7f4e-4d6e-a983-74489865665c" />
<img width="2672" height="1455" alt="Screenshot 2026-06-10 at 15 42 04" src="https://github.com/user-attachments/assets/3087c0b9-d597-480d-8c13-4cc6eefd4321" />
