### PR TITLE
fix(login): allow editable usernames MAASENG-6555

### DIFF
--- a/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/src/app/base/components/FormikForm/FormikForm.tsx
@@ -24,6 +24,7 @@ const FormikForm = <V extends object, E = null>({
   buttonsHelpClassName,
   buttonsHelp,
   cancelDisabled,
+  cancelLabel,
   children,
   className,
   cleanup,
@@ -65,6 +66,7 @@ const FormikForm = <V extends object, E = null>({
         buttonsHelp={buttonsHelp}
         buttonsHelpClassName={buttonsHelpClassName}
         cancelDisabled={cancelDisabled}
+        cancelLabel={cancelLabel}
         className={className}
         cleanup={cleanup}
         editable={editable}

--- a/src/app/login/Login/Login.test.tsx
+++ b/src/app/login/Login/Login.test.tsx
@@ -77,6 +77,81 @@ describe("Login", () => {
     });
   });
 
+  it("shows the username as a disabled field in step 2 for local users", async () => {
+    renderWithProviders(<Login />, { initialEntries: ["/login"], state });
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: Labels.Username }),
+      "koala"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(Labels.Password)).toBeInTheDocument();
+    });
+
+    const usernameField = screen.getByRole("textbox", {
+      name: Labels.Username,
+    });
+    expect(usernameField).toBeInTheDocument();
+    expect(usernameField).toBeDisabled();
+    expect(usernameField).toHaveValue("koala");
+  });
+
+  it("shows the username as a disabled field in step 2 for OIDC users", async () => {
+    mockServer.use(
+      authResolvers.isOidcUser.handler({
+        is_oidc: true,
+        provider_name: "ExampleProvider",
+        auth_url: "http://login.provider.com",
+      })
+    );
+
+    renderWithProviders(<Login />, { initialEntries: ["/login"], state });
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: Labels.Username }),
+      "koala"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Login with ExampleProvider" })
+      ).toBeInTheDocument();
+    });
+
+    const usernameField = screen.getByRole("textbox", {
+      name: Labels.Username,
+    });
+    expect(usernameField).toBeInTheDocument();
+    expect(usernameField).toBeDisabled();
+    expect(usernameField).toHaveValue("koala");
+  });
+
+  it("can go back to step 1 from step 2", async () => {
+    renderWithProviders(<Login />, { initialEntries: ["/login"], state });
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: Labels.Username }),
+      "koala"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(Labels.Password)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: Labels.Back }));
+
+    // Back to step 1: username is editable, password is hidden
+    const usernameField = screen.getByRole("textbox", {
+      name: Labels.Username,
+    });
+    expect(usernameField).not.toBeDisabled();
+    expect(screen.queryByLabelText(Labels.Password)).not.toBeInTheDocument();
+  });
+
   it("can login locally when the user is local", async () => {
     const { store } = renderWithProviders(<Login />, {
       initialEntries: ["/login"],
@@ -90,7 +165,6 @@ describe("Login", () => {
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
     await waitFor(() => {
-      expect(authResolvers.isOidcUser.resolved).toBeTruthy();
       expect(screen.getByLabelText(Labels.Password)).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: Labels.Submit })
@@ -138,7 +212,6 @@ describe("Login", () => {
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
     await waitFor(() => {
-      expect(authResolvers.isOidcUser.resolved).toBeTruthy();
       expect(screen.queryByLabelText(Labels.Password)).not.toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Login with ExampleProvider" })
@@ -177,7 +250,6 @@ describe("Login", () => {
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
     await waitFor(() => {
-      expect(authResolvers.isOidcUser.resolved).toBeTruthy();
       expect(screen.getByRole("alert")).toHaveTextContent(
         Labels.MissingProviderConfig
       );
@@ -197,7 +269,6 @@ describe("Login", () => {
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
     await waitFor(() => {
-      expect(authResolvers.isOidcUser.resolved).toBeTruthy();
       expect(screen.getByLabelText(Labels.Password)).toBeInTheDocument();
     });
 

--- a/src/app/login/Login/Login.tsx
+++ b/src/app/login/Login/Login.tsx
@@ -40,6 +40,7 @@ export type LoginValues = {
 
 export const Labels = {
   APILoginForm: "Login",
+  Back: "Back",
   ExternalLoginButton: "Go to login page",
   NoUsers: "No admin user has been created yet",
   Password: "Password",
@@ -107,6 +108,21 @@ export const Login = (): ReactElement => {
     }
   }, [dispatch, externalAuthURL]);
 
+  const handleBack = useCallback(
+    (
+      _values: LoginValues,
+      formikContext: {
+        setFieldTouched: (field: string, isTouched?: boolean) => void;
+        setFieldValue: (field: string, value: string) => void;
+      }
+    ) => {
+      setSubmittedUsername(null);
+      formikContext.setFieldValue("password", "");
+      formikContext.setFieldTouched("password", false);
+    },
+    [setSubmittedUsername]
+  );
+
   const handleSubmit = (values: LoginValues) => {
     authenticate.mutate({
       body: {
@@ -164,10 +180,12 @@ export const Login = (): ReactElement => {
                 ) : (
                   <FormikForm<LoginValues, LoginError>
                     aria-label={Labels.APILoginForm}
+                    cancelLabel={Labels.Back}
                     initialValues={{
                       password: "",
                       username: "",
                     }}
+                    onCancel={hasEnteredUsername ? handleBack : null}
                     onSubmit={(values) => {
                       if (!hasEnteredUsername) {
                         setSubmittedUsername(values.username);
@@ -201,9 +219,8 @@ export const Login = (): ReactElement => {
                       </p>
                     ) : null}
                     <FormikField
-                      aria-hidden={hasEnteredUsername}
-                      hidden={hasEnteredUsername}
-                      label={hasEnteredUsername ? "" : Labels.Username}
+                      disabled={hasEnteredUsername}
+                      label={Labels.Username}
                       name="username"
                       required={true}
                       takeFocus={!hasEnteredUsername}


### PR DESCRIPTION
## Done

- Added a read-only username field above the password field when signing in
- Added a "back" button to go back to the username and edit it

## QA steps
Feel free to use the demo instance as the backend
- [x] In the username field, type "maas"
- [x] Click "next"
- [x] Ensure the password field is visible, and the username input is disabled
- [x] Ensure the "back" buttton is visible, and click it
- [x] Enter an OIDC username (or one that doesn't exist, like `jon@canonical.com`)
- [x] Ensure the "Login with Auth0..." button is visible, and the username field is readonly

## Fixes

Resolves [MAASENG-6555](https://warthogs.atlassian.net/browse/MAASENG-6555)

## Screenshots

<img width="1053" height="482" alt="Screenshot from 2026-06-12 10-34-18" src="https://github.com/user-attachments/assets/1ccc467c-9f6e-41b4-b58e-4272500726b6" />



[MAASENG-6555]: https://warthogs.atlassian.net/browse/MAASENG-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ