### PR TITLE
docs: Updated docs URLs to point to RTD LP#2156275 (3.6)

### DIFF
--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -1,39 +1,39 @@
 const docsUrls = {
   aboutNativeTLS:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#configure-tls-3-3",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/enhance-maas-security/#configure-tls-3-3",
   addMachines:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#add-a-machine",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/manage-machines/#add-a-machine",
   addNodesViaChassis:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#add-via-chassis",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/manage-machines/#add-via-chassis",
   autoRenewTLSCert:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#renew-certificates",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/enhance-maas-security/#renew-certificates",
   cloudInit:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/reference/configuration-guides/cloud-init/#basic-cloud-init-configurations-for-maas",
+    "https://canonical.com/maas/docs/pre-3.7/reference/configuration-guides/cloud-init/#basic-cloud-init-configurations-for-maas",
   configurationJourney:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/get-maas-up-and-running/#web-ui-setup",
-  dhcp: "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/networking/#dhcp",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/get-maas-up-and-running/#web-ui-setup",
+  dhcp: "https://canonical.com/maas/docs/pre-3.7/explanation/networking/#dhcp",
   hardwareSync:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/deploying-running-machines/#hardware-sync",
-  ipmi: "https://canonical-maas.readthedocs-hosted.com/pre-3.7/reference/configuration-guides/power-drivers/#id6",
+    "https://canonical.com/maas/docs/pre-3.7/explanation/deploying-running-machines/#hardware-sync",
+  ipmi: "https://canonical.com/maas/docs/pre-3.7/reference/configuration-guides/power-drivers/#id6",
   ipRanges:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/networking/#ip-range-management-and-static-ip-assignments",
+    "https://canonical.com/maas/docs/pre-3.7/explanation/networking/#ip-range-management-and-static-ip-assignments",
   kvmIntroduction:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#use-lxd-vms",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/manage-machines/#use-lxd-vms",
   networkDiscovery:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/networking/#network-discovery",
+    "https://canonical.com/maas/docs/pre-3.7/explanation/networking/#network-discovery",
   rackController:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/controllers/#rack-controllers",
+    "https://canonical.com/maas/docs/pre-3.7/explanation/controllers/#rack-controllers",
   sshKeys:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#manage-users",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/enhance-maas-security/#manage-users",
   tagsAutomatic:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/machine-groups/#machine-groups",
+    "https://canonical.com/maas/docs/pre-3.7/explanation/machine-groups/#machine-groups",
   tagsKernelOptions:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#kernel-configuration",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/manage-machines/#kernel-configuration",
   tagsXpathExpressions: "https://www.w3schools.com/xml/XPath_intro.asp",
   vaultIntegration:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#manage-vault",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/enhance-maas-security/#manage-vault",
   windowsImages:
-    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/build-custom-images/#build-custom-images",
+    "https://canonical.com/maas/docs/pre-3.7/how-to-guides/build-custom-images/#build-custom-images",
 } as const;
 
 export default docsUrls;

--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -7,6 +7,8 @@ const docsUrls = {
     "https://canonical.com/maas/docs/pre-3.7/how-to-guides/manage-machines/#add-via-chassis",
   autoRenewTLSCert:
     "https://canonical.com/maas/docs/pre-3.7/how-to-guides/enhance-maas-security/#renew-certificates",
+  customisingDeployedMachines:
+    "https://canonical.com/maas/docs/pre-3.7/explanation/machine-customization/#machine-customization",
   cloudInit:
     "https://canonical.com/maas/docs/pre-3.7/reference/configuration-guides/cloud-init/#basic-cloud-init-configurations-for-maas",
   configurationJourney:

--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -1,30 +1,39 @@
 const docsUrls = {
-  aboutNativeTLS: "https://maas.io/docs/how-to-implement-tls#enabling-tls-2",
-  addMachines: "https://maas.io/docs/how-to-manage-machines",
+  aboutNativeTLS:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#configure-tls-3-3",
+  addMachines:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#add-a-machine",
   addNodesViaChassis:
-    "https://maas.io/docs/how-to-manage-machines#add-machines-via-chassis-ui-2",
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#add-via-chassis",
   autoRenewTLSCert:
-    "https://maas.io/docs/how-to-implement-tls#auto-renew-certs-8",
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#renew-certificates",
   cloudInit:
-    "https://maas.io/docs/how-to-customise-machines#pre-seed-cloud-init-2",
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/reference/configuration-guides/cloud-init/#basic-cloud-init-configurations-for-maas",
   configurationJourney:
-    "https://maas.io/docs/how-to-install-maas#configure-maas-with-the-ui-10",
-  customisingDeployedMachines: "https://maas.io/docs/how-to-customise-machines",
-  dhcp: "https://maas.io/docs/how-to-enable-dhcp",
-  ipmi: "https://maas.io/docs/reference-power-drivers#ipmi-6",
-  ipRanges: "https://maas.io/docs/how-to-enable-dhcp#create-an-ip-range-ui-2",
-  kvmIntroduction: "https://maas.io/docs/about-virtual-machines",
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/get-maas-up-and-running/#web-ui-setup",
+  dhcp: "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/networking/#dhcp",
+  hardwareSync:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/deploying-running-machines/#hardware-sync",
+  ipmi: "https://canonical-maas.readthedocs-hosted.com/pre-3.7/reference/configuration-guides/power-drivers/#id6",
+  ipRanges:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/networking/#ip-range-management-and-static-ip-assignments",
+  kvmIntroduction:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#use-lxd-vms",
   networkDiscovery:
-    "https://maas.io/docs/about-maas-networks#network-discovery-5",
-  rackController: "https://maas.io/docs/how-to-configure-controllers",
-  sshKeys: "https://maas.io/docs/how-to-manage-user-access#add-ssh-keys-5",
-  tagsAutomatic: "https://maas.io/docs/how-to-manage-tags#automatic-tags-17",
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/networking/#network-discovery",
+  rackController:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/controllers/#rack-controllers",
+  sshKeys:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#manage-users",
+  tagsAutomatic:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/explanation/machine-groups/#machine-groups",
   tagsKernelOptions:
-    "https://maas.io/docs/how-to-manage-tags#update-tag-kernel-options-22",
-  tagsXpathExpressions:
-    "https://maas.io/docs/how-to-manage-tags#automatic-tags-17",
-  vaultIntegration: "https://maas.io/docs/how-to-integrate-vault",
-  windowsImages: "https://maas.io/docs/how-to-build-a-windows-image",
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/manage-machines/#kernel-configuration",
+  tagsXpathExpressions: "https://www.w3schools.com/xml/XPath_intro.asp",
+  vaultIntegration:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/enhance-maas-security/#manage-vault",
+  windowsImages:
+    "https://canonical-maas.readthedocs-hosted.com/pre-3.7/how-to-guides/build-custom-images/#build-custom-images",
 } as const;
 
 export default docsUrls;


### PR DESCRIPTION
## Done

- Updated stale docs URLs to point to ReadTheDocs

## QA steps

- [ ] Ensure the updated URLs load
- [ ] Ensure the updated URLs are correct replacements for the old URLs

## Fixes

Fixes [LP#2156275](https://bugs.launchpad.net/maas-ui/+bug/2156275) (3.6)