### PR TITLE
docs: Updated docs URLs to point to RTD LP#2156275 (3.8/latest)

### DIFF
--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -1,36 +1,39 @@
 const docsUrls = {
   aboutNativeTLS:
-    "https://canonical.com/maas/docs/how-to-enhance-maas-security#p-9102-configure-tls-33",
+    "https://canonical.com/maas/docs/latest/how-to-guides/enhance-maas-security/#configure-tls-3-3",
   addMachines:
-    "https://canonical.com/maas/docs/how-to-manage-machines#p-9078-add-configure-machines",
-  addNodesViaChassis: "https://canonical.com/maas/docs/how-to-manage-machines",
+    "https://canonical.com/maas/docs/latest/how-to-guides/manage-machines/#add-a-machine",
+  addNodesViaChassis:
+    "https://canonical.com/maas/docs/latest/how-to-guides/manage-machines/#add-via-chassis",
   autoRenewTLSCert:
-    "https://canonical.com/maas/docs/how-to-enhance-maas-security#p-9102-renew-certificates",
-  cloudInit: "https://canonical.com/maas/docs/how-to-use-cloud-init-with-maas",
+    "https://canonical.com/maas/docs/latest/how-to-guides/enhance-maas-security/#renew-certificates",
+  cloudInit:
+    "https://canonical.com/maas/docs/latest/reference/configuration-guides/cloud-init/#basic-cloud-init-configurations-for-maas",
   configurationJourney:
-    "https://canonical.com/maas/docs/how-to-get-maas-up-and-running#p-9034-maas-ui-setup",
-  dhcp: "https://canonical.com/maas/docs/about-maas-networking#p-20679-dhcp",
+    "https://canonical.com/maas/docs/latest/how-to-guides/get-started/install-maas/#access-the-maas-ui",
+  dhcp: "https://canonical.com/maas/docs/latest/explanation/networking/#dhcp",
   hardwareSync:
-    "https://canonical.com/maas/docs/how-to-manage-machines#p-9078-enable-hardware-sync-maas-32",
-  ipmi: "https://canonical.com/maas/docs/reference-power-drivers#p-17434-ipmi",
+    "https://canonical.com/maas/docs/latest/explanation/deploying-running-machines/#hardware-sync",
+  ipmi: "https://canonical.com/maas/docs/latest/reference/configuration-guides/power-drivers/#id6",
   ipRanges:
-    "https://canonical.com/maas/docs/about-maas-networking#p-20679-ip-range-management-and-static-ip-assignments",
+    "https://canonical.com/maas/docs/latest/explanation/networking/#ip-range-management-and-static-ip-assignments",
   kvmIntroduction:
-    "https://canonical.com/maas/docs/how-to-manage-machines#p-9078-add-vms",
+    "https://canonical.com/maas/docs/latest/how-to-guides/manage-machines/#use-lxd-vms",
   networkDiscovery:
-    "https://canonical.com/maas/docs/about-maas-networking#p-20679-network-discovery",
+    "https://canonical.com/maas/docs/latest/explanation/networking/#network-discovery",
   rackController:
-    "https://canonical.com/maas/docs/about-controllers#p-13954-rack-controllers",
+    "https://canonical.com/maas/docs/latest/explanation/controllers/#rack-controllers",
   sshKeys:
-    "https://canonical.com/maas/docs/how-to-enhance-maas-security#p-9102-manage-users",
-  tagsAutomatic: "https://canonical.com/maas/docs/about-machine-groups",
+    "https://canonical.com/maas/docs/latest/how-to-guides/enhance-maas-security/#manage-users",
+  tagsAutomatic:
+    "https://canonical.com/maas/docs/latest/explanation/machine-groups/#machine-groups",
   tagsKernelOptions:
-    "https://canonical.com/maas/docs/how-to-manage-machines#p-9078-set-kernel-parameters",
+    "https://canonical.com/maas/docs/latest/how-to-guides/manage-machines/#kernel-configuration",
   tagsXpathExpressions: "https://www.w3schools.com/xml/XPath_intro.asp",
   vaultIntegration:
-    "https://canonical.com/maas/docs/how-to-enhance-maas-security#p-9102-manage-vault",
+    "https://canonical.com/maas/docs/latest/how-to-guides/enhance-maas-security/#manage-vault",
   windowsImages:
-    "https://canonical.com/maas/docs/how-to-build-custom-images#p-17423-build-windows-images",
+    "https://canonical.com/maas/docs/latest/how-to-guides/build-custom-images/#build-custom-images",
 } as const;
 
 export default docsUrls;


### PR DESCRIPTION
## Done

- Updated stale docs URLs to point to ReadTheDocs

## QA steps

- [ ] Ensure the updated URLs load
- [ ] Ensure the updated URLs are correct replacements for the old URLs

## Fixes

Fixes [LP#2156275](https://bugs.launchpad.net/maas-ui/+bug/2156275) (3.8/latest)