### PR TITLE
chore(base): migrate MachineSelectTable to GenericTable MAASENG-5670

### DIFF
--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -8,11 +8,11 @@ import * as query from "@/app/store/machine/utils/query";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
 import {
-  userEvent,
-  screen,
-  waitFor,
-  within,
+  fireEvent,
   renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
 } from "@/testing/utils";
 
 vi.mock("@reduxjs/toolkit", async () => {
@@ -177,12 +177,18 @@ describe("DhcpFormFields", () => {
     await waitFor(() => {
       expect(screen.getByRole("grid")).toHaveAttribute("aria-busy", "false");
     });
-    await userEvent.click(
-      within(screen.getByRole("grid")).getByText(machine.hostname)
+    // need to use fireEvent here to click through the element and trigger the onCLick handler
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(
+      screen.getByRole("cell", {
+        name: new RegExp(machine.hostname),
+      }).firstChild as Element
     );
-    expect(
-      screen.getByRole("button", { name: new RegExp(machine.hostname, "i") })
-    ).toHaveAccessibleDescription(Labels.AppliesTo);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: new RegExp(machine.hostname, "i") })
+      ).toHaveAccessibleDescription(Labels.AppliesTo);
+    });
     // Change the type. The select value should be cleared.
     await userEvent.selectOptions(typeSelect, "subnet");
     expect(

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -1,7 +1,7 @@
 import type { HTMLProps } from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 
-import { useId, useOnEscapePressed } from "@canonical/react-components";
+import { useOnEscapePressed } from "@canonical/react-components";
 import Field from "@canonical/react-components/dist/components/Field";
 import className from "classnames";
 import { useFormikContext } from "formik";
@@ -51,10 +51,10 @@ export const MachineSelect = ({
     []
   );
   const handleSelect = (machine: Machine | null) => {
-    handleClose();
     setFieldValue(name, machine?.system_id || null).catch((reason: unknown) => {
       throw new FormikFieldChangeError(name, "setFieldValue", reason as string);
     });
+    setIsOpen(false);
   };
   useOnEscapePressed(handleClose);
   const { machine } = useFetchMachine(value as string);

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
@@ -49,7 +49,6 @@ const MachineSelectBox = ({
           onMachineClick={(machine) => {
             onSelect(machine);
           }}
-          pageSize={pageSize}
           searchText={searchText}
           setSearchText={setSearchText}
         />

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -1,14 +1,9 @@
-import MachineSelectTable, { Label } from "./MachineSelectTable";
+import MachineSelectTable from "./MachineSelectTable";
 
 import type { Machine } from "@/app/store/machine/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
-import {
-  userEvent,
-  screen,
-  within,
-  renderWithProviders,
-} from "@/testing/utils";
+import { renderWithProviders, screen, userEvent } from "@/testing/utils";
 
 describe("MachineSelectTable", () => {
   let machines: Machine[];
@@ -47,14 +42,14 @@ describe("MachineSelectTable", () => {
     renderWithProviders(
       <MachineSelectTable
         machines={machines}
+        machinesLoading={true}
         onMachineClick={vi.fn()}
-        pageSize={machines.length}
         searchText=""
         setSearchText={vi.fn()}
       />,
       { state }
     );
-    expect(screen.getByRole("grid")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("highlights the substring that matches the search text", async () => {
@@ -62,18 +57,13 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={[machines[0]]}
         onMachineClick={vi.fn()}
-        pageSize={machines.length}
         searchText="fir"
         setSearchText={vi.fn()}
       />,
       { state }
     );
 
-    const hostnameCol = screen.getByRole("gridcell", {
-      name: Label.Hostname,
-    });
-
-    expect(hostnameCol.querySelector("strong")).toHaveTextContent("fir");
+    expect(screen.getByText("fir")).toBeInTheDocument();
   });
 
   it("runs onMachineClick function on row click", async () => {
@@ -83,14 +73,17 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={onMachineClick}
-        pageSize={machines.length}
         searchText=""
         setSearchText={vi.fn()}
       />,
       { state }
     );
 
-    await userEvent.click(screen.getByRole("row", { name: "first" }));
+    // have to click through to the span that has the click handler
+    await userEvent.click(
+      screen.getByRole("cell", { name: new RegExp(machines[0].hostname) })
+        .firstChild as Element
+    );
     expect(onMachineClick).toHaveBeenCalledWith(machines[0]);
   });
 
@@ -99,38 +92,12 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={vi.fn()}
-        pageSize={machines.length}
         searchText=""
         setSearchText={vi.fn()}
       />,
       { state }
     );
-    const ownerCols = screen.getAllByRole("gridcell", {
-      name: Label.Owner,
-    });
-    expect(within(ownerCols[0]).getByText("tagA")).toBeInTheDocument();
-  });
-
-  it("can select machine by pressing Enter key", async () => {
-    const onMachineClick = vi.fn();
-    const machine = machines[0];
-    renderWithProviders(
-      <MachineSelectTable
-        machines={machines}
-        onMachineClick={onMachineClick}
-        pageSize={machines.length}
-        searchText=""
-        setSearchText={vi.fn()}
-      />,
-      { state }
-    );
-    screen
-      .getByRole("row", {
-        name: machine.hostname,
-      })
-      .focus();
-    await userEvent.keyboard("{enter}");
-    expect(onMachineClick).toHaveBeenCalledWith(machine);
+    expect(screen.getByText("tagA")).toBeInTheDocument();
   });
 
   it("renders with partial search string", async () => {
@@ -139,7 +106,6 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={onMachineClick}
-        pageSize={machines.length}
         searchText="id:("
         setSearchText={vi.fn()}
       />,

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -1,29 +1,15 @@
-import type { KeyboardEvent } from "react";
-
-import { MainTable } from "@canonical/react-components";
-import { highlightSubString as baseHighlightSubString } from "@canonical/react-components/dist/utils";
+import { GenericTable } from "@canonical/maas-react-components";
 import { useSelector } from "react-redux";
 
-import Placeholder from "../Placeholder";
-import VisuallyHidden from "../VisuallyHidden";
+import useMachineSelectTableColumns from "./useMachineSelectTableColumns";
 
-import DoubleRow from "@/app/base/components/DoubleRow";
 import { useFetchActions } from "@/app/base/hooks";
 import machineSelectors from "@/app/store/machine/selectors";
 import type { Machine } from "@/app/store/machine/types";
 import { tagActions } from "@/app/store/tag";
 import tagSelectors from "@/app/store/tag/selectors";
-import type { Tag } from "@/app/store/tag/types";
-import { getTagNamesForIds } from "@/app/store/tag/utils";
-
-export enum Label {
-  Loading = "Loading...",
-  Hostname = "Hostname",
-  Owner = "Owner",
-}
 
 type Props = {
-  pageSize: number;
   machines: Machine[];
   onMachineClick: (machine: Machine | null) => void;
   searchText: string;
@@ -31,102 +17,9 @@ type Props = {
   setSearchText: (searchText: string) => void;
 };
 
-const safeGetRegexString = (searchText: string): string => {
-  try {
-    new RegExp(searchText, "i");
-    return searchText;
-  } catch {
-    return "";
-  }
-};
-const highlightSubString = (text: string, highlight: string) =>
-  baseHighlightSubString(text, safeGetRegexString(highlight));
-
-const generateRows = (
-  machines: Machine[],
-  searchText: string,
-  onRowClick: (machine: Machine) => void,
-  tags: Tag[]
-) => {
-  const highlightedText = (text: string) => (
-    <span
-      dangerouslySetInnerHTML={{
-        __html: highlightSubString(text, searchText).text,
-      }}
-    />
-  );
-  return machines.map((machine) => ({
-    "aria-label": machine.hostname,
-    className: "machine-select-table__row",
-    columns: [
-      {
-        "aria-label": Label.Hostname,
-        content: (
-          <DoubleRow
-            primary={highlightedText(machine.hostname)}
-            secondary={highlightedText(machine.system_id)}
-          />
-        ),
-      },
-      {
-        "aria-label": Label.Owner,
-        content: (
-          <DoubleRow
-            primary={machine.owner || "-"}
-            secondary={
-              machine.tags.length
-                ? highlightedText(
-                    getTagNamesForIds(machine.tags, tags).join(", ")
-                  )
-                : "-"
-            }
-          />
-        ),
-      },
-    ],
-    "data-testid": "machine-select-row",
-    onClick: () => {
-      onRowClick(machine);
-    },
-    onKeyPress: (e: KeyboardEvent<HTMLTableRowElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        onRowClick(machine);
-      }
-    },
-    tabIndex: 0,
-  }));
-};
-
-const getSkeletonRows = (count = 3) =>
-  Array.from(Array(count)).map((_, i) => ({
-    columns: [
-      {
-        content: (
-          <DoubleRow
-            primary={<Placeholder>xxxxxxxxx.xxxx</Placeholder>}
-            secondary={<Placeholder>xxxxxxxxx.xxxx</Placeholder>}
-          />
-        ),
-      },
-      {
-        content: (
-          <DoubleRow
-            primary={<Placeholder>xxxxxxxxx.xxxx</Placeholder>}
-            secondary={<Placeholder>xxxxxxxxx.xxxx</Placeholder>}
-          />
-        ),
-      },
-    ],
-    "data-testid": "machine-select-row",
-    tabIndex: -1,
-    key: i,
-  }));
-
 export const MachineSelectTable = ({
   machines,
   machinesLoading,
-  pageSize,
   onMachineClick,
   searchText,
   setSearchText,
@@ -136,49 +29,21 @@ export const MachineSelectTable = ({
 
   useFetchActions([tagActions.fetch]);
 
-  const rows = generateRows(
-    machines,
+  const columns = useMachineSelectTableColumns({
+    onMachineClick,
     searchText,
-    (machine) => {
-      setSearchText(machine.hostname);
-      onMachineClick(machine);
-    },
-    tags
-  );
-
-  const skeletonRows = getSkeletonRows(pageSize);
+    setSearchText,
+    tags,
+  });
 
   return (
-    <>
-      <MainTable
-        aria-busy={machinesLoading || loadingMachines ? "true" : "false"}
-        emptyStateMsg={
-          !machinesLoading ? "No machines match the search criteria." : null
-        }
-        headers={[
-          {
-            content: (
-              <>
-                <div>{Label.Hostname}</div>
-                <div>system_id</div>
-              </>
-            ),
-          },
-          {
-            content: (
-              <>
-                <div>{Label.Owner}</div>
-                <div>Tags</div>
-              </>
-            ),
-          },
-        ]}
-        rows={machinesLoading ? skeletonRows : rows}
-      />
-      <VisuallyHidden>
-        <div aria-live="polite">{machinesLoading ? "loading" : null}</div>
-      </VisuallyHidden>
-    </>
+    <GenericTable
+      className="machine-select-table"
+      columns={columns}
+      data={machines}
+      isLoading={!!(machinesLoading || loadingMachines)}
+      noData="No machines match the search criteria."
+    />
   );
 };
 

--- a/src/app/base/components/MachineSelectTable/_index.scss
+++ b/src/app/base/components/MachineSelectTable/_index.scss
@@ -1,5 +1,5 @@
 @mixin MachineSelectTable {
-  .machine-select-table {
+  .p-generic-table.machine-select-table {
     tr.p-generic-table__individual-row {
       cursor: pointer;
 
@@ -12,6 +12,18 @@
     // substrings, so it's increased slightly here.
     strong {
       font-weight: 600;
+    }
+
+    th.p-column-header.owner {
+      text-align: left;
+    }
+
+    td {
+      padding: 0;
+    }
+
+    .machine-select-table__cell {
+      padding: 0.75rem;
     }
   }
 }

--- a/src/app/base/components/MachineSelectTable/_index.scss
+++ b/src/app/base/components/MachineSelectTable/_index.scss
@@ -1,9 +1,11 @@
 @mixin MachineSelectTable {
-  .machine-select-table__row {
-    cursor: pointer;
+  .machine-select-table {
+    tr.p-generic-table__individual-row {
+      cursor: pointer;
 
-    &:hover {
-      background-color: var(--vf-color-background-hover);
+      &:hover {
+        background-color: var(--vf-color-background-hover);
+      }
     }
 
     // The default <strong> font-weight is a bit subtle for highlighting

--- a/src/app/base/components/MachineSelectTable/useMachineSelectTableColumns.tsx
+++ b/src/app/base/components/MachineSelectTable/useMachineSelectTableColumns.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from "react";
+
+import { highlightSubString as baseHighlightSubString } from "@canonical/react-components/dist/utils";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import DoubleRow from "@/app/base/components/DoubleRow";
+import type { Machine } from "@/app/store/machine/types";
+import type { Tag } from "@/app/store/tag/types";
+import { getTagNamesForIds } from "@/app/store/tag/utils";
+
+const safeGetRegexString = (searchText: string): string => {
+  try {
+    new RegExp(searchText, "i");
+    return searchText;
+  } catch {
+    return "";
+  }
+};
+
+const highlightSubString = (text: string, highlight: string) =>
+  baseHighlightSubString(text, safeGetRegexString(highlight));
+
+type Params = {
+  onMachineClick: (machine: Machine | null) => void;
+  searchText: string;
+  setSearchText: (searchText: string) => void;
+  tags: Tag[];
+};
+
+type MachineColumnDef = ColumnDef<Machine, Partial<Machine>>;
+
+const useMachineSelectTableColumns = ({
+  onMachineClick,
+  searchText,
+  setSearchText,
+  tags,
+}: Params): MachineColumnDef[] => {
+  return useMemo(
+    () => [
+      {
+        id: "hostname",
+        accessorKey: "hostname",
+        enableSorting: false,
+        header: () => (
+          <>
+            <div>Hostname</div>
+            <div>system_id</div>
+          </>
+        ),
+        cell: ({ row }) => {
+          const machine = row.original;
+          const highlightedText = (text: string) => (
+            <span
+              dangerouslySetInnerHTML={{
+                __html: highlightSubString(text, searchText).text,
+              }}
+            />
+          );
+          return (
+            <span
+              onClick={() => {
+                setSearchText(machine.hostname);
+                onMachineClick(machine);
+              }}
+            >
+              <DoubleRow
+                primary={highlightedText(machine.hostname)}
+                secondary={highlightedText(machine.system_id)}
+              />
+            </span>
+          );
+        },
+      },
+      {
+        id: "owner",
+        accessorKey: "owner",
+        enableSorting: false,
+        header: () => (
+          <>
+            <div>Owner</div>
+            <div>Tags</div>
+          </>
+        ),
+        cell: ({ row }) => {
+          const machine = row.original;
+          const highlightedText = (text: string) => (
+            <span
+              dangerouslySetInnerHTML={{
+                __html: highlightSubString(text, searchText).text,
+              }}
+            />
+          );
+          return (
+            <span
+              onClick={() => {
+                setSearchText(machine.hostname);
+                onMachineClick(machine);
+              }}
+            >
+              <DoubleRow
+                primary={machine.owner || "-"}
+                secondary={
+                  machine.tags.length
+                    ? highlightedText(
+                        getTagNamesForIds(machine.tags, tags).join(", ")
+                      )
+                    : "-"
+                }
+              />
+            </span>
+          );
+        },
+      },
+    ],
+    [onMachineClick, searchText, setSearchText, tags]
+  );
+};
+
+export default useMachineSelectTableColumns;

--- a/src/app/base/components/MachineSelectTable/useMachineSelectTableColumns.tsx
+++ b/src/app/base/components/MachineSelectTable/useMachineSelectTableColumns.tsx
@@ -57,7 +57,8 @@ const useMachineSelectTableColumns = ({
             />
           );
           return (
-            <span
+            <div
+              className="machine-select-table__cell"
               onClick={() => {
                 setSearchText(machine.hostname);
                 onMachineClick(machine);
@@ -67,7 +68,7 @@ const useMachineSelectTableColumns = ({
                 primary={highlightedText(machine.hostname)}
                 secondary={highlightedText(machine.system_id)}
               />
-            </span>
+            </div>
           );
         },
       },
@@ -91,7 +92,8 @@ const useMachineSelectTableColumns = ({
             />
           );
           return (
-            <span
+            <div
+              className="machine-select-table__cell"
               onClick={() => {
                 setSearchText(machine.hostname);
                 onMachineClick(machine);
@@ -107,7 +109,7 @@ const useMachineSelectTableColumns = ({
                     : "-"
                 }
               />
-            </span>
+            </div>
           );
         },
       },

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -78,7 +78,8 @@ describe("CloneForm", () => {
 
     // Select a source machine - form should update
     await userEvent.click(
-      screen.getByRole("row", { name: machines[1].hostname })
+      screen.getByRole("cell", { name: new RegExp(machines[1].hostname) })
+        .firstChild as Element
     );
 
     expect(
@@ -154,7 +155,8 @@ describe("CloneForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("row", { name: machines[2].hostname })
+      screen.getByRole("cell", { name: new RegExp(machines[2].hostname) })
+        .firstChild as Element
     );
 
     await userEvent.click(

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -99,10 +99,12 @@ describe("CloneFormFields", () => {
       </Formik>,
       { state }
     );
+
+    // nested span contains the onClick handler
     await userEvent.click(
-      screen.getByRole("row", {
+      screen.getByRole("cell", {
         name: new RegExp(`^${machine.hostname}`),
-      })
+      }).firstChild as Element
     );
     const expectedAction = machineActions.get(machine.system_id, callId);
 

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -8,10 +8,10 @@ import * as query from "@/app/store/machine/utils/query";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
 import {
-    renderWithProviders,
-    screen,
-    userEvent,
-    waitFor,
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
 } from "@/testing/utils";
 
 const callId = "mocked-nanoid";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -8,10 +8,10 @@ import * as query from "@/app/store/machine/utils/query";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
 import {
-  renderWithProviders,
-  screen,
-  userEvent,
-  waitFor,
+    renderWithProviders,
+    screen,
+    userEvent,
+    waitFor,
 } from "@/testing/utils";
 
 const callId = "mocked-nanoid";
@@ -99,7 +99,11 @@ describe("CloneFormFields", () => {
       </Formik>,
       { state }
     );
-    await userEvent.click(screen.getAllByTestId("machine-select-row")[0]);
+    await userEvent.click(
+      screen.getByRole("row", {
+        name: new RegExp(`^${machine.hostname}`),
+      })
+    );
     const expectedAction = machineActions.get(machine.system_id, callId);
 
     await waitFor(() => {

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
@@ -73,7 +73,6 @@ export const SourceMachineSelect = ({
           machines={machines}
           machinesLoading={loading}
           onMachineClick={onMachineClick}
-          pageSize={pageSize}
           searchText={searchText}
           setSearchText={setSearchText}
         />

--- a/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -16,6 +16,7 @@ import { callId, enableCallIdMocks } from "@/testing/callId-mock";
 import * as factory from "@/testing/factories";
 import { mockFormikFormSaved } from "@/testing/mockFormikFormSaved";
 import {
+  fireEvent,
   renderWithProviders,
   screen,
   userEvent,
@@ -180,9 +181,10 @@ describe("DiscoveryAddForm", () => {
         name: "Select parent (optional) - open list",
       })
     );
-    await userEvent.click(
-      within(screen.getByRole("listbox")).getByText("abc123")
-    );
+
+    // fireEvent is necessary to click through the element and trigger the handler
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(within(screen.getByRole("listbox")).getByText("abc123"));
 
     await userEvent.clear(
       screen.getByRole("textbox", {


### PR DESCRIPTION
## Done

- migrated machineselecttable to generic table

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] go to machines
- [x] select a machine
- [x] click "Action" --> "Clone from"
- [x] ensure the mini table of machines appears as expected
- [x] click on a row
- [x] ensure that machine is selected and the table turns to a card
- [x] click the "X" button to clear the machine
- [x] ensure the table re-appears

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5670](https://warthogs.atlassian.net/browse/MAASENG-5670)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->



[MAASENG-5670]: https://warthogs.atlassian.net/browse/MAASENG-5670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ