### PR TITLE
feat(images): Image source switch column MAASENG-6604

### DIFF
--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -5,8 +5,14 @@ import ImagesTable from "./ImagesTable";
 
 import DeleteImages from "@/app/images/components/DeleteImages";
 import { ConfigNames } from "@/app/store/config/types";
-import { imageFactory, imageStatusFactory } from "@/testing/factories";
+import {
+  availableImageFactory,
+  imageFactory,
+  imageSourceFactory,
+  imageStatusFactory,
+} from "@/testing/factories";
 import { configurationsResolvers } from "@/testing/resolvers/configurations";
+import { imageSourceResolvers } from "@/testing/resolvers/imageSources";
 import { imageSyncResolvers } from "@/testing/resolvers/imageSync";
 import { imageResolvers } from "@/testing/resolvers/images";
 import {
@@ -27,6 +33,8 @@ const mockServer = setupMockServer(
   imageResolvers.listCustomImages.handler(),
   imageResolvers.listCustomImageStatistics.handler(),
   imageResolvers.listCustomImageStatuses.handler(),
+  imageResolvers.listAvailableSelections.handler(),
+  imageSourceResolvers.listImageSources.handler(),
   imageSyncResolvers.startSynchronization.handler(),
   imageSyncResolvers.stopSynchronization.handler(),
   configurationsResolvers.getConfiguration.handler({
@@ -81,6 +89,7 @@ describe("ImagesTable", () => {
         "Size",
         "Version",
         "Status",
+        "Source",
         "Actions",
       ].forEach((column) => {
         expect(
@@ -111,6 +120,31 @@ describe("ImagesTable", () => {
   });
 
   describe("permissions", () => {
+    it("disables image source change for images being downloaded", async () => {
+      mockServer.use(
+        imageResolvers.listSelections.handler({
+          items: [
+            imageFactory.build({ id: 1, release: "jammy", title: "22.04 LTS" }),
+          ],
+          total: 1,
+        }),
+        imageResolvers.listSelectionStatuses.handler({
+          items: [imageStatusFactory.build({ id: 1, status: "Downloading" })],
+          total: 1,
+        })
+      );
+      renderWithProviders(
+        <ImagesTable selectedRows={{}} setSelectedRows={vi.fn} />
+      );
+      await waitForLoading();
+
+      const row = screen.getByRole("row", { name: /jammy/i });
+      const sourceToggle = within(row).getByRole("button", {
+        name: /MAAS Stable/i,
+      });
+      expect(sourceToggle).toBeAriaDisabled();
+    });
+
     it("disables delete and select for default commissioning release images", async () => {
       renderWithProviders(
         <ImagesTable selectedRows={{}} setSelectedRows={vi.fn} />
@@ -226,6 +260,68 @@ describe("ImagesTable", () => {
   });
 
   describe("actions", () => {
+    it("calls image delete, and then adds the new selection on source change", async () => {
+      mockServer.use(
+        imageResolvers.listSelections.handler({
+          items: [
+            imageFactory.build({
+              id: 1,
+              release: "jammy",
+              title: "22.04 LTS",
+              architecture: "amd64",
+              boot_source_id: 1,
+            }),
+          ],
+          total: 1,
+        }),
+        imageResolvers.listAvailableSelections.handler({
+          items: [
+            availableImageFactory.build({
+              os: "ubuntu",
+              release: "jammy",
+              architecture: "amd64",
+              source_id: 1,
+            }),
+            availableImageFactory.build({
+              os: "ubuntu",
+              release: "jammy",
+              architecture: "amd64",
+              source_id: 2,
+            }),
+          ],
+        }),
+        imageSourceResolvers.listImageSources.handler({
+          items: [
+            imageSourceFactory.build({ id: 1, name: "MAAS Stable" }),
+            imageSourceFactory.build({ id: 2, name: "MAAS Daily" }),
+          ],
+          total: 2,
+        }),
+        imageResolvers.deleteSelections.handler(),
+        imageResolvers.addSelections.handler()
+      );
+      renderWithProviders(
+        <ImagesTable selectedRows={{}} setSelectedRows={vi.fn} />
+      );
+      await waitForLoading();
+
+      const row = screen.getByRole("row", { name: /jammy/i });
+      await userEvent.click(
+        within(row).getByRole("button", { name: /MAAS Stable/i })
+      );
+
+      await userEvent.click(
+        screen.getByRole("menuitem", { name: "MAAS Daily" })
+      );
+
+      await waitFor(() => {
+        expect(imageResolvers.deleteSelections.resolved).toBeTruthy();
+      });
+      await waitFor(() => {
+        expect(imageResolvers.addSelections.resolved).toBeTruthy();
+      });
+    });
+
     it("opens delete image side panel form", async () => {
       mockServer.use(
         imageResolvers.listSelections.handler({

--- a/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
+++ b/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
@@ -1,7 +1,9 @@
 import { type Dispatch, type SetStateAction, useMemo } from "react";
 
+import type { MenuLink } from "@canonical/react-components";
 import {
   Button,
+  ContextualMenu,
   Icon,
   Spinner,
   Tooltip,
@@ -16,7 +18,14 @@ import type {
 } from "@tanstack/react-table";
 import pluralize from "pluralize";
 
+import { useImageSources } from "@/app/api/query/imageSources";
 import { useStartImageSync, useStopImageSync } from "@/app/api/query/imageSync";
+import {
+  useAddSelections,
+  useAvailableSelections,
+  useDeleteSelections,
+} from "@/app/api/query/images";
+import type { BootSourceResponse } from "@/app/apiclient";
 import DoubleRow from "@/app/base/components/DoubleRow/DoubleRow";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import DeleteImages from "@/app/images/components/DeleteImages";
@@ -69,6 +78,30 @@ const useImageTableColumns = ({
   const { failure } = useToastNotification();
   const startSync = useStartImageSync();
   const stopSync = useStopImageSync();
+
+  const { data: sources, isPending: isSourcesPending } = useImageSources();
+  const { data: availableImages, isPending: isAvailableImagesPending } =
+    useAvailableSelections();
+  const addSelections = useAddSelections();
+  const deleteSelections = useDeleteSelections();
+
+  // Pre-compute a map of os/release/arch -> deduplicated BootSourceResponse[]
+  const sourcesByImageKey = useMemo(() => {
+    const map: Record<string, BootSourceResponse[]> = {};
+    if (!sources?.items || !availableImages?.items) return map;
+
+    for (const image of availableImages.items) {
+      const key = `${image.os}/${image.release}/${image.architecture}`;
+      const source = sources.items.find((s) => s.id === image.source_id);
+      if (!source) continue;
+      if (!map[key]) {
+        map[key] = [source];
+      } else if (!map[key].some((s) => s.id === source.id)) {
+        map[key].push(source);
+      }
+    }
+    return map;
+  }, [sources, availableImages]);
 
   return useMemo(
     () =>
@@ -298,6 +331,67 @@ const useImageTableColumns = ({
           },
         },
         {
+          id: "source",
+          accessorKey: "source",
+          enableSorting: false,
+          header: () => "Source",
+          cell: ({ row: { original } }) => {
+            if (!original.isUpstream) {
+              return null;
+            }
+
+            if (isSourcesPending || isAvailableImagesPending) {
+              return <Spinner text="Loading..." />;
+            }
+
+            const key = `${original.os}/${original.release}/${original.architecture}`;
+            const switchableSources = sourcesByImageKey[key] ?? [];
+            const currentSource = switchableSources.find(
+              (source) => source.id === original.boot_source_id
+            );
+
+            return (
+              <>
+                <span>{currentSource?.name}</span>
+                <ContextualMenu
+                  className="p-table-menu"
+                  hasToggleIcon
+                  links={[
+                    "Change source:",
+                    ...switchableSources.map(
+                      (source): MenuLink => ({
+                        disabled: source.id === original.boot_source_id,
+                        children: source.name,
+                        onClick: () => {
+                          deleteSelections
+                            .mutateAsync({
+                              query: { id: [Number.parseInt(original.id)] },
+                            })
+                            .then(() => {
+                              addSelections.mutate({
+                                body: [
+                                  {
+                                    os: original.os,
+                                    release: original.release,
+                                    arch: original.architecture,
+                                    boot_source_id: source.id,
+                                  },
+                                ],
+                              });
+                            });
+                        },
+                      })
+                    ),
+                  ]}
+                  position="right"
+                  toggleAppearance="base"
+                  toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+                />
+              </>
+            );
+          },
+        },
+        {
           id: "actions",
           accessorKey: "id",
           enableSorting: false,
@@ -457,6 +551,11 @@ const useImageTableColumns = ({
     [
       isStatisticsLoading,
       isStatusLoading,
+      isSourcesPending,
+      isAvailableImagesPending,
+      sourcesByImageKey,
+      deleteSelections,
+      addSelections,
       commissioningRelease,
       startSync,
       stopSync,

--- a/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
+++ b/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
@@ -335,59 +335,82 @@ const useImageTableColumns = ({
           accessorKey: "source",
           enableSorting: false,
           header: () => "Source",
-          cell: ({ row: { original } }) => {
-            if (!original.isUpstream) {
+          cell: ({
+            row: {
+              original: {
+                id,
+                os,
+                release,
+                architecture,
+                boot_source_id,
+                isUpstream,
+                status,
+                update_status,
+              },
+            },
+          }) => {
+            if (!isUpstream) {
               return null;
             }
 
-            if (isSourcesPending || isAvailableImagesPending) {
+            if (
+              isStatusLoading ||
+              isSourcesPending ||
+              isAvailableImagesPending
+            ) {
               return <Spinner text="Loading..." />;
             }
 
-            const key = `${original.os}/${original.release}/${original.architecture}`;
+            const key = `${os}/${release}/${architecture}`;
             const switchableSources = sourcesByImageKey[key] ?? [];
             const currentSource = switchableSources.find(
-              (source) => source.id === original.boot_source_id
+              (source) => source.id === boot_source_id
             );
 
             return (
-              <>
-                <span>{currentSource?.name}</span>
-                <ContextualMenu
-                  className="p-table-menu"
-                  hasToggleIcon
-                  links={[
-                    "Change source:",
-                    ...switchableSources.map(
-                      (source): MenuLink => ({
-                        disabled: source.id === original.boot_source_id,
-                        children: source.name,
-                        onClick: () => {
-                          deleteSelections
-                            .mutateAsync({
-                              query: { id: [Number.parseInt(original.id)] },
-                            })
-                            .then(() => {
-                              addSelections.mutate({
-                                body: [
-                                  {
-                                    os: original.os,
-                                    release: original.release,
-                                    arch: original.architecture,
-                                    boot_source_id: source.id,
-                                  },
-                                ],
-                              });
+              <ContextualMenu
+                className="p-table-menu"
+                hasToggleIcon
+                links={[
+                  "Change source:",
+                  ...switchableSources.map(
+                    (source): MenuLink => ({
+                      disabled: source.id === currentSource?.id,
+                      children: source.name,
+                      onClick: () => {
+                        deleteSelections
+                          .mutateAsync({
+                            query: { id: [Number.parseInt(id)] },
+                          })
+                          .then(() => {
+                            addSelections.mutate({
+                              body: [
+                                {
+                                  os: os,
+                                  release: release,
+                                  arch: architecture,
+                                  boot_source_id: source.id,
+                                },
+                              ],
                             });
-                        },
-                      })
-                    ),
-                  ]}
-                  position="right"
-                  toggleAppearance="base"
-                  toggleClassName="u-no-margin--bottom p-table-menu__toggle"
-                />
-              </>
+                          });
+                      },
+                    })
+                  ),
+                ]}
+                position="right"
+                toggleAppearance="base"
+                toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+                toggleDisabled={
+                  status === "Downloading" ||
+                  status === "OptimisticDownloading" ||
+                  status === "OptimisticStopping" ||
+                  update_status === "Downloading" ||
+                  update_status === "OptimisticDownloading" ||
+                  update_status === "OptimisticStopping"
+                }
+                toggleLabel={currentSource?.name}
+              />
             );
           },
         },


### PR DESCRIPTION
## Done

- Added "Source" column with image source switch
- Added tests for source switching

## QA steps

- [x] Point this branch's UI to point to a local MAAS (demo is throwing 500s)
- [x] Ensure you have multiple sources enabled
- [x] Verify there is a "Source" column in the image table
- [x] Verify the column has an interactive context menu that lists alternative sources for the image
- [x] Verify switching the source initiates a download from the new source
- [x] Verify the source switch is disabled when the image is being downloaded

## Fixes

Resolves [MAASENG-6604](https://warthogs.atlassian.net/browse/MAASENG-6604)


[MAASENG-6604]: https://warthogs.atlassian.net/browse/MAASENG-6604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ