### PR TITLE
fix: add missing condition for enabling redirect_uri form field

### DIFF
--- a/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnFormFields/SingleSignOnFormFields.tsx
+++ b/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnFormFields/SingleSignOnFormFields.tsx
@@ -71,7 +71,7 @@ const SingleSignOnFormFields = ({
         type="text"
       />
       <FormikField
-        disabled
+        disabled={!canEdit}
         help="The redirect URI in the application where the OIDC provider will redirect users after successful authentication. Unless you have specific requirements, this should be set to your MAAS URL followed by /r/login/oidc/callback."
         label="Redirect URI"
         name="redirect_uri"


### PR DESCRIPTION
## Done

- In the single sign on form, the "Redirect URI" form field is always disabled. Instead, it should only be disabled when `disabled={!canEdit}`


