### PR TITLE
fix(machines): use name for zone update request MAASENG-6603

### DIFF
--- a/src/app/base/components/ZoneSelect/ZoneSelect.tsx
+++ b/src/app/base/components/ZoneSelect/ZoneSelect.tsx
@@ -3,14 +3,13 @@ import type { HTMLProps } from "react";
 import { Select } from "@canonical/react-components";
 
 import { useZones } from "@/app/api/query/zones";
-import type { ZoneResponse } from "@/app/apiclient";
 import FormikField from "@/app/base/components/FormikField";
 
 type Props = HTMLProps<HTMLSelectElement> & {
   disabled?: boolean;
   label?: string;
   name: string;
-  valueKey?: keyof ZoneResponse;
+  valueKey?: "id" | "name";
 };
 
 export enum Label {
@@ -37,7 +36,7 @@ export const ZoneSelect = ({
         ...(zones.data?.items?.map((zone) => ({
           key: `zone-${zone.id}`,
           label: zone.name,
-          value: zone.id,
+          value: zone[valueKey ?? "id"],
         })) || []),
       ]}
       {...props}

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
@@ -12,7 +12,7 @@ const MachineFormFields = (): React.ReactElement => {
       <Col size={6}>
         <ArchitectureSelect name="architecture" />
         <MinimumKernelSelect name="minHweKernel" />
-        <ZoneSelect name="zone" />
+        <ZoneSelect name="zone" valueKey="name" />
         <ResourcePoolSelect name="pool" />
         <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
         <FormikField component={Textarea} label="Note" name="description" />


### PR DESCRIPTION
## Done

- The machine configuration form was incorrectly passing the "zone_id" in the zone update request, whereas the backend expects the zone name, causing update requests to fail.
- There was another issue where the zone field was initialized to `machine.zone.name`, but no option had that as its value, so it would fall back to the first available zone. For example, if there were two zones called "Amsterdam" and "default" and a machine was in the "default" zone, opening the form and clicking "Edit" would incorrectly display "Amsterdam" in the zone select menu. This is also fixed
- Resolves [lp:2156441](https://bugs.launchpad.net/maas-ui/+bug/2156441)

## QA steps
You can use `maas-ui-demo` for this QA. Also, keep a separate tab open for the current `maas-ui-demo`.
- [x] Sign in to MAAS
- [x] Go to the configuration page for a particular machine (e.g. `/machine/wrrxhx/configuration`)
- [x] Click "Edit"
- [x] Your local server should show "default" for the zone input (which is correct), whereas in the current `maas-ui-demo` page, it will say "Test zone"
- [x] Change the zone to "Test zone" and save
- [x] Ensure the zone has been updated without errors and is immediately reflected in the form

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6603](https://warthogs.atlassian.net/browse/MAASENG-6603)

## Notes
- PRs for 3.7 and 3.6 will also be created soon

[MAASENG-6603]: https://warthogs.atlassian.net/browse/MAASENG-6603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ