### PR TITLE
chore(deps): upgrade maas-react-components to 2.4.0

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -2,11 +2,11 @@ import "@testing-library/cypress/add-commands";
 import type { Result } from "axe-core";
 import { LONG_TIMEOUT } from "../constants";
 import {
-  generateId,
-  generateMAASURL,
-  generateMac,
-  generateName,
-  generateVid,
+    generateId,
+    generateMAASURL,
+    generateMac,
+    generateName,
+    generateVid,
 } from "../e2e/utils";
 import type { A11yPageContext } from "./e2e";
 
@@ -134,7 +134,7 @@ Cypress.Commands.add(
     vlan = `cy-vlan-${vid}`,
   }) => {
     cy.visit(generateMAASURL("/networks"));
-    cy.waitForTableToLoad({ name: "Subnets by fabric" });
+    cy.waitForTableToLoad({ name: "Subnets by fabric", role: "treegrid" });
     cy.findByRole("button", { name: "Add" }).click();
     cy.findByRole("menuitem", { name: "Subnet" }).click();
     cy.findByRole("textbox", { name: "CIDR" }).type(cidr);
@@ -193,12 +193,15 @@ Cypress.Commands.add("waitForPageToLoad", () => {
   cy.findAllByRole("heading", { level: 1 }).should("have.length.at.least", 1);
 });
 
-Cypress.Commands.add("waitForTableToLoad", ({ name } = { name: undefined }) => {
-  cy.findByRole("grid", { name: /Loading/i, timeout: LONG_TIMEOUT }).should(
-    "not.exist"
-  );
-  return cy.findByRole("grid", { name }).should("exist");
-});
+Cypress.Commands.add(
+  "waitForTableToLoad",
+  ({ name, role = "grid" } = { name: undefined }) => {
+    cy.findByRole(role, { name: /Loading/i, timeout: LONG_TIMEOUT }).should(
+      "not.exist"
+    );
+    return cy.findByRole(role, { name }).should("exist");
+  }
+);
 
 Cypress.Commands.add("getMainNavigation", () => {
   return cy.findByRole("banner", { name: /main navigation/i });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -2,11 +2,11 @@ import "@testing-library/cypress/add-commands";
 import type { Result } from "axe-core";
 import { LONG_TIMEOUT } from "../constants";
 import {
-    generateId,
-    generateMAASURL,
-    generateMac,
-    generateName,
-    generateVid,
+  generateId,
+  generateMAASURL,
+  generateMac,
+  generateName,
+  generateVid,
 } from "../e2e/utils";
 import type { A11yPageContext } from "./e2e";
 

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,8 +1,8 @@
 /// <reference types="cypress" />
 
+import "@percy/cypress";
 import "cypress-axe";
 import "cypress-wait-until";
-import "@percy/cypress";
 import "./commands";
 
 export type A11yPageContext = { url?: string; title?: string };
@@ -31,6 +31,7 @@ declare global {
       waitForPageToLoad(): void;
       waitForTableToLoad(options?: {
         name?: string | RegExp;
+        role?: string;
       }): Cypress.Chainable<JQuery<HTMLElement>>;
       getMainNavigation(): Cypress.Chainable<JQuery<HTMLElement>>;
       expandMainNavigation(): void;

--- a/cypress/support/step_definitions/common/environment.steps.ts
+++ b/cypress/support/step_definitions/common/environment.steps.ts
@@ -9,5 +9,5 @@ Given("the page is loaded", () => {
 });
 
 Given("the {string} table has loaded", (name: string) => {
-  cy.waitForTableToLoad({ name: name });
+  cy.waitForTableToLoad({ name, role: "treegrid" });
 });

--- a/cypress/support/step_definitions/controllers/controllers.steps.ts
+++ b/cypress/support/step_definitions/controllers/controllers.steps.ts
@@ -2,7 +2,7 @@ import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import { generateId } from "../../../e2e/utils";
 
 Given("the user navigates to details page of the first controller", () => {
-  cy.findByRole("grid", { name: /controllers list/i }).within(() =>
+  cy.findByRole("treegrid", { name: /controllers list/i }).within(() =>
     cy.findAllByRole("link").first().click()
   );
   cy.waitForPageToLoad();
@@ -43,7 +43,7 @@ When("the user clicks the created tag", () => {
 });
 
 When("the user clicks name of the first script", () => {
-  cy.findByRole("grid").within(() => {
+  cy.findByRole("treegrid").within(() => {
     cy.get("tbody tr")
       .first()
       .within(() => {
@@ -62,7 +62,7 @@ Then("the correct tag is displayed in the searchbox", () => {
 });
 
 Then("the correct number of controllers is displayed", () => {
-  cy.findByRole("grid", { name: "controllers list" }).within(() => {
+  cy.findByRole("treegrid", { name: "controllers list" }).within(() => {
     cy.get("tbody tr").should("have.length", 1);
   });
 });

--- a/cypress/support/step_definitions/domains/domainsRecords.steps.ts
+++ b/cypress/support/step_definitions/domains/domainsRecords.steps.ts
@@ -14,7 +14,7 @@ When("the user enters a record name", () => {
 });
 
 When("the DNS default domain row is opened", () => {
-  cy.findByRole("grid", { name: "Domains table" }).within(() => {
+  cy.findByRole("treegrid", { name: "Domains table" }).within(() => {
     cy.get("[data-testid='domain-name']").first().click();
   });
 });

--- a/cypress/support/step_definitions/machines/machines_actions.steps.ts
+++ b/cypress/support/step_definitions/machines/machines_actions.steps.ts
@@ -1,12 +1,12 @@
 import {
-  Before,
-  DataTable,
-  Given,
-  Then,
-  When,
+    Before,
+    DataTable,
+    Given,
+    Then,
+    When,
 } from "@badeball/cypress-cucumber-preprocessor";
-import { generateName } from "../../../e2e/utils";
 import { LONG_TIMEOUT } from "../../../constants";
+import { generateName } from "../../../e2e/utils";
 
 let machineName = "";
 let newPoolName = "";
@@ -146,12 +146,16 @@ Then("the new pool name should be visible in the machines grid", () => {
 Then(
   "the {string} table should contain the new tag marked {string}",
   (tableName: string, status: string) => {
-    cy.findByRole("grid", { name: new RegExp(tableName, "i") }).within(() => {
-      cy.findByRole("cell", { name: new RegExp(status, "i") }).should("exist");
-      cy.findByRole("cell", { name: new RegExp(newTagName, "i") }).should(
-        "exist"
-      );
-    });
+    cy.findByRole("treegrid", { name: new RegExp(tableName, "i") }).within(
+      () => {
+        cy.findByRole("gridcell", { name: new RegExp(status, "i") }).should(
+          "exist"
+        );
+        cy.findByRole("gridcell", { name: new RegExp(newTagName, "i") }).should(
+          "exist"
+        );
+      }
+    );
   }
 );
 

--- a/cypress/support/step_definitions/machines/machines_actions.steps.ts
+++ b/cypress/support/step_definitions/machines/machines_actions.steps.ts
@@ -1,9 +1,9 @@
 import {
-    Before,
-    DataTable,
-    Given,
-    Then,
-    When,
+  Before,
+  DataTable,
+  Given,
+  Then,
+  When,
 } from "@badeball/cypress-cucumber-preprocessor";
 import { LONG_TIMEOUT } from "../../../constants";
 import { generateName } from "../../../e2e/utils";

--- a/cypress/support/step_definitions/machines/machines_details.steps.ts
+++ b/cypress/support/step_definitions/machines/machines_details.steps.ts
@@ -64,7 +64,7 @@ When("the user deletes the machine", () => {
 });
 
 When("the user opens the first commissioning details row", () => {
-  cy.findByRole("grid").within(() => {
+  cy.findByRole("treegrid").within(() => {
     cy.get("tbody tr")
       .first()
       .within(() => {

--- a/cypress/support/step_definitions/networks/networksAdd.steps.ts
+++ b/cypress/support/step_definitions/networks/networksAdd.steps.ts
@@ -1,9 +1,9 @@
 import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import {
-  generateCidr,
-  generateId,
-  generateMAASURL,
-  generateVid,
+    generateCidr,
+    generateId,
+    generateMAASURL,
+    generateVid,
 } from "../../../e2e/utils";
 import { completeAddVlanForm, completeForm } from "./add.helpers";
 
@@ -83,11 +83,13 @@ Then("the subnet appears under the correct fabric", function () {
   cy.findAllByRole("row", { name: new RegExp(this.fabric) })
     .next("tr")
     .within(() => {
-      cy.findAllByRole("cell").eq(1).should("contain.text", this.subnetName);
-      cy.findAllByRole("cell")
+      cy.findAllByRole("gridcell")
+        .eq(1)
+        .should("contain.text", this.subnetName);
+      cy.findAllByRole("gridcell")
         .eq(2)
         .should("have.text", `${this.vid} (${this.vlan})`);
-      cy.findAllByRole("cell").eq(5).should("have.text", this.spaceName);
+      cy.findAllByRole("gridcell").eq(5).should("have.text", this.spaceName);
     });
 });
 

--- a/cypress/support/step_definitions/networks/networksAdd.steps.ts
+++ b/cypress/support/step_definitions/networks/networksAdd.steps.ts
@@ -1,9 +1,9 @@
 import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import {
-    generateCidr,
-    generateId,
-    generateMAASURL,
-    generateVid,
+  generateCidr,
+  generateId,
+  generateMAASURL,
+  generateVid,
 } from "../../../e2e/utils";
 import { completeAddVlanForm, completeForm } from "./add.helpers";
 

--- a/cypress/support/step_definitions/networks/networksReservedIpForMachine.steps.ts
+++ b/cypress/support/step_definitions/networks/networksReservedIpForMachine.steps.ts
@@ -1,11 +1,11 @@
 import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import { LONG_TIMEOUT } from "../../../constants";
 import {
-  generateCidr,
-  generateId,
-  generateMAASURL,
-  generateMac,
-  generateVid,
+    generateCidr,
+    generateId,
+    generateMAASURL,
+    generateMac,
+    generateVid,
 } from "../../../e2e/utils";
 import { completeAddVlanForm, completeForm } from "./add.helpers";
 
@@ -73,7 +73,7 @@ When("the user reserves a static DHCP lease", function () {
 });
 
 Then("the new static DHCP lease appears in the table", function () {
-  cy.findByRole("table", { name: /static dhcp leases/i }).within(() => {
+  cy.findByRole("treegrid", { name: /static dhcp leases/i }).within(() => {
     cy.findByText(new RegExp(this.reservedMac, "i")).should("exist");
   });
 });
@@ -81,7 +81,7 @@ Then("the new static DHCP lease appears in the table", function () {
 When("the user edits the static DHCP lease comment", function () {
   this.updatedComment = `cy-updated-${generateId()}`;
 
-  cy.findByRole("table", { name: /static dhcp leases/i }).within(() => {
+  cy.findByRole("treegrid", { name: /static dhcp leases/i }).within(() => {
     cy.findByText(new RegExp(this.reservedMac, "i"))
       .closest("tr")
       .findByRole("button", { name: /edit/i })
@@ -105,14 +105,14 @@ When("the user edits the static DHCP lease comment", function () {
 Then(
   "the updated comment is visible in the static DHCP leases table",
   function () {
-    cy.findByRole("table", { name: /static dhcp leases/i }).within(() => {
+    cy.findByRole("treegrid", { name: /static dhcp leases/i }).within(() => {
       cy.findByText(this.updatedComment).should("exist");
     });
   }
 );
 
 When("the user deletes the static DHCP lease", function () {
-  cy.findByRole("table", { name: /static dhcp leases/i }).within(() => {
+  cy.findByRole("treegrid", { name: /static dhcp leases/i }).within(() => {
     cy.findByText(new RegExp(this.reservedMac, "i"))
       .closest("tr")
       .findByRole("button", { name: /delete/i })
@@ -129,7 +129,7 @@ When("the user deletes the static DHCP lease", function () {
 });
 
 Then("the static DHCP lease should not exist", function () {
-  cy.findByRole("table", { name: /static dhcp leases/i }).within(() => {
+  cy.findByRole("treegrid", { name: /static dhcp leases/i }).within(() => {
     cy.findByText(new RegExp(this.reservedMac, "i")).should("not.exist");
   });
 });
@@ -181,7 +181,7 @@ Then(
   "the machine is linked to the static DHCP lease in the table",
   function () {
     cy.reload();
-    cy.findByRole("table", { name: /static dhcp leases/i }).within(() => {
+    cy.findByRole("treegrid", { name: /static dhcp leases/i }).within(() => {
       cy.findByText(new RegExp(this.reservedMac, "i"))
         .closest("tr")
         .within(() => {

--- a/cypress/support/step_definitions/networks/networksReservedIpForMachine.steps.ts
+++ b/cypress/support/step_definitions/networks/networksReservedIpForMachine.steps.ts
@@ -1,11 +1,11 @@
 import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import { LONG_TIMEOUT } from "../../../constants";
 import {
-    generateCidr,
-    generateId,
-    generateMAASURL,
-    generateMac,
-    generateVid,
+  generateCidr,
+  generateId,
+  generateMAASURL,
+  generateMac,
+  generateVid,
 } from "../../../e2e/utils";
 import { completeAddVlanForm, completeForm } from "./add.helpers";
 

--- a/cypress/support/step_definitions/networks/networksStaticroutes.steps.ts
+++ b/cypress/support/step_definitions/networks/networksStaticroutes.steps.ts
@@ -2,7 +2,7 @@ import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
 import { LONG_TIMEOUT } from "../../../constants";
 
 When("the user opens the first subnet", () => {
-  cy.findByRole("grid", { name: "Subnets by fabric" }).within(() => {
+  cy.findByRole("treegrid", { name: "Subnets by fabric" }).within(() => {
     cy.get("tbody")
       .find('tr[class="p-generic-table__individual-row"]')
       .find("a")

--- a/cypress/support/step_definitions/networks/networksSubnets.steps.ts
+++ b/cypress/support/step_definitions/networks/networksSubnets.steps.ts
@@ -17,7 +17,7 @@ When("the user selects grouping by space", () => {
 Then("correct headers exist", () => {
   const expectedHeaders = ["VLAN", "DHCP", "Subnet", "Available IPs", "Space"];
 
-  cy.findByRole("grid", { name: "Subnets by fabric" }).within(() => {
+  cy.findByRole("treegrid", { name: "Subnets by fabric" }).within(() => {
     expectedHeaders.forEach((name) => {
       cy.findByRole("columnheader", { name }).should("exist");
     });
@@ -34,7 +34,7 @@ Then("the URL gets updated to default grouping", () => {
 });
 
 Then("subnets are by default grouped by fabric", () => {
-  cy.findByRole("grid", { name: "Subnets by fabric" }).within(() => {
+  cy.findByRole("treegrid", { name: "Subnets by fabric" }).within(() => {
     cy.get("tbody tr").first().should("include.text", "fabric");
   });
 
@@ -50,7 +50,7 @@ Then("subnets are by default grouped by fabric", () => {
 });
 
 Then("subnets are grouped by space", () => {
-  cy.findByRole("grid", { name: "Subnets by space" }).within(() => {
+  cy.findByRole("treegrid", { name: "Subnets by space" }).within(() => {
     cy.get("tbody tr").first().should("include.text", "space");
   });
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@canonical/maas-react-components": "2.0.4",
+    "@canonical/maas-react-components": "2.4.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "4.5.2",
     "@redux-devtools/extension": "3.3.0",

--- a/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -149,7 +149,7 @@ describe("DHCPTable", () => {
           state,
         }
       );
-      const subnetSnippets = screen.getAllByRole("cell", {
+      const subnetSnippets = screen.getAllByRole("gridcell", {
         name: /subnet-name/,
       });
 

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -175,12 +175,15 @@ describe("DhcpFormFields", () => {
       screen.getByRole("button", { name: /Choose machine/ })
     );
     await waitFor(() => {
-      expect(screen.getByRole("grid")).toHaveAttribute("aria-busy", "false");
+      expect(screen.getByRole("treegrid")).toHaveAttribute(
+        "aria-busy",
+        "false"
+      );
     });
     // need to use fireEvent here to click through the element and trigger the onCLick handler
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(
-      screen.getByRole("cell", {
+      screen.getByRole("gridcell", {
         name: new RegExp(machine.hostname),
       }).firstChild as Element
     );

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -81,7 +81,7 @@ describe("MachineSelectTable", () => {
 
     // have to click through to the span that has the click handler
     await userEvent.click(
-      screen.getByRole("cell", { name: new RegExp(machines[0].hostname) })
+      screen.getByRole("gridcell", { name: new RegExp(machines[0].hostname) })
         .firstChild as Element
     );
     expect(onMachineClick).toHaveBeenCalledWith(machines[0]);
@@ -111,6 +111,6 @@ describe("MachineSelectTable", () => {
       />,
       { state }
     );
-    expect(screen.getByRole("grid")).toBeInTheDocument();
+    expect(screen.getByRole("treegrid")).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
+++ b/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
@@ -38,7 +38,7 @@ describe("NetworkCardTable", () => {
       );
 
       expect(
-        screen.getByRole("cell", { name: "No interfaces available." })
+        screen.getByRole("gridcell", { name: "No interfaces available." })
       ).toBeInTheDocument();
     });
 
@@ -52,7 +52,7 @@ describe("NetworkCardTable", () => {
       );
 
       expect(
-        screen.getByRole("cell", { name: /fabric-name/ })
+        screen.getByRole("gridcell", { name: /fabric-name/ })
       ).toBeInTheDocument();
     });
 
@@ -61,7 +61,9 @@ describe("NetworkCardTable", () => {
       renderWithProviders(
         <NetworkCardTable interfaces={[iface]} node={state.device.items[0]} />
       );
-      expect(screen.getByRole("cell", { name: "10 Gbps" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("gridcell", { name: "10 Gbps" })
+      ).toBeInTheDocument();
     });
   });
 
@@ -77,7 +79,7 @@ describe("NetworkCardTable", () => {
       );
 
       expect(
-        screen.getByRole("cell", { name: "External (192.168.1.1)" })
+        screen.getByRole("gridcell", { name: "External (192.168.1.1)" })
       ).toBeInTheDocument();
     });
 
@@ -90,7 +92,7 @@ describe("NetworkCardTable", () => {
       );
 
       expect(
-        screen.getByRole("cell", { name: "MAAS-provided" })
+        screen.getByRole("gridcell", { name: "MAAS-provided" })
       ).toBeInTheDocument();
     });
 
@@ -107,11 +109,11 @@ describe("NetworkCardTable", () => {
       );
 
       expect(
-        screen.getByRole("cell", { name: /Relayed/i })
+        screen.getByRole("gridcell", { name: /Relayed/i })
       ).toBeInTheDocument();
 
       await userEvent.click(
-        within(screen.getByRole("cell", { name: /Relayed/i })).getByRole(
+        within(screen.getByRole("gridcell", { name: /Relayed/i })).getByRole(
           "button",
           { name: "information" }
         )
@@ -129,7 +131,9 @@ describe("NetworkCardTable", () => {
         { state }
       );
 
-      expect(screen.getByRole("cell", { name: "No DHCP" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("gridcell", { name: "No DHCP" })
+      ).toBeInTheDocument();
     });
   });
 
@@ -140,6 +144,6 @@ describe("NetworkCardTable", () => {
       { state }
     );
 
-    expect(screen.getByRole("cell", { name: "Yes" })).toBeInTheDocument();
+    expect(screen.getByRole("gridcell", { name: "Yes" })).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.test.tsx
+++ b/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.test.tsx
@@ -119,7 +119,7 @@ describe("NodeSummaryNetworkCard", () => {
       { state }
     );
 
-    const tables = screen.getAllByRole("grid");
+    const tables = screen.getAllByRole("treegrid");
 
     expect(within(tables[0]).getAllByRole("row")).toHaveLength(5);
     expect(within(tables[1]).getAllByRole("row")).toHaveLength(4);

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -86,7 +86,7 @@ describe("AvailableStorageTable", () => {
       expect(rows).toHaveLength(1);
 
       // The first cell is the checkbox, so the second cell should have the name
-      expect(within(rows[0]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[0]).getAllByRole("gridcell")[1]).toHaveTextContent(
         availableDisk.name
       );
     });

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
@@ -121,10 +121,10 @@ describe("CreateDatastore", () => {
 
     const rows = screen.getAllByRole("row");
     expect(rows).toHaveLength(3);
-    expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(
+    expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
       selectedDisk.name
     );
-    expect(within(rows[2]).getAllByRole("cell")[0]).toHaveTextContent(
+    expect(within(rows[2]).getAllByRole("gridcell")[0]).toHaveTextContent(
       selectedPartition.name
     );
   });

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx
@@ -55,10 +55,10 @@ describe("CreateVolumeGroupForm", () => {
 
       const rows = screen.getAllByRole("row");
       expect(rows).toHaveLength(3);
-      expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(
+      expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
         selectedDisk.name
       );
-      expect(within(rows[2]).getAllByRole("cell")[0]).toHaveTextContent(
+      expect(within(rows[2]).getAllByRole("gridcell")[0]).toHaveTextContent(
         selectedPartition.name
       );
       expect(screen.getByText(new RegExp(selectedPartition.name, "i")));

--- a/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
@@ -40,7 +40,7 @@ describe("CacheSetsTable", () => {
 
     const rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
     expect(rows).toHaveLength(1);
-    expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(
+    expect(within(rows[0]).getAllByRole("gridcell")[0]).toHaveTextContent(
       cacheSet.name
     );
   });

--- a/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
@@ -133,11 +133,11 @@ describe("DatastoresTable", () => {
         state,
       });
 
-      expect(screen.getByRole("cell", { name: dsDisk.name })).toHaveClass(
+      expect(screen.getByRole("gridcell", { name: dsDisk.name })).toHaveClass(
         "name"
       );
       expect(
-        screen.queryByRole("cell", { name: notDsDisk.name })
+        screen.queryByRole("gridcell", { name: notDsDisk.name })
       ).not.toBeInTheDocument();
     });
   });

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
@@ -143,10 +143,12 @@ describe("FilesystemsTable", () => {
         state,
       });
 
-      expect(screen.getByRole("cell", { name: "disk-fs" })).toHaveClass("name");
-      expect(screen.getByRole("cell", { name: "/disk-fs/path" })).toHaveClass(
-        "mountPoint"
+      expect(screen.getByRole("gridcell", { name: "disk-fs" })).toHaveClass(
+        "name"
       );
+      expect(
+        screen.getByRole("gridcell", { name: "/disk-fs/path" })
+      ).toHaveClass("mountPoint");
     });
 
     it("can show filesystems associated with partitions", () => {
@@ -170,11 +172,11 @@ describe("FilesystemsTable", () => {
         state,
       });
 
-      expect(screen.getByRole("cell", { name: "partition-fs" })).toHaveClass(
-        "name"
-      );
       expect(
-        screen.getByRole("cell", { name: "/partition-fs/path" })
+        screen.getByRole("gridcell", { name: "partition-fs" })
+      ).toHaveClass("name");
+      expect(
+        screen.getByRole("gridcell", { name: "/partition-fs/path" })
       ).toHaveClass("mountPoint");
     });
 
@@ -194,9 +196,11 @@ describe("FilesystemsTable", () => {
         state,
       });
 
-      expect(screen.getAllByRole("cell", { name: "—" })[0]).toHaveClass("name");
+      expect(screen.getAllByRole("gridcell", { name: "—" })[0]).toHaveClass(
+        "name"
+      );
       expect(
-        screen.getByRole("cell", { name: "/special-fs/path" })
+        screen.getByRole("gridcell", { name: "/special-fs/path" })
       ).toHaveClass("mountPoint");
     });
   });

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -144,7 +144,7 @@ describe("NetworkTable", () => {
       );
 
       const row = screen.getAllByRole("row")[1];
-      const cells = within(row).getAllByRole("cell");
+      const cells = within(row).getAllByRole("gridcell");
       const subnetCell = cells[6];
       expect(subnetCell).toHaveTextContent("Unconfigured");
       const ipCell = cells[7];
@@ -192,7 +192,7 @@ describe("NetworkTable", () => {
       );
 
       const row = screen.getAllByRole("row")[1];
-      const cells = within(row).getAllByRole("cell");
+      const cells = within(row).getAllByRole("gridcell");
       const subnetCell = cells[6];
       expect(subnetCell).toHaveTextContent("subnet-cidr");
       const ipCell = cells[7];
@@ -247,7 +247,7 @@ describe("NetworkTable", () => {
 
       const rows = screen.getAllByRole("row").slice(1);
       rows.forEach((row, index) => {
-        const cells = within(row).getAllByRole("cell");
+        const cells = within(row).getAllByRole("gridcell");
         const nameCell = cells[1];
         expect(nameCell).toHaveTextContent("alias");
         const subnetCell = cells[6];
@@ -296,7 +296,7 @@ describe("NetworkTable", () => {
       const bondRow = rows[1];
       expect(within(bondRow).getByRole("checkbox")).toBeInTheDocument();
       const nicRow = rows[2];
-      expect(within(nicRow).queryByRole("checkbox")).toBeDisabled();
+      expect(within(nicRow).queryByRole("checkbox")).not.toBeInTheDocument();
     });
 
     it("does not include parent interfaces in the selection", async () => {
@@ -341,16 +341,16 @@ describe("NetworkTable", () => {
         { state }
       );
       const row = screen.getAllByRole("row")[2];
-      const cells = within(row).queryAllByRole("cell");
-      const fabricCell = cells[5];
+      const cells = within(row).queryAllByRole("gridcell");
+      const fabricCell = cells[4];
       expect(fabricCell).toHaveTextContent("");
-      const subnetCell = cells[6];
+      const subnetCell = cells[5];
       expect(subnetCell).toHaveTextContent("");
-      const ipCell = cells[7];
+      const ipCell = cells[6];
       expect(ipCell).toHaveTextContent("");
-      const dhcpCell = cells[8];
+      const dhcpCell = cells[7];
       expect(dhcpCell).toHaveTextContent("");
-      const actionCell = cells[9];
+      const actionCell = cells[8];
       expect(actionCell).toHaveTextContent("");
     });
   });

--- a/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
@@ -64,7 +64,7 @@ it("displays correct text when loading", function () {
     }
   );
 
-  const vlanTable = screen.getByRole("grid", { name: "Controller VLANs" });
+  const vlanTable = screen.getByRole("treegrid", { name: "Controller VLANs" });
   expect(within(vlanTable).getByText("Loading...")).toBeInTheDocument();
 });
 
@@ -93,7 +93,7 @@ it("displays correct text for no VLANs", function () {
     }
   );
 
-  const vlanTable = screen.getByRole("grid", { name: "Controller VLANs" });
+  const vlanTable = screen.getByRole("treegrid", { name: "Controller VLANs" });
   expect(within(vlanTable).getByText(/No VLANs found/)).toBeInTheDocument();
 });
 
@@ -122,7 +122,7 @@ it("displays a VLANs table with a single row", function () {
     }
   );
 
-  const vlanTable = screen.getByRole("grid", { name: "Controller VLANs" });
+  const vlanTable = screen.getByRole("treegrid", { name: "Controller VLANs" });
   expect(vlanTable).toBeInTheDocument();
   const tableBody = within(vlanTable).getAllByRole("rowgroup")[1];
   const vlanTableRows = within(tableBody).getAllByRole("row");
@@ -208,7 +208,7 @@ it("displays correct text within each cell", () => {
   });
 
   Object.values(expectedColumnContent).forEach((value, index) => {
-    expect(within(row).getAllByRole("cell")[index]).toHaveTextContent(
+    expect(within(row).getAllByRole("gridcell")[index]).toHaveTextContent(
       new RegExp(value)
     );
   });

--- a/src/app/controllers/views/ControllerList/components/ControllersTable/ControllersTable.test.tsx
+++ b/src/app/controllers/views/ControllerList/components/ControllersTable/ControllersTable.test.tsx
@@ -93,13 +93,13 @@ describe("ControllersTable", () => {
 
       let rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
 
-      expect(within(rows[0]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[0]).getAllByRole("gridcell")[1]).toHaveTextContent(
         /anaconda/i
       );
-      expect(within(rows[1]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[1]).getAllByRole("gridcell")[1]).toHaveTextContent(
         /lion/i
       );
-      expect(within(rows[2]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[2]).getAllByRole("gridcell")[1]).toHaveTextContent(
         /zebra/i
       );
 
@@ -108,13 +108,13 @@ describe("ControllersTable", () => {
 
       rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
 
-      expect(within(rows[0]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[0]).getAllByRole("gridcell")[1]).toHaveTextContent(
         /zebra/i
       );
-      expect(within(rows[1]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[1]).getAllByRole("gridcell")[1]).toHaveTextContent(
         /lion/i
       );
-      expect(within(rows[2]).getAllByRole("cell")[1]).toHaveTextContent(
+      expect(within(rows[2]).getAllByRole("gridcell")[1]).toHaveTextContent(
         /anaconda/i
       );
     });

--- a/src/app/devices/components/DeviceNetwork/DeviceNetwork.test.tsx
+++ b/src/app/devices/components/DeviceNetwork/DeviceNetwork.test.tsx
@@ -13,7 +13,7 @@ describe("DeviceNetwork", () => {
 
     renderWithProviders(<DeviceNetwork systemId="abc123" />, { state });
     expect(screen.queryByLabelText("Device network")).not.toBeInTheDocument();
-    expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+    expect(screen.queryByRole("treegrid")).not.toBeInTheDocument();
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
@@ -26,9 +26,9 @@ describe("DeviceNetwork", () => {
 
     renderWithProviders(<DeviceNetwork systemId="abc123" />, { state });
     expect(screen.getByLabelText("Device network")).toBeInTheDocument();
-    expect(screen.getByRole("grid", { name: /DHCP/ })).toBeInTheDocument();
+    expect(screen.getByRole("treegrid", { name: /DHCP/ })).toBeInTheDocument();
     expect(
-      screen.getByRole("grid", { name: "Interfaces" })
+      screen.getByRole("treegrid", { name: "Interfaces" })
     ).toBeInTheDocument();
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });

--- a/src/app/devices/components/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/src/app/devices/components/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -60,7 +60,7 @@ describe("DeviceNetworkTable", () => {
     it("displays a table when loaded", () => {
       renderWithProviders(<DeviceNetworkTable systemId="abc123" />, { state });
 
-      expect(screen.getByRole("grid")).toBeInTheDocument();
+      expect(screen.getByRole("treegrid")).toBeInTheDocument();
     });
 
     it("displays the columns correctly", () => {
@@ -107,7 +107,7 @@ describe("DeviceNetworkTable", () => {
 
       renderWithProviders(<DeviceNetworkTable systemId="abc123" />, { state });
       expect(
-        within(screen.getAllByRole("row")[1]).getAllByRole("cell")[3]
+        within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[3]
       ).toHaveTextContent("Unconfigured");
     });
 

--- a/src/app/domains/components/ResourceRecordsTable/ResourceRecordsTable.test.tsx
+++ b/src/app/domains/components/ResourceRecordsTable/ResourceRecordsTable.test.tsx
@@ -56,7 +56,7 @@ describe("ResourceRecordsTable", () => {
     renderWithProviders(<ResourceRecordsTable domain={items} id={1} />);
 
     expect(
-      screen.getByRole("cell", { name: "Domain contains no records." })
+      screen.getByRole("gridcell", { name: "Domain contains no records." })
     ).toBeInTheDocument();
   });
 
@@ -65,10 +65,10 @@ describe("ResourceRecordsTable", () => {
 
     const row = within(screen.getAllByRole("row")[1]);
 
-    expect(row.getAllByRole("cell")[0]).toHaveTextContent("abc");
-    expect(row.getAllByRole("cell")[1]).toHaveTextContent(RecordType.A);
-    expect(row.getAllByRole("cell")[2]).toHaveTextContent("20");
-    expect(row.getAllByRole("cell")[3]).toHaveTextContent("192.168.1.1");
+    expect(row.getAllByRole("gridcell")[0]).toHaveTextContent("abc");
+    expect(row.getAllByRole("gridcell")[1]).toHaveTextContent(RecordType.A);
+    expect(row.getAllByRole("gridcell")[2]).toHaveTextContent("20");
+    expect(row.getAllByRole("gridcell")[3]).toHaveTextContent("192.168.1.1");
   });
 
   it("renders a link in the name column when id is auto-generated", () => {
@@ -76,7 +76,7 @@ describe("ResourceRecordsTable", () => {
     renderWithProviders(<ResourceRecordsTable domain={items} id={1} />);
 
     expect(
-      screen.getByRole("cell", { name: "abc" }).firstChild
+      screen.getByRole("gridcell", { name: "abc" }).firstChild
     ).toHaveAttribute(
       "href",
       expect.stringMatching(/^\/(machine|controller|device)\/132$/)

--- a/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -29,7 +29,7 @@ describe("DomainsList", () => {
     });
 
     expect(
-      screen.getByRole("grid", { name: DomainsTableLabels.TableLable })
+      screen.getByRole("treegrid", { name: DomainsTableLabels.TableLable })
     ).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
+++ b/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
@@ -68,10 +68,10 @@ describe("NumaResourcesCard", () => {
       name: new RegExp(`^Hugepage`, "i"),
     });
     expect(within(hugepagesData).getByText("(Size: 1KiB)")).toBeInTheDocument();
-    expect(within(hugepagesData).getAllByRole("cell")[1]).toHaveTextContent(
+    expect(within(hugepagesData).getAllByRole("gridcell")[1]).toHaveTextContent(
       "5B"
     ); // Allocated
-    expect(within(hugepagesData).getAllByRole("cell")[2]).toHaveTextContent(
+    expect(within(hugepagesData).getAllByRole("gridcell")[2]).toHaveTextContent(
       "7B"
     ); // Free
   });

--- a/src/app/kvm/views/KVMList/components/VirshTable/VirshTable.test.tsx
+++ b/src/app/kvm/views/KVMList/components/VirshTable/VirshTable.test.tsx
@@ -48,8 +48,12 @@ describe("VirshTable", () => {
       const rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole(
         "row"
       );
-      expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(/b/i);
-      expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(/a/i);
+      expect(within(rows[0]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /b/i
+      );
+      expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /a/i
+      );
     });
 
     it("displays a message when empty", () => {
@@ -75,26 +79,42 @@ describe("VirshTable", () => {
       await waitForLoading();
 
       let rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-      expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(/b/i);
-      expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(/a/i);
+      expect(within(rows[0]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /b/i
+      );
+      expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /a/i
+      );
 
       await userEvent.click(screen.getByRole("button", { name: /name/i }));
       rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-      expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(/a/i);
-      expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(/b/i);
+      expect(within(rows[0]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /a/i
+      );
+      expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /b/i
+      );
 
       // Click the VMs table header to order by descending VMs count
       await userEvent.click(screen.getByRole("button", { name: /VMs/i }));
       rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
 
-      expect(within(rows[0]).getAllByRole("cell")[1]).toHaveTextContent(/2/i);
-      expect(within(rows[1]).getAllByRole("cell")[1]).toHaveTextContent(/1/i);
+      expect(within(rows[0]).getAllByRole("gridcell")[1]).toHaveTextContent(
+        /2/i
+      );
+      expect(within(rows[1]).getAllByRole("gridcell")[1]).toHaveTextContent(
+        /1/i
+      );
 
       await userEvent.click(screen.getByRole("button", { name: /VMs/i }));
       rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
 
-      expect(within(rows[0]).getAllByRole("cell")[1]).toHaveTextContent(/1/i);
-      expect(within(rows[1]).getAllByRole("cell")[1]).toHaveTextContent(/2/i);
+      expect(within(rows[0]).getAllByRole("gridcell")[1]).toHaveTextContent(
+        /1/i
+      );
+      expect(within(rows[1]).getAllByRole("gridcell")[1]).toHaveTextContent(
+        /2/i
+      );
     });
 
     it("can sort by pod resource pool", async () => {
@@ -110,18 +130,22 @@ describe("VirshTable", () => {
       await waitForLoading();
 
       let rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-      expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(/b/i);
-      expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(/a/i);
+      expect(within(rows[0]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /b/i
+      );
+      expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
+        /a/i
+      );
 
       await userEvent.click(
         screen.getByRole("button", { name: /Resource Pool/i })
       );
 
       rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-      expect(within(rows[0]).getAllByRole("cell")[3]).toHaveTextContent(
+      expect(within(rows[0]).getAllByRole("gridcell")[3]).toHaveTextContent(
         /gene/i
       );
-      expect(within(rows[1]).getAllByRole("cell")[3]).toHaveTextContent(
+      expect(within(rows[1]).getAllByRole("gridcell")[3]).toHaveTextContent(
         /swimming/i
       );
 
@@ -129,10 +153,10 @@ describe("VirshTable", () => {
         screen.getByRole("button", { name: /Resource Pool/i })
       );
       rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-      expect(within(rows[0]).getAllByRole("cell")[3]).toHaveTextContent(
+      expect(within(rows[0]).getAllByRole("gridcell")[3]).toHaveTextContent(
         /swimming/i
       );
-      expect(within(rows[1]).getAllByRole("cell")[3]).toHaveTextContent(
+      expect(within(rows[1]).getAllByRole("gridcell")[3]).toHaveTextContent(
         /gene/i
       );
     });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -78,7 +78,7 @@ describe("CloneForm", () => {
 
     // Select a source machine - form should update
     await userEvent.click(
-      screen.getByRole("cell", { name: new RegExp(machines[1].hostname) })
+      screen.getByRole("gridcell", { name: new RegExp(machines[1].hostname) })
         .firstChild as Element
     );
 
@@ -155,7 +155,7 @@ describe("CloneForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("cell", { name: new RegExp(machines[2].hostname) })
+      screen.getByRole("gridcell", { name: new RegExp(machines[2].hostname) })
         .firstChild as Element
     );
 

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -102,7 +102,7 @@ describe("CloneFormFields", () => {
 
     // nested span contains the onClick handler
     await userEvent.click(
-      screen.getByRole("cell", {
+      screen.getByRole("gridcell", {
         name: new RegExp(`^${machine.hostname}`),
       }).firstChild as Element
     );
@@ -131,7 +131,7 @@ describe("CloneFormFields", () => {
       </Formik>,
       { state }
     );
-    let tableContainer = screen.getByRole("grid", {
+    let tableContainer = screen.getByRole("treegrid", {
       name: "Clone network",
     }).parentElement;
     // Table has unselected styling by default
@@ -143,7 +143,7 @@ describe("CloneFormFields", () => {
     );
 
     await waitFor(() => {
-      tableContainer = screen.getByRole("grid", {
+      tableContainer = screen.getByRole("treegrid", {
         name: "Clone network",
       }).parentElement;
       expect(tableContainer).not.toHaveClass("not-selected");

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
@@ -34,7 +34,7 @@ describe("CloneNetworkTable", () => {
     });
 
     // should only be the single empty state cell from GenericTable
-    expect(screen.getAllByRole("cell")).toHaveLength(1);
+    expect(screen.getAllByRole("gridcell")).toHaveLength(1);
   });
 
   it("renders machine network details if machine is provided", () => {
@@ -81,7 +81,7 @@ describe("CloneNetworkTable", () => {
     });
 
     expect(
-      within(screen.getAllByRole("row")[1]).getAllByRole("cell")[0]
+      within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[0]
     ).toHaveTextContent("Unconfigured");
   });
 
@@ -115,7 +115,7 @@ describe("CloneNetworkTable", () => {
     });
 
     expect(
-      within(screen.getAllByRole("row")[1]).getAllByRole("cell")[0]
+      within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[0]
     ).toHaveTextContent("subnet-cidr");
   });
 
@@ -156,7 +156,9 @@ describe("CloneNetworkTable", () => {
       state,
     });
 
-    const cell = within(screen.getAllByRole("row")[2]).getAllByRole("cell")[0];
+    const cell = within(screen.getAllByRole("row")[2]).getAllByRole(
+      "gridcell"
+    )[0];
 
     expect(within(cell).getByTestId("primary")).toHaveTextContent("alias:1");
     expect(within(cell).getByTestId("secondary")).toHaveTextContent(
@@ -218,7 +220,7 @@ describe("CloneNetworkTable", () => {
     );
     const names = dataRows.map(
       (row) =>
-        within(within(row).getAllByRole("cell")[0]).getByTestId("primary")
+        within(within(row).getAllByRole("gridcell")[0]).getByTestId("primary")
           .textContent
     );
 

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
@@ -41,7 +41,7 @@ describe("CloneStorageTable", () => {
       <CloneStorageTable machine={machine} selected={false} />
     );
     const availableCell = within(screen.getAllByRole("row")[1]).getAllByRole(
-      "cell"
+      "gridcell"
     )[4];
     expect(availableCell.querySelector("i")).toHaveClass("p-icon--tick");
   });
@@ -54,7 +54,7 @@ describe("CloneStorageTable", () => {
       <CloneStorageTable machine={machine} selected={false} />
     );
     const availableCell = within(screen.getAllByRole("row")[1]).getAllByRole(
-      "cell"
+      "gridcell"
     )[4];
     expect(availableCell.querySelector("i")).toHaveClass("p-icon--close");
   });
@@ -71,7 +71,7 @@ describe("CloneStorageTable", () => {
       <CloneStorageTable machine={machine} selected={false} />
     );
     const availableCell = within(screen.getAllByRole("row")[2]).getAllByRole(
-      "cell"
+      "gridcell"
     )[4];
     expect(availableCell.querySelector("i")).toHaveClass("p-icon--tick");
   });
@@ -90,7 +90,7 @@ describe("CloneStorageTable", () => {
       <CloneStorageTable machine={machine} selected={false} />
     );
     const availableCell = within(screen.getAllByRole("row")[2]).getAllByRole(
-      "cell"
+      "gridcell"
     )[4];
     expect(availableCell.querySelector("i")).toHaveClass("p-icon--close");
   });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
@@ -317,7 +317,7 @@ it("updates the new tags after creating a tag", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: AddTagFormLabel.Submit })
   );
-  const changes = screen.getByRole("grid", {
+  const changes = screen.getByRole("treegrid", {
     name: TagFormChangesLabel.Table,
   });
   await waitFor(() => {

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -61,7 +61,7 @@ beforeEach(() => {
   });
 });
 
-const getTable = () => screen.getByRole("grid", { name: Label.Table });
+const getTable = () => screen.getByRole("treegrid", { name: Label.Table });
 
 const findRowByTagName = (tagName: string) =>
   within(getTable())

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -82,7 +82,7 @@ it("displays available tags in the dropdown", async () => {
     </Formik>,
     { state }
   );
-  const changes = screen.getByRole("grid", {
+  const changes = screen.getByRole("treegrid", {
     name: TagFormChangesLabel.Table,
   });
   const tagRow = within(changes)
@@ -131,7 +131,7 @@ it("displays the tags to be added", () => {
     </Formik>,
     { state }
   );
-  const changes = screen.getByRole("grid", {
+  const changes = screen.getByRole("treegrid", {
     name: TagFormChangesLabel.Table,
   });
   expect(
@@ -163,7 +163,7 @@ it.skip("updates the new tags after creating a tag", async () => {
     </Formik>
   );
   const { rerender } = renderWithProviders(<Form tags={[]} />, { state });
-  const changes = screen.getByRole("grid", {
+  const changes = screen.getByRole("treegrid", {
     name: TagFormChangesLabel.Table,
   });
   const newTag = factory.tag({ id: 8, name: "new-tag" });

--- a/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
@@ -50,7 +50,7 @@ describe("MachineInstances", () => {
     });
 
     expect(
-      screen.getByRole("grid", { name: /machine instances/i })
+      screen.getByRole("treegrid", { name: /machine instances/i })
     ).toBeInTheDocument();
   });
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -75,7 +75,7 @@ describe("AddBondForm", () => {
     expect(
       screen.getByRole("form", { name: "Create bond" })
     ).toBeInTheDocument();
-    expect(screen.getByRole("grid")).toBeInTheDocument();
+    expect(screen.getByRole("treegrid")).toBeInTheDocument();
   });
 
   it("displays the selected interfaces when not editing members", async () => {
@@ -106,7 +106,7 @@ describe("AddBondForm", () => {
       />,
       { state }
     );
-    const table = screen.getByRole("grid");
+    const table = screen.getByRole("treegrid");
     expect(within(table).getByText("test-interface-1")).toBeInTheDocument();
     expect(within(table).getByText("test-interface-2")).toBeInTheDocument();
   });
@@ -169,7 +169,7 @@ describe("AddBondForm", () => {
       />,
       { state }
     );
-    let table = screen.getByRole("grid");
+    let table = screen.getByRole("treegrid");
     // Check that selected interfaces are shown
     expect(within(table).getByText("test-interface-1")).toBeInTheDocument();
     expect(within(table).getByText("test-interface-2")).toBeInTheDocument();
@@ -191,7 +191,7 @@ describe("AddBondForm", () => {
       within(table).queryByText("test-interface-7")
     ).not.toBeInTheDocument();
     await userEvent.click(screen.getByTestId("edit-members"));
-    table = screen.getByRole("grid");
+    table = screen.getByRole("treegrid");
 
     // Check that only valid interfaces are shown
     expect(within(table).getByText("test-interface-1")).toBeInTheDocument();

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -70,7 +70,7 @@ describe("AddBridgeForm", () => {
       />,
       { state }
     );
-    const table = screen.getByRole("grid");
+    const table = screen.getByRole("treegrid");
     expect(within(table).getAllByRole("row")).toHaveLength(2);
     expect(within(table).getByText("eth2")).toBeInTheDocument();
   });
@@ -178,7 +178,7 @@ describe("AddBridgeForm", () => {
     );
 
     // Ensure both interfaces are shown in the table
-    const table = screen.getByRole("grid");
+    const table = screen.getByRole("treegrid");
     const rows = within(within(table).getAllByRole("rowgroup")[1]).getAllByRole(
       "row"
     );

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
@@ -84,7 +84,7 @@ describe("EditBondForm", () => {
       />,
       { state }
     );
-    expect(screen.getByRole("grid")).toBeInTheDocument();
+    expect(screen.getByRole("treegrid")).toBeInTheDocument();
   });
 
   it("displays the selected interfaces when not editing members", () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -41,7 +41,7 @@ describe("InterfaceFormTable", () => {
       { state }
     );
 
-    expect(screen.getByRole("grid")).toBeInTheDocument();
+    expect(screen.getByRole("treegrid")).toBeInTheDocument();
   });
 
   it("displays a PXE column by default", () => {

--- a/src/app/networks/components/ReservedRangesTable/ReservedRangesTable.test.tsx
+++ b/src/app/networks/components/ReservedRangesTable/ReservedRangesTable.test.tsx
@@ -58,7 +58,7 @@ describe("ReservedRangesTable", () => {
       screen.getByRole("region", {
         name: "Reserved ranges",
       })
-    ).getByRole("grid");
+    ).getByRole("treegrid");
 
     [
       Labels.Actions,
@@ -99,7 +99,7 @@ describe("ReservedRangesTable", () => {
       screen.getByRole("region", {
         name: "Reserved ranges",
       })
-    ).getByRole("grid");
+    ).getByRole("treegrid");
 
     [
       Labels.Actions,
@@ -169,14 +169,18 @@ describe("ReservedRangesTable", () => {
       screen.getByRole("region", {
         name: "Reserved ranges",
       })
-    ).getByRole("grid");
+    ).getByRole("treegrid");
 
     expect(
-      within(ReservedRangesTableTable).getAllByRole("cell", { name: "Dynamic" })
+      within(ReservedRangesTableTable).getAllByRole("gridcell", {
+        name: "Dynamic",
+      })
     ).toHaveLength(2);
 
     expect(
-      within(ReservedRangesTableTable).getAllByRole("cell", { name: "MAAS" })
+      within(ReservedRangesTableTable).getAllByRole("gridcell", {
+        name: "MAAS",
+      })
     ).toHaveLength(1);
   });
 
@@ -191,16 +195,18 @@ describe("ReservedRangesTable", () => {
       screen.getByRole("region", {
         name: "Reserved ranges",
       })
-    ).getByRole("grid");
+    ).getByRole("treegrid");
 
     expect(
-      within(ReservedRangesTableTable).getAllByRole("cell", {
+      within(ReservedRangesTableTable).getAllByRole("gridcell", {
         name: "Reserved",
       })
     ).toHaveLength(1);
 
     expect(
-      within(ReservedRangesTableTable).getAllByRole("cell", { name: "wombat" })
+      within(ReservedRangesTableTable).getAllByRole("gridcell", {
+        name: "wombat",
+      })
     ).toHaveLength(1);
   });
 

--- a/src/app/networks/views/Fabrics/views/FabricDetails/components/FabricVLANsTable/FabricVLANsTable.test.tsx
+++ b/src/app/networks/views/Fabrics/views/FabricDetails/components/FabricVLANsTable/FabricVLANsTable.test.tsx
@@ -38,19 +38,19 @@ it("renders correct details", () => {
   ).toBeInTheDocument();
 
   expect(
-    screen.getByRole("cell", { name: new RegExp(vlan.name) })
+    screen.getByRole("gridcell", { name: new RegExp(vlan.name) })
   ).toBeInTheDocument();
 
   expect(
-    screen.getByRole("cell", { name: new RegExp(space.name) })
+    screen.getByRole("gridcell", { name: new RegExp(space.name) })
   ).toBeInTheDocument();
 
   expect(
-    screen.getByRole("cell", { name: new RegExp(subnet.name) })
+    screen.getByRole("gridcell", { name: new RegExp(subnet.name) })
   ).toBeInTheDocument();
 
   expect(
-    screen.getByRole("cell", { name: subnet.statistics.available_string })
+    screen.getByRole("gridcell", { name: subnet.statistics.available_string })
   ).toBeInTheDocument();
 });
 
@@ -71,7 +71,9 @@ it("handles a VLAN without any subnets", () => {
   });
   renderWithProviders(<FabricVLANsTable fabric={fabric} />, { state });
 
-  expect(screen.getByRole("cell", { name: "No subnets" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("gridcell", { name: "No subnets" })
+  ).toBeInTheDocument();
 });
 
 it("handles a VLAN with multiple subnets", () => {
@@ -109,8 +111,8 @@ it("handles a VLAN with multiple subnets", () => {
     "row"
   );
 
-  const firstRowCells = within(dataRows[0]).getAllByRole("cell");
-  const secondRowCells = within(dataRows[1]).getAllByRole("cell");
+  const firstRowCells = within(dataRows[0]).getAllByRole("gridcell");
+  const secondRowCells = within(dataRows[1]).getAllByRole("gridcell");
 
   // first row for this vlan should contain name and space
   expect(firstRowCells[0]).toHaveTextContent(new RegExp(vlan.name));

--- a/src/app/networks/views/Fabrics/views/FabricsList/FabricsList.test.tsx
+++ b/src/app/networks/views/Fabrics/views/FabricsList/FabricsList.test.tsx
@@ -22,7 +22,7 @@ describe("FabricsList", () => {
     renderWithProviders(<FabricsList />);
 
     expect(
-      screen.getByRole("grid", { name: "Fabrics table" })
+      screen.getByRole("treegrid", { name: "Fabrics table" })
     ).toBeInTheDocument();
   });
 

--- a/src/app/networks/views/Spaces/views/SpacesList/SpacesList.test.tsx
+++ b/src/app/networks/views/Spaces/views/SpacesList/SpacesList.test.tsx
@@ -22,7 +22,7 @@ describe("SpacesList", () => {
     renderWithProviders(<SpacesList />);
 
     expect(
-      screen.getByRole("grid", { name: "Spaces table" })
+      screen.getByRole("treegrid", { name: "Spaces table" })
     ).toBeInTheDocument();
   });
 

--- a/src/app/networks/views/Subnets/views/SubnetDetails/components/EditBootArchitectures/BootArchitecturesTable/BootArchitecturesTable.test.tsx
+++ b/src/app/networks/views/Subnets/views/SubnetDetails/components/EditBootArchitectures/BootArchitecturesTable/BootArchitecturesTable.test.tsx
@@ -32,7 +32,7 @@ it("renders a table of known boot architectures", () => {
   );
 
   const rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-  const firstRowCells = within(rows[0]).getAllByRole("cell");
+  const firstRowCells = within(rows[0]).getAllByRole("gridcell");
 
   expect(firstRowCells[0]).toHaveTextContent(knownBootArchitecture.name);
   expect(firstRowCells[1]).toHaveTextContent(
@@ -67,7 +67,7 @@ it("renders a '—' if bootloader_arches or arch_octect are empty", () => {
   );
 
   const rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
-  const firstRowCells = within(rows[0]).getAllByRole("cell");
+  const firstRowCells = within(rows[0]).getAllByRole("gridcell");
 
   expect(firstRowCells[2]).toHaveTextContent("—");
   expect(firstRowCells[4]).toHaveTextContent("—");
@@ -95,13 +95,13 @@ it("sorts by name by default", () => {
 
   const rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
 
-  expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(
+  expect(within(rows[0]).getAllByRole("gridcell")[0]).toHaveTextContent(
     knownBootArchitectures[0].name
   );
-  expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent(
+  expect(within(rows[1]).getAllByRole("gridcell")[0]).toHaveTextContent(
     knownBootArchitectures[1].name
   );
-  expect(within(rows[2]).getAllByRole("cell")[0]).toHaveTextContent(
+  expect(within(rows[2]).getAllByRole("gridcell")[0]).toHaveTextContent(
     knownBootArchitectures[2].name
   );
 });

--- a/src/app/networks/views/Subnets/views/SubnetDetails/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/src/app/networks/views/Subnets/views/SubnetDetails/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -47,7 +47,7 @@ describe("EditBootArchitectures", () => {
     renderWithProviders(<EditBootArchitectures subnetId={1} />, { state });
     const nameCells = within(screen.getAllByRole("rowgroup")[1])
       .getAllByRole("row")
-      .map((row) => within(row).getAllByRole("cell")[0]);
+      .map((row) => within(row).getAllByRole("gridcell")[0]);
 
     // First arch is disabled, second arch is not.
     expect(within(nameCells[0]).getByRole("checkbox")).not.toBeChecked();
@@ -58,7 +58,7 @@ describe("EditBootArchitectures", () => {
     renderWithProviders(<EditBootArchitectures subnetId={1} />, { state });
     const nameCells = within(screen.getAllByRole("rowgroup")[1])
       .getAllByRole("row")
-      .map((row) => within(row).getAllByRole("cell")[0]);
+      .map((row) => within(row).getAllByRole("gridcell")[0]);
 
     await userEvent.click(within(nameCells[0]).getByRole("checkbox"));
     await userEvent.click(within(nameCells[1]).getByRole("checkbox"));
@@ -81,7 +81,7 @@ describe("EditBootArchitectures", () => {
     );
     const nameCells = within(screen.getAllByRole("rowgroup")[1])
       .getAllByRole("row")
-      .map((row) => within(row).getAllByRole("cell")[0]);
+      .map((row) => within(row).getAllByRole("gridcell")[0]);
 
     await userEvent.click(within(nameCells[0]).getByRole("checkbox"));
     await userEvent.click(within(nameCells[1]).getByRole("checkbox"));

--- a/src/app/networks/views/Subnets/views/SubnetsList/SubnetsList.test.tsx
+++ b/src/app/networks/views/Subnets/views/SubnetsList/SubnetsList.test.tsx
@@ -26,7 +26,7 @@ describe("SubnetsList", () => {
       state,
     });
 
-    expect(screen.getAllByRole("grid")).toHaveLength(1);
+    expect(screen.getAllByRole("treegrid")).toHaveLength(1);
     await userEvent.type(screen.getByRole("searchbox"), "non-existent-fabric");
     await waitFor(() => {
       expect(screen.getByText(/Loading.../)).toBeInTheDocument();
@@ -39,13 +39,13 @@ describe("SubnetsList", () => {
       state,
     });
 
-    expect(screen.getAllByRole("grid")).toHaveLength(1);
+    expect(screen.getAllByRole("treegrid")).toHaveLength(1);
 
     await userEvent.type(screen.getByRole("searchbox"), "non-existent-fabric");
 
     await waitFor(() => {
       expect(
-        within(screen.getByRole("grid")).getByText(/No results/)
+        within(screen.getByRole("treegrid")).getByText(/No results/)
       ).toBeInTheDocument();
     });
   });

--- a/src/app/networks/views/Subnets/views/SubnetsList/components/SubnetsTable/SubnetsTable.test.tsx
+++ b/src/app/networks/views/Subnets/views/SubnetsList/components/SubnetsTable/SubnetsTable.test.tsx
@@ -34,7 +34,7 @@ describe("SubnetsTable", () => {
       });
 
       expect(
-        screen.getByRole("grid", { name: "Subnets by fabric" })
+        screen.getByRole("treegrid", { name: "Subnets by fabric" })
       ).toBeInTheDocument();
 
       const firstRow = within(screen.getAllByRole("rowgroup")[1]).getAllByRole(
@@ -52,7 +52,7 @@ describe("SubnetsTable", () => {
       });
 
       expect(
-        screen.getByRole("grid", { name: "Subnets by space" })
+        screen.getByRole("treegrid", { name: "Subnets by space" })
       ).toBeInTheDocument();
     });
 
@@ -64,7 +64,7 @@ describe("SubnetsTable", () => {
       });
 
       expect(
-        screen.getByRole("grid", { name: "Subnets by space" })
+        screen.getByRole("treegrid", { name: "Subnets by space" })
       ).toBeInTheDocument();
 
       expect(
@@ -80,7 +80,7 @@ describe("SubnetsTable", () => {
       });
 
       expect(
-        screen.getByRole("grid", { name: "Subnets by fabric" })
+        screen.getByRole("treegrid", { name: "Subnets by fabric" })
       ).toBeInTheDocument();
 
       expect(
@@ -303,7 +303,7 @@ it("displays a correct number of pages", () => {
   });
 
   expect(
-    screen.getByRole("grid", { name: "Subnets by fabric" })
+    screen.getByRole("treegrid", { name: "Subnets by fabric" })
   ).toBeInTheDocument();
 
   const numberOfPages = Math.ceil(

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -200,7 +200,7 @@ describe("DHCPReservedRanges", () => {
         { state }
       );
 
-      const subnetCell = screen.getByRole("cell", {
+      const subnetCell = screen.getByRole("gridcell", {
         name: new RegExp(subnet.name),
       });
       expect(within(subnetCell).getByRole("link")).toHaveAttribute(
@@ -209,13 +209,13 @@ describe("DHCPReservedRanges", () => {
       );
 
       expect(
-        screen.getByRole("cell", { name: ipRange.start_ip })
+        screen.getByRole("gridcell", { name: ipRange.start_ip })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("cell", { name: ipRange.end_ip })
+        screen.getByRole("gridcell", { name: ipRange.end_ip })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("cell", { name: `${subnet.gateway_ip}` })
+        screen.getByRole("gridcell", { name: `${subnet.gateway_ip}` })
       ).toBeInTheDocument();
     });
 
@@ -239,14 +239,13 @@ describe("DHCPReservedRanges", () => {
       );
 
       expect(
-        within(screen.getByRole("cell", { name: /Select subnet/i })).getByRole(
-          "combobox",
-          { name: "Subnet" }
-        )
+        within(
+          screen.getByRole("gridcell", { name: /Select subnet/i })
+        ).getByRole("combobox", { name: "Subnet" })
       ).toBeInTheDocument();
 
       // all the other cells should be empty
-      expect(screen.getAllByRole("cell", { name: "" })).toHaveLength(3);
+      expect(screen.getAllByRole("gridcell", { name: "" })).toHaveLength(3);
     });
 
     it("renders a subnet select field and prepopulated fields for a reserved range if no IP ranges exist and a subnet is selected", async () => {

--- a/src/app/networks/views/VLANs/views/VLANDetails/components/VLANSubnetsTable/VLANSubnetsTable.test.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/VLANSubnetsTable/VLANSubnetsTable.test.tsx
@@ -23,7 +23,7 @@ it("renders correct details", () => {
     screen.getByRole("region", {
       name: "Subnets on this VLAN",
     })
-  ).getByRole("grid");
+  ).getByRole("treegrid");
 
   expect(within(vlanSubnetsTable).getByRole("link")).toHaveAttribute(
     "href",

--- a/src/app/networks/views/VLANs/views/VLANsList/VLANsList.test.tsx
+++ b/src/app/networks/views/VLANs/views/VLANsList/VLANsList.test.tsx
@@ -30,7 +30,7 @@ describe("VLANsList", () => {
     renderWithProviders(<VLANsList />, { state });
 
     expect(
-      screen.getByRole("grid", { name: "VLANs table" })
+      screen.getByRole("treegrid", { name: "VLANs table" })
     ).toBeInTheDocument();
   });
 

--- a/src/app/preferences/views/APIKeys/components/APIKeyTable/APIKeyTable.test.tsx
+++ b/src/app/preferences/views/APIKeys/components/APIKeyTable/APIKeyTable.test.tsx
@@ -29,7 +29,7 @@ describe("APIKeyList", () => {
   it("can render the table", () => {
     renderWithProviders(<APIKeyList />, { state });
     expect(
-      screen.getByRole("grid", { name: APIKeyListLabels.Title })
+      screen.getByRole("treegrid", { name: APIKeyListLabels.Title })
     ).toBeInTheDocument();
   });
 

--- a/src/app/settings/views/UserManagement/views/Groups/components/GroupEntitlementsTable/GroupEntitlementsTable.test.tsx
+++ b/src/app/settings/views/UserManagement/views/Groups/components/GroupEntitlementsTable/GroupEntitlementsTable.test.tsx
@@ -93,7 +93,7 @@ describe("GroupEntitlementsTable", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(0);
+        expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(1);
       });
 
       const [, firstRowCheckbox] = screen.getAllByRole("checkbox");

--- a/src/app/settings/views/UserManagement/views/Groups/components/GroupMembersTable/GroupMembersTable.test.tsx
+++ b/src/app/settings/views/UserManagement/views/Groups/components/GroupMembersTable/GroupMembersTable.test.tsx
@@ -86,7 +86,7 @@ describe("GroupMembersTable", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(0);
+        expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(1);
       });
 
       const [, firstRowCheckbox] = screen.getAllByRole("checkbox");

--- a/src/app/tags/components/TagTable/TagTable.test.tsx
+++ b/src/app/tags/components/TagTable/TagTable.test.tsx
@@ -91,10 +91,10 @@ it("displays the tags in order", () => {
     />
   );
   expect(
-    within(screen.getAllByRole("row")[1]).getAllByRole("cell")[0]
+    within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[0]
   ).toHaveTextContent("cool");
   expect(
-    within(screen.getAllByRole("row")[2]).getAllByRole("cell")[0]
+    within(screen.getAllByRole("row")[2]).getAllByRole("gridcell")[0]
   ).toHaveTextContent("rad");
 });
 
@@ -111,20 +111,20 @@ it("can change the sort order", async () => {
   );
 
   expect(
-    within(screen.getAllByRole("row")[1]).getAllByRole("cell")[0]
+    within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[0]
   ).toHaveTextContent("cool");
   expect(
-    within(screen.getAllByRole("row")[2]).getAllByRole("cell")[0]
+    within(screen.getAllByRole("row")[2]).getAllByRole("gridcell")[0]
   ).toHaveTextContent("rad");
   await userEvent.click(
     screen.getByRole("button", { name: `${Label.Name} ascending` })
   );
 
   expect(
-    within(screen.getAllByRole("row")[1]).getAllByRole("cell")[0]
+    within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[0]
   ).toHaveTextContent("rad");
   expect(
-    within(screen.getAllByRole("row")[2]).getAllByRole("cell")[0]
+    within(screen.getAllByRole("row")[2]).getAllByRole("gridcell")[0]
   ).toHaveTextContent("cool");
 });
 
@@ -142,7 +142,7 @@ it("shows an icon for automatic tags", () => {
   );
 
   expect(
-    within(screen.getAllByRole("row")[1]).getAllByRole("cell")[2].firstChild
+    within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[2].firstChild
   ).toHaveClass("p-icon--success-grey");
 });
 
@@ -160,7 +160,8 @@ it("does not show an icon for manual tags", () => {
   );
 
   expect(
-    within(screen.getAllByRole("row")[1]).queryAllByRole("cell")[2].firstChild
+    within(screen.getAllByRole("row")[1]).queryAllByRole("gridcell")[2]
+      .firstChild
   ).toBeNull();
 });
 
@@ -178,7 +179,7 @@ it("shows an icon for kernel options", () => {
   );
 
   expect(
-    within(screen.getAllByRole("row")[1]).getAllByRole("cell")[4].firstChild
+    within(screen.getAllByRole("row")[1]).getAllByRole("gridcell")[4].firstChild
   ).toHaveClass("p-icon--success-grey");
 });
 
@@ -196,7 +197,8 @@ it("does not show an icon for tags without kernel options", () => {
   );
 
   expect(
-    within(screen.getAllByRole("row")[1]).queryAllByRole("cell")[4].firstChild
+    within(screen.getAllByRole("row")[1]).queryAllByRole("gridcell")[4]
+      .firstChild
   ).toBeNull();
 });
 

--- a/src/app/tags/views/TagList/TagList.test.tsx
+++ b/src/app/tags/views/TagList/TagList.test.tsx
@@ -24,5 +24,5 @@ beforeEach(() => {
 it("renders", () => {
   renderWithProviders(<TagList />, { state, initialEntries: ["/tags"] });
   expect(screen.getByLabelText("pagination")).toBeInTheDocument();
-  expect(screen.getByRole("grid")).toBeInTheDocument();
+  expect(screen.getByRole("treegrid")).toBeInTheDocument();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
   integrity sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==
 
-"@canonical/maas-react-components@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-2.0.4.tgz#143fa5f050d127c069f09e26737bed8c04963036"
-  integrity sha512-pr6YpqaKKmrMcS8D50IH7PvOuGFch6MhS1HAqJAoGo9BAhDdBVeofgBfSRBzXoteS0kBNLG4ksBBo5ccFVQRCg==
+"@canonical/maas-react-components@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-2.4.0.tgz#e081c103e8e8f23dafd9b009a5827a8836ad945a"
+  integrity sha512-vgd3wVJIWkgs64ZLxBL3ZcAAxt9ShjgmC3t5tqsp1xckGfAiDxSvbpHQVs08S513ZWxGF7cWGeuLKGno0un/Ww==
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"


### PR DESCRIPTION
## Done

- upgrade maas-react-components to 2.4.0
- changed queries for "cell" to "gridcell" in tests for generic tables
- changed queries for "grid" to "treegrid" in tests for generic tables

<!--
- Itemised list of what was changed by this PR.
-->
