### PR TITLE
fix(settings): add vendor field to OIDC form

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -331,6 +331,7 @@ jobs:
             enabled=True \
             issuer_url="http://${HOST_IP}:8080/realms/test-realm" \
             token_type="JWT" \
+            vendor="Keycloak" \
             redirect_uri="https://localhost:8400/MAAS/r/login/oidc/callback" \
             scopes="openid profile email offline_access"
       - name: Enable TLS for MAAS

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -105,6 +105,7 @@ import {
   getOauthProvider,
   getOauthProviderById,
   getOperation,
+  getOperationTasks,
   getPackageRepository,
   getRack,
   getRackAgent,
@@ -503,6 +504,9 @@ import type {
   GetOperationData,
   GetOperationError,
   GetOperationResponse,
+  GetOperationTasksData,
+  GetOperationTasksError,
+  GetOperationTasksResponse,
   GetPackageRepositoryData,
   GetPackageRepositoryError,
   GetPackageRepositoryResponse,
@@ -3397,6 +3401,36 @@ export const getOperationOptions = (options: Options<GetOperationData>) =>
       return data;
     },
     queryKey: getOperationQueryKey(options),
+  });
+
+export const getOperationTasksQueryKey = (
+  options: Options<GetOperationTasksData>
+) => createQueryKey("getOperationTasks", options);
+
+/**
+ * Get Operation Tasks
+ *
+ * Get a paginated list of tasks for a specific operation.
+ */
+export const getOperationTasksOptions = (
+  options: Options<GetOperationTasksData>
+) =>
+  queryOptions<
+    GetOperationTasksResponse,
+    GetOperationTasksError,
+    GetOperationTasksResponse,
+    ReturnType<typeof getOperationTasksQueryKey>
+  >({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getOperationTasks({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getOperationTasksQueryKey(options),
   });
 
 export const listOperationsQueryKey = (options?: Options<ListOperationsData>) =>

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -312,6 +312,9 @@ import type {
   GetOperationData,
   GetOperationErrors,
   GetOperationResponses,
+  GetOperationTasksData,
+  GetOperationTasksErrors,
+  GetOperationTasksResponses,
   GetPackageRepositoryData,
   GetPackageRepositoryErrors,
   GetPackageRepositoryResponses,
@@ -2206,6 +2209,20 @@ export const getOperation = <ThrowOnError extends boolean = false>(
     GetOperationErrors,
     ThrowOnError
   >({ url: "/MAAS/a/v3/operations/{operation_uuid}", ...options });
+
+/**
+ * Get Operation Tasks
+ *
+ * Get a paginated list of tasks for a specific operation.
+ */
+export const getOperationTasks = <ThrowOnError extends boolean = false>(
+  options: Options<GetOperationTasksData, ThrowOnError>
+) =>
+  (options.client ?? client).get<
+    GetOperationTasksResponses,
+    GetOperationTasksErrors,
+    ThrowOnError
+  >({ url: "/MAAS/a/v3/operations/{operation_uuid}/tasks", ...options });
 
 /**
  * List Operations

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -2343,6 +2343,7 @@ export type OAuthProviderRequest = {
    */
   redirect_uri: string;
   token_type: OAuthTokenTypeChoices;
+  vendor: OAuthVendorChoices;
   /**
    * Scopes
    *
@@ -2403,6 +2404,7 @@ export type OAuthProviderResponse = {
    */
   user_count?: number;
   token_type: OAuthTokenTypeChoices;
+  vendor: OAuthVendorChoices;
 };
 
 /**
@@ -2431,6 +2433,11 @@ export type OAuthProvidersListResponse = {
  * OAuthTokenTypeChoices
  */
 export type OAuthTokenTypeChoices = "JWT" | "Opaque";
+
+/**
+ * OAuthVendorChoices
+ */
+export type OAuthVendorChoices = "Auth0" | "EntraID" | "Generic" | "Keycloak";
 
 /**
  * OpenFGAEntitlementResourceType
@@ -2519,6 +2526,82 @@ export type OperationStatus =
   | "COMPLETED"
   | "FAILED"
   | "RUNNING";
+
+/**
+ * OperationTaskResponse
+ */
+export type OperationTaskResponse = {
+  _links?: BaseHal;
+  /**
+   * Embedded
+   */
+  _embedded?: Record<string, unknown>;
+  /**
+   * Kind
+   */
+  kind?: string;
+  /**
+   * Id
+   */
+  id: number;
+  /**
+   * Started At
+   */
+  started_at?: string;
+  /**
+   * Finished At
+   */
+  finished_at?: string;
+  /**
+   * Name
+   */
+  name: string;
+  status: OperationTaskStatus;
+  /**
+   * Result
+   */
+  result?: Record<string, unknown>;
+  /**
+   * Task Number
+   */
+  task_number: number;
+  /**
+   * Operation Uuid
+   */
+  operation_uuid: string;
+};
+
+/**
+ * OperationTaskStatus
+ */
+export type OperationTaskStatus =
+  | "CANCELLED"
+  | "COMPLETED"
+  | "FAILED"
+  | "RUNNING"
+  | "WAITING";
+
+/**
+ * OperationTasksListResponse
+ */
+export type OperationTasksListResponse = {
+  /**
+   * Items
+   */
+  items: OperationTaskResponse[];
+  /**
+   * Total
+   */
+  total: number;
+  /**
+   * Next
+   */
+  next?: string;
+  /**
+   * Kind
+   */
+  kind?: string;
+};
 
 /**
  * OperationType
@@ -2996,6 +3079,7 @@ export type PublicConfigName =
   | "enable_kernel_crash_dump"
   | "enable_third_party_drivers"
   | "enlist_commissioning"
+  | "experimental_switch_provisioning"
   | "force_v1_network_yaml"
   | "hardware_sync_interval"
   | "http_proxy"
@@ -8910,7 +8994,14 @@ export type CancelOperationData = {
      */
     operation_uuid: string;
   };
-  query?: never;
+  query?: {
+    /**
+     * Force
+     *
+     * If true, force termination of the related workflow instead of requesting cancellation.
+     */
+    force?: boolean;
+  };
   url: "/MAAS/a/v3/operations/{operation_uuid}";
 };
 
@@ -8976,6 +9067,51 @@ export type GetOperationResponses = {
 
 export type GetOperationResponse =
   GetOperationResponses[keyof GetOperationResponses];
+
+export type GetOperationTasksData = {
+  body?: never;
+  path: {
+    /**
+     * Operation Uuid
+     */
+    operation_uuid: string;
+  };
+  query?: {
+    /**
+     * Page
+     */
+    page?: number;
+    /**
+     * Size
+     */
+    size?: number;
+  };
+  url: "/MAAS/a/v3/operations/{operation_uuid}/tasks";
+};
+
+export type GetOperationTasksErrors = {
+  /**
+   * Not Found
+   */
+  404: NotFoundBodyResponse;
+  /**
+   * Unprocessable Content
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type GetOperationTasksError =
+  GetOperationTasksErrors[keyof GetOperationTasksErrors];
+
+export type GetOperationTasksResponses = {
+  /**
+   * Successful Response
+   */
+  200: OperationTasksListResponse;
+};
+
+export type GetOperationTasksResponse =
+  GetOperationTasksResponses[keyof GetOperationTasksResponses];
 
 export type ListOperationsData = {
   body?: never;

--- a/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnForm.test.tsx
+++ b/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnForm.test.tsx
@@ -79,6 +79,9 @@ describe("SingleSignOnForm", () => {
     expect(screen.getByRole("combobox", { name: /Token type/i })).toHaveValue(
       mockAuthProvider.token_type
     );
+    expect(screen.getByRole("combobox", { name: /Vendor/i })).toHaveValue(
+      mockAuthProvider.vendor
+    );
   });
 
   it("disables the editable fields when the user cannot edit", () => {
@@ -138,6 +141,10 @@ describe("SingleSignOnForm", () => {
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: /Token type/i }),
       mockAuthProvider.token_type
+    );
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /Vendor/i }),
+      mockAuthProvider.vendor
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -210,6 +217,10 @@ describe("SingleSignOnForm", () => {
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: /Token type/i }),
       mockAuthProvider.token_type
+    );
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /Vendor/i }),
+      mockAuthProvider.vendor
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));

--- a/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnForm.tsx
+++ b/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnForm.tsx
@@ -14,6 +14,7 @@ import type { WithHeaders } from "@/app/api/utils";
 import type {
   OAuthProviderResponse,
   OAuthTokenTypeChoices,
+  OAuthVendorChoices,
 } from "@/app/apiclient";
 import { getOauthProviderQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
 import FormikForm from "@/app/base/components/FormikForm";
@@ -50,6 +51,7 @@ const SingleSignOnForm = ({
       redirect_uri: maasURL + "/r/login/oidc/callback",
       scopes: "",
       token_type: "JWT",
+      vendor: "Generic",
     }
   );
 
@@ -69,6 +71,7 @@ const SingleSignOnForm = ({
         redirect_uri: maasURL + "/r/login/oidc/callback",
         scopes: "",
         token_type: "JWT",
+        vendor: "Generic",
       }
     );
   };
@@ -89,6 +92,7 @@ const SingleSignOnForm = ({
             scopes: values.scopes,
             enabled: true,
             token_type: values.token_type as OAuthTokenTypeChoices,
+            vendor: values.vendor as OAuthVendorChoices,
           },
           path: { provider_id: provider.id },
         },
@@ -111,6 +115,7 @@ const SingleSignOnForm = ({
           scopes: values.scopes,
           enabled: true,
           token_type: values.token_type as OAuthTokenTypeChoices,
+          vendor: values.vendor as OAuthVendorChoices,
         },
       });
     }

--- a/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnFormFields/SingleSignOnFormFields.tsx
+++ b/src/app/settings/views/UserManagement/views/SingleSignOn/components/SingleSignOnForm/SingleSignOnFormFields/SingleSignOnFormFields.tsx
@@ -31,6 +31,7 @@ const SingleSignOnFormFields = ({
           redirect_uri: maasURL + "/r/login/oidc/callback",
           scopes: "",
           token_type: "JWT",
+          vendor: "Generic",
         },
       });
     }
@@ -45,6 +46,21 @@ const SingleSignOnFormFields = ({
         name="name"
         required
         type="text"
+      />
+      <FormikField
+        component={Select}
+        disabled={!canEdit}
+        help="The OIDC provider vendor. Select from predefined vendors or use 'Generic' for other providers."
+        label="Vendor"
+        name="vendor"
+        options={[
+          { label: "Select vendor", value: "", disabled: true },
+          { label: "Auth0", value: "Auth0" },
+          { label: "Microsoft Entra ID", value: "EntraID" },
+          { label: "Keycloak", value: "Keycloak" },
+          { label: "Generic", value: "Generic" },
+        ]}
+        required
       />
       <FormikField
         disabled={!canEdit}

--- a/src/testing/factories/auth.ts
+++ b/src/testing/factories/auth.ts
@@ -35,6 +35,7 @@ export const oAuthProviderFactory = Factory.define<OAuthProviderResponse>(
         seed: sequence,
       }),
       token_type: "JWT",
+      vendor: "Generic",
       enabled: true,
       metadata: {
         authorization_endpoint: chance.url() + "/authorize",


### PR DESCRIPTION
## Done

- Added the "vendor" form field to the Single Sign-On form in the settings

## QA steps

- [ ] Go to the settings page
- [ ] Go to OIDC/Single Sign-On
- [ ] Ensure the "Vendor" form field is visible with 4 options: "Generic", "EntraID", "Auth0" and "Keycloak"
