### PR TITLE
fix(machines): use name instead of ID for getting zone

### DIFF
--- a/src/app/base/components/ZoneSelect/ZoneSelect.tsx
+++ b/src/app/base/components/ZoneSelect/ZoneSelect.tsx
@@ -3,14 +3,13 @@ import type { HTMLProps } from "react";
 import { Select } from "@canonical/react-components";
 
 import { useZones } from "@/app/api/query/zones";
-import type { ZoneResponse } from "@/app/apiclient";
 import FormikField from "@/app/base/components/FormikField";
 
 type Props = HTMLProps<HTMLSelectElement> & {
   disabled?: boolean;
   label?: string;
   name: string;
-  valueKey?: keyof ZoneResponse;
+  valueKey?: "id" | "name";
 };
 
 export enum Label {
@@ -21,6 +20,7 @@ export const ZoneSelect = ({
   disabled = false,
   label = Label.Zone,
   name,
+  valueKey,
   ...props
 }: Props): React.ReactElement => {
   const zones = useZones();
@@ -36,7 +36,7 @@ export const ZoneSelect = ({
         ...(zones.data?.items?.map((zone) => ({
           key: `zone-${zone.id}`,
           label: zone.name,
-          value: zone.id,
+          value: zone[valueKey ?? "id"],
         })) || []),
       ]}
       {...props}

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
@@ -12,7 +12,7 @@ const MachineFormFields = (): React.ReactElement => {
       <Col size={6}>
         <ArchitectureSelect name="architecture" />
         <MinimumKernelSelect name="minHweKernel" />
-        <ZoneSelect name="zone" />
+        <ZoneSelect name="zone" valueKey="name" />
         <ResourcePoolSelect name="pool" />
         <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
         <FormikField component={Textarea} label="Note" name="description" />


### PR DESCRIPTION
## Done

-- Copied over from [PR 6089](https://github.com/canonical/maas-ui/pull/6089) --

- The machine configuration form was incorrectly passing the "zone_id" in the zone update request, whereas the backend expects the zone name, causing update requests to fail.
- There was another issue where the zone field was initialized to `machine.zone.name`, but no option had that as its value, so it would fall back to the first available zone. For example, if there were two zones called "Amsterdam" and "default" and a machine was in the "default" zone, opening the form and clicking "Edit" would incorrectly display "Amsterdam" in the zone select menu. This is also fixed
- Resolves [lp:2156441](https://bugs.launchpad.net/maas-ui/+bug/2156441)

## QA steps
You may need a 3.7 MAAS instance.
- [ ] Sign in to MAAS
- [ ] Go to `MAAS/r/zones` and create a new zone (say, "Test zone")
- [ ] Go to the configuration page for a particular machine (e.g. `/machine/wrrxhx/configuration`)
- [ ] Click "Edit"
- [ ] Ensure that clicking Edit retains the correct zone for that machine (which should be `default`)
- [ ] Change the zone to "Test zone" and save
- [ ] Ensure the zone has been updated without errors and is immediately reflected in the form

## Fixes

- Resolves [lp:2156441](https://bugs.launchpad.net/maas-ui/+bug/2156441)
