### PR TITLE
fix: change sitespeed.io db source

### DIFF
--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           maas-url: ${{ env.MAAS_URL }}/MAAS
           use-maasdb-dump: true
-          maasdb-dump-url: https://github.com/canonical/maas-ui-testing/raw/main/db/maasdb-24.04-master-1000.dump
+          maasdb-dump-url: https://github.com/canonical/maas-ui-testing/raw/main/db/maasdb-26.04-master-1000.dump
       - name: Create MAAS admin
         run: lxc exec maas-backend -- maas createadmin --username=admin --password=test --email=fake@example.org
       - name: Wait for MAAS


### PR DESCRIPTION
## Done

- Updated sitespeed.io test db source to a 26.04 sampledata database
- A test run that passes with this change: https://github.com/nehjoshi/maas-ui/actions/runs/28777436016/job/85324641217