### PR TITLE
fix: wait for websocket connection before rendering content

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -79,6 +79,7 @@ export const App = (): React.ReactElement => {
   const authenticating = useSelector(status.authenticating);
   const connected = useSelector(status.connected);
   const connecting = useSelector(status.connecting);
+  const connectedCount = useSelector(status.connectedCount);
   const connectionError = useSelector(status.error);
   const configLoading = useSelector(configSelectors.loading);
   const configErrors = useSelector(configSelectors.errors);
@@ -122,7 +123,10 @@ export const App = (): React.ReactElement => {
   const hasVaultError =
     configErrors === VaultErrors.REQUEST_FAILED ||
     configErrors === VaultErrors.CONNECTION_FAILED;
-  const isLoaded = user.isSuccess && authenticated;
+  // Wait for the websocket to have connected at least once before rendering
+  // routed content.
+  const hasConnected = connectedCount > 0;
+  const isLoaded = user.isSuccess && authenticated && hasConnected;
 
   let content: ReactNode = null;
   // display loading spinner only on initial load


### PR DESCRIPTION
## Done

- This bug was observed in TOR3, that causes the subnet details page (`/subnet/:id/summary`) to return "Subnet not found" when the page is visited directly via its URL, or by refreshing the page
- This occurs due to the page loading before the websocket connection is established
- The fix is to wait for at least 1 successful websocket connection before rendering the page

## QA steps
Use TOR3 MAAS as the backend (`http://maas-tor3.internal`) 
- [x] Sign in to TOR3 MAAS
- [x] Go to the "networks" page from the side navigation
- [x] Visit the page for any subnet
- [x] Repeatedly refresh the page and ensure you do **not** get a "subnet not found" error
- [x] If you do this on the real, deployed TOR3, you will see that this error frequently occurs when you refresh the page for a subnet

