### PR TITLE
fix(base): ensure notifications without IDs can be dismissed MAASENG-6672

### DIFF
--- a/src/app/api/query/notifications.ts
+++ b/src/app/api/query/notifications.ts
@@ -47,6 +47,9 @@ export const convertToastNotificationIdToBackendId = (id: string): number => {
   throw new Error(`Invalid notification ID format: ${id}`);
 };
 
+export const isBackendNotificationId = (id: string): boolean =>
+  /^notification-\d+$/.test(id);
+
 export const useNotifications = () => {
   const backendNotifications = useListNotifications({
     query: { only_active: true },
@@ -124,6 +127,12 @@ export const useDismissNotifications = (dismissMutation: DismissMutateFn) => {
   return (notifications: ToastNotificationType[] | undefined) => {
     if (notifications) {
       notifications.forEach((notification) => {
+        // Temporary/local toasts (e.g. those created via `failure`) don't have
+        // a backend notification ID, so there's nothing to dismiss on the
+        // server. They're removed from the stack by the provider directly.
+        if (!isBackendNotificationId(notification.id)) {
+          return;
+        }
         dismissMutation({
           path: {
             notification_id: convertToastNotificationIdToBackendId(


### PR DESCRIPTION
## Done

- ensured the dismiss function returns if there is no notification ID

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] create a button to trigger a test notification in StatusBar.tsx:
```tsx
const StatusBar = () => {
  const { info } = useToastNotification();
  ...
  return (
    <AppStatus>
      ...
      <Button onClick={() => info("Test notification")}>
        Send test notification
      </Button>
    </AppStatus>
  )
}
```
- [x] trigger a test nofication
- [x] dismiss it
- [x] ensure it disappears
- [x] trigger multiple test notifications and click "dismiss all"
- [x] ensure they are dismissed

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6672](https://warthogs.atlassian.net/browse/MAASENG-6672)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

[MAASENG-6672]: https://warthogs.atlassian.net/browse/MAASENG-6672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ