### PR TITLE
fix(machines): Commissioning scripts default ascending sort

### DIFF
--- a/src/app/base/components/node/NodeTestsTable/components/NodeTestsTable/NodeTestsTable.tsx
+++ b/src/app/base/components/node/NodeTestsTable/components/NodeTestsTable/NodeTestsTable.tsx
@@ -86,7 +86,7 @@ const NodeTestsTable = ({ isLoading, node, scriptResults }: Props) => {
     setExpanded,
   });
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "name", desc: true },
+    { id: "name", desc: false },
   ]);
   const history = useScriptResultHistory(scriptResults);
   const data = useMemo(() => {


### PR DESCRIPTION
## Done

- Reversed the default commissioning scripts sort order to be ascending

## QA steps

- [x] Navigate to any machine's /scripts/commissioning
- [x] Verify the default sort is alphabetically ascending (A/0 first, Z/9 last)