### PR TITLE
feat: create switch side panels MAASENG-6489

### DIFF
--- a/src/app/switches/components/AddSwitch/AddSwitch.test.tsx
+++ b/src/app/switches/components/AddSwitch/AddSwitch.test.tsx
@@ -1,0 +1,109 @@
+import { waitFor } from "@testing-library/react";
+
+import AddSwitch from "./AddSwitch";
+
+import { imageResolvers } from "@/testing/resolvers/images";
+import { switchResolvers } from "@/testing/resolvers/switches";
+import {
+  mockSidePanel,
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  userEvent,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  switchResolvers.createSwitch.handler(),
+  imageResolvers.listSelections.handler()
+);
+const { mockClose } = await mockSidePanel();
+
+describe("AddSwitch", () => {
+  it("runs closeForm function when the cancel button is clicked", async () => {
+    renderWithProviders(<AddSwitch />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("calls create switch on save click", async () => {
+    renderWithProviders(<AddSwitch />);
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /MAC address/i }),
+      "00:11:22:33:44:55"
+    );
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /^Name$/i }),
+      "test-switch"
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Save switch/i }));
+
+    await waitFor(() => {
+      expect(switchResolvers.createSwitch.resolved).toBeTruthy();
+    });
+  });
+
+  it("populates the image dropdown with available images", async () => {
+    renderWithProviders(<AddSwitch />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", { name: /centos\/centos7 - 7\.0/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("displays error message when create switch fails", async () => {
+    mockServer.use(
+      switchResolvers.createSwitch.error({ code: 400, message: "Uh oh!" })
+    );
+
+    renderWithProviders(<AddSwitch />);
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /MAC address/i }),
+      "00:11:22:33:44:55"
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Save switch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Uh oh!/i)).toBeInTheDocument();
+    });
+  });
+
+  it("displays the detailed error message when available", async () => {
+    mockServer.use(
+      switchResolvers.createSwitch.error({
+        code: 422,
+        message: "Failed to validate the request.",
+        kind: "Error",
+        details: [
+          {
+            type: "InvalidArgumentViolation",
+            message: "Boot resource 'ubuntu/noble/s390x' not found.",
+            field: "image",
+            location: "body",
+          },
+        ],
+      })
+    );
+
+    renderWithProviders(<AddSwitch />);
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /MAC address/i }),
+      "00:11:22:33:44:55"
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Save switch/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Boot resource 'ubuntu\/noble\/s390x' not found\./i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/switches/components/AddSwitch/AddSwitch.tsx
+++ b/src/app/switches/components/AddSwitch/AddSwitch.tsx
@@ -10,6 +10,7 @@ import type { CreateSwitchError, SwitchRequest } from "@/app/apiclient";
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
 import { MAC_ADDRESS_REGEX } from "@/app/base/validation";
+import { getOsDisplayName } from "@/app/images/utils";
 import { getSwitchErrorMessage } from "@/app/switches/utils";
 
 const SwitchSchema = Yup.object().shape({
@@ -30,7 +31,7 @@ const AddSwitch = (): ReactElement => {
     { label: "Select an image", value: "", disabled: true },
     ...(availableImages.data?.items ?? []).map((image, index) => ({
       key: `${image.title}-${index}`,
-      label: `${image.os}/${image.release} - ${image.title} (${image.architecture})`,
+      label: `${getOsDisplayName(image.os)}/${image.release} - ${image.title} (${image.architecture})`,
       value: `${image.os}/${image.release}/${image.architecture}`,
     })),
   ];

--- a/src/app/switches/components/AddSwitch/AddSwitch.tsx
+++ b/src/app/switches/components/AddSwitch/AddSwitch.tsx
@@ -1,0 +1,81 @@
+import type { ReactElement } from "react";
+
+import { useSidePanel } from "@canonical/maas-react-components";
+import { Select } from "@canonical/react-components";
+import * as Yup from "yup";
+
+import { useSelections } from "@/app/api/query/images";
+import { useCreateSwitch } from "@/app/api/query/switches";
+import type { CreateSwitchError, SwitchRequest } from "@/app/apiclient";
+import FormikField from "@/app/base/components/FormikField";
+import FormikForm from "@/app/base/components/FormikForm";
+import { MAC_ADDRESS_REGEX } from "@/app/base/validation";
+import { getSwitchErrorMessage } from "@/app/switches/utils";
+
+const SwitchSchema = Yup.object().shape({
+  mac_address: Yup.string()
+    .required("MAC address is required")
+    .matches(MAC_ADDRESS_REGEX, "Invalid MAC address"),
+  name: Yup.string(),
+  image: Yup.string(),
+});
+
+const AddSwitch = (): ReactElement => {
+  const { closeSidePanel } = useSidePanel();
+  const createSwitch = useCreateSwitch();
+  // TODO: Replace with an endpoint that only returns switch-compatible images when API is ready
+  const availableImages = useSelections();
+
+  const imageOptions = [
+    { label: "Select an image", value: "", disabled: true },
+    ...(availableImages.data?.items ?? []).map((image, index) => ({
+      key: `${image.title}-${index}`,
+      label: `${image.os}/${image.release} - ${image.title} (${image.architecture})`,
+      value: `${image.os}/${image.release}/${image.architecture}`,
+    })),
+  ];
+
+  return (
+    <FormikForm<SwitchRequest, CreateSwitchError>
+      aria-label="Add switch"
+      errors={getSwitchErrorMessage(createSwitch.error)}
+      initialValues={{
+        mac_address: "",
+        name: "",
+        image: "",
+      }}
+      onCancel={closeSidePanel}
+      onSubmit={(values) => {
+        createSwitch.mutate({
+          body: {
+            mac_address: values.mac_address,
+            name: values.name,
+            image: values.image,
+          },
+        });
+      }}
+      onSuccess={closeSidePanel}
+      resetOnSave={true}
+      saved={createSwitch.isSuccess}
+      saving={createSwitch.isPending}
+      submitLabel="Save switch"
+      validationSchema={SwitchSchema}
+    >
+      <FormikField label="Name" name="name" type="text" />
+      <FormikField
+        label="MAC address"
+        name="mac_address"
+        required
+        type="text"
+      />
+      <FormikField
+        component={Select}
+        label="Image"
+        name="image"
+        options={imageOptions}
+      />
+    </FormikForm>
+  );
+};
+
+export default AddSwitch;

--- a/src/app/switches/components/AddSwitch/index.ts
+++ b/src/app/switches/components/AddSwitch/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddSwitch";

--- a/src/app/switches/components/DeleteSwitch/DeleteSwitch.test.tsx
+++ b/src/app/switches/components/DeleteSwitch/DeleteSwitch.test.tsx
@@ -1,0 +1,72 @@
+import DeleteSwitch from "./DeleteSwitch";
+
+import { switchResolvers } from "@/testing/resolvers/switches";
+import {
+  mockSidePanel,
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  userEvent,
+  waitFor,
+  waitForLoading,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  switchResolvers.getSwitch.handler(),
+  switchResolvers.deleteSwitch.handler()
+);
+const { mockClose } = await mockSidePanel();
+
+describe("DeleteSwitch", () => {
+  it("calls closeForm on cancel click", async () => {
+    renderWithProviders(<DeleteSwitch id={2} />);
+    await waitForLoading();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("calls delete switch on save click", async () => {
+    renderWithProviders(<DeleteSwitch id={2} />);
+    await waitForLoading();
+    await userEvent.click(screen.getByRole("button", { name: /Delete/i }));
+    await waitFor(() => {
+      expect(switchResolvers.deleteSwitch.resolved).toBeTruthy();
+    });
+  });
+
+  it("displays error messages when delete switch fails", async () => {
+    mockServer.use(
+      switchResolvers.deleteSwitch.error({ code: 400, message: "Uh oh!" })
+    );
+    renderWithProviders(<DeleteSwitch id={2} />);
+    await waitForLoading();
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(screen.getByText(/Uh oh!/i)).toBeInTheDocument();
+    });
+  });
+
+  it("displays the detailed error message when available", async () => {
+    mockServer.use(
+      switchResolvers.deleteSwitch.error({
+        code: 422,
+        message: "Failed to validate the request.",
+        kind: "Error",
+        details: [
+          {
+            type: "InvalidArgumentViolation",
+            message: "Switch is still in use.",
+            field: "switch_id",
+            location: "path",
+          },
+        ],
+      })
+    );
+    renderWithProviders(<DeleteSwitch id={2} />);
+    await waitForLoading();
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(screen.getByText(/Switch is still in use\./i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/switches/components/DeleteSwitch/DeleteSwitch.tsx
+++ b/src/app/switches/components/DeleteSwitch/DeleteSwitch.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from "react";
+
+import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  Notification as NotificationBanner,
+  Spinner,
+} from "@canonical/react-components";
+
+import { useDeleteSwitch, useGetSwitch } from "@/app/api/query/switches";
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { getSwitchErrorMessage } from "@/app/switches/utils";
+
+type DeleteSwitchProps = {
+  id: number;
+};
+
+const DeleteSwitch = ({ id }: DeleteSwitchProps): ReactElement => {
+  const { closeSidePanel } = useSidePanel();
+  const switchDetails = useGetSwitch({ path: { switch_id: id } });
+
+  const eTag = switchDetails.data?.headers?.get("ETag");
+  const deleteSwitch = useDeleteSwitch();
+
+  return (
+    <>
+      {switchDetails.isPending && <Spinner text="Loading..." />}
+      {switchDetails.isError && (
+        <NotificationBanner severity="negative">
+          {switchDetails.error.message}
+        </NotificationBanner>
+      )}
+      {switchDetails.isSuccess && switchDetails.data && (
+        <ModelActionForm
+          aria-label="Confirm switch deletion"
+          errors={getSwitchErrorMessage(deleteSwitch.error)}
+          initialValues={{}}
+          modelType="switch"
+          onCancel={closeSidePanel}
+          onSubmit={() => {
+            deleteSwitch.mutate({
+              headers: { ETag: eTag },
+              path: { switch_id: id },
+            });
+          }}
+          onSuccess={closeSidePanel}
+          saved={deleteSwitch.isSuccess}
+          saving={deleteSwitch.isPending}
+        />
+      )}
+    </>
+  );
+};
+
+export default DeleteSwitch;

--- a/src/app/switches/components/DeleteSwitch/index.ts
+++ b/src/app/switches/components/DeleteSwitch/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteSwitch";

--- a/src/app/switches/components/EditSwitch/EditSwitch.test.tsx
+++ b/src/app/switches/components/EditSwitch/EditSwitch.test.tsx
@@ -1,0 +1,108 @@
+import { waitFor } from "@testing-library/react";
+
+import EditSwitch from "./EditSwitch";
+
+import { imageResolvers } from "@/testing/resolvers/images";
+import { switchResolvers } from "@/testing/resolvers/switches";
+import {
+  mockSidePanel,
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  userEvent,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  switchResolvers.getSwitch.handler(),
+  switchResolvers.updateSwitch.handler(),
+  imageResolvers.listSelections.handler()
+);
+const { mockClose } = await mockSidePanel();
+
+describe("EditSwitch", () => {
+  const testSwitchId = 1;
+
+  it("runs closeForm function when the cancel button is clicked", async () => {
+    renderWithProviders(<EditSwitch id={testSwitchId} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancel" })
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("calls update switch on save click", async () => {
+    renderWithProviders(<EditSwitch id={testSwitchId} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.type(screen.getByLabelText("Name"), "updated-switch");
+
+    await userEvent.click(screen.getByRole("button", { name: /Save switch/i }));
+
+    await waitFor(() => {
+      expect(switchResolvers.updateSwitch.resolved).toBeTruthy();
+    });
+  });
+
+  it("displays error message when update switch fails", async () => {
+    mockServer.use(
+      switchResolvers.updateSwitch.error({ code: 400, message: "Uh oh!" })
+    );
+
+    renderWithProviders(<EditSwitch id={testSwitchId} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByLabelText("Name"), "test");
+
+    await userEvent.click(screen.getByRole("button", { name: /Save switch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Uh oh!")).toBeInTheDocument();
+    });
+  });
+
+  it("displays the detailed error message when available", async () => {
+    mockServer.use(
+      switchResolvers.updateSwitch.error({
+        code: 422,
+        message: "Failed to validate the request.",
+        kind: "Error",
+        details: [
+          {
+            type: "InvalidArgumentViolation",
+            message: "Boot resource 'ubuntu/noble/s390x' not found.",
+            field: "image",
+            location: "body",
+          },
+        ],
+      })
+    );
+
+    renderWithProviders(<EditSwitch id={testSwitchId} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByLabelText("Name"), "test");
+
+    await userEvent.click(screen.getByRole("button", { name: /Save switch/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Boot resource 'ubuntu\/noble\/s390x' not found\./i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/switches/components/EditSwitch/EditSwitch.tsx
+++ b/src/app/switches/components/EditSwitch/EditSwitch.tsx
@@ -1,0 +1,104 @@
+import type { ReactElement } from "react";
+
+import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  Notification as NotificationBanner,
+  Select,
+  Spinner,
+} from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import * as Yup from "yup";
+
+import { useSelections } from "@/app/api/query/images";
+import { useGetSwitch, useUpdateSwitch } from "@/app/api/query/switches";
+import type { SwitchUpdateRequest, UpdateSwitchError } from "@/app/apiclient";
+import { getSwitchQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
+import FormikField from "@/app/base/components/FormikField";
+import FormikForm from "@/app/base/components/FormikForm";
+import { getSwitchErrorMessage } from "@/app/switches/utils";
+
+type EditSwitchProps = {
+  id: number;
+};
+
+const SwitchSchema = Yup.object().shape({
+  name: Yup.string(),
+  image: Yup.string(),
+});
+
+const EditSwitch = ({ id }: EditSwitchProps): ReactElement => {
+  const { closeSidePanel } = useSidePanel();
+  const queryClient = useQueryClient();
+  const switchDetails = useGetSwitch({ path: { switch_id: id } });
+  // TODO: Replace with an endpoint that only returns switch-compatible images when API is ready
+  const availableImages = useSelections();
+
+  const eTag = switchDetails.data?.headers?.get("ETag");
+  const updateSwitch = useUpdateSwitch();
+
+  const imageOptions = [
+    { label: "Select an image", value: "", disabled: true },
+    ...(availableImages.data?.items ?? []).map((image, index) => ({
+      key: `${image.title}-${index}`,
+      label: `${image.os}/${image.release} - ${image.title} (${image.architecture})`,
+      value: `${image.os}/${image.release}/${image.architecture}`,
+    })),
+  ];
+
+  return (
+    <>
+      {switchDetails.isPending && <Spinner text="Loading..." />}
+      {switchDetails.isError && (
+        <NotificationBanner severity="negative">
+          {switchDetails.error.message}
+        </NotificationBanner>
+      )}
+      {switchDetails.isSuccess && switchDetails.data && (
+        <FormikForm<SwitchUpdateRequest, UpdateSwitchError>
+          aria-label="Edit switch"
+          errors={getSwitchErrorMessage(updateSwitch.error)}
+          initialValues={{
+            name: switchDetails.data.name ?? "",
+            image: switchDetails.data.target_image ?? "",
+          }}
+          onCancel={closeSidePanel}
+          onSubmit={(values) => {
+            updateSwitch.mutate({
+              headers: {
+                ETag: eTag,
+              },
+              body: {
+                name: values.name,
+                image: values.image,
+              },
+              path: { switch_id: id },
+            });
+          }}
+          onSuccess={() => {
+            return queryClient
+              .invalidateQueries({
+                queryKey: getSwitchQueryKey({
+                  path: { switch_id: id },
+                }),
+              })
+              .then(closeSidePanel);
+          }}
+          saved={updateSwitch.isSuccess}
+          saving={updateSwitch.isPending}
+          submitLabel="Save switch"
+          validationSchema={SwitchSchema}
+        >
+          <FormikField label="Name" name="name" type="text" />
+          <FormikField
+            component={Select}
+            label="Image"
+            name="image"
+            options={imageOptions}
+          />
+        </FormikForm>
+      )}
+    </>
+  );
+};
+
+export default EditSwitch;

--- a/src/app/switches/components/EditSwitch/index.ts
+++ b/src/app/switches/components/EditSwitch/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditSwitch";

--- a/src/app/switches/components/SwitchesTable/useSwitchesTableColumns/useSwitchesTableColumns.tsx
+++ b/src/app/switches/components/SwitchesTable/useSwitchesTableColumns/useSwitchesTableColumns.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { useSidePanel } from "@canonical/maas-react-components";
 import { Button, Icon } from "@canonical/react-components";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Link } from "react-router";
@@ -7,10 +8,13 @@ import { Link } from "react-router";
 import type { SwitchResponse } from "@/app/apiclient";
 import DoubleRow from "@/app/base/components/DoubleRow";
 import TableActions from "@/app/base/components/TableActions";
+import DeleteSwitch from "@/app/switches/components/DeleteSwitch";
+import EditSwitch from "@/app/switches/components/EditSwitch";
 
 type SwitchColumnDef = ColumnDef<SwitchResponse>;
 
 const useSwitchesTableColumns = (): SwitchColumnDef[] => {
+  const { openSidePanel } = useSidePanel();
   return useMemo(
     () => [
       {
@@ -73,12 +77,31 @@ const useSwitchesTableColumns = (): SwitchColumnDef[] => {
         accessorKey: "id",
         enableSorting: false,
         header: "Actions",
-        cell: () => (
-          <TableActions onDelete={() => undefined} onEdit={() => undefined} />
+        cell: ({
+          row: {
+            original: { id },
+          },
+        }) => (
+          <TableActions
+            onDelete={() => {
+              openSidePanel({
+                component: DeleteSwitch,
+                title: "Delete switch",
+                props: { id },
+              });
+            }}
+            onEdit={() => {
+              openSidePanel({
+                component: EditSwitch,
+                title: "Edit switch",
+                props: { id },
+              });
+            }}
+          />
         ),
       },
     ],
-    []
+    [openSidePanel]
   );
 };
 

--- a/src/app/switches/utils.ts
+++ b/src/app/switches/utils.ts
@@ -1,0 +1,18 @@
+import type { BaseExceptionDetail } from "@/app/apiclient";
+
+type SwitchApiError = {
+  message?: string;
+  details?: BaseExceptionDetail[];
+};
+
+export const getSwitchErrorMessage = (
+  error?: SwitchApiError | null
+): string | null => {
+  if (!error) {
+    return null;
+  }
+  if (error.details?.length) {
+    return error.details.map((detail) => detail.message).join(" ");
+  }
+  return error.message ?? null;
+};

--- a/src/app/switches/views/SwitchesList/SwitchesListHeader/SwitchesListHeader.tsx
+++ b/src/app/switches/views/SwitchesList/SwitchesListHeader/SwitchesListHeader.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 
-import { MainToolbar } from "@canonical/maas-react-components";
+import { MainToolbar, useSidePanel } from "@canonical/maas-react-components";
 import { Button } from "@canonical/react-components";
 
 import DebounceSearchBox from "@/app/base/components/DebounceSearchBox";
 import type { SetSearchFilter } from "@/app/base/types";
+import AddSwitch from "@/app/switches/components/AddSwitch";
 
 type Props = {
   searchFilter: string;
@@ -12,6 +13,7 @@ type Props = {
 };
 
 const SwitchesListHeader = ({ searchFilter, setSearchFilter }: Props) => {
+  const { openSidePanel } = useSidePanel();
   const [searchText, setSearchText] = useState(searchFilter);
 
   useEffect(() => {
@@ -30,7 +32,14 @@ const SwitchesListHeader = ({ searchFilter, setSearchFilter }: Props) => {
           searchText={searchText}
           setSearchText={setSearchText}
         />
-        <Button data-testid="add-switch">Add switch</Button>
+        <Button
+          data-testid="add-switch"
+          onClick={() => {
+            openSidePanel({ component: AddSwitch, title: "Add switch" });
+          }}
+        >
+          Add switch
+        </Button>
       </MainToolbar.Controls>
     </MainToolbar>
   );


### PR DESCRIPTION
## Done

- Created switch-related side panels for adding, editing and deleting switches.
- Added tests for each

## QA steps
Note: Since switches are difficult to add due to them requiring a specific type of image, some data will need to be mocked. Use the following mocked data:

In `src/app/switches/views/SwitchesList/SwitchesList.tsx`, add the following `useEffect`:
```ts
  const { openSidePanel } = useSidePanel();
  useEffect(() => {
    // openSidePanel({
    //   component: EditSwitch,
    //   title: "Edit switch",
    //   props: { id: 1 },
    // });
    // openSidePanel({
    //   component: DeleteSwitch,
    //   title: "Delete switch",
    //   props: { id: 1 },
    // });
  }, [openSidePanel]);
```

In `src/app/switches/components/EditSwitch/EditSwitch.tsx`:
```ts
  // const switchDetails = useGetSwitch({ path: { switch_id: id } });
  const switchDetails = {
    isPending: false,
    isError: false,
    error: { message: "" },
    isSuccess: true,
    data: {
      name: "sample-switch",
      target_image: "ubuntu-nos/noble/amd64",
      headers: new Headers({ ETag: "sample-etag" }),
    },
  };
```

And, in `src/app/switches/components/DeleteSwitch/DeleteSwitch.tsx`:
```ts
  // const switchDetails = useGetSwitch({ path: { switch_id: id } });
  const switchDetails = {
    isPending: false,
    isError: false,
    error: { message: "" },
    isSuccess: true,
    data: {
      name: "sample-switch",
      target_image: "ubuntu-nos/noble/amd64",
      headers: new Headers({ ETag: "sample-etag" }),
    },
  };
```
Now, you may use `maas-ui-demo` as the backend. Ensure the `VITE_APP_SWITCH_PROVISIONING` flag is set to true.
- [x] Sign in to MAAS
- [x] Go to the switches page from the side navigation
- [x] Click "Add Switch"
- [x] Ensure three fields are shown, with the image field being a dropdown
- [x] Edit the `useEffect` in `SwitchesList.tsx` and uncomment the block of code for opening the `EditSwitch` side panel
- [x] Verify only two fields are shown (name and image)
- [x] Comment out the EditSwitch block, and uncomment the block of code for opening the `DeleteSwitch` side panel
- [x] Ensure the confirmation message is shown


<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6489](https://warthogs.atlassian.net/browse/MAASENG-6489)



[MAASENG-6489]: https://warthogs.atlassian.net/browse/MAASENG-6489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ