### PR TITLE
feat: create switch from network discovery MAASENG-6611

### DIFF
--- a/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -15,16 +15,24 @@ import {
 import { callId, enableCallIdMocks } from "@/testing/callId-mock";
 import * as factory from "@/testing/factories";
 import { mockFormikFormSaved } from "@/testing/mockFormikFormSaved";
+import { imageResolvers } from "@/testing/resolvers/images";
+import { switchResolvers } from "@/testing/resolvers/switches";
 import {
   fireEvent,
   renderWithProviders,
   screen,
+  setupMockServer,
   userEvent,
   waitFor,
   within,
 } from "@/testing/utils";
 
 enableCallIdMocks();
+
+const mockServer = setupMockServer(
+  switchResolvers.createSwitch.handler(),
+  imageResolvers.listSelections.handler()
+);
 
 describe("DiscoveryAddForm", () => {
   let state: RootState;
@@ -346,6 +354,125 @@ describe("DiscoveryAddForm", () => {
         store.getActions().find((action) => action.type === "message/add")
           .payload.message
       ).toBe("An interface has been added.");
+    });
+  });
+});
+
+describe("DiscoveryAddForm switch", () => {
+  let state: RootState;
+  const discovery = factory.discovery({
+    ip: "1.2.3.4",
+    mac_address: "aa:bb:cc:dd:ee:ff",
+    subnet_id: 9,
+    vlan_id: 8,
+    hostname: "discovery-hostname.domain-name",
+  });
+
+  beforeEach(() => {
+    state = factory.rootState({
+      device: factory.deviceState({ loaded: true }),
+      domain: factory.domainState({ loaded: true }),
+      machine: factory.machineState({
+        loaded: true,
+        lists: {
+          [callId]: factory.machineStateList({
+            loaded: true,
+            groups: [
+              factory.machineStateListGroup({
+                items: [],
+                name: "Deployed",
+              }),
+            ],
+          }),
+        },
+      }),
+      subnet: factory.subnetState({ loaded: true }),
+      vlan: factory.vlanState({ loaded: true }),
+    });
+  });
+
+  const selectSwitchType = async () => {
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: FormFieldLabels.Type }),
+      DeviceType.SWITCH
+    );
+  };
+
+  it("shows switch specific fields when the Switch type is selected", async () => {
+    renderWithProviders(<DiscoveryAddForm discovery={discovery} />, { state });
+
+    await selectSwitchType();
+
+    expect(
+      screen.getByRole("textbox", { name: FormFieldLabels.Name })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: FormFieldLabels.MacAddress })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: FormFieldLabels.Image })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "IP assignment" })
+    ).toBeInTheDocument();
+  });
+
+  it("pre-populates the MAC address from the discovery", async () => {
+    renderWithProviders(<DiscoveryAddForm discovery={discovery} />, { state });
+
+    await selectSwitchType();
+
+    expect(
+      screen.getByRole("textbox", { name: FormFieldLabels.MacAddress })
+    ).toHaveValue("aa:bb:cc:dd:ee:ff");
+  });
+
+  it("shows Cancel, Save and Save and go to switch listing buttons", async () => {
+    renderWithProviders(<DiscoveryAddForm discovery={discovery} />, { state });
+
+    await selectSwitchType();
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: DiscoveryAddFormLabels.SwitchSubmitLabel,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: DiscoveryAddFormLabels.SubmitLabel })
+    ).toBeInTheDocument();
+  });
+
+  it("populates the image dropdown with available images", async () => {
+    renderWithProviders(<DiscoveryAddForm discovery={discovery} />, { state });
+
+    await selectSwitchType();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", { name: /centos\/centos7 - 7\.0/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls create switch on save", async () => {
+    renderWithProviders(<DiscoveryAddForm discovery={discovery} />, { state });
+
+    await selectSwitchType();
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: FormFieldLabels.Name }),
+      "test-switch"
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: DiscoveryAddFormLabels.SwitchSubmitLabel,
+      })
+    );
+
+    await waitFor(() => {
+      expect(switchResolvers.createSwitch.resolved).toBeTruthy();
     });
   });
 });

--- a/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -29,7 +29,7 @@ import {
 
 enableCallIdMocks();
 
-const mockServer = setupMockServer(
+setupMockServer(
   switchResolvers.createSwitch.handler(),
   imageResolvers.listSelections.handler()
 );

--- a/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.tsx
+++ b/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddForm.tsx
@@ -12,12 +12,13 @@ import DiscoveryAddFormFields from "./DiscoveryAddFormFields";
 import type { DiscoveryAddValues } from "./types";
 import { DeviceType } from "./types";
 
+import { useCreateSwitch } from "@/app/api/query/switches";
 import type { DiscoveryResponse } from "@/app/apiclient";
 import { listDiscoveriesQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
 import FormikForm from "@/app/base/components/FormikForm";
 import { useCycled, useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";
-import { hostnameValidation } from "@/app/base/validation";
+import { hostnameValidation, MAC_ADDRESS_REGEX } from "@/app/base/validation";
 import { deviceActions } from "@/app/store/device";
 import deviceSelectors from "@/app/store/device/selectors";
 import type { CreateInterfaceParams, Device } from "@/app/store/device/types";
@@ -32,12 +33,14 @@ import subnetSelectors from "@/app/store/subnet/selectors";
 import { FetchNodeStatus } from "@/app/store/types/node";
 import { vlanActions } from "@/app/store/vlan";
 import vlanSelectors from "@/app/store/vlan/selectors";
+import { getSwitchErrorMessage } from "@/app/switches/utils";
 import { preparePayload } from "@/app/utils";
 
 export enum Labels {
   SubmitLabel = "Save",
   SecondarySubmitParent = "Save and go to machine details",
   SecondarySubmitNoParent = "Save and go to device listing",
+  SwitchSubmitLabel = "Save and go to switch listing",
 }
 
 type Props = {
@@ -116,6 +119,14 @@ const DiscoveryAddSchema = Yup.object().shape({
   ip_assignment: Yup.string(),
   parent: Yup.string(),
   type: Yup.string(),
+  name: Yup.string(),
+  image: Yup.string(),
+  mac_address: Yup.string().when("type", {
+    is: DeviceType.SWITCH,
+    then: Yup.string()
+      .required("MAC address is required")
+      .matches(MAC_ADDRESS_REGEX, "Invalid MAC address"),
+  }),
 });
 
 const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
@@ -126,6 +137,8 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
   const initialDeviceType = DeviceType.DEVICE;
   const [deviceType, setDeviceType] = useState<DeviceType>(initialDeviceType);
   const [device, setDevice] = useState<Device[DeviceMeta.PK] | null>(null);
+  const createSwitch = useCreateSwitch();
+  const isSwitch = deviceType === DeviceType.SWITCH;
   const devicesLoaded = useSelector(deviceSelectors.loaded);
   const defaultDomain = useSelector(domainSelectors.getDefault);
   let hostname = discovery.hostname;
@@ -151,9 +164,16 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
   const [createdInterface] = useCycled(
     !creatingInterface && creatingInterfaceErrors.length === 0
   );
-  const processing =
-    deviceType === DeviceType.DEVICE ? saving : creatingInterface;
-  const processed = deviceType === DeviceType.DEVICE ? saved : createdInterface;
+  const processing = isSwitch
+    ? createSwitch.isPending
+    : deviceType === DeviceType.DEVICE
+      ? saving
+      : creatingInterface;
+  const processed = isSwitch
+    ? createSwitch.isSuccess
+    : deviceType === DeviceType.DEVICE
+      ? saved
+      : createdInterface;
   const { loaded: machinesLoaded } = useFetchMachines({
     filters: { status: FetchNodeStatus.DEPLOYED },
   });
@@ -189,7 +209,7 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
       allowUnchanged
       aria-label="Add discovery"
       className="u-width--full"
-      errors={errors}
+      errors={isSwitch ? getSwitchErrorMessage(createSwitch.error) : errors}
       initialValues={{
         [DeviceMeta.PK]: "",
         domain: (domainByName || defaultDomain)?.name || "",
@@ -197,6 +217,9 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
         ip_assignment: DeviceIpAssignment.DYNAMIC,
         parent: "",
         type: initialDeviceType,
+        name: "",
+        mac_address: discovery.mac_address || "",
+        image: "",
       }}
       onCancel={closeSidePanel}
       onSaveAnalytics={{
@@ -205,6 +228,18 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
         label: "Add discovery form",
       }}
       onSubmit={(values) => {
+        if (values.type === DeviceType.SWITCH) {
+          // The primary "Save" button should not redirect anywhere.
+          setRedirect(null);
+          createSwitch.mutate({
+            body: {
+              mac_address: values.mac_address ?? "",
+              name: values.name,
+              image: values.image,
+            },
+          });
+          return;
+        }
         // The normal submit button should not redirect anywhere.
         setRedirect(null);
         formSubmit(dispatch, discovery, values);
@@ -218,7 +253,9 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
         if (!redirect) {
           closeSidePanel();
           let device: string;
-          if (values.hostname) {
+          if (values.type === DeviceType.SWITCH) {
+            device = values.name || "A switch";
+          } else if (values.hostname) {
             device = values.hostname;
           } else if (values.type === DeviceType.INTERFACE) {
             device = `An ${values.type}`;
@@ -236,15 +273,33 @@ const DiscoveryAddForm = ({ discovery }: Props): ReactElement => {
       saved={processed}
       savedRedirect={redirect}
       saving={processing}
-      secondarySubmit={(values) => {
-        // The secondary submit should redirect to the device/devices.
-        setRedirectURL(values, setRedirect);
-        formSubmit(dispatch, discovery, values);
-      }}
-      secondarySubmitLabel={(values) =>
-        values.parent
-          ? Labels.SecondarySubmitParent
-          : Labels.SecondarySubmitNoParent
+      secondarySubmit={
+        isSwitch
+          ? (values) => {
+              // The switch secondary submit should redirect to the switch
+              // listing.
+              setRedirect(urls.switches.index);
+              createSwitch.mutate({
+                body: {
+                  mac_address: values.mac_address ?? "",
+                  name: values.name,
+                  image: values.image,
+                },
+              });
+            }
+          : (values) => {
+              // The secondary submit should redirect to the device/devices.
+              setRedirectURL(values, setRedirect);
+              formSubmit(dispatch, discovery, values);
+            }
+      }
+      secondarySubmitLabel={
+        isSwitch
+          ? Labels.SwitchSubmitLabel
+          : (values) =>
+              values.parent
+                ? Labels.SecondarySubmitParent
+                : Labels.SecondarySubmitNoParent
       }
       submitLabel={Labels.SubmitLabel}
       validationSchema={DiscoveryAddSchema}

--- a/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/src/app/networkDiscovery/components/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router";
 import type { DiscoveryAddValues } from "../types";
 import { DeviceType } from "../types";
 
+import { useSelections } from "@/app/api/query/images";
 import type { DiscoveryResponse } from "@/app/apiclient";
 import MachineSelect from "@/app/base/components/DhcpFormFields/MachineSelect";
 import FormikField from "@/app/base/components/FormikField";
@@ -13,6 +14,7 @@ import { FormikFieldChangeError } from "@/app/base/components/FormikField/Formik
 import IpAssignmentSelect from "@/app/base/components/IpAssignmentSelect";
 import TooltipButton from "@/app/base/components/TooltipButton";
 import urls from "@/app/base/urls";
+import { getOsDisplayName } from "@/app/images/utils";
 import deviceSelectors from "@/app/store/device/selectors";
 import type { Device } from "@/app/store/device/types";
 import { DeviceMeta } from "@/app/store/device/types";
@@ -37,6 +39,7 @@ export enum Labels {
   Device = "Device",
   DeviceName = "Device Name",
   Interface = "Interface",
+  Switch = "Switch",
   Parent = "Parent",
   Hostname = "Hostname (optional)",
   InterfaceName = "Interface name (optional)",
@@ -46,6 +49,10 @@ export enum Labels {
   Fabric = "Fabric",
   Vlan = "VLAN",
   Subnet = "Subnet",
+  Name = "Name",
+  MacAddress = "MAC address",
+  Image = "Image",
+  SelectImage = "Select an image",
 }
 
 const DiscoveryAddFormFields = ({
@@ -64,10 +71,23 @@ const DiscoveryAddFormFields = ({
   const { setFieldValue, values } = useFormikContext<DiscoveryAddValues>();
   const isDevice = values.type === DeviceType.DEVICE;
   const isInterface = values.type === DeviceType.INTERFACE;
+  const isSwitch = values.type === DeviceType.SWITCH;
   // Only include static when the discovery has a subnet.
   const includeStatic = !!discovery.subnet_id || discovery.subnet_id === 0;
   const subnetDisplay = getSubnetDisplay(subnet);
   const vlanDisplay = getVLANDisplay(vlan);
+
+  // TODO: Replace with an endpoint that only returns switch-compatible images
+  // when API is ready.
+  const availableImages = useSelections();
+  const imageOptions = [
+    { label: Labels.SelectImage, value: "", disabled: true },
+    ...(availableImages.data?.items ?? []).map((image, index) => ({
+      key: `${image.title}-${index}`,
+      label: `${getOsDisplayName(image.os)}/${image.release} - ${image.title} (${image.architecture})`,
+      value: `${image.os}/${image.release}/${image.architecture}`,
+    })),
+  ];
 
   return (
     <>
@@ -95,14 +115,33 @@ const DiscoveryAddFormFields = ({
               { label: Labels.ChooseType, value: "", disabled: true },
               { label: Labels.Device, value: DeviceType.DEVICE },
               { label: Labels.Interface, value: DeviceType.INTERFACE },
+              { label: Labels.Switch, value: DeviceType.SWITCH },
             ]}
             required
           />
-          <FormikField
-            label={isDevice ? Labels.Hostname : Labels.InterfaceName}
-            name="hostname"
-            type="text"
-          />
+          {isSwitch ? (
+            <>
+              <FormikField label={Labels.Name} name="name" type="text" />
+              <FormikField
+                label={Labels.MacAddress}
+                name="mac_address"
+                required
+                type="text"
+              />
+              <FormikField
+                component={Select}
+                label={Labels.Image}
+                name="image"
+                options={imageOptions}
+              />
+            </>
+          ) : (
+            <FormikField
+              label={isDevice ? Labels.Hostname : Labels.InterfaceName}
+              name="hostname"
+              type="text"
+            />
+          )}
           {isDevice ? (
             <FormikField
               component={Select}
@@ -150,7 +189,7 @@ const DiscoveryAddFormFields = ({
               ]}
               required
             />
-          ) : (
+          ) : isDevice ? (
             <FormikField
               component={MachineSelect}
               defaultOption={Labels.SelectParent}
@@ -163,7 +202,7 @@ const DiscoveryAddFormFields = ({
               }
               name="parent"
             />
-          )}
+          ) : null}
         </Col>
         <Col size={12}>
           <IpAssignmentSelect
@@ -175,7 +214,9 @@ const DiscoveryAddFormFields = ({
             <p>{Labels.Fabric}</p>
             <p>
               <Link
-                to={urls.networks.fabric.index({ id: discovery.fabric_id! })}
+                to={urls.networks.fabric.index({
+                  id: discovery.fabric_id!,
+                })}
               >
                 {discovery.fabric_name}
               </Link>
@@ -196,7 +237,9 @@ const DiscoveryAddFormFields = ({
             {discovery.subnet_id && subnetDisplay ? (
               <p>
                 <Link
-                  to={urls.networks.subnet.index({ id: discovery.subnet_id })}
+                  to={urls.networks.subnet.index({
+                    id: discovery.subnet_id,
+                  })}
                 >
                   {subnetDisplay}
                 </Link>

--- a/src/app/networkDiscovery/components/DiscoveryAddForm/types.ts
+++ b/src/app/networkDiscovery/components/DiscoveryAddForm/types.ts
@@ -8,6 +8,7 @@ import type { Domain } from "@/app/store/domain/types";
 export enum DeviceType {
   DEVICE = "device",
   INTERFACE = "interface",
+  SWITCH = "switch",
 }
 
 export type DiscoveryAddValues = {
@@ -17,4 +18,7 @@ export type DiscoveryAddValues = {
   ip_assignment: DeviceIpAssignment;
   parent: Device["parent"];
   type: DeviceType | "";
+  name?: string;
+  mac_address?: string;
+  image?: string;
 };


### PR DESCRIPTION
## Done

- Created a form for adding a switch from network discovery

## QA steps

- [x] Sign in to MAAS
- [x] Go to "Network Discovery"
- [x] Click the Actions icon for any row in the discovery table
- [x] Select "Add Discovery"
- [x] Change the type to "Switch"
- [x] Ensure there are 4 fields: Name, MAC address, Image and IP assignment
- [x] Ensure the MAC address field is populated with the discovery MAC address
- [x] Ensure the images dropdown shows all available images (in the future, this should only show ONIE images, for now, it'll show all images)
- [x] Ensure the design matches the network discovery form in [Figma](https://www.figma.com/design/kRfq9OizEH1E2EQpcS0pPj/Switch-provisioning?node-id=13-31&p=f&t=QC1s3kfrZhsojEzY-0)

## Fixes

Resolves [MAASENG-6611](https://warthogs.atlassian.net/browse/MAASENG-6611)

## Notes

- The "Save" buttons will not work, as switches require a special onie-compatible image


[MAASENG-6611]: https://warthogs.atlassian.net/browse/MAASENG-6611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ