### PR TITLE
test: header tests to exists instead of assuming one match

### DIFF
--- a/cypress/support/step_definitions/common/layout.steps.ts
+++ b/cypress/support/step_definitions/common/layout.steps.ts
@@ -13,7 +13,7 @@ Then("the side navigation title should be {string}", (expectedHeading) => {
 });
 
 Then("the heading should be {string}", (expectedHeading: string) => {
-  cy.findByRole("heading", { level: 1 }).contains(expectedHeading);
+  cy.findByRole("heading", { level: 1, name: expectedHeading }).should("exist");
 });
 
 Then("the heading matching {string} text should exist", (heading: string) => {

--- a/cypress/support/step_definitions/networks/networksStaticroutes.steps.ts
+++ b/cypress/support/step_definitions/networks/networksStaticroutes.steps.ts
@@ -12,7 +12,7 @@ When("the user opens the first subnet", () => {
 });
 
 When("the user navigates to static routes", () => {
-  cy.findByRole("heading", { level: 1 }).invoke("text").as("subnet");
+  cy.findAllByRole("heading", { level: 1 }).last().invoke("text").as("subnet");
 
   cy.findByRole("link", { name: /static routes/i }).click();
 });


### PR DESCRIPTION
## Done

- Changed header checks to `exists` rather than `contains` due to the addition of a11y header by Layout

## QA

- [ ] Run controllerList, networksSubnets and networksStaticroutes features locally
- [ ] Confirm they pass