### PR TITLE
feat(machines): lazy-load side panels MAASENG-6782

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@canonical/maas-react-components": "2.8.0",
+    "@canonical/maas-react-components": "2.8.1",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "4.5.2",
     "@redux-devtools/extension": "3.3.0",

--- a/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -1,12 +1,12 @@
 import type { ActionFormProps } from "./ActionForm";
-import ActionForm, { Labels } from "./ActionForm";
+import ActionForm from "./ActionForm";
 
 import { TestIds } from "@/app/base/components/FormikFormButtons";
-import { userEvent, screen, renderWithProviders } from "@/testing/utils";
+import { renderWithProviders, screen, userEvent } from "@/testing/utils";
 
 describe("ActionForm", () => {
   it("shows a spinner if form has not fully loaded", () => {
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <ActionForm
         actionName="action"
         initialValues={{}}
@@ -19,7 +19,7 @@ describe("ActionForm", () => {
     );
 
     expect(
-      screen.getByRole("alert", { name: Labels.LoadingForm })
+      result.container.querySelector(".aside-skeleton")
     ).toBeInTheDocument();
   });
 

--- a/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Spinner, Strip } from "@canonical/react-components";
+import { SidePanel } from "@canonical/maas-react-components";
 
 import type { FormikFormProps } from "@/app/base/components/FormikForm";
 import FormikForm from "@/app/base/components/FormikForm";
@@ -73,11 +73,7 @@ const ActionForm = <V extends object, E = null>({
   });
 
   if (!loaded) {
-    return (
-      <Strip>
-        <Spinner aria-label={Labels.LoadingForm} text="Loading..." />
-      </Strip>
-    );
+    return <SidePanel.Skeleton />;
   }
   // TODO: remove processingComplete once actionStatus has been implemented across all forms
   // https://warthogs.atlassian.net/browse/MAASENG-2312

--- a/src/app/machines/components/MachineActions/hooks.tsx
+++ b/src/app/machines/components/MachineActions/hooks.tsx
@@ -1,23 +1,12 @@
-import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  lazyLoadSidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { Button, Icon, Switch } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
-import DeleteMachine from "../MachineForms/DeleteMachine/DeleteMachine";
-import CloneForm from "../MachineForms/MachineActionFormWrapper/CloneForm";
-import CommissionForm from "../MachineForms/MachineActionFormWrapper/CommissionForm";
-import DeployForm from "../MachineForms/MachineActionFormWrapper/DeployForm";
-import MarkBrokenForm from "../MachineForms/MachineActionFormWrapper/MarkBrokenForm";
-import OverrideTestForm from "../MachineForms/MachineActionFormWrapper/OverrideTestForm";
-import ReleaseForm from "../MachineForms/MachineActionFormWrapper/ReleaseForm";
-import SetMachineZoneForm from "../MachineForms/MachineActionFormWrapper/SetMachineZoneForm/SetMachineZoneForm";
-import SetPoolForm from "../MachineForms/MachineActionFormWrapper/SetPoolForm";
-import TagForm from "../MachineForms/MachineActionFormWrapper/TagForm";
-import TestMachineForm from "../MachineForms/MachineActionFormWrapper/TestMachineForm";
-
 import type { MachineActionGroup } from "./types";
 
-import FieldlessForm from "@/app/base/components/node/FieldlessForm";
-import PowerOffForm from "@/app/base/components/node/PowerOffForm";
 import { machineActions } from "@/app/store/machine";
 import machineSelectors from "@/app/store/machine/selectors";
 import type { Machine } from "@/app/store/machine/types";
@@ -26,6 +15,47 @@ import { useSelectedMachinesActionsDispatch } from "@/app/store/machine/utils/ho
 import type { RootState } from "@/app/store/root/types";
 import { NodeActions } from "@/app/store/types/node";
 import { canOpenActionForm } from "@/app/store/utils";
+
+const CommissionForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/CommissionForm")
+);
+const DeployForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/DeployForm")
+);
+const ReleaseForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/ReleaseForm")
+);
+const CloneForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/CloneForm")
+);
+const MarkBrokenForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/MarkBrokenForm")
+);
+const OverrideTestForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/OverrideTestForm")
+);
+const TagForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/TagForm")
+);
+const SetMachineZoneForm = lazyLoadSidePanel(
+  () =>
+    import("../MachineForms/MachineActionFormWrapper/SetMachineZoneForm/SetMachineZoneForm")
+);
+const SetPoolForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/SetPoolForm")
+);
+const TestMachineForm = lazyLoadSidePanel(
+  () => import("../MachineForms/MachineActionFormWrapper/TestMachineForm")
+);
+const DeleteMachine = lazyLoadSidePanel(
+  () => import("../MachineForms/DeleteMachine/DeleteMachine")
+);
+const FieldlessForm = lazyLoadSidePanel(
+  () => import("@/app/base/components/node/FieldlessForm")
+);
+const PowerOffForm = lazyLoadSidePanel(
+  () => import("@/app/base/components/node/PowerOffForm")
+);
 
 export const useMachineActionMenus = (
   isViewingDetails: boolean,

--- a/src/app/machines/components/MachineForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
@@ -140,13 +140,15 @@ describe("AddChassisForm", () => {
     });
   });
 
-  it("displays a spinner if data has not loaded", () => {
+  it("displays a skeleton if data has not loaded", () => {
     state.domain.loaded = false;
     state.general.powerTypes.loaded = false;
-    renderWithProviders(<AddChassisForm />, {
+    const { result } = renderWithProviders(<AddChassisForm />, {
       state,
     });
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("correctly dispatches action to add chassis", async () => {

--- a/src/app/machines/components/MachineForms/AddChassis/AddChassisForm/AddChassisForm.tsx
+++ b/src/app/machines/components/MachineForms/AddChassis/AddChassisForm/AddChassisForm.tsx
@@ -1,8 +1,11 @@
 import type { ReactElement } from "react";
 import { useState } from "react";
 
-import { ExternalLink, useSidePanel } from "@canonical/maas-react-components";
-import { Spinner, Strip } from "@canonical/react-components";
+import {
+  ExternalLink,
+  SidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -54,9 +57,7 @@ export const AddChassisForm = (): ReactElement => {
   return (
     <>
       {!(domainsLoaded && powerTypesLoaded) ? (
-        <Strip shallow>
-          <Spinner text="Loading" />
-        </Strip>
+        <SidePanel.Skeleton />
       ) : (
         <FormikForm
           buttonsHelp={

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -96,11 +96,13 @@ describe("AddMachineForm", () => {
     });
   });
 
-  it("displays a spinner if data has not loaded", () => {
-    renderWithProviders(<AddMachineForm />, {
+  it("displays a skeleton if data has not loaded", () => {
+    const { result } = renderWithProviders(<AddMachineForm />, {
       state,
     });
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("enables submit when a power type with no fields is chosen", async () => {

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -1,8 +1,11 @@
 import type { ReactElement } from "react";
 import { useState } from "react";
 
-import { ExternalLink, useSidePanel } from "@canonical/maas-react-components";
-import { Spinner, Strip } from "@canonical/react-components";
+import {
+  ExternalLink,
+  SidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -102,9 +105,7 @@ export const AddMachineForm = (): ReactElement => {
   return (
     <>
       {!allLoaded ? (
-        <Strip data-testid="loading" shallow>
-          <Spinner text="Loading" />
-        </Strip>
+        <SidePanel.Skeleton />
       ) : (
         <FormikForm<AddMachineValues>
           buttonsHelp={

--- a/src/app/machines/components/MachineForms/DeleteMachine/DeleteMachine.tsx
+++ b/src/app/machines/components/MachineForms/DeleteMachine/DeleteMachine.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import type { Action, Dispatch } from "redux";
@@ -57,7 +56,7 @@ export const DeleteMachine = ({
   };
 
   if (selectedCountLoading) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.tsx
@@ -1,8 +1,11 @@
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
-import { ExternalLink, useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import {
+  ExternalLink,
+  SidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -90,7 +93,7 @@ export const CloneForm = ({
   }, [dispatch]);
 
   if (selectedCountLoading) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -1,10 +1,7 @@
 import type { ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import {
-  Notification as NotificationBanner,
-  Spinner,
-} from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
+import { Notification as NotificationBanner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router";
 import * as Yup from "yup";
@@ -126,7 +123,7 @@ export const CommissionForm = ({
   useFetchActions([scriptActions.fetch]);
 
   if (selectedCountLoading) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -107,7 +107,7 @@ describe("DeployForm", () => {
     });
   });
 
-  it("shows a spinner if data has not loaded yet", () => {
+  it("shows a skeleton if data has not loaded yet", () => {
     const state = factory.rootState({
       general: factory.generalState({
         osInfo: factory.osInfoState({
@@ -118,9 +118,14 @@ describe("DeployForm", () => {
         loaded: false,
       }),
     });
-    renderWithProviders(<DeployForm isViewingDetails={false} />, { state });
+    const { result } = renderWithProviders(
+      <DeployForm isViewingDetails={false} />,
+      { state }
+    );
 
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
     expect(screen.queryByRole("form")).not.toBeInTheDocument();
   });
 

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import * as Yup from "yup";
@@ -99,7 +98,7 @@ export const DeployForm = ({
     !configLoaded ||
     selectedCountLoading
   ) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
 
   // Default OS+release is set in the backend even if the image has not yet been

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useEffect } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import * as Yup from "yup";
@@ -64,7 +63,7 @@ export const MarkBrokenForm = ({
   );
 
   if (selectedCountLoading) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Col, Row, Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router";
 import * as Yup from "yup";
@@ -66,7 +66,7 @@ export const OverrideTestForm = ({
     : null;
 
   if (selectedCountLoading) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from "react";
 import { useEffect } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner, Strip } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
+import { Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import * as Yup from "yup";
@@ -76,7 +76,7 @@ export const ReleaseForm = ({
   }, [dispatch]);
 
   if (selectedCountLoading || !configLoaded) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TestMachineForm/TestMachineForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TestMachineForm/TestMachineForm.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "@/app/base/components/ActionForm";
@@ -104,7 +103,7 @@ const TestMachineForm = ({
   }, [dispatch, scriptsLoaded]);
 
   if (selectedCountLoading) {
-    return <Spinner text={"Loading..."} />;
+    return <SidePanel.Skeleton />;
   }
 
   return (

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -82,9 +82,9 @@ describe("AddAliasOrVlan", () => {
     });
   });
 
-  it("displays a spinner when data is loading", () => {
+  it("displays a skeleton when data is loading", () => {
     state.machine.items = [];
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <AddAliasOrVlan
         interfaceType={NetworkInterfaceTypes.VLAN}
         nic={nic}
@@ -92,7 +92,9 @@ describe("AddAliasOrVlan", () => {
       />,
       { state }
     );
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("displays a save-another button for aliases", () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useCallback, useState } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -84,7 +83,7 @@ const AddAliasOrVlan = ({
   const canAddAnother = isAlias || (!isAlias && unusedVLANs.length > 1);
 
   if (!nicVLAN || !isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
   return (
     <div ref={onRenderRef}>

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -265,26 +265,30 @@ describe("AddBondForm", () => {
     expect(store.getActions().some((action) => action.type === "vlan/fetch"));
   });
 
-  it("displays a spinner when data is loading", async () => {
+  it("displays a skeleton when data is loading", async () => {
     state.fabric.loaded = false;
     state.subnet.loaded = false;
     state.vlan.loaded = false;
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <AddBondForm selected={[]} setSelected={vi.fn()} systemId="abc123" />,
       { state }
     );
-    expect(screen.getByText("Loading")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
-  it("displays a spinner if the VLAN hasn't been set", async () => {
+  it("displays a skeleton if the VLAN hasn't been set", async () => {
     state.fabric.loaded = true;
     state.subnet.loaded = true;
     state.vlan.loaded = true;
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <AddBondForm selected={[]} setSelected={vi.fn()} systemId="abc123" />,
       { state }
     );
-    expect(screen.getByTestId("data-loading")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("can dispatch an action to add a bond", async () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useCallback, useEffect, useState } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -162,7 +161,7 @@ const AddBondForm = ({
     !subnetsLoaded ||
     !bondVLAN
   ) {
-    return <Spinner data-testid="data-loading" />;
+    return <SidePanel.Skeleton />;
   }
   const subnet = getInterfaceSubnet(
     machine,

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useEffect, useState, useCallback } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -114,7 +113,7 @@ const AddBridgeForm = ({
   }, [bridgeVLAN, firstNic, setBridgeVLAN]);
 
   if (vlansLoading || !bridgeVLAN || !isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
 
   const macAddress = firstNic?.mac_address || "";

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from "react";
 import { useCallback } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Col, Input, Row, Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
+import { Col, Input, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -72,7 +72,7 @@ const AddInterface = ({ systemId }: AddInterfaceProps): ReactElement => {
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
 
   if (!isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
   return (
     <div ref={onRenderRef}>

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -58,12 +58,12 @@ describe("EditAliasOrVlanForm", () => {
     });
   });
 
-  it("displays a spinner when data is loading", () => {
+  it("displays a skeleton when data is loading", () => {
     state.fabric.loaded = false;
     state.subnet.loaded = false;
     state.vlan.loaded = false;
     state.machine.items = [];
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <EditAliasOrVlanForm
         interfaceType={NetworkInterfaceTypes.VLAN}
         nic={nic}
@@ -71,7 +71,9 @@ describe("EditAliasOrVlanForm", () => {
       />,
       { state }
     );
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("displays a tag field for a VLAN", () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from "react";
 import { useCallback } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Col, Row, Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -94,7 +94,7 @@ const EditAliasOrVlanForm = ({
   ]);
 
   if (!nic || !isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
 
   const subnet = getInterfaceSubnet(

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.test.tsx
@@ -313,11 +313,11 @@ describe("EditBondForm", () => {
     expect(store.getActions().some((action) => action.type === "vlan/fetch"));
   });
 
-  it("displays a spinner when data is loading", async () => {
+  it("displays a skeleton when data is loading", async () => {
     state.fabric.loaded = false;
     state.subnet.loaded = false;
     state.vlan.loaded = false;
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <EditBondForm
         nic={nic}
         selected={[]}
@@ -326,7 +326,9 @@ describe("EditBondForm", () => {
       />,
       { state }
     );
-    expect(screen.getByText("Loading")).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("can dispatch an action to update a bond", async () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useCallback, useState } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -141,7 +140,7 @@ const EditBondForm = ({
     !fabricsLoaded ||
     !subnetsLoaded
   ) {
-    return <Spinner />;
+    return <SidePanel.Skeleton />;
   }
   const subnet = getInterfaceSubnet(
     machine,

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import EditBridgeForm from "./EditBridgeForm";
 
 import type { RootState } from "@/app/store/root/types";
@@ -10,7 +8,7 @@ import {
 } from "@/app/store/types/enum";
 import type { NetworkInterface, NetworkLink } from "@/app/store/types/node";
 import * as factory from "@/testing/factories";
-import { renderWithProviders, screen } from "@/testing/utils";
+import { renderWithProviders, screen, userEvent } from "@/testing/utils";
 
 describe("EditBridgeForm", () => {
   let nic: NetworkInterface;
@@ -65,14 +63,16 @@ describe("EditBridgeForm", () => {
     ).toBe(true);
   });
 
-  it("displays a spinner when data is loading", () => {
+  it("displays a skeleton when data is loading", () => {
     state.vlan.loaded = false;
     state.vlan.loading = true;
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <EditBridgeForm link={link} nic={nic} systemId="abc123" />,
       { state }
     );
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("can dispatch an action to update a bridge", async () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useCallback } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -76,7 +75,7 @@ const EditBridgeForm = ({
   useFetchActions([vlanActions.fetch]);
 
   if (vlansLoading || !nic || !isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
   const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
   return (

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.test.tsx
@@ -22,15 +22,17 @@ describe("EditInterface", () => {
     });
   });
 
-  it("displays a spinner when data is loading", () => {
+  it("displays a skeleton when data is loading", () => {
     state.machine.items = [];
-    renderWithProviders(
+    const { result } = renderWithProviders(
       <EditInterface selected={[]} setSelected={vi.fn()} systemId="abc123" />,
       {
         state,
       }
     );
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    expect(
+      result.container.querySelector(".aside-skeleton")
+    ).toBeInTheDocument();
   });
 
   it("displays a form for editing a physical interface", () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { SidePanel } from "@canonical/maas-react-components";
 import { useSelector } from "react-redux";
 
 import EditAliasOrVlanForm from "../EditAliasOrVlanForm";
@@ -43,7 +43,7 @@ const EditInterface = ({
   );
   const link = getLinkFromNic(nic, linkId);
   if (!isMachineDetails(machine)) {
-    return <Spinner text="Loading..." />;
+    return <SidePanel.Skeleton />;
   }
   const interfaceType = getInterfaceType(machine, nic, link);
   let form: ReactNode;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { useCallback } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
-import { Spinner } from "@canonical/react-components";
+import { SidePanel, useSidePanel } from "@canonical/maas-react-components";
 import * as ipaddr from "ipaddr.js";
 import { isIP, isIPv4 } from "is-ip";
 import { useDispatch, useSelector } from "react-redux";
@@ -150,7 +149,7 @@ const EditPhysicalForm = ({
   ]);
 
   if (!isMachineDetails(machine) || !nic) {
-    return <Spinner />;
+    return <SidePanel.Skeleton />;
   }
 
   const subnet = getInterfaceSubnet(

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
@@ -1,6 +1,5 @@
 import MachineNetworkActions from "./MachineNetworkActions";
 
-import TestMachineForm from "@/app/machines/components/MachineForms/MachineActionFormWrapper/TestMachineForm";
 import AddBondForm from "@/app/machines/views/MachineDetails/MachineNetwork/AddBondForm";
 import AddBridgeForm from "@/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm";
 import type { RootState } from "@/app/store/root/types";
@@ -76,7 +75,7 @@ describe("MachineNetworkActions", () => {
         screen.getByRole("button", { name: /Validate network configuration/i })
       );
       expect(mockOpen).toHaveBeenCalledWith({
-        component: TestMachineForm,
+        component: expect.any(Function),
         title: "Test machine",
         props: {
           applyConfiguredNetworking: true,

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.tsx
@@ -1,6 +1,9 @@
 import type { Dispatch, ReactElement, SetStateAction } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  lazyLoadSidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { Button } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
@@ -10,7 +13,6 @@ import type { Expanded } from "@/app/base/components/NodeNetworkTab/NodeNetworkT
 import { ExpandedState } from "@/app/base/components/NodeNetworkTab/NodeNetworkTab";
 import type { Selected } from "@/app/base/components/node/networking/types";
 import { useIsAllNetworkingDisabled, useSendAnalytics } from "@/app/base/hooks";
-import TestMachineForm from "@/app/machines/components/MachineForms/MachineActionFormWrapper/TestMachineForm";
 import machineSelectors from "@/app/store/machine/selectors";
 import type { Machine, MachineDetails } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
@@ -21,6 +23,11 @@ import {
   getInterfaceType,
   getLinkFromNic,
 } from "@/app/store/utils";
+
+const TestMachineForm = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/components/MachineForms/MachineActionFormWrapper/TestMachineForm")
+);
 
 type Action = {
   disabled: [boolean, string?][];

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -1,3 +1,5 @@
+import { lazyLoadSidePanel } from "@canonical/maas-react-components";
+
 import NetworkTableActions from "./NetworkTableActions";
 
 import type { MachineDetails } from "@/app/store/machine/types";
@@ -175,6 +177,11 @@ describe("NetworkTableActions", () => {
     renderWithProviders(<NetworkTableActions nic={nic} systemId="abc123" />, {
       state,
     });
+
+    const MarkConnectedForm = lazyLoadSidePanel(
+      () =>
+        import("@/app/machines/views/MachineDetails/MachineNetwork/MarkConnectedForm")
+    );
     // Open the menu:
     await openMenu();
     const editPhysicalButton = screen.getByRole("menuitem", {
@@ -184,7 +191,7 @@ describe("NetworkTableActions", () => {
     await userEvent.click(editPhysicalButton);
     expect(mockOpen).toHaveBeenCalledWith(
       expect.objectContaining({
-        component: expect.any(Function),
+        component: MarkConnectedForm,
         title: "Mark as connected",
       })
     );

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -1,5 +1,3 @@
-import { lazyLoadSidePanel } from "@canonical/maas-react-components";
-
 import NetworkTableActions from "./NetworkTableActions";
 
 import type { MachineDetails } from "@/app/store/machine/types";
@@ -178,10 +176,6 @@ describe("NetworkTableActions", () => {
       state,
     });
 
-    const MarkConnectedForm = lazyLoadSidePanel(
-      () =>
-        import("@/app/machines/views/MachineDetails/MachineNetwork/MarkConnectedForm")
-    );
     // Open the menu:
     await openMenu();
     const editPhysicalButton = screen.getByRole("menuitem", {
@@ -191,7 +185,7 @@ describe("NetworkTableActions", () => {
     await userEvent.click(editPhysicalButton);
     expect(mockOpen).toHaveBeenCalledWith(
       expect.objectContaining({
-        component: MarkConnectedForm,
+        component: expect.any(Function),
         title: "Mark as connected",
       })
     );

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -1,8 +1,5 @@
-import EditInterface from "../../EditInterface";
-
 import NetworkTableActions from "./NetworkTableActions";
 
-import MarkConnectedForm from "@/app/machines/views/MachineDetails/MachineNetwork/MarkConnectedForm";
 import type { MachineDetails } from "@/app/store/machine/types";
 import type { RootState } from "@/app/store/root/types";
 import { NetworkInterfaceTypes, NetworkLinkMode } from "@/app/store/types/enum";
@@ -165,7 +162,8 @@ describe("NetworkTableActions", () => {
     await userEvent.click(editBondButton);
     expect(mockOpen).toHaveBeenCalledWith(
       expect.objectContaining({
-        component: EditInterface,
+        component: expect.any(Function),
+        title: "Edit Bond",
       })
     );
   });
@@ -186,7 +184,8 @@ describe("NetworkTableActions", () => {
     await userEvent.click(editPhysicalButton);
     expect(mockOpen).toHaveBeenCalledWith(
       expect.objectContaining({
-        component: MarkConnectedForm,
+        component: expect.any(Function),
+        title: "Mark as connected",
       })
     );
   });

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -1,9 +1,10 @@
-import type { ComponentType, ReactElement } from "react";
+import type { ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  lazyLoadSidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { useSelector } from "react-redux";
-
-import EditInterface from "../../EditInterface";
 
 import TableMenu from "@/app/base/components/TableMenu";
 import type { Props as TableMenuProps } from "@/app/base/components/TableMenu/TableMenu";
@@ -13,10 +14,7 @@ import type {
   SetSelected,
 } from "@/app/base/components/node/networking/types";
 import { useIsAllNetworkingDisabled } from "@/app/base/hooks";
-import AddAliasOrVlan from "@/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan";
-import MarkConnectedForm from "@/app/machines/views/MachineDetails/MachineNetwork/MarkConnectedForm";
 import { ConnectionState } from "@/app/machines/views/MachineDetails/MachineNetwork/MarkConnectedForm/MarkConnectedForm";
-import RemovePhysicalForm from "@/app/machines/views/MachineDetails/MachineNetwork/RemovePhysicalForm";
 import machineSelectors from "@/app/store/machine/selectors";
 import type { Machine } from "@/app/store/machine/types";
 import {
@@ -32,6 +30,20 @@ import {
   getInterfaceTypeText,
   hasInterfaceType,
 } from "@/app/store/utils";
+
+const EditInterface = lazyLoadSidePanel(() => import("../../EditInterface"));
+const AddAliasOrVlan = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan")
+);
+const MarkConnectedForm = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/views/MachineDetails/MachineNetwork/MarkConnectedForm")
+);
+const RemovePhysicalForm = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/views/MachineDetails/MachineNetwork/RemovePhysicalForm")
+);
 
 type NetworkTableActionsProps = {
   link?: NetworkLink | null;
@@ -204,10 +216,7 @@ const NetworkTableActions = ({
         children: `Remove ${getInterfaceTypeText(machine, nic, link)}...`,
         onClick: () => {
           openSidePanel({
-            // Cast component type to appease TiCS, local compiler shows no error
-            component: RemovePhysicalForm as ComponentType<
-              Record<string, unknown>
-            >,
+            component: RemovePhysicalForm,
             title: `Remove ${getInterfaceTypeText(machine, nic, link)}`,
             props: {
               systemId: machine.system_id,

--- a/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayoutMenu/ChangeStorageLayoutMenu.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayoutMenu/ChangeStorageLayoutMenu.tsx
@@ -1,11 +1,18 @@
 import type { ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  lazyLoadSidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { ContextualMenu } from "@canonical/react-components";
 
-import ChangeStorageLayout from "@/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout";
 import type { Machine, StorageLayoutOption } from "@/app/store/machine/types";
 import { StorageLayout } from "@/app/store/types/enum";
+
+const ChangeStorageLayout = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout")
+);
 
 // TODO: Once the API returns a list of allowed storage layouts for a given
 // machine we should either filter this list, or add a boolean e.g. "allowable"

--- a/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.tsx
@@ -1,10 +1,19 @@
 import type { ReactElement } from "react";
 
-import { useSidePanel } from "@canonical/maas-react-components";
+import {
+  lazyLoadSidePanel,
+  useSidePanel,
+} from "@canonical/maas-react-components";
 import { ContextualMenu } from "@canonical/react-components";
 
-import AddChassisForm from "@/app/machines/components/MachineForms/AddChassis/AddChassisForm";
-import AddMachineForm from "@/app/machines/components/MachineForms/AddMachine/AddMachineForm";
+const AddChassisForm = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/components/MachineForms/AddChassis/AddChassisForm")
+);
+const AddMachineForm = lazyLoadSidePanel(
+  () =>
+    import("@/app/machines/components/MachineForms/AddMachine/AddMachineForm")
+);
 
 type AddHardwareMenuProps = {
   disabled?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
   integrity sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==
 
-"@canonical/maas-react-components@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-2.8.0.tgz#ff018ff1877465cef44dafa6cec1682c0263f27b"
-  integrity sha512-5Z6X+wFuaxsyKSy9S6cjSLNwng/QLnMzpCWHQ5qNZCYIs/XVLRKEX6ZIHzNe5TIZxrgCQUo65TLh8xWU1/gxHw==
+"@canonical/maas-react-components@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-2.8.1.tgz#a9f0aff9bb3a831f92e18093e56d0a15947c1549"
+  integrity sha512-+C9t/ykwDxMtpKvC+QJ7h6bPpgHNJH69GfcoYPRtL4mKxhLgV0Faul6L0AMVIfZZ7xGT/odmxdp0y/7ECZYKqw==
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"


### PR DESCRIPTION
## Done

- introduced lazy-loaded side panels to machines
- upgrade maas-react-components to 2.8.1

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] go to machines
- [x] test each side panel
- [x] ensure they load correctly
- [x] ensure they display a skeleton while lazy loading

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6782](https://warthogs.atlassian.net/browse/MAASENG-6782)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

[MAASENG-6782]: https://warthogs.atlassian.net/browse/MAASENG-6782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ